### PR TITLE
Add opscenter to robotest suite.

### DIFF
--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -81,6 +81,10 @@ EOF
       done
     done
   done
+  suite+=$(cat <<EOF
+ install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:latest","storage_driver":"overlay2","ops_advertise_addr":"example.com:443"}
+EOF
+)
   echo $suite
 }
 


### PR DESCRIPTION
To catch regressions in opscenter app installation.

Requires https://github.com/gravitational/robotest/pull/129.

Closes https://github.com/gravitational/gravity.e/issues/3738.