### PR TITLE
Minor tweaks to CLI experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ build:
 # 'install' uses the host's Golang to place output into $GOPATH/bin
 .PHONY:install
 install:
-	go install ./tool/tele ./tool/gravity
+	go install -ldflags "$(VERSION_FLAGS)" ./tool/tele ./tool/gravity
 
 # 'clean' removes the build artifacts
 .PHONY: clean

--- a/tool/tele/main.go
+++ b/tool/tele/main.go
@@ -32,7 +32,7 @@ import (
 func main() {
 	teleutils.InitLogger(teleutils.LoggingForCLI, log.WarnLevel)
 	stdlog.SetOutput(log.StandardLogger().Writer())
-	app := kingpin.New("tele", "Gravity CLI client")
+	app := kingpin.New("tele", "Gravity tool for building and publishing application bundles")
 	if err := run(app); err != nil {
 		log.Error(trace.DebugReport(err))
 		common.PrintError(err)


### PR DESCRIPTION
- "make install" target adds golang flags for version/gitref
- "tele help" is more descriptive

(it's a tiny PR but I need to get it out of the way before I context-switch to another project for a couple of days)