### PR TITLE
Write system log during upgrade.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -210,11 +210,14 @@ const (
 	// GravityPackagePrefix defines base prefix of gravity package
 	GravityPackagePrefix = "gravitational.io/gravity"
 
-	// TelekubeSystemLog defines the default location for the system log
-	TelekubeSystemLog = "/var/log/telekube-system.log"
+	// TelekubeSystemLogFile is the system log file name
+	TelekubeSystemLogFile = "telekube-system.log"
 
-	// TelekubeUserLog the default location for user-facing log file
-	TelekubeUserLog = "/var/log/telekube-install.log"
+	// TelekubeUserLogFile is the user log file name
+	TelekubeUserLogFile = "telekube-install.log"
+
+	// SystemLogDir is the directory where gravity logs go
+	SystemLogDir = "/var/log"
 
 	// TelekubePackage is the Telekube application package name
 	TelekubePackage = "telekube"
@@ -1023,6 +1026,12 @@ var (
 	// CertificateExpiry is the validity period of certificates generated
 	// during cluster installation (such as apiserver, etcd, kubelet, etc.)
 	CertificateExpiry time.Duration = 10 * 365 * 24 * time.Hour // 10 years
+
+	// TelekubeSystemLog defines the default location for the system log
+	TelekubeSystemLog = filepath.Join(SystemLogDir, TelekubeSystemLogFile)
+
+	// TelekubeUserLog the default location for user-facing log file
+	TelekubeUserLog = filepath.Join(SystemLogDir, TelekubeUserLogFile)
 )
 
 // HookSecurityContext returns default securityContext for hook pods

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -211,10 +211,10 @@ const (
 	GravityPackagePrefix = "gravitational.io/gravity"
 
 	// TelekubeSystemLog defines the default location for the system log
-	TelekubeSystemLog = "./telekube-system.log"
+	TelekubeSystemLog = "/var/log/telekube-system.log"
 
 	// TelekubeUserLog the default location for user-facing log file
-	TelekubeUserLog = "./telekube-install.log"
+	TelekubeUserLog = "/var/log/telekube-install.log"
 
 	// TelekubePackage is the Telekube application package name
 	TelekubePackage = "telekube"

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -60,8 +60,6 @@ type PeerConfig struct {
 	Context context.Context
 	// Cancel can be used to cancel the context above
 	Cancel context.CancelFunc
-	// SystemLogFile is the telekube-system.log file path
-	SystemLogFile string
 	// AdvertiseAddr is advertise addr of this node
 	AdvertiseAddr string
 	// ServerAddr is optional address of the agent server.
@@ -158,9 +156,6 @@ func NewPeer(cfg PeerConfig) (*Peer, error) {
 
 // Init initializes the peer
 func (p *Peer) Init() error {
-	if err := install.InitLogging(p.SystemLogFile); err != nil {
-		return trace.Wrap(err)
-	}
 	if err := p.bootstrap(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/install/hook.go
+++ b/lib/install/hook.go
@@ -31,6 +31,10 @@ func InitLogging(logFile string) {
 	log.StandardLogger().Hooks.Add(&Hook{
 		path: logFile,
 	})
+	setLoggingOptions()
+}
+
+func setLoggingOptions() {
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(ioutil.Discard)
 }

--- a/lib/install/hook.go
+++ b/lib/install/hook.go
@@ -27,13 +27,12 @@ import (
 )
 
 // InitLogging initalizes logging for local installer
-func InitLogging(logFile string) error {
+func InitLogging(logFile string) {
 	log.StandardLogger().Hooks.Add(&Hook{
 		path: logFile,
 	})
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(ioutil.Discard)
-	return nil
 }
 
 // Hook implements log.Hook and multiplexes log messages

--- a/lib/install/hook.go
+++ b/lib/install/hook.go
@@ -22,33 +22,18 @@ import (
 
 	"github.com/gravitational/gravity/lib/defaults"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 )
 
 // InitLogging initalizes logging for local installer
 func InitLogging(logFile string) error {
-	hook, err := NewLogHook(logFile)
-	if err != nil {
-		return trace.Wrap(err, "failed to create log file %v", logFile)
-	}
-	log.StandardLogger().Hooks.Add(hook)
+	log.StandardLogger().Hooks.Add(&Hook{
+		path: logFile,
+	})
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(ioutil.Discard)
 	return nil
-}
-
-// NewLogHook returns new logging hook
-func NewLogHook(path string) (*Hook, error) {
-	// Truncate the contents of the log file
-	f, err := os.Create(path)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	f.Close()
-	return &Hook{
-		path: path,
-	}, nil
 }
 
 // Hook implements log.Hook and multiplexes log messages

--- a/lib/install/process.go
+++ b/lib/install/process.go
@@ -35,10 +35,7 @@ func InitProcess(ctx context.Context, installerConfig Config, gravityConfig proc
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = InitLogging(installerConfig.SystemLogFile)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	InitLogging(installerConfig.SystemLogFile)
 	err = p.InitRPCCredentials()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/install/process.go
+++ b/lib/install/process.go
@@ -35,7 +35,7 @@ func InitProcess(ctx context.Context, installerConfig Config, gravityConfig proc
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	InitLogging(installerConfig.SystemLogFile)
+	setLoggingOptions()
 	err = p.InitRPCCredentials()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -493,7 +493,6 @@ func (j *JoinConfig) ToPeerConfig(env, joinEnv *localenv.LocalEnvironment) (*exp
 	return &expand.PeerConfig{
 		Context:       ctx,
 		Cancel:        cancel,
-		SystemLogFile: j.SystemLogFile,
 		Peers:         peers,
 		AdvertiseAddr: advertiseAddr,
 		ServerAddr:    j.ServerAddr,

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -123,10 +123,8 @@ func Join(env, joinEnv *localenv.LocalEnvironment, j JoinConfig) error {
 }
 
 type leaveConfig struct {
-	force         bool
-	confirmed     bool
-	systemLogFile string
-	userLogFile   string
+	force     bool
+	confirmed bool
 }
 
 func leave(env *localenv.LocalEnvironment, c leaveConfig) error {
@@ -147,10 +145,6 @@ func leave(env *localenv.LocalEnvironment, c leaveConfig) error {
 
 func tryLeave(env *localenv.LocalEnvironment, c leaveConfig) error {
 	if err := checkRunningAsRoot(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := install.InitLogging(c.systemLogFile); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -185,11 +179,9 @@ func tryLeave(env *localenv.LocalEnvironment, c leaveConfig) error {
 	}
 
 	err = remove(env, removeConfig{
-		server:        server.Hostname,
-		confirmed:     true,
-		force:         c.force,
-		systemLogFile: c.systemLogFile,
-		userLogFile:   c.userLogFile,
+		server:    server.Hostname,
+		confirmed: true,
+		force:     c.force,
 	})
 	if err != nil {
 		return trace.BadParameter(
@@ -207,11 +199,9 @@ func (r *removeConfig) checkAndSetDefaults() error {
 }
 
 type removeConfig struct {
-	server        string
-	force         bool
-	confirmed     bool
-	systemLogFile string
-	userLogFile   string
+	server    string
+	force     bool
+	confirmed bool
 }
 
 func remove(env *localenv.LocalEnvironment, c removeConfig) error {
@@ -220,10 +210,6 @@ func remove(env *localenv.LocalEnvironment, c removeConfig) error {
 	}
 
 	if err := c.checkAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := install.InitLogging(c.systemLogFile); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -353,10 +339,6 @@ func agent(env *localenv.LocalEnvironment, config agentConfig, serviceName strin
 	}
 
 	if err := config.checkAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err := install.InitLogging(config.systemLogFile); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
-	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/pack"
@@ -61,12 +60,7 @@ func rpcAgentInstall(env *localenv.LocalEnvironment, args []string) error {
 }
 
 // rpcAgentRun runs a local agent executing the function specified with optional args
-func rpcAgentRun(localEnv, upgradeEnv *localenv.LocalEnvironment, args []string, systemLogFile string) error {
-	err := install.InitLogging(systemLogFile)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+func rpcAgentRun(localEnv, upgradeEnv *localenv.LocalEnvironment, args []string) error {
 	server, err := startAgent()
 	if err != nil {
 		return trace.Wrap(err)
@@ -371,4 +365,5 @@ type deployAgentsRequest struct {
 	clusterName  string
 	proxy        *teleclient.ProxyClient
 	leaderParams []string
+	leader       *storage.Server
 }

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/pack"
@@ -60,7 +61,12 @@ func rpcAgentInstall(env *localenv.LocalEnvironment, args []string) error {
 }
 
 // rpcAgentRun runs a local agent executing the function specified with optional args
-func rpcAgentRun(localEnv, upgradeEnv *localenv.LocalEnvironment, args []string) error {
+func rpcAgentRun(localEnv, upgradeEnv *localenv.LocalEnvironment, args []string, systemLogFile string) error {
+	err := install.InitLogging(systemLogFile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	server, err := startAgent()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -135,7 +135,6 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.UpgradeCmd.FullCommand(),
 		g.SystemRollbackCmd.FullCommand(),
 		g.SystemUninstallCmd.FullCommand(),
-		g.UpgradeCmd.FullCommand(),
 		g.RollbackCmd.FullCommand(),
 		g.UpdateSystemCmd.FullCommand(),
 		g.RPCAgentShutdownCmd.FullCommand(),
@@ -292,7 +291,8 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return updateTrigger(localEnv,
 			upgradeEnv,
 			*g.UpdateTriggerCmd.App,
-			*g.UpdateTriggerCmd.Manual)
+			*g.UpdateTriggerCmd.Manual,
+			*g.SystemLogFile)
 	case g.UpgradeCmd.FullCommand():
 		if *g.UpgradeCmd.Resume {
 			*g.UpgradeCmd.Phase = fsm.RootPhase
@@ -313,7 +313,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			upgradeEnv,
 			*g.UpgradeCmd.App,
 			*g.UpgradeCmd.Manual,
-		)
+			*g.SystemLogFile)
 	case g.RollbackCmd.FullCommand():
 		return rollbackOperationPhase(localEnv,
 			upgradeEnv,
@@ -719,7 +719,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.RPCAgentInstallCmd.FullCommand():
 		return rpcAgentInstall(localEnv, *g.RPCAgentInstallCmd.Args)
 	case g.RPCAgentRunCmd.FullCommand():
-		return rpcAgentRun(localEnv, upgradeEnv, *g.RPCAgentRunCmd.Args)
+		return rpcAgentRun(localEnv, upgradeEnv,
+			*g.RPCAgentRunCmd.Args,
+			*g.SystemLogFile)
 	case g.RPCAgentShutdownCmd.FullCommand():
 		return rpcAgentShutdown(localEnv)
 	case g.CheckCmd.FullCommand():

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
+	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -51,7 +52,14 @@ func updateTrigger(
 	localEnv *localenv.LocalEnvironment,
 	upgradeEnv *localenv.LocalEnvironment,
 	appPackage string,
-	manual bool) (err error) {
+	manual bool,
+	systemLogFile string,
+) error {
+	err := install.InitLogging(systemLogFile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	operator, err := localEnv.SiteOperator()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR makes sure that `telekube-system` log file is written during automatic upgrade on the node where master agent is running. Also includes the following changes/improvements:

* Capture update hook output and write it to the system log as well, similar to what install does.
* Move default location of our log files to `/var/log` instead of the "current working dir". This gives us a stable well-known location where these files can be found, as opposed to currently having to search for them everywhere because the working dir may be completely different depending on how the command was run (e.g. if it's run via an agent, then the file will end up in / and so on).
* Do not truncate telekube-system log file every time. I think it doesn't make sense to truncate it since it oftentimes useful to look at the past logs.

Closes https://github.com/gravitational/gravity.e/issues/3596.
