### PR TITLE
Pull packages by operation ID.

### DIFF
--- a/lib/install/phases/pull.go
+++ b/lib/install/phases/pull.go
@@ -167,7 +167,7 @@ func (p *pullExecutor) applyInstalledLabels() error {
 		constants.GravityPackage,
 	}
 	locators := []loc.Locator{p.runtimePackage}
-	err := pack.ForeachPackageInRepo(p.WizardPackages, defaults.SystemAccountOrg,
+	err := pack.ForeachPackageInRepo(p.LocalPackages, defaults.SystemAccountOrg,
 		func(e pack.PackageEnvelope) error {
 			if utils.StringInSlice(packages, e.Locator.Name) {
 				locators = append(locators, e.Locator)
@@ -253,7 +253,7 @@ func (p *pullExecutor) collectMasterPackages() ([]pack.PackageEnvelope, error) {
 					p.Phase.Data.Server.AdvertiseIP,
 				},
 			})
-			if pull {
+			if pull && e.RuntimeLabels[pack.OperationIDLabel] == p.Plan.OperationID {
 				envelopes = append(envelopes, e)
 			}
 			return nil
@@ -275,7 +275,7 @@ func (p *pullExecutor) collectNodePackages() ([]pack.PackageEnvelope, error) {
 					p.Phase.Data.Server.AdvertiseIP,
 				},
 			})
-			if pull {
+			if pull && e.RuntimeLabels[pack.OperationIDLabel] == p.Plan.OperationID {
 				envelopes = append(envelopes, e)
 			}
 			return nil

--- a/lib/ops/opsservice/systemupdate.go
+++ b/lib/ops/opsservice/systemupdate.go
@@ -28,7 +28,7 @@ import (
 
 // rotateSecrets generates a new set of TLS keys for the given node
 // as a package that will be automatically downloaded during upgrade
-func (s *site) rotateSecrets(node *ProvisionedServer, installOp ops.SiteOperation) (*ops.RotatePackageResponse, error) {
+func (s *site) rotateSecrets(ctx *operationContext, node *ProvisionedServer, installOp ops.SiteOperation) (*ops.RotatePackageResponse, error) {
 	secretsPackage, err := s.planetSecretsNextPackage(node)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -41,7 +41,7 @@ func (s *site) rotateSecrets(node *ProvisionedServer, installOp ops.SiteOperatio
 	}
 
 	if !node.IsMaster() {
-		resp, err := s.getPlanetNodeSecretsPackage(node, secretsPackage)
+		resp, err := s.getPlanetNodeSecretsPackage(ctx, node, secretsPackage)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -60,7 +60,7 @@ func (s *site) rotateSecrets(node *ProvisionedServer, installOp ops.SiteOperatio
 		masterParams.sniHost = trustedCluster.GetSNIHost()
 	}
 
-	resp, err := s.getPlanetMasterSecretsPackage(masterParams)
+	resp, err := s.getPlanetMasterSecretsPackage(ctx, masterParams)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -57,7 +57,12 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (*ops.RotatePacka
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := cluster.rotateSecrets(node, *op)
+	ctx, err := cluster.newOperationContext(*op)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := cluster.rotateSecrets(ctx, node, *op)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/pack/constants.go
+++ b/lib/pack/constants.go
@@ -27,6 +27,8 @@ const (
 	PurposeLabel = "purpose"
 	// AdvertiseIPLabel contains advertise IP of the server the package is for
 	AdvertiseIPLabel = "advertise-ip"
+	// OperationIDLabel contains ID of the operation the package was configured for
+	OperationIDLabel = "operation-id"
 
 	// PurposeCA marks the planet certificate authority package
 	PurposeCA = "ca"


### PR DESCRIPTION
Add operation-id label to each configured package and use that label during the pull phase. This makes sure only packages specific to the operation will be pulled. Fixes the install->upgrade->join scenario.
