### PR TITLE
Force http 1.0 in install instructions.

### DIFF
--- a/lib/ops/opsservice/instructions.go
+++ b/lib/ops/opsservice/instructions.go
@@ -39,7 +39,7 @@ var (
 #!/bin/bash
 set -e
 
-CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --silent --show-error"
+CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --silent --show-error --http1.1"
 echo "$(date) [INFO] Downloading install agent..."
 curl $CURL_OPTS {{if .devmode}}--insecure{{end}} -H "Authorization: Bearer {{.ops_token}}" {{.gravity_url}} -o {{.gravity_bin_path}}
 chmod 755 {{.gravity_bin_path}}
@@ -87,7 +87,7 @@ echo "$(date) [INFO] Install agent will be using ${TMPDIR:-/tmp} for temporary f
 
 	downloadInstructionsTemplate = template.Must(
 		template.New("instructions").Parse(`
-curl -s --tlsv1.2 {{if .devmode}}--insecure{{end}} "{{.url}}" | sudo bash
+curl -s --tlsv1.2 --http1.1 {{if .devmode}}--insecure{{end}} "{{.url}}" | sudo bash
 `))
 )
 

--- a/lib/ops/opsservice/instructions.go
+++ b/lib/ops/opsservice/instructions.go
@@ -39,7 +39,7 @@ var (
 #!/bin/bash
 set -e
 
-CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --silent --show-error --http1.1"
+CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --silent --show-error --http1.0"
 echo "$(date) [INFO] Downloading install agent..."
 curl $CURL_OPTS {{if .devmode}}--insecure{{end}} -H "Authorization: Bearer {{.ops_token}}" {{.gravity_url}} -o {{.gravity_bin_path}}
 chmod 755 {{.gravity_bin_path}}
@@ -87,7 +87,7 @@ echo "$(date) [INFO] Install agent will be using ${TMPDIR:-/tmp} for temporary f
 
 	downloadInstructionsTemplate = template.Must(
 		template.New("instructions").Parse(`
-curl -s --tlsv1.2 --http1.1 {{if .devmode}}--insecure{{end}} "{{.url}}" | sudo bash
+curl -s --tlsv1.2 --http1.0 {{if .devmode}}--insecure{{end}} "{{.url}}" | sudo bash
 `))
 )
 


### PR DESCRIPTION
Newer versions of curl detect http2 support in the server (since we're running http/grpc on the same port) and try to upgrade connection which fails. Updates https://github.com/gravitational/gravity.e/issues/3753.