### PR TITLE
Move cluster to degraded based on planet status.

### DIFF
--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -566,7 +566,7 @@ func (p *Process) startSiteStatusChecker(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	p.Info("Starting site status checker.")
+	p.Info("Starting cluster status checker.")
 	ticker := time.NewTicker(defaults.SiteStatusCheckInterval)
 	for {
 		select {
@@ -576,10 +576,11 @@ func (p *Process) startSiteStatusChecker(ctx context.Context) error {
 				SiteDomain: site.Domain,
 			}
 			if err := p.operator.CheckSiteStatus(key); err != nil {
-				p.Errorf("Site status check failed: %v.", trace.DebugReport(err))
+				p.Errorf("Cluster status check failed: %v.",
+					trace.DebugReport(err))
 			}
 		case <-ctx.Done():
-			p.Info("Stopping site status checker.")
+			p.Info("Stopping cluster status checker.")
 			ticker.Stop()
 			return nil
 		}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -488,8 +488,8 @@ const (
 	ReasonLicenseInvalid Reason = "license_invalid"
 	// ReasonStatusCheckFailed means that the site's status check failed
 	ReasonStatusCheckFailed Reason = "status_check_failed"
-	// ReasonNodeDegraded means one or more of cluster nodes are degraded
-	ReasonNodeDegraded Reason = "node_degraded"
+	// ReasonClusterDegraded means one or more of cluster nodes are degraded
+	ReasonClusterDegraded Reason = "cluster_degraded"
 )
 
 // Description returns human-readable description of the reason
@@ -499,7 +499,7 @@ func (r *Reason) Description() string {
 		return "the license is not valid"
 	case ReasonStatusCheckFailed:
 		return "application status check failed"
-	case ReasonNodeDegraded:
+	case ReasonClusterDegraded:
 		return "one or more of cluster nodes are not healthy"
 	default:
 		return "unknown reason"
@@ -508,7 +508,7 @@ func (r *Reason) Description() string {
 
 func (r *Reason) Check() error {
 	switch *r {
-	case "", ReasonLicenseInvalid, ReasonStatusCheckFailed, ReasonNodeDegraded:
+	case "", ReasonLicenseInvalid, ReasonStatusCheckFailed, ReasonClusterDegraded:
 		return nil
 	}
 	return trace.BadParameter("unsupported reason: %s", r)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -488,6 +488,8 @@ const (
 	ReasonLicenseInvalid Reason = "license_invalid"
 	// ReasonStatusCheckFailed means that the site's status check failed
 	ReasonStatusCheckFailed Reason = "status_check_failed"
+	// ReasonNodeDegraded means one or more of cluster nodes are degraded
+	ReasonNodeDegraded Reason = "node_degraded"
 )
 
 // Description returns human-readable description of the reason
@@ -497,6 +499,8 @@ func (r *Reason) Description() string {
 		return "the license is not valid"
 	case ReasonStatusCheckFailed:
 		return "application status check failed"
+	case ReasonNodeDegraded:
+		return "one or more of cluster nodes are not healthy"
 	default:
 		return "unknown reason"
 	}
@@ -504,7 +508,7 @@ func (r *Reason) Description() string {
 
 func (r *Reason) Check() error {
 	switch *r {
-	case "", ReasonLicenseInvalid, ReasonStatusCheckFailed:
+	case "", ReasonLicenseInvalid, ReasonStatusCheckFailed, ReasonNodeDegraded:
 		return nil
 	}
 	return trace.BadParameter("unsupported reason: %s", r)

--- a/tool/gravity/cli/ops.go
+++ b/tool/gravity/cli/ops.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/pack/encryptedpack"
 	"github.com/gravitational/gravity/lib/state"
@@ -104,6 +105,13 @@ func uploadUpdate(env *localenv.LocalEnvironment, opsURL string) error {
 	cluster, err := clusterOperator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	if cluster.State == ops.SiteStateDegraded {
+		return trace.BadParameter("The cluster is in degraded state so " +
+			"uploading new applications is prohibited. Please check " +
+			"gravity status output and correct the situation before " +
+			"attempting again.")
 	}
 
 	var tarballPackages pack.PackageService = env.Packages

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -349,7 +349,10 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 }
 
 func isClusterDegrated(status clusterStatus) bool {
-	return (status.Cluster == nil || status.Agent == nil || status.Agent.SystemStatus != pb.SystemStatus_Running)
+	return (status.Cluster == nil ||
+		status.Cluster.State == ops.SiteStateDegraded ||
+		status.Agent == nil ||
+		status.Agent.SystemStatus != pb.SystemStatus_Running)
 }
 
 func unknownFallback(text string) string {


### PR DESCRIPTION
This PR introduces the following changes:

* Cluster moves to degraded state if any of the nodes in the planet agent report are degraded. I've extended the existing status checker for this (the one that runs app status hook).
* Prohibit new app version upload when cluster is degraded.
* Allow shrinking degraded clusters (to be able to remove offline nodes).

This PR concludes the work started by adding disk space checkers as it makes sure that if high watermark is reached and cluster becomes degraded, new apps can't be uploaded and upgrade can't be started.

Closes https://github.com/gravitational/gravity.e/issues/3440.

Also updates https://github.com/gravitational/gravity.e/issues/3206 because with this change cluster UI now automatically shows red "with issues" state icon when a node becomes unhealthy.