### PR TITLE
Delay docker setup during install

### DIFF
--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -510,6 +510,12 @@ func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	dockerConfig := ops.DockerConfigFromSchemaValue(app.Manifest.SystemDocker())
+	ops.OverrideDockerConfig(&dockerConfig, r.Docker)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// expand token is used when joining nodes to the cluster
 	expandToken, err := users.CryptoRandomToken(defaults.ProvisioningTokenBytes)
 	if err != nil {
@@ -549,7 +555,7 @@ func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
 		DNSOverrides: r.DNSOverrides,
 		DNSConfig:    r.DNSConfig,
 		ClusterState: storage.ClusterState{
-			Docker: r.Docker,
+			Docker: dockerConfig,
 		},
 	}
 	if runtimeLoc := app.Manifest.Base(); runtimeLoc != nil {

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1060,11 +1060,6 @@ func (m *Handler) createSite(w http.ResponseWriter, r *http.Request, p httproute
 		return nil, trace.Wrap(err)
 	}
 
-	dockerConfig, err := dockerConfig(input.AppPackage, context.Applications)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	req := ops.NewSiteRequest{
 		AppPackage: input.AppPackage,
 		AccountID:  context.User.GetAccountID(),
@@ -1072,7 +1067,6 @@ func (m *Handler) createSite(w http.ResponseWriter, r *http.Request, p httproute
 		DomainName: input.DomainName,
 		License:    input.License,
 		Labels:     input.Labels,
-		Docker:     *dockerConfig,
 	}
 
 	var vars storage.OperationVariables
@@ -2040,19 +2034,4 @@ type webAPIResponse struct {
 // makeResponse takes a collection of objects and returns API response object
 func makeResponse(items interface{}) (interface{}, error) {
 	return webAPIResponse{Items: items}, nil
-}
-
-func dockerConfig(appPackage string, apps app.Applications) (*storage.DockerConfig, error) {
-	appLoc, err := loc.ParseLocator(appPackage)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	app, err := apps.GetApp(*appLoc)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	dockerConfig := ops.DockerConfigFromSchemaValue(app.Manifest.SystemDocker())
-	return &dockerConfig, nil
 }

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -75,23 +75,10 @@ func startInstall(env *localenv.LocalEnvironment, i InstallConfig) error {
 		return trace.Wrap(err)
 	}
 
-	wizard, err := localenv.LoginWizard(fmt.Sprintf("https://%v",
-		installerConfig.Process.Config().Pack.GetAddr().Addr))
+	installer, err := install.Init(context.TODO(), *installerConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	installer, err := install.Init(context.TODO(), *installerConfig, wizard)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	dockerConfig, err := install.GetDockerConfig(installerConfig.Docker, wizard.Apps,
-		*installerConfig.AppPackage)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	installer.Docker = *dockerConfig
 
 	err = installer.Start()
 	if err != nil {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -75,10 +75,23 @@ func startInstall(env *localenv.LocalEnvironment, i InstallConfig) error {
 		return trace.Wrap(err)
 	}
 
-	installer, err := install.Init(context.TODO(), *installerConfig)
+	wizard, err := localenv.LoginWizard(fmt.Sprintf("https://%v",
+		installerConfig.Process.Config().Pack.GetAddr().Addr))
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	installer, err := install.Init(context.TODO(), *installerConfig, wizard)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	dockerConfig, err := install.GetDockerConfig(installerConfig.Docker, wizard.Apps,
+		*installerConfig.AppPackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	installer.Docker = *dockerConfig
 
 	err = installer.Start()
 	if err != nil {


### PR DESCRIPTION
~~Delay docker setup until after `Init` to account for bootstrapping behavior of the enterprise.~~
Move merging of docker configuration during install to `CreateSite` API.

Requires https://github.com/gravitational/gravity.e/pull/3756.