### PR TITLE
Do not require merged docker configuration for local checks

### DIFF
--- a/assets/opscenter/resources/app.yaml
+++ b/assets/opscenter/resources/app.yaml
@@ -61,4 +61,4 @@ hooks:
                 command: ["/usr/local/bin/kubectl", "delete", "services", "-l", "app=gravity-opscenter", "--ignore-not-found"]
 systemOptions:
   docker:
-    storageDriver: overlay
+    storageDriver: overlay2

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -82,7 +82,7 @@ EOF
     done
   done
   suite+=$(cat <<EOF
- install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:latest","storage_driver":"overlay2","ops_advertise_addr":"example.com:443"}
+ install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:latest","ops_advertise_addr":"example.com:443"}
 EOF
 )
   echo $suite

--- a/lib/network/validation/validation.go
+++ b/lib/network/validation/validation.go
@@ -24,6 +24,7 @@ import (
 	pb "github.com/gravitational/gravity/lib/network/validation/proto"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/satellite/agent/health"
@@ -139,11 +140,11 @@ func (_ *Server) Validate(ctx context.Context, req *pb.ValidateRequest) (resp *p
 	}
 
 	var failedProbes []*agentpb.Probe
-	dockerSchema := schema.Docker{
+	dockerConfig := storage.DockerConfig{
 		StorageDriver: req.Docker.StorageDriver,
 	}
 	if req.FullRequirements {
-		failedProbes, err = checks.ValidateManifest(manifest, *profile, dockerSchema, stateDir)
+		failedProbes, err = checks.ValidateManifest(manifest, *profile, dockerConfig, stateDir)
 		failedProbes = append(failedProbes, checks.RunBasicChecks(ctx, req.Options)...)
 	} else {
 		failedProbes, err = validateManifest(*profile, manifest, stateDir)

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	appservice "github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -510,8 +511,8 @@ func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	dockerConfig := ops.DockerConfigFromSchemaValue(app.Manifest.SystemDocker())
-	ops.OverrideDockerConfig(&dockerConfig, r.Docker)
+	dockerConfig := checks.DockerConfigFromSchemaValue(app.Manifest.SystemDocker())
+	checks.OverrideDockerConfig(&dockerConfig, r.Docker)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -19,6 +19,7 @@ package opsservice
 import (
 	"path/filepath"
 
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
@@ -353,8 +354,8 @@ func (s *site) validateDockerConfig(updateManifest schema.Manifest) error {
 			return trace.Wrap(err)
 		}
 
-		defaultConfig := ops.DockerConfigFromSchemaValue(s.app.Manifest.SystemDocker())
-		ops.OverrideDockerConfig(&defaultConfig, installOperation.InstallExpand.Vars.System.Docker)
+		defaultConfig := checks.DockerConfigFromSchemaValue(s.app.Manifest.SystemDocker())
+		checks.OverrideDockerConfig(&defaultConfig, installOperation.InstallExpand.Vars.System.Docker)
 		existingDocker = defaultConfig
 	}
 

--- a/lib/ops/utils.go
+++ b/lib/ops/utils.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/pack/encryptedpack"
-	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 
 	licenseapi "github.com/gravitational/license"
@@ -330,29 +329,3 @@ func MatchByType(opType string) OperationMatcher {
 
 // OperationMatcher is a function type that matches the given operation
 type OperationMatcher func(SiteOperation) bool
-
-// OverrideDockerConfig updates given config with values from overrideConfig where necessary
-func OverrideDockerConfig(config *storage.DockerConfig, overrideConfig storage.DockerConfig) {
-	if overrideConfig.StorageDriver != "" {
-		config.StorageDriver = overrideConfig.StorageDriver
-	}
-	if len(overrideConfig.Args) != 0 {
-		config.Args = overrideConfig.Args
-	}
-}
-
-// DockerConfigFromSchema converts the specified Docker schema to storage configuration format
-func DockerConfigFromSchema(dockerSchema *schema.Docker) (config storage.DockerConfig) {
-	if dockerSchema == nil {
-		return config
-	}
-	return DockerConfigFromSchemaValue(*dockerSchema)
-}
-
-// DockerConfigFromSchemaValue converts the specified Docker schema to storage configuration format
-func DockerConfigFromSchemaValue(dockerSchema schema.Docker) (config storage.DockerConfig) {
-	return storage.DockerConfig{
-		StorageDriver: dockerSchema.StorageDriver,
-		Args:          dockerSchema.Args,
-	}
-}

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
@@ -160,8 +161,8 @@ func (f *fsmUpdateEngine) commitClusterChanges(cluster *storage.Site, op ops.Sit
 		cluster.App.Base = updateBaseApp.PackageEnvelope.ToPackagePtr()
 	}
 
-	ops.OverrideDockerConfig(&cluster.ClusterState.Docker,
-		ops.DockerConfigFromSchema(updateApp.Manifest.SystemOptions.DockerConfig()))
+	checks.OverrideDockerConfig(&cluster.ClusterState.Docker,
+		checks.DockerConfigFromSchema(updateApp.Manifest.SystemOptions.DockerConfig()))
 
 	return nil
 }

--- a/lib/update/phase_init.go
+++ b/lib/update/phase_init.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/install"
@@ -98,8 +99,8 @@ func NewUpdatePhaseInit(c FSMConfig, plan storage.OperationPlan, phase storage.O
 		return nil, trace.Wrap(err, "failed to query installed application")
 	}
 
-	existingDocker := ops.DockerConfigFromSchemaValue(installedApp.Manifest.SystemDocker())
-	ops.OverrideDockerConfig(&existingDocker, installOperation.InstallExpand.Vars.System.Docker)
+	existingDocker := checks.DockerConfigFromSchemaValue(installedApp.Manifest.SystemDocker())
+	checks.OverrideDockerConfig(&existingDocker, installOperation.InstallExpand.Vars.System.Docker)
 
 	return &updatePhaseInit{
 		Backend:      c.Backend,

--- a/tool/gravity/cli/checks.go
+++ b/tool/gravity/cli/checks.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/localenv"
-	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
@@ -42,7 +41,6 @@ func checkManifest(env *localenv.LocalEnvironment, manifestPath, profileName str
 
 	result, err := checks.ValidateLocal(checks.LocalChecksRequest{
 		Manifest: *manifest,
-		Docker:   ops.DockerConfigFromSchemaValue(manifest.SystemDocker()),
 		Role:     profileName,
 		AutoFix:  autoFix,
 	})


### PR DESCRIPTION
Merge docker configuration at the point of use - in `RunLocalChecks` instead of requiring the merged configuration to be provided as function configuration.

Fixes the 'docker configuration is required' during installation with defaults.

I had to move `OverrideDockerConfigXXX` and Co to a more appropriate location (lib/checks) to avoid import cycles.
I also set `overlay2` as the default docker storage driver for `opscenter` application and removed the `storagedriver` CLI option for robotest to have this tested.