### PR TITLE
Use default system log for shrink agent.

### DIFF
--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -491,7 +490,6 @@ func (s *site) launchAgent(ctx *operationContext, server storage.Server) (*serve
 		"--advertise-addr", server.AdvertiseIP,
 		"--server-addr", serverAddr,
 		"--token", tokenID,
-		"--system-log-file", filepath.Join(server.StateDir(), defaults.TelekubeSystemLog),
 		"--vars", fmt.Sprintf("%v:%v", ops.AgentMode, ops.AgentModeShrink),
 		"--service-uid", s.uid(),
 		"--service-gid", s.gid(),

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -110,6 +110,7 @@ func InitAndCheck(g *Application, cmd string) error {
 	// addition to journald)
 	switch cmd {
 	case g.InstallCmd.FullCommand(),
+		g.WizardCmd.FullCommand(),
 		g.JoinCmd.FullCommand(),
 		g.AutoJoinCmd.FullCommand(),
 		g.UpdateTriggerCmd.FullCommand(),


### PR DESCRIPTION
Fixes the `Failed to fire hook: open /var/lib/gravity/var/log/telekube-system.log: no such file or directory` issue for shrink agent. Related to https://github.com/gravitational/gravity.e/issues/3761.

Also add "wizard" command to the list of commands that write to /var/log/telekube-system.log too (forgot to add it originally), otherwise it only writes to journald.

Also closes https://github.com/gravitational/gravity.e/issues/3763.