### PR TITLE
Skip unrecognized objects during vendoring.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ TF_PROVIDERS ?= terraform-provider-gravity
 # the default target is a containerized CI/CD build
 .PHONY:build
 build:
-	$(MAKE) -C build.assets buildbox build
+	$(MAKE) -C build.assets build
 
 # 'install' uses the host's Golang to place output into $GOPATH/bin
 .PHONY:install

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -193,7 +193,7 @@ validate-deps: buildbox
 # build gravity binaries in a buildbox container
 #
 .PHONY: build-in-container
-build-in-container:
+build-in-container: buildbox
 	docker run --rm=true -u $$(id -u) \
 		   -v $(TOP):$(SRCDIR) \
 		   -e "LOCAL_BUILDDIR=$(LOCAL_BUILDDIR)" \

--- a/lib/app/resources/decode_test.go
+++ b/lib/app/resources/decode_test.go
@@ -59,6 +59,16 @@ func (_ *ResourceCodecSuite) TestDecodesAndEncodes(c *C) {
 	}
 }
 
+func (*ResourceCodecSuite) TestDecodeUnrecognizedResource(c *C) {
+	r := strings.NewReader(unrecognizedResource)
+
+	_, err := Decode(r)
+	c.Assert(err, NotNil)
+
+	_, err = Decode(r, SkipUnrecognized())
+	c.Assert(err, IsNil)
+}
+
 func (_ *ResourceCodecSuite) TestEncodesInProperFormat(c *C) {
 	var testCases = []struct {
 		resource string
@@ -207,3 +217,21 @@ const resourcesJSON = `
    }
 }
 `
+
+const unrecognizedResource = `apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+    - ct`

--- a/lib/app/resources/decode_test.go
+++ b/lib/app/resources/decode_test.go
@@ -234,4 +234,13 @@ spec:
     singular: crontab
     kind: CronTab
     shortNames:
-    - ct`
+    - ct
+---
+apiVersion: stable.example.com/v1
+kind: CronTab
+metadata:
+  name: my-new-cron-object
+spec:
+  cronSpec: "* * * * */5"
+  image: my-awesome-cron-image
+`

--- a/lib/app/resources/resourcefiles.go
+++ b/lib/app/resources/resourcefiles.go
@@ -101,7 +101,7 @@ func NewResourceFile(path string) (*ResourceFile, error) {
 	defer file.Close()
 
 	// decode the contents of the resource file into an object
-	resource, err := Decode(file)
+	resource, err := Decode(file, SkipUnrecognized())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/resources/utils.go
+++ b/lib/app/resources/utils.go
@@ -98,7 +98,7 @@ func renderResourceTemplate(path string, serviceUser systeminfo.User) error {
 		os.Remove(tmp.Name())
 	}()
 
-	res, err := Decode(in)
+	res, err := Decode(in, SkipUnrecognized())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -628,7 +628,7 @@ func resourceFromChart(path string) (*resources.Resource, error) {
 	if err != nil {
 		return nil, trace.Wrap(err, buf.String())
 	}
-	return resources.Decode(buf)
+	return resources.Decode(buf, resources.SkipUnrecognized())
 }
 
 // resourcesFromPath collects resource files in root for further processing.

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -420,7 +420,7 @@ const (
 	HumanDateFormatMilli = "Mon Jan _2 15:04:05.000 UTC"
 
 	// ShortDateFormat is the short version of human readable timestamp format
-	ShortDateFormat = "01/02/15 15:04"
+	ShortDateFormat = "01/02/06 15:04"
 
 	// LatestVersion is the shortcut for the latest Telekube version
 	LatestVersion = "latest"

--- a/lib/schema/extensions.go
+++ b/lib/schema/extensions.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// init registers additional Kubernetes resources which are not normally
+// registered so our parser can recognize them
+func init() {
+	runtime.Must(apiextensions.AddToScheme(scheme.Scheme))
+	runtime.Must(v1beta1.AddToScheme(scheme.Scheme))
+}

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -42,6 +42,12 @@ func IsAbortError(err error) bool {
 	return ok
 }
 
+// IsContinueError returns true if provided error if of ContinueRetry type
+func IsContinueError(err error) bool {
+	_, ok := trace.Unwrap(err).(*ContinueRetry)
+	return ok
+}
+
 // Continue causes Retry function to continue trying and logging message
 func Continue(format string, args ...interface{}) *ContinueRetry {
 	return &ContinueRetry{Message: fmt.Sprintf(format, args...)}

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -42,7 +42,7 @@ func IsAbortError(err error) bool {
 	return ok
 }
 
-// IsContinueError returns true if provided error if of ContinueRetry type
+// IsContinueError returns true if provided error is of ContinueRetry type
 func IsContinueError(err error) bool {
 	_, ok := trace.Unwrap(err).(*ContinueRetry)
 	return ok


### PR DESCRIPTION
Closes https://github.com/gravitational/gravity.e/issues/3764.

Also this PR accumulated a couple of other small fixes:

* Fix year short date format (I used hours instead of year by mistake).
* Fix default build target to remove buildbox b/c it breaks the build on Mac (where bins are built on host).
* Fix issue with infinite logging recursion when invoking gravity install without sudo.