### PR TITLE
gravity gc: do not remove required packages

### DIFF
--- a/lib/vacuum/prune/pack/pack_test.go
+++ b/lib/vacuum/prune/pack/pack_test.go
@@ -42,6 +42,12 @@ type S struct{}
 
 var _ = Suite(&S{})
 
+func (*S) SetUpSuite(c *C) {
+	if testing.Verbose() {
+		log.SetLevel(log.DebugLevel)
+	}
+}
+
 func (*S) TestDoesnotPruneDirectDependencies(c *C) {
 	// setup
 	runtimePackage := newPackage("gravitational.io/planet:0.0.1", pack.PurposeLabel, pack.PurposeRuntime)
@@ -250,7 +256,6 @@ func (*S) TestDoesnotPruneRequiredLegacyPlanetPackages(c *C) {
 	p, err := New(Config{
 		Config: prune.Config{
 			FieldLogger: log.WithField("test", "TestDoesnotPruneRequiredLegacyPlanetPackages"),
-			Emitter:     emitter{},
 		},
 		App:      a,
 		Packages: &allPackages,

--- a/lib/vacuum/prune/registry/registry.go
+++ b/lib/vacuum/prune/registry/registry.go
@@ -176,7 +176,7 @@ func (r *cleanup) waitForService(ctx context.Context, status string) error {
 	err := utils.RetryWithInterval(localCtx, b, func() error {
 		out, err := r.serviceStatus(localCtx)
 		actualStatus := strings.TrimSpace(string(out))
-		if actualStatus == status {
+		if strings.HasPrefix(actualStatus, status) {
 			return nil
 		}
 		return trace.Retry(err, "unexpected service status: %s", actualStatus)


### PR DESCRIPTION
This fixes an issue with the package pruner that would delete legacy planet packages regardless of whether they're used.
This was not caught before as the name of the planet package changed and legacy packages were deleted unconditionally.
Now that we want to reuse (some) garbage collection functionality on older clusters, this should be changed.