### PR TITLE
Add planet package to package dependencies

### DIFF
--- a/assets/kubernetes/resources/app.yaml
+++ b/assets/kubernetes/resources/app.yaml
@@ -72,6 +72,7 @@ dependencies:
     - gravitational.io/gravity:0.0.0
     - gravitational.io/web-assets:0.0.0
     - gravitational.io/teleport:0.0.0
+    - gravitational.io/planet:0.0.0
   apps:
     - gravitational.io/rbac-app:0.0.0
     - gravitational.io/dns-app:0.0.0

--- a/lib/app/dependency.go
+++ b/lib/app/dependency.go
@@ -43,6 +43,7 @@ func GetDependencies(app *Application, apps Applications) (result *Dependencies,
 			result.Apps = append(result.Apps, locator)
 		}
 	}
+	result.Packages = loc.Deduplicate(result.Packages)
 	return result, nil
 }
 
@@ -87,9 +88,10 @@ type Dependencies struct {
 
 func getDependencies(app *Application, apps Applications, state *state) error {
 	log.Infof("Getting dependencies for %v.", app.Package)
-	for _, dependency := range append(
+	packageDeps := loc.Deduplicate(append(
 		app.Manifest.Dependencies.GetPackages(),
-		app.Manifest.NodeProfiles.RuntimePackages()...) {
+		app.Manifest.NodeProfiles.RuntimePackages()...))
+	for _, dependency := range packageDeps {
 		packageName := dependency.String()
 		if _, ok := state.visitedPackages[packageName]; !ok {
 			state.visitedPackages[packageName] = struct{}{}

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -199,6 +199,23 @@ func MustParseLocator(v string) Locator {
 	return *l
 }
 
+// Deduplicate returns ls with duplicates removed
+func Deduplicate(ls []Locator) (result []Locator) {
+	if len(ls) == 0 {
+		return ls
+	}
+	result = make([]Locator, 0, len(ls))
+	seen := make(map[Locator]struct{}, len(ls))
+	for _, loc := range ls {
+		if _, exists := seen[loc]; exists {
+			continue
+		}
+		result = append(result, loc)
+		seen[loc] = struct{}{}
+	}
+	return result
+}
+
 var (
 	// OpsCenterCertificateAuthority is locator for the package containing certificate and private
 	// key for the OpsCenter

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -19,6 +19,8 @@ package loc
 import (
 	"testing"
 
+	"github.com/gravitational/gravity/lib/compare"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -136,4 +138,20 @@ func (s *LocatorSuite) TestIsUpdate(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(result, Equals, test.result, Commentf("%v", test))
 	}
+}
+
+func (s *LocatorSuite) TestDeduplicate(c *C) {
+	locs := []Locator{
+		MustParseLocator("test1/foo:1.0.0"),
+		MustParseLocator("test2/bar:1.0.0"),
+		MustParseLocator("test3/qux:1.0.0"),
+		MustParseLocator("test2/bar:1.0.0"),
+	}
+	uniq := Deduplicate(locs)
+	expected := []Locator{
+		MustParseLocator("test1/foo:1.0.0"),
+		MustParseLocator("test2/bar:1.0.0"),
+		MustParseLocator("test3/qux:1.0.0"),
+	}
+	c.Assert(uniq, compare.DeepEquals, expected)
 }

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -29,8 +29,8 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/utils"
-	"github.com/gravitational/trace"
 
+	"github.com/gravitational/trace"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -279,7 +279,7 @@ func (m Manifest) AllPackageDependencies() (deps []loc.Locator) {
 		deps = append(deps, m.SystemOptions.Dependencies.Runtime.Locator)
 	}
 	deps = append(deps, m.NodeProfiles.RuntimePackages()...)
-	return append(m.Dependencies.GetPackages(), deps...)
+	return loc.Deduplicate(append(m.Dependencies.GetPackages(), deps...))
 }
 
 // PackageDependencies returns the list of package dependencies
@@ -289,7 +289,7 @@ func (m Manifest) PackageDependencies(profile string) (deps []loc.Locator, err e
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return append(m.Dependencies.GetPackages(), *runtimePackage), nil
+	return loc.Deduplicate(append(m.Dependencies.GetPackages(), *runtimePackage)), nil
 }
 
 // Header is manifest header
@@ -383,15 +383,7 @@ func (d Dependencies) GetApps() []loc.Locator {
 	for _, app := range d.Apps {
 		apps = append(apps, app.Locator)
 	}
-	return apps
-}
-
-// All returns a list of locators of all package and application dependencies
-func (d Dependencies) All() (deps []loc.Locator) {
-	for _, dep := range append(d.Packages, d.Apps...) {
-		deps = append(deps, dep.Locator)
-	}
-	return deps
+	return loc.Deduplicate(apps)
 }
 
 // Dependency represents a package or app dependency


### PR DESCRIPTION
Add planet package to package dependencies to keep compatibility with older versions.
This will allow older versions to correctly pull the package when building an installer.
Newer versions will ignore the dependency (as it was moved elsewhere).

As a side effect, (application) packages as provided in the application manifest are deduplicated.

Fixes https://github.com/gravitational/gravity.e/issues/3768