### PR TITLE
Dmitri/3770 dnsconfig

### DIFF
--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -258,9 +258,6 @@ func (c *Config) CheckAndSetDefaults() (err error) {
 	if c.NewProcess == nil {
 		c.NewProcess = process.NewProcess
 	}
-	if c.DNSConfig.IsEmpty() {
-		c.DNSConfig = storage.DefaultDNSConfig
-	}
 	return nil
 }
 

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -937,10 +937,7 @@ func (s *site) getPlanetConfigPackage(
 		args = append(args, fmt.Sprintf("--vxlan-port=%v", vxlanPort))
 	}
 
-	dnsConfig := s.backendSite.DNSConfig
-	if dnsConfig.IsEmpty() {
-		dnsConfig = storage.DefaultDNSConfig
-	}
+	dnsConfig := s.dnsConfig()
 	for _, addr := range dnsConfig.Addrs {
 		args = append(args, fmt.Sprintf("--dns-listen-addr=%v", addr))
 	}

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -482,6 +482,7 @@ func validateLabels(labels map[string]string) error {
 }
 
 func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
+	o.Infof("CreateSite(%#v).", r)
 	err := o.validateNewSiteRequest(&r)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -439,6 +439,15 @@ func (o *Operator) validateNewSiteRequest(req *ops.NewSiteRequest) error {
 		return trace.Wrap(err)
 	}
 
+	serviceUser := req.ServiceUser
+	if serviceUser.IsEmpty() {
+		req.ServiceUser = storage.DefaultOSUser()
+	}
+
+	if req.DNSConfig.IsEmpty() {
+		req.DNSConfig = storage.DefaultDNSConfig
+	}
+
 	if req.License == "" {
 		if app.RequiresLicense() {
 			return trace.BadParameter("the app requires a license")
@@ -449,15 +458,6 @@ func (o *Operator) validateNewSiteRequest(req *ops.NewSiteRequest) error {
 	err = ops.VerifyLicense(o.packages(), req.License)
 	if err != nil {
 		return trace.Wrap(err, "failed to validate provided license")
-	}
-
-	serviceUser := req.ServiceUser
-	if serviceUser.IsEmpty() {
-		req.ServiceUser = storage.DefaultOSUser()
-	}
-
-	if req.DNSConfig.IsEmpty() {
-		req.DNSConfig = storage.DefaultDNSConfig
 	}
 
 	return nil

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -613,6 +613,13 @@ func (s site) dockerConfig() storage.DockerConfig {
 	return s.backendSite.ClusterState.Docker
 }
 
+func (s site) dnsConfig() storage.DNSConfig {
+	if s.backendSite.DNSConfig.IsEmpty() {
+		return storage.DefaultDNSConfig
+	}
+	return s.backendSite.DNSConfig
+}
+
 func (s site) serviceUser() storage.OSUser {
 	if !s.backendSite.ServiceUser.IsEmpty() {
 		return s.backendSite.ServiceUser

--- a/lib/ops/site.go
+++ b/lib/ops/site.go
@@ -93,6 +93,7 @@ func ConvertOpsSite(in Site) storage.Site {
 		ServiceUser:     in.ServiceUser,
 		CloudConfig:     in.CloudConfig,
 		DNSOverrides:    in.DNSOverrides,
+		DNSConfig:       in.DNSConfig,
 	}
 	if in.License != nil {
 		cluster.License = in.License.Raw

--- a/lib/ops/site.go
+++ b/lib/ops/site.go
@@ -61,7 +61,7 @@ func NewClusterFromSite(site Site) *storage.ClusterV2 {
 
 // ConvertOpsSite converts ops.Site to storage.Site
 func ConvertOpsSite(in Site) storage.Site {
-	site := storage.Site{
+	cluster := storage.Site{
 		AccountID: in.AccountID,
 		Domain:    in.Domain,
 		Created:   in.Created,
@@ -95,7 +95,10 @@ func ConvertOpsSite(in Site) storage.Site {
 		DNSOverrides:    in.DNSOverrides,
 	}
 	if in.License != nil {
-		site.License = in.License.Raw
+		cluster.License = in.License.Raw
 	}
-	return site
+	if in.DNSConfig.IsEmpty() {
+		cluster.DNSConfig = storage.DefaultDNSConfig
+	}
+	return cluster
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1065,6 +1065,15 @@ var LegacyDNSConfig = DNSConfig{
 	Interfaces: []string{"lo"},
 }
 
+// String returns textual representation of this DNS configuration
+func (r DNSConfig) String() string {
+	var addrs []string
+	for _, addr := range r.Addrs {
+		addrs = append(addrs, fmt.Sprintf("%v:%v", addr, r.Port))
+	}
+	return strings.Join(addrs, ",")
+}
+
 // Addr returns the DNS server address as ip:port.
 // Requires that !r.IsEmpty.
 func (r DNSConfig) Addr() string {

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -196,9 +196,6 @@ func (i *InstallConfig) CheckAndSetDefaults() (err error) {
 	if i.VxlanPort == 0 {
 		i.VxlanPort = defaults.VxlanPort
 	}
-	if i.DNSConfig.IsEmpty() {
-		i.DNSConfig = storage.DefaultDNSConfig
-	}
 	if err := i.validateDNSConfig(); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR updates the DNS configuration in the cluster record copy when a cluster is installed via an Ops Center and the Ops Center is older than the version of gravity used to create the cluster.

I removed all default DNS configuration settings besides those in `CreateSite` (and now one in `RequestClusterCopy`).

Fixes https://github.com/gravitational/gravity.e/issues/3770.