### PR TITLE
Dmitri/3779 system upgrade

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -955,6 +955,10 @@ const (
 
 	// RemoteClusterDialAddr is the "from" address used when dialing remote cluster
 	RemoteClusterDialAddr = "127.0.0.1:3024"
+
+	// ElectionWaitTimeout specifies the maximum amount of time to wait to resume elections
+	// on a master node
+	ElectionWaitTimeout = 1 * time.Minute
 )
 
 var (

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -135,6 +135,7 @@ func newClusterEnvironment(args clusterEnvironmentArgs) (*ClusterEnvironment, er
 		Apps:     apps,
 		Users:    users,
 		StateDir: siteDir,
+		Local:    true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/ops/opsservice/resume.go
+++ b/lib/ops/opsservice/resume.go
@@ -61,7 +61,12 @@ func (s *site) resumeShrink() (*ops.SiteOperationKey, error) {
 
 	s.Debugf("resuming shrink operation: %v", op)
 
-	err = s.executeOperation(key, s.shrinkOperationStart)
+	ctx, err := s.newOperationContext(*op)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = s.executeOperationWithContext(ctx, op, s.shrinkOperationStart)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -406,13 +406,13 @@ func (s *site) executeOperation(key ops.SiteOperationKey, fn func(ctx *operation
 	return nil
 }
 
-func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOperation, fn func(ctx *operationContext) error) {
+func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOperation, fn func(ctx *operationContext) error) error {
 	defer ctx.Close()
 
 	opErr := fn(ctx)
 
 	if opErr == nil {
-		return
+		return trace.Wrap(opErr)
 	}
 
 	ctx.Errorf("operation failure: %v", trace.DebugReport(opErr))
@@ -432,6 +432,7 @@ func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOp
 		Completion: constants.Completed,
 		Message:    opErr.Error(),
 	})
+	return trace.Wrap(err)
 }
 
 type transformFn func(reader io.Reader) (io.ReadCloser, error)

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -101,6 +101,8 @@ type OperationPhaseData struct {
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// InstalledPackage references the installed application package
 	InstalledPackage *loc.Locator `json:"installed_package,omitempty" yaml:"installed_package,omitempty"`
+	// RuntimePackage references the update runtime package
+	RuntimePackage *loc.Locator `json:"runtime_package,omitempty" yaml:"runtime_package,omitempty"`
 	// UpdatePlanet indicates whether the planet needs to be updated during bootstrap
 	UpdatePlanet bool `json:"update_planet" yaml:"update_planet"`
 	// ElectionChange describes changes to make to cluster elections

--- a/lib/update/builder.go
+++ b/lib/update/builder.go
@@ -168,62 +168,66 @@ func (r phaseBuilder) runtime(updates []loc.Locator, rbacUpdateAvailable bool) *
 // masters returns a new phase for upgrading master servers.
 // leadMaster is the master node that is upgraded first and gets to be the leader during the operation.
 // otherMasters lists the rest of the master nodes (can be empty)
-func (r phaseBuilder) masters(leadMaster storage.Server, otherMasters []storage.Server, supportsTaints bool,
-	application loc.Locator) *phase {
+func (r phaseBuilder) masters(leadMaster serverWithRuntime, otherMasters []serverWithRuntime,
+	supportsTaints bool) *phase {
 	root := root(phase{
 		ID:          "masters",
 		Description: "Update master nodes",
 	})
 
-	node := r.node(leadMaster, root, "Update system software on master node %q")
+	node := r.node(leadMaster.Server, root, "Update system software on master node %q")
 	if len(otherMasters) != 0 {
 		node.AddSequential(phase{
 			ID:          "kubelet-permissions",
 			Executor:    kubeletPermissions,
 			Description: fmt.Sprintf("Add permissions to kubelet on %q", leadMaster.Hostname),
 			Data: &storage.OperationPhaseData{
-				Server: &leadMaster,
+				Server: &leadMaster.Server,
 			}})
 
 		// election - stepdown first node we will upgrade
 		enable := []storage.Server{}
-		disable := []storage.Server{leadMaster}
-		node.AddSequential(setLeaderElection(enable, disable, leadMaster, "stepdown", "Step down %q as Kubernetes leader"))
+		disable := []storage.Server{leadMaster.Server}
+		node.AddSequential(setLeaderElection(enable, disable, leadMaster.Server, "stepdown", "Step down %q as Kubernetes leader"))
 	}
-	node.AddSequential(r.commonNode(leadMaster, leadMaster, supportsTaints,
-		waitsForEndpoints(len(otherMasters) == 0), application)...)
+
+	node.AddSequential(r.commonNode(leadMaster.Server, leadMaster.runtime, leadMaster.Server, supportsTaints,
+		waitsForEndpoints(len(otherMasters) == 0))...)
 	root.AddSequential(node)
 
 	if len(otherMasters) != 0 {
 		// election - force election to first upgraded node
-		enable := []storage.Server{leadMaster}
-		disable := otherMasters
-		root.AddSequential(setLeaderElection(enable, disable, leadMaster, "elect", "Make node %q Kubernetes leader"))
+		enable := []storage.Server{leadMaster.Server}
+		var disable []storage.Server
+		for _, node := range otherMasters {
+			disable = append(disable, node.Server)
+		}
+		root.AddSequential(setLeaderElection(enable, disable, leadMaster.Server, "elect", "Make node %q Kubernetes leader"))
 	}
 
 	for _, server := range otherMasters {
-		node = r.node(server, root, "Update system software on master node %q")
-		node.AddSequential(r.commonNode(server, leadMaster, supportsTaints, waitsForEndpoints(true), application)...)
-
+		node = r.node(server.Server, root, "Update system software on master node %q")
+		node.AddSequential(r.commonNode(server.Server, server.runtime, leadMaster.Server, supportsTaints,
+			waitsForEndpoints(true))...)
 		// election - enable election on the upgraded node
-		enable := []storage.Server{server}
+		enable := []storage.Server{server.Server}
 		disable := []storage.Server{}
-		node.AddSequential(setLeaderElection(enable, disable, server, "enable", "Enable leader election on node %q"))
+		node.AddSequential(setLeaderElection(enable, disable, server.Server, "enable", "Enable leader election on node %q"))
 		root.AddSequential(node)
 	}
 	return &root
 }
 
-func (r phaseBuilder) nodes(leadMaster storage.Server, nodes []storage.Server, supportsTaints bool, application loc.Locator) *phase {
+func (r phaseBuilder) nodes(leadMaster storage.Server, nodes []serverWithRuntime, supportsTaints bool) *phase {
 	root := root(phase{
 		ID:          "nodes",
 		Description: "Update regular nodes",
 	})
 
 	for _, server := range nodes {
-		node := r.node(server, root, "Update system software on node %q")
-		node.AddSequential(r.commonNode(server, leadMaster, supportsTaints,
-			waitsForEndpoints(true), application)...)
+		node := r.node(server.Server, root, "Update system software on node %q")
+		node.AddSequential(r.commonNode(server.Server, server.runtime, leadMaster, supportsTaints,
+			waitsForEndpoints(true))...)
 		root.AddParallel(node)
 	}
 	return &root
@@ -237,8 +241,8 @@ func (r phaseBuilder) node(server storage.Server, parent phase, format string) p
 }
 
 // commonNode returns a list of operations required for any node role to upgrade its system software
-func (r phaseBuilder) commonNode(server storage.Server, leadMaster storage.Server, supportsTaints bool,
-	waitsForEndpoints waitsForEndpoints, application loc.Locator) []phase {
+func (r phaseBuilder) commonNode(server storage.Server, runtimePackage loc.Locator, leadMaster storage.Server, supportsTaints bool,
+	waitsForEndpoints waitsForEndpoints) []phase {
 	phases := []phase{
 		phase{
 			ID:          "drain",
@@ -253,8 +257,8 @@ func (r phaseBuilder) commonNode(server storage.Server, leadMaster storage.Serve
 			Executor:    updateSystem,
 			Description: fmt.Sprintf("Update system software on node %q", server.Hostname),
 			Data: &storage.OperationPhaseData{
-				Server:  &server,
-				Package: &application,
+				Server:         &server,
+				RuntimePackage: &runtimePackage,
 			}},
 	}
 	if supportsTaints {
@@ -383,3 +387,18 @@ func (r phases) asPhases() (result []storage.OperationPhase) {
 type phases []phase
 
 type waitsForEndpoints bool
+
+func (r serversWithRuntime) asServers() (result []storage.Server) {
+	result = make([]storage.Server, 0, len(r))
+	for _, server := range r {
+		result = append(result, server.Server)
+	}
+	return result
+}
+
+type serversWithRuntime []serverWithRuntime
+
+type serverWithRuntime struct {
+	storage.Server
+	runtime loc.Locator
+}

--- a/lib/update/phase_system.go
+++ b/lib/update/phase_system.go
@@ -49,18 +49,10 @@ func NewUpdatePhaseSystem(c FSMConfig, plan storage.OperationPlan, phase storage
 	if phase.Data == nil || phase.Data.Server == nil {
 		return nil, trace.NotFound("no server specified for phase %q", phase.ID)
 	}
-	if phase.Data.Package == nil {
-		return nil, trace.NotFound("no application package specified for phase %q", phase.ID)
+	if phase.Data.RuntimePackage == nil {
+		return nil, trace.NotFound("no runtime package specified for phase %q", phase.ID)
 	}
 	gravityPath, err := getGravityPath()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	app, err := c.Apps.GetApp(*phase.Data.Package)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	runtimePackage, err := app.Manifest.RuntimePackageForProfile(phase.Data.Server.Role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -70,7 +62,7 @@ func NewUpdatePhaseSystem(c FSMConfig, plan storage.OperationPlan, phase storage
 		GravityPath:    gravityPath,
 		FieldLogger:    log.NewEntry(log.New()),
 		remote:         remote,
-		runtimePackage: *runtimePackage,
+		runtimePackage: *phase.Data.RuntimePackage,
 	}, nil
 }
 

--- a/lib/update/plan.go
+++ b/lib/update/plan.go
@@ -266,7 +266,7 @@ func newOperationPlan(p newPlanParams) (*storage.OperationPlan, error) {
 	bootstrapPhase := *builder.bootstrap(p.servers,
 		p.installedApp.Package, p.updateApp.Package).Require(initPhase)
 
-	var masters, nodes serversWithRuntime
+	var masters, nodes runtimeServers
 	for _, server := range p.servers {
 		runtimePackage, err := p.updateApp.Manifest.RuntimePackageForProfile(server.Role)
 		if err != nil {
@@ -274,9 +274,9 @@ func newOperationPlan(p newPlanParams) (*storage.OperationPlan, error) {
 		}
 
 		if fsm.IsMasterServer(server) {
-			masters = append(masters, serverWithRuntime{server, *runtimePackage})
+			masters = append(masters, runtimeServer{Server: server, runtime: *runtimePackage})
 		} else {
-			nodes = append(nodes, serverWithRuntime{server, *runtimePackage})
+			nodes = append(nodes, runtimeServer{Server: server, runtime: *runtimePackage})
 		}
 	}
 

--- a/lib/update/plan.go
+++ b/lib/update/plan.go
@@ -266,12 +266,17 @@ func newOperationPlan(p newPlanParams) (*storage.OperationPlan, error) {
 	bootstrapPhase := *builder.bootstrap(p.servers,
 		p.installedApp.Package, p.updateApp.Package).Require(initPhase)
 
-	var masters, nodes []storage.Server
+	var masters, nodes serversWithRuntime
 	for _, server := range p.servers {
+		runtimePackage, err := p.updateApp.Manifest.RuntimePackageForProfile(server.Role)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		if fsm.IsMasterServer(server) {
-			masters = append(masters, server)
+			masters = append(masters, serverWithRuntime{server, *runtimePackage})
 		} else {
-			nodes = append(nodes, server)
+			nodes = append(nodes, serverWithRuntime{server, *runtimePackage})
 		}
 	}
 
@@ -296,10 +301,10 @@ func newOperationPlan(p newPlanParams) (*storage.OperationPlan, error) {
 	// Choose the first master node for upgrade to be the leader during the operation
 	leadMaster := masters[0]
 
-	mastersPhase := *builder.masters(leadMaster, masters[1:], supportsTaints,
-		p.updateApp.Package).Require(checksPhase, bootstrapPhase, preUpdatePhase)
-	nodesPhase := *builder.nodes(leadMaster, nodes, supportsTaints,
-		p.updateApp.Package).Require(mastersPhase)
+	mastersPhase := *builder.masters(leadMaster, masters[1:], supportsTaints).
+		Require(checksPhase, bootstrapPhase, preUpdatePhase)
+	nodesPhase := *builder.nodes(leadMaster.Server, nodes, supportsTaints).
+		Require(mastersPhase)
 
 	runtimeUpdates, err := app.GetUpdatedDependencies(p.installedRuntime, p.updateRuntime)
 	if err != nil && !trace.IsNotFound(err) {
@@ -349,7 +354,8 @@ func newOperationPlan(p newPlanParams) (*storage.OperationPlan, error) {
 		}
 
 		if updateEtcd {
-			etcdPhase := *builder.etcdPlan(leadMaster, masters[1:], nodes, currentVersion, desiredVersion)
+			etcdPhase := *builder.etcdPlan(leadMaster.Server, masters[1:].asServers(), nodes.asServers(),
+				currentVersion, desiredVersion)
 			phases = append(phases, etcdPhase)
 		}
 

--- a/lib/update/plan_test.go
+++ b/lib/update/plan_test.go
@@ -62,9 +62,9 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 	})
 
 	runtimeLoc := loc.MustParseLocator("gravitational.io/planet:2.0.0")
-	var servers serversWithRuntime
+	var servers runtimeServers
 	for _, server := range params.servers {
-		servers = append(servers, serverWithRuntime{server, runtimeLoc})
+		servers = append(servers, runtimeServer{server, runtimeLoc})
 	}
 
 	builder := phaseBuilder{}
@@ -72,7 +72,7 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 	checks := *builder.checks(appLoc1, appLoc2).Require(init)
 	preUpdate := *builder.preUpdate(appLoc2).Require(init)
 	bootstrap := *builder.bootstrap(params.servers, appLoc1, appLoc2).Require(init)
-	leadMaster := serverWithRuntime{params.servers[0], runtimeLoc}
+	leadMaster := runtimeServer{params.servers[0], runtimeLoc}
 	masters := *builder.masters(leadMaster, servers[1:2], false).Require(checks, bootstrap, preUpdate)
 	nodes := *builder.nodes(leadMaster.Server, servers[2:], false).Require(masters)
 	etcd := *builder.etcdPlan(leadMaster.Server, params.servers[1:2], params.servers[2:], "1.0.0", "2.0.0")

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -121,11 +121,24 @@ func systemRollback(env *localenv.LocalEnvironment, changesetID, serviceName str
 		return trace.Wrap(err)
 	}
 
-	if withStatus {
-		err = getLocalNodeStatus(env)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	if !withStatus {
+		env.Printf("system rolled back: %v\n", rollback)
+		return nil
+	}
+
+	runtimePackage, err := findRuntimePackage(env.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = ensureServiceRunning(*runtimePackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = getLocalNodeStatus(env)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	env.Printf("system rolled back: %v\n", rollback)
@@ -193,11 +206,19 @@ func systemUpdate(env *localenv.LocalEnvironment, changesetID string, serviceNam
 		return trace.Wrap(err)
 	}
 
-	if withStatus {
-		err = getLocalNodeStatus(env)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	if !withStatus {
+		env.Printf("System successfully updated: %v.\n", changeset)
+		return nil
+	}
+
+	err = ensureServiceRunning(runtimePackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = getLocalNodeStatus(env)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	env.Printf("System successfully updated: %v.\n", changeset)
@@ -1239,6 +1260,17 @@ func updateInstalledLabelIfNecessary(packages pack.PackageService, locator loc.L
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func ensureServiceRunning(servicePackage loc.Locator) error {
+	services, err := systemservice.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	noBlock := true
+	err = services.StartPackageService(servicePackage, noBlock)
+	return trace.Wrap(err)
 }
 
 func getLocalNodeStatus(env *localenv.LocalEnvironment) error {

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -126,16 +126,6 @@ func systemRollback(env *localenv.LocalEnvironment, changesetID, serviceName str
 		return nil
 	}
 
-	runtimePackage, err := findRuntimePackage(env.Packages)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = ensureServiceRunning(*runtimePackage)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	err = getLocalNodeStatus(env)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
* Move the application/manifest query to plan generation phase for system-upgrade phase to minimize chance of errors (e.g. when the planet service is not active, etc.)
 * Force the operator created by `NewClusterEnvironment` to be local, to properly follow operation logs in 'gravity status'
 * Make shrink operation as executed by the leader `lib/process.Process` synchronous to avoid issues with multiple operations in flight. Avoid executing multiple shrink operations by avoiding any work if the leader has not changed in leader update tick.
 * Retry install elections phase on transient etcd errors

Fixes gravitational/gravity.e#3761.
Fixes gravitational/gravity.e#3779.