### PR TITLE
Strip original registry when tagging images to local registry.

### DIFF
--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -204,12 +204,14 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	log.Infof("Images: %v.", images)
 
 	// vendor chart images as well
 	chartImages, err := chartResources.Images()
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	log.Infof("Chart images: %v.", chartImages)
 	log.Infof("Found images captured from charts: %v.", chartResources)
 	for _, resourceFile := range chartResources {
 		if err := printResourceStatus(resourceFile, req.ManifestPath, req.ProgressReporter, "Helm chart"); err != nil {


### PR DESCRIPTION
If the image used in Helm chart includes registry address, then it won't be stripped when pushing images to local registry leading to issues like:

```
INFO             Tagging localhost:5000/confluentinc/cp-kafka:5.0.0 with opts={127.0.0.1:38001/localhost:5000/confluentinc/cp-kafka 5.0.0 true}. export-directory:/tmp/vendor390533500 service/docker.go:124
```

This PR changes image parsing during push to use our `loc.ParseDockerImage()` method that strips registries.

Also add a bit more detailed logging for vendoring.