### PR TITLE
Dmitri/3755 runtime labels

### DIFF
--- a/lib/update/phase_bootstrap.go
+++ b/lib/update/phase_bootstrap.go
@@ -164,11 +164,15 @@ func (p *updatePhaseBootstrap) Execute(context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	err = p.updateExistingRuntimePackageLabels()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	err = p.pullSystemUpdates()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.updateRuntimePackage()
+	err = p.addUpdateRuntimePackageLabel()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -270,7 +274,7 @@ func (p *updatePhaseBootstrap) syncPlan() error {
 	return nil
 }
 
-// updateRuntimePackage updates labels on the runtime package
+// updateExistingRuntimePackageLabels updates labels on the runtime packages
 // from the previous installation so the system package pull
 // step can find and pull the correct package update.
 //
@@ -280,7 +284,7 @@ func (p *updatePhaseBootstrap) syncPlan() error {
 // the sibling runtime package (i.e. 'planet-master' on a regular node
 // and vice versa), will be updated to _not_ include the installed label
 // to simplify the search
-func (p *updatePhaseBootstrap) updateRuntimePackage() error {
+func (p *updatePhaseBootstrap) updateExistingRuntimePackageLabels() error {
 	type updateLabels struct {
 		loc.Locator
 		add    map[string]string
@@ -290,14 +294,6 @@ func (p *updatePhaseBootstrap) updateRuntimePackage() error {
 	runtimePackages = append(runtimePackages, updateLabels{
 		Locator: p.installedRuntime,
 		add:     utils.CombineLabels(pack.RuntimePackageLabels, pack.InstalledLabels),
-	})
-	// Include the runtime package from the update as it might not have the proper
-	// runtime label if generated on the Ops Center that does not replicate remote
-	// package labels when building installers
-	// See: https://github.com/gravitational/gravity.e/issues/3768
-	runtimePackages = append(runtimePackages, updateLabels{
-		Locator: p.runtimePackage,
-		add:     pack.RuntimePackageLabels,
 	})
 	if loc.IsLegacyRuntimePackage(p.installedRuntime) {
 		var runtimePackageToClear loc.Locator
@@ -320,6 +316,18 @@ func (p *updatePhaseBootstrap) updateRuntimePackage() error {
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
+	}
+	return nil
+}
+
+// addUpdateRuntimePackageLabel adds the runtime label on the runtime package from the update
+// in case the installer been generated on the Ops Center that does not replicate remote
+// package labels.
+// See: https://github.com/gravitational/gravity.e/issues/3768
+func (p *updatePhaseBootstrap) addUpdateRuntimePackageLabel() error {
+	err := p.LocalPackages.UpdatePackageLabels(p.runtimePackage, pack.RuntimePackageLabels, nil)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	return nil
 }


### PR DESCRIPTION
Add the runtime labels proactively to mark both installed and to be installed planet packages as `runtime` packages so they are found during system upgrade.

Fixes https://github.com/gravitational/gravity.e/issues/3755.