### PR TITLE
Dmitri/3770 missing dnsconfig

### DIFF
--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -56,6 +56,8 @@ type planBuilder struct {
 	RegularAgent storage.LoginEntry
 	// ServiceUser is the cluster system user
 	ServiceUser storage.OSUser
+	// DNSConfig specifies the custom cluster DNS configuration
+	DNSConfig storage.DNSConfig
 }
 
 // AddConfigurePhase appends package configuration phase to the plan
@@ -84,6 +86,7 @@ func (b *planBuilder) AddBootstrapPhase(plan *storage.OperationPlan) {
 			Package:     &b.Application.Package,
 			Agent:       agent,
 			ServiceUser: &b.ServiceUser,
+			DNSConfig:   &b.DNSConfig,
 		},
 	})
 }
@@ -338,6 +341,7 @@ func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {
 		AdminAgent:      *adminAgent,
 		RegularAgent:    *regularAgent,
 		ServiceUser:     ctx.Cluster.ServiceUser,
+		DNSConfig:       ctx.Cluster.DNSConfig,
 	}, nil
 }
 

--- a/lib/expand/fsm.go
+++ b/lib/expand/fsm.go
@@ -146,7 +146,17 @@ type fsmEngine struct {
 
 // GetExecutor returns a new executor based on the provided parameters
 func (e *fsmEngine) GetExecutor(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
-	return e.Spec(p, remote)
+	logger := &fsm.Logger{
+		FieldLogger: logrus.WithField(constants.FieldPhase, p.Phase.ID),
+		Key:         p.Key(),
+		Operator:    e.Operator,
+	}
+	executor, err := e.Spec(p, remote)
+	if err != nil {
+		logger.Warnf("Failed to initialize phase: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+	return executor, nil
 }
 
 // ChangePhaseState updates the phase state based on the provided parameters

--- a/lib/expand/fsmspec.go
+++ b/lib/expand/fsmspec.go
@@ -41,8 +41,7 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 				config.Operator,
 				config.Apps,
 				config.LocalBackend,
-				remote,
-				config.DNSConfig)
+				remote)
 
 		case strings.HasPrefix(p.Phase.ID, installphases.PullPhase):
 			return installphases.NewPull(p,

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -710,9 +710,6 @@ func (p *Peer) Wait() error {
 			return nil
 		case event := <-p.EventsC:
 			if event.Error != nil {
-				if utils.IsContextCancelledError(event.Error) {
-					return nil
-				}
 				return trace.Wrap(event.Error)
 			}
 			progress := event.Progress

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -57,6 +57,7 @@ type PlanSuite struct {
 	installOp       *ops.SiteOperation
 	joinOpKey       *ops.SiteOperationKey
 	joinOp          *ops.SiteOperation
+	dnsConfig       storage.DNSConfig
 }
 
 var _ = check.Suite(&PlanSuite{})
@@ -75,12 +76,17 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.teleportPackage, err = app.Manifest.Dependencies.ByName(constants.TeleportPackage)
 	c.Assert(err, check.IsNil)
+	s.dnsConfig = storage.DNSConfig{
+		Addrs: []string{"127.0.0.3"},
+		Port:  10053,
+	}
 	s.cluster, err = s.services.Operator.CreateSite(
 		ops.NewSiteRequest{
 			AccountID:  account.ID,
 			DomainName: "example.com",
 			AppPackage: s.appPackage.String(),
 			Provider:   schema.ProviderAWS,
+			DNSConfig:  s.dnsConfig,
 		})
 	c.Assert(err, check.IsNil)
 	_, err = s.services.Users.CreateClusterAdminAgent(s.cluster.Domain,
@@ -237,6 +243,7 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 			Package:     &s.appPackage,
 			Agent:       s.adminAgent,
 			ServiceUser: &s.serviceUser,
+			DNSConfig:   &s.dnsConfig,
 		},
 	}, phase)
 }

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -399,7 +399,7 @@ func (f *FSM) executeOnePhase(ctx context.Context, p Params, phase storage.Opera
 
 	err = executor.PreCheck(ctx)
 	if err != nil {
-		executor.Errorf("Phase %v precheck failed: %v.", phase.ID, err)
+		executor.Errorf("Phase precheck failed: %v.", err)
 		return trace.Wrap(err)
 	}
 
@@ -416,7 +416,7 @@ func (f *FSM) executeOnePhase(ctx context.Context, p Params, phase storage.Opera
 
 	err = executor.Execute(ctx)
 	if err != nil {
-		executor.Errorf("Phase %v execution failed: %v.", phase.ID, err)
+		executor.Errorf("Phase execution failed: %v.", err)
 		if err := f.ChangePhaseState(ctx,
 			StateChange{
 				Phase: phase.ID,
@@ -430,7 +430,7 @@ func (f *FSM) executeOnePhase(ctx context.Context, p Params, phase storage.Opera
 
 	err = executor.PostCheck(ctx)
 	if err != nil {
-		executor.Errorf("Phase %v postcheck failed: %v.", phase.ID, err)
+		executor.Errorf("Phase postcheck failed: %v.", err)
 		return trace.Wrap(err)
 	}
 

--- a/lib/fsm/logger.go
+++ b/lib/fsm/logger.go
@@ -32,7 +32,7 @@ import (
 type Logger struct {
 	// FieldLogger is the underlying standard logger
 	logrus.FieldLogger
-	// key is the operation the logger is for
+	// Key is the operation the logger is for
 	Key ops.SiteOperationKey
 	// Operator is the operator service where log entries are submitted
 	Operator ops.Operator

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -58,16 +58,16 @@ func (i *Installer) StartInteractiveInstall() error {
 			if tm.IsZero() {
 				return trace.ConnectionProblem(nil, "timeout")
 			}
-			sites, err := i.Operator.GetSites(i.AccountID)
+			clusters, err := i.Operator.GetSites(i.AccountID)
 			if err != nil {
 				i.Warnf("Failed to get sites: %v.", trace.DebugReport(err))
 				continue
 			}
-			if len(sites) == 0 {
-				i.Info("No sites created yet.")
+			if len(clusters) == 0 {
+				i.Info("No clusters created yet.")
 				continue
 			}
-			i.Cluster = &sites[0]
+			i.Cluster = &clusters[0]
 			// set site domain set by user, otherwise we will attempt
 			// to generate new cluster
 			i.SiteDomain = i.Cluster.Domain
@@ -409,7 +409,7 @@ func (i *Installer) waitForAgents() error {
 	for {
 		select {
 		case <-i.Context.Done():
-			return trace.ConnectionProblem(nil, "context is closing")
+			return trace.ConnectionProblem(i.Context.Err(), "context is closing")
 		case tm := <-ticker.C:
 			if tm.IsZero() {
 				return trace.ConnectionProblem(nil, "timed out waiting for agents to join")
@@ -500,7 +500,7 @@ func PollProgress(ctx context.Context, send func(Event), operator ops.Operator,
 	for {
 		select {
 		case <-ctx.Done():
-			send(Event{Error: trace.ConnectionProblem(nil, "context is closing")})
+			send(Event{Error: trace.ConnectionProblem(ctx.Err(), "context is closing")})
 		case <-agentDoneCh:
 			log.Debug("Agent shut down.")
 			// avoid receiving on closed channel

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -77,7 +77,7 @@ type FSMConfig struct {
 	UserLogFile string
 	// ReportProgress controls whether engine should report progress to Operator
 	ReportProgress bool
-	// DNSConfig specifies the DNS configuration to set
+	// DNSConfig specifies the DNS configuration to use
 	DNSConfig storage.DNSConfig
 }
 
@@ -104,9 +104,6 @@ func (c *FSMConfig) CheckAndSetDefaults() (err error) {
 	}
 	if c.LocalBackend == nil {
 		return trace.BadParameter("missing LocalBackend")
-	}
-	if c.DNSConfig.IsEmpty() {
-		return trace.BadParameter("missing DNSConfig")
 	}
 	if c.Spec == nil {
 		c.Spec = FSMSpec(*c)

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -227,7 +227,17 @@ func (f *fsmEngine) ChangePhaseState(ctx context.Context, change fsm.StateChange
 // GetExecutor returns the appropriate install phase executor based on the
 // provided parameters
 func (f *fsmEngine) GetExecutor(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
-	return f.Spec(p, remote)
+	logger := &fsm.Logger{
+		FieldLogger: logrus.WithField(constants.FieldPhase, p.Phase.ID),
+		Key:         p.Key(),
+		Operator:    f.Operator,
+	}
+	executor, err := f.Spec(p, remote)
+	if err != nil {
+		logger.Warnf("Failed to initialize phase: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+	return executor, nil
 }
 
 // RunCommand executes the phase specified by params on the specified server

--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -44,7 +44,7 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 			return phases.NewBootstrap(p,
 				config.Operator,
 				config.Apps,
-				config.LocalBackend, remote, config.DNSConfig)
+				config.LocalBackend, remote)
 
 		case strings.HasPrefix(p.Phase.ID, phases.PullPhase):
 			return phases.NewPull(p,

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -406,9 +406,6 @@ func (i *Installer) Wait() error {
 			return nil
 		case event := <-i.EventsC:
 			if event.Error != nil {
-				if utils.IsContextCancelledError(event.Error) {
-					return nil
-				}
 				return trace.Wrap(event.Error)
 			}
 			progress := event.Progress

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -119,7 +119,7 @@ type Engine interface {
 	// NewClusterRequest constructs a request to create a new cluster
 	NewClusterRequest() ops.NewSiteRequest
 	// GetOperationPlan builds a plan for the provided operation
-	GetOperationPlan(ops.SiteOperation) (*storage.OperationPlan, error)
+	GetOperationPlan(ops.Site, ops.SiteOperation) (*storage.OperationPlan, error)
 	// GetFSM returns the installer FSM engine
 	GetFSM() (*fsm.FSM, error)
 	// OnPlanComplete is called when install plan finishes execution
@@ -257,6 +257,9 @@ func (c *Config) CheckAndSetDefaults() (err error) {
 	}
 	if c.NewProcess == nil {
 		c.NewProcess = process.NewProcess
+	}
+	if c.DNSConfig.IsEmpty() {
+		c.DNSConfig = storage.DefaultDNSConfig
 	}
 	return nil
 }
@@ -403,6 +406,10 @@ func (i *Installer) Wait() error {
 			return nil
 		case event := <-i.EventsC:
 			if event.Error != nil {
+				if trace.Unwrap(event.Error) == context.DeadlineExceeded {
+					i.Debug("Context is closing.")
+					return nil
+				}
 				return trace.Wrap(event.Error)
 			}
 			progress := event.Progress

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -406,8 +406,7 @@ func (i *Installer) Wait() error {
 			return nil
 		case event := <-i.EventsC:
 			if event.Error != nil {
-				if trace.Unwrap(event.Error) == context.DeadlineExceeded {
-					i.Debug("Context is closing.")
+				if utils.IsContextCancelledError(event.Error) {
 					return nil
 				}
 				return trace.Wrap(event.Error)

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -43,12 +43,15 @@ import (
 
 // NewBootstrap returns a new "bootstrap" phase executor
 func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications, backend storage.Backend,
-	remote fsm.Remote, dnsConfig storage.DNSConfig) (*bootstrapExecutor, error) {
+	remote fsm.Remote) (*bootstrapExecutor, error) {
 	if p.Phase.Data == nil || p.Phase.Data.ServiceUser == nil {
 		return nil, trace.BadParameter("service user is required: %#v", p.Phase.Data)
 	}
 	if p.Phase.Data.Package == nil {
 		return nil, trace.BadParameter("application package is required: %#v", p.Phase.Data)
+	}
+	if p.Phase.Data.DNSConfig == nil {
+		return nil, trace.BadParameter("DNS configuration is required: %#v", p.Phase.Data)
 	}
 
 	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
@@ -91,7 +94,7 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		ExecutorParams:   p,
 		ServiceUser:      *serviceUser,
 		remote:           remote,
-		dnsConfig:        dnsConfig,
+		dnsConfig:        *p.Phase.Data.DNSConfig,
 	}, nil
 }
 

--- a/lib/install/phases/postsystem.go
+++ b/lib/install/phases/postsystem.go
@@ -85,7 +85,7 @@ func (p *waitExecutor) Execute(ctx context.Context) error {
 				return trace.BadParameter("not all planets have come up yet: %v",
 					status)
 			}
-			if status.SystemStatus != agentpb.SystemStatus_Running {
+			if status.GetSystemStatus() != agentpb.SystemStatus_Running {
 				return trace.BadParameter("planet is not running yet: %v",
 					status)
 			}

--- a/lib/install/plan.go
+++ b/lib/install/plan.go
@@ -46,7 +46,7 @@ func (i *Installer) initOperationPlan() error {
 	if plan != nil {
 		return trace.AlreadyExists("plan is already initialized")
 	}
-	plan, err = i.engine.GetOperationPlan(*op)
+	plan, err = i.engine.GetOperationPlan(clusters[0], *op)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -59,8 +59,8 @@ func (i *Installer) initOperationPlan() error {
 }
 
 // GetOperationPlan builds a plan for the provided operation
-func (i *Installer) GetOperationPlan(op ops.SiteOperation) (*storage.OperationPlan, error) {
-	builder, err := i.GetPlanBuilder(op)
+func (i *Installer) GetOperationPlan(cluster ops.Site, op ops.SiteOperation) (*storage.OperationPlan, error) {
+	builder, err := i.GetPlanBuilder(cluster, op)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -61,6 +61,7 @@ type PlanSuite struct {
 	sitePackage        *loc.Locator
 	serviceUser        systeminfo.User
 	operationKey       *ops.SiteOperationKey
+	dnsConfig          storage.DNSConfig
 }
 
 var _ = check.Suite(&PlanSuite{})
@@ -105,6 +106,10 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 		KeyPair:  *ca,
 	})
 	c.Assert(err, check.IsNil)
+	s.dnsConfig = storage.DNSConfig{
+		Addrs: []string{"127.0.0.3"},
+		Port:  10053,
+	}
 	cluster, err := s.services.Operator.CreateSite(
 		ops.NewSiteRequest{
 			AccountID:  account.ID,
@@ -112,6 +117,7 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 			AppPackage: appPackage.String(),
 			Provider:   schema.ProviderAWS,
 			Resources:  configMap,
+			DNSConfig:  s.dnsConfig,
 		})
 	_, err = s.services.Users.CreateClusterAdminAgent(cluster.Domain,
 		storage.NewUser(storage.ClusterAdminAgent(cluster.Domain), storage.UserSpecV2{
@@ -168,6 +174,7 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 			Resources:   configMap,
 			ServiceUser: s.serviceUser,
 			Mode:        constants.InstallModeCLI,
+			DNSConfig:   s.dnsConfig,
 		},
 		FieldLogger: logrus.WithField(trace.Component, "plan-suite"),
 		AppPackage:  appPackage,
@@ -245,6 +252,7 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 					Package:     &s.installer.AppPackage,
 					Agent:       s.adminAgent,
 					ServiceUser: serviceUser,
+					DNSConfig:   &s.dnsConfig,
 				},
 			},
 			{
@@ -255,6 +263,7 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 					Package:     &s.installer.AppPackage,
 					Agent:       s.regularAgent,
 					ServiceUser: serviceUser,
+					DNSConfig:   &s.dnsConfig,
 				},
 			},
 		},

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -60,6 +60,8 @@ type PlanBuilder struct {
 	RegularAgent storage.LoginEntry
 	// ServiceUser is the cluster system user
 	ServiceUser storage.OSUser
+	// DNSConfig specifies the custom cluster DNS configuration
+	DNSConfig storage.DNSConfig
 }
 
 // AddChecksPhase appends preflight checks phase to the provided plan
@@ -107,6 +109,7 @@ func (b *PlanBuilder) AddBootstrapPhase(plan *storage.OperationPlan) {
 				Package:     &b.Application.Package,
 				Agent:       agent,
 				ServiceUser: &b.ServiceUser,
+				DNSConfig:   &b.DNSConfig,
 			},
 			Step: 3,
 		})
@@ -443,7 +446,7 @@ func (b *PlanBuilder) AddEnableElectionPhase(plan *storage.OperationPlan) {
 
 // GetPlanBuilder returns a new plan builder for this installer and provided
 // operation that can be used to build operation plan phases
-func (i *Installer) GetPlanBuilder(op ops.SiteOperation) (*PlanBuilder, error) {
+func (i *Installer) GetPlanBuilder(cluster ops.Site, op ops.SiteOperation) (*PlanBuilder, error) {
 	// determine which app and runtime are being installed
 	application, err := i.Apps.GetApp(i.AppPackage)
 	if err != nil {
@@ -522,6 +525,7 @@ func (i *Installer) GetPlanBuilder(op ops.SiteOperation) (*PlanBuilder, error) {
 			UID:  strconv.Itoa(i.Config.ServiceUser.UID),
 			GID:  strconv.Itoa(i.Config.ServiceUser.GID),
 		},
+		DNSConfig: cluster.DNSConfig,
 	}, nil
 }
 

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -135,7 +135,6 @@ func newClusterEnvironment(args clusterEnvironmentArgs) (*ClusterEnvironment, er
 		Apps:     apps,
 		Users:    users,
 		StateDir: siteDir,
-		Local:    true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/network/validation/proto/validation.pb.go
+++ b/lib/network/validation/proto/validation.pb.go
@@ -305,9 +305,9 @@ func (m *ValidateResponse) GetFailed() []*agentpb.Probe {
 type ValidateOptions struct {
 	// VxlanPort is the custom overlay network port
 	VxlanPort int32 `protobuf:"varint,1,opt,name=vxlan_port,json=vxlanPort,proto3" json:"vxlan_port,omitempty"`
-	// DnsAddrs specifies the list of listen IP addresses for dnsmasq
+	// DnsAddrs specifies the list of listen IP addresses for coredns
 	DnsAddrs []string `protobuf:"bytes,2,rep,name=dns_addrs,json=dnsAddrs" json:"dns_addrs,omitempty"`
-	// DnsPort specifies the DNS port for dnsmasq
+	// DnsPort specifies the DNS port for coredns
 	DnsPort int32 `protobuf:"varint,3,opt,name=dns_port,json=dnsPort,proto3" json:"dns_port,omitempty"`
 }
 

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -146,7 +146,7 @@ func (s *site) validateShrinkRequest(req ops.CreateSiteShrinkOperationRequest, c
 	teleserver := servers.getWithLabels(labels{ops.Hostname: server.Hostname})
 	if len(teleserver) == 0 {
 		if !req.Force {
-			return nil, trace.Wrap(err,
+			return nil, trace.BadParameter(
 				"node %q is offline, add --force flag to force removal", serverName)
 		}
 		log.Warnf("Node %q is offline, forcing removal.", serverName)

--- a/lib/ops/opsservice/status.go
+++ b/lib/ops/opsservice/status.go
@@ -91,7 +91,7 @@ func (s *site) checkPlanetStatus(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if planetStatus.SystemStatus != agentpb.SystemStatus_Running {
+	if planetStatus.GetSystemStatus() != agentpb.SystemStatus_Running {
 		return trace.BadParameter("cluster is not healthy: %#v", planetStatus)
 	}
 	return nil

--- a/lib/rpc/server/agent_group_test.go
+++ b/lib/rpc/server/agent_group_test.go
@@ -135,7 +135,7 @@ func (r *S) TestAgentGroupReconnects(c *C) {
 	go p2.Serve()
 	defer withTestCtx(p2.Stop)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 	c.Assert(store.expect(ctx, 2), IsNil)
 	cancel()
 

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -414,7 +414,9 @@ func (r SystemStatus) String() string {
 		return "running"
 	case pb.SystemStatus_Degraded:
 		return "degraded"
-	default: // pb.SystemStatus_Unknown:
+	case pb.SystemStatus_Unknown:
+		return "unknown"
+	default:
 		return "unknown"
 	}
 }

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -111,7 +111,7 @@ func (s Status) Check() error {
 	if s.State == ops.SiteStateDegraded {
 		return trace.BadParameter("Cluster status: degraded")
 	}
-	if s.Agent != nil && s.Agent.SystemStatus != pb.SystemStatus_Running {
+	if s.Agent != nil && s.Agent.GetSystemStatus() != pb.SystemStatus_Running {
 		return trace.BadParameter("Cluster status: degraded")
 	}
 	// if the operation is in bad state, return error
@@ -136,7 +136,7 @@ func FromPlanetAgent(ctx context.Context, servers []storage.Server) (*Agent, err
 	}
 
 	return &Agent{
-		SystemStatus: status.Status,
+		SystemStatus: SystemStatus(status.Status),
 		Nodes:        nodes,
 	}, nil
 }
@@ -212,10 +212,15 @@ type ClusterOperationProgress struct {
 	Created time.Time `json:"created"`
 }
 
+// GetSystemStatus returns the status of the system
+func (r Agent) GetSystemStatus() pb.SystemStatus_Type {
+	return pb.SystemStatus_Type(r.SystemStatus)
+}
+
 // Agent specifies the status of the system and individual nodes
 type Agent struct {
 	// SystemStatus defines the health status of the whole cluster
-	SystemStatus pb.SystemStatus_Type `json:"system_status"`
+	SystemStatus SystemStatus `json:"system_status"`
 	// Nodes lists status of each individual cluster node
 	Nodes []ClusterServer `json:"nodes"`
 }
@@ -401,6 +406,26 @@ func diskSpaceProbeErrorDetail(p pb.Probe) (string, error) {
 	}
 	return data.FailureMessage(), nil
 }
+
+// String returns a textual representation of this system status
+func (r SystemStatus) String() string {
+	switch pb.SystemStatus_Type(r) {
+	case pb.SystemStatus_Running:
+		return "running"
+	case pb.SystemStatus_Degraded:
+		return "degraded"
+	default: // pb.SystemStatus_Unknown:
+		return "unknown"
+	}
+}
+
+// GoString returns a textual representation of this system status
+func (r SystemStatus) GoString() string {
+	return r.String()
+}
+
+// SystemStatus is an alias for system status type
+type SystemStatus pb.SystemStatus_Type
 
 const (
 	// NodeHealthy is the status of a healthy node

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -120,6 +120,8 @@ type OperationPhaseData struct {
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`
 	// Data is arbitrary text data to provide to a phase executor
 	Data string `json:"data,omitempty" yaml:"data,omitempty"`
+	// DNSConfig specifies custom cluster DNS configuration
+	DNSConfig *DNSConfig `json:"dns_config,omitempty" yaml:"dns_config,omitempty"`
 }
 
 // ElectionChange describes changes to make to cluster elections

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -85,7 +85,11 @@ func startInstall(env *localenv.LocalEnvironment, i InstallConfig) error {
 		return trace.Wrap(err)
 	}
 
-	return installer.Wait()
+	err = installer.Wait()
+	if utils.IsContextCancelledError(err) {
+		return nil
+	}
+	return trace.Wrap(err)
 }
 
 func Join(env, joinEnv *localenv.LocalEnvironment, j JoinConfig) error {
@@ -119,7 +123,12 @@ func Join(env, joinEnv *localenv.LocalEnvironment, j JoinConfig) error {
 		return trace.Wrap(err)
 	}
 
-	return peer.Wait()
+	err = peer.Wait()
+	if utils.IsContextCancelledError(err) {
+		return nil
+	}
+	return trace.Wrap(err)
+
 }
 
 type leaveConfig struct {

--- a/tool/gravity/cli/ops.go
+++ b/tool/gravity/cli/ops.go
@@ -101,7 +101,9 @@ func uploadUpdate(env *localenv.LocalEnvironment, opsURL string) error {
 
 	clusterOperator, err := defaultEnv.SiteOperator()
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "unable to access cluster.\n"+
+			"Use 'gravity status' to check the cluster state and make sure "+
+			"that the cluster DNS is working properly.")
 	}
 
 	cluster, err := clusterOperator.GetLocalSite()

--- a/tool/gravity/cli/planet.go
+++ b/tool/gravity/cli/planet.go
@@ -117,7 +117,7 @@ func getMasterNodes(ctx context.Context, servers []storage.Server) (addrs []stri
 		return nil, trace.Wrap(err)
 	}
 
-	if status.SystemStatus != agentpb.SystemStatus_Running {
+	if status.GetSystemStatus() != agentpb.SystemStatus_Running {
 		return nil, trace.BadParameter("cluster is degraded")
 	}
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -369,10 +369,12 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.StatusCmd.FullCommand():
 		printOptions := printOptions{
 			token:       *g.StatusCmd.Token,
-			tail:        *g.StatusCmd.Tail,
 			operationID: *g.StatusCmd.OperationID,
 			quiet:       *g.Silent,
 			format:      *g.StatusCmd.Output,
+		}
+		if *g.StatusCmd.Tail {
+			return tailStatus(localEnv, *g.StatusCmd.OperationID)
 		}
 		if *g.StatusCmd.Seconds != 0 {
 			return statusPeriodic(localEnv, printOptions, *g.StatusCmd.Seconds)

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -377,7 +377,7 @@ func isClusterDegrated(status clusterStatus) bool {
 	return (status.Cluster == nil ||
 		status.Cluster.State == ops.SiteStateDegraded ||
 		status.Agent == nil ||
-		status.Agent.SystemStatus != pb.SystemStatus_Running)
+		status.Agent.GetSystemStatus() != pb.SystemStatus_Running)
 }
 
 func unknownFallback(text string) string {

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -111,14 +111,13 @@ func tailStatus(env *localenv.LocalEnvironment, operationID string) error {
 	case operationID != "" && status.Cluster.Operation != nil:
 		opKey = status.Operation.Key()
 	case len(status.Cluster.ActiveOperations) != 0:
+		if len(status.Cluster.ActiveOperations) > 1 {
+			return trace.BadParameter("multiple active operations in progress. " +
+				"Please specify the operation with --operation-id")
+		}
 		opKey = status.Cluster.ActiveOperations[0].Key()
 	default:
 		return nil
-	}
-
-	if len(status.Cluster.ActiveOperations) > 1 {
-		return trace.BadParameter("multiple active operations in progress. " +
-			"Please specify the operation with --operation-id")
 	}
 
 	return trace.Wrap(tailOperationLogs(operator, opKey))

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -67,9 +67,6 @@ func (g *Application) getEnv(stateDir string) (*localenv.LocalEnvironment, error
 		EtcdRetryTimeout: *g.EtcdRetryTimeout,
 		Reporter:         common.ProgressReporter(*g.Silent),
 	}
-	if len(*g.InstallCmd.DNSListenAddrs) != 0 {
-		args.DNS = localenv.DNSConfig(g.InstallCmd.DNSConfig())
-	}
 	if *g.StateDir != defaults.LocalGravityDir {
 		args.LocalKeyStoreDir = *g.StateDir
 	}


### PR DESCRIPTION
This PR fixes a regression with DNS configuration not propagating during install/expand by moving the configuration to the operation plan (for the `bootstrap` step).

Also included are various improvements to issues I discovered while working on the original issue.

I tested wizard installs/expands (w/ and w/o custom DNS configuration), CLI installs/expands and Ops Center-based install/expand.

Requires https://github.com/gravitational/gravity.e/pull/3799.
Fixes https://github.com/gravitational/gravity.e/issues/3770.