### PR TITLE
better handling of redirects to install complete step

### DIFF
--- a/web/devServer.js
+++ b/web/devServer.js
@@ -92,12 +92,17 @@ server.app.use(changeProxyResponse(
         return false;
     },
     (req, res, body) => {
-      // body is a Buffer with the current response; return Buffer or string with the modified response
+        // body is a Buffer with the current response; return Buffer or string with the modified response
         // can also return a Promise.
         var str = body.toString();
         res.set({
           'content-security-policy': ""
         })
+
+        if (req.path.endsWith('/complete/')) {
+          return body;
+        }
+
         var htmlWithTokens = htmlToSend;
         htmlWithTokens = replaceToken(new RegExp(/<meta name="grv_csrf_token" .*\>/), str, htmlWithTokens);
         htmlWithTokens = replaceToken(new RegExp(/<meta name="grv_bearer_token" .*\>/), str, htmlWithTokens);

--- a/web/src/app/config.js
+++ b/web/src/app/config.js
@@ -105,6 +105,7 @@ let cfg = {
     installerBase: '/web/installer',
     installerNewSite: '/web/installer/new/:repository/:name/:version',
     installerExistingSite: '/web/installer/site/:siteId',
+    installerComplete: '/web/installer/site/:siteId/complete/',
 
     // settings
     settingsUsers: 'users',
@@ -478,6 +479,10 @@ let cfg = {
 
   getInstallerProvisionUrl(siteId){
     return formatPattern(cfg.routes.installerExistingSite, {siteId});
+  },
+
+  getInstallerLastStepUrl(siteId){
+    return formatPattern(cfg.routes.installerComplete, {siteId});
   },
 
   getCheckDomainNameUrl(domainName){

--- a/web/src/app/index.jsx
+++ b/web/src/app/index.jsx
@@ -80,6 +80,10 @@ const Root = () => (
 
 // enable hot reloading
 if (module.hot) {
+  module.hot.accept('./modules/installer', () => {
+    require('./modules/installer');
+  })
+
   module.hot.accept('./modules/site', () => {
     require('./modules/site');
   })

--- a/web/src/app/modules/installer/components/progress/main.jsx
+++ b/web/src/app/modules/installer/components/progress/main.jsx
@@ -21,10 +21,11 @@ import getters from './../../flux/progress/getters';
 import { fetchOpProgress} from './../../flux/progress/actions';
 import LogViewer from 'app/components/logViewer';
 import connect from 'app/lib/connect';
+import cfg from 'app/config';
 
 import { SiteOperationLogProvider } from 'app/components/dataProviders';
 
-const PROGRESS_STATE_STRINGS = [  
+const PROGRESS_STATE_STRINGS = [
   'Provisioning Instances',
   'Connecting to instances',
   'Verifying instances',
@@ -121,7 +122,7 @@ class ProgressIndicactor extends React.Component {
 }
 
 class Progress extends React.Component {
-  
+
   constructor(props) {
     super(props);
     this.state = {
@@ -136,8 +137,8 @@ class Progress extends React.Component {
   }
 
   scrollIntoView() {
-    let container = document.querySelector('.grv-installer-logviewer');
-    container.scrollIntoView()    
+    const container = document.querySelector('.grv-installer-logviewer');
+    container.scrollIntoView()
   }
 
   componentDidMount(){
@@ -148,26 +149,27 @@ class Progress extends React.Component {
   componentWillUnmount() {
     clearInterval(this.refreshInterval);
   }
-    
+
   render() {
     if(!this.props.model){
       return null;
     }
 
-    let { isError, isCompleted, step, siteId, opId, siteUrl, crashReportUrl } = this.props.model;
-    let { isLogsVisible } = this.state;            
-    let expandIconClass = classnames('fa', {
+    const { isError, isCompleted, step, siteId, opId, crashReportUrl } = this.props.model;
+    const { isLogsVisible } = this.state;
+    const completeInstallUrl = cfg.getInstallerLastStepUrl(siteId);
+    const expandIconClass = classnames('fa', {
       'fa-caret-down': isLogsVisible,
       'fa-caret-up': !isLogsVisible
-    });    
+    });
 
-    let logViewerClassName = classnames('grv-installer-logviewer m-b', {
+    const logViewerClassName = classnames('grv-installer-logviewer m-b', {
       hidden: !isLogsVisible
-    })    
-    
+    })
+
     return (
       <div>
-        { isCompleted ? <Success siteUrl={siteUrl}/> : null }
+        { isCompleted && <Success siteUrl={completeInstallUrl}/> }
         { isError ? <Failure tarballUrl={crashReportUrl}/> :
           <div>
             <div className="inline">
@@ -181,15 +183,15 @@ class Progress extends React.Component {
             <small>Click here to see/hide executable logs </small>
             <i className={expandIconClass} />
           </button>
-        </div>        
+        </div>
         <div>
-          <LogViewer                  
-            wrap={true}  
+          <LogViewer
+            wrap={true}
             className={logViewerClassName}
             autoScroll={true}
-            provider={ <SiteOperationLogProvider siteId={siteId} opId={opId} /> }            
-          />                                                          
-        </div>        
+            provider={ <SiteOperationLogProvider siteId={siteId} opId={opId} /> }
+          />
+        </div>
       </div>
     );
   }
@@ -197,8 +199,8 @@ class Progress extends React.Component {
 
 function mapStateToProps() {
   return {
-    model: getters.installProgress()    
-  }  
+    model: getters.installProgress()
+  }
 }
 
 export default connect(mapStateToProps)(Progress);


### PR DESCRIPTION
Instead of redirecting to last installation step (bandwagon app), redirect a user back to installer if last installation step has not been completed.

The installer in this case will show that installation has been completed and ask a user to click a button to complete the installation.

Also fixes https://github.com/gravitational/gravity.e/issues/3781