### PR TITLE
Fix tele build repo override.

### DIFF
--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -78,7 +78,7 @@ type Config struct {
 	// NewSyncer is used to initialize package cache syncer for the builder
 	NewSyncer NewSyncerFunc
 	// GetRepository is a function that returns package source repository
-	GetRepository GetRepositoryFn
+	GetRepository GetRepositoryFunc
 	// FieldLogger is used for logging
 	logrus.FieldLogger
 	// Progress allows builder to report build progress
@@ -233,7 +233,7 @@ func (b *Builder) SyncPackageCache(runtimeVersion *semver.Version) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	b.Info("Synchronizing package cache with %v.", repository)
+	b.Infof("Synchronizing package cache with %v.", repository)
 	b.NextStep("Downloading dependencies from %v", repository)
 	return b.syncer.Sync(b, runtimeVersion)
 }
@@ -452,8 +452,8 @@ func ensureCacheDir(opsURL string) (string, error) {
 	return dir, nil
 }
 
-// GetRepositoryFn defines function that returns package source repository
-type GetRepositoryFn func(*Builder) (string, error)
+// GetRepositoryFunc defines function that returns package source repository
+type GetRepositoryFunc func(*Builder) (string, error)
 
 // getRepository returns package source repository for the provided builder
 func getRepository(b *Builder) (string, error) {

--- a/lib/builder/syncer.go
+++ b/lib/builder/syncer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package builder
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -45,8 +44,6 @@ type Syncer interface {
 	// SelectRuntime picks an appropriate runtime for the application that's
 	// being built
 	SelectRuntime(*Builder) (*semver.Version, error)
-	// GetRepository returns the syncer repository
-	GetRepository() string
 }
 
 // NewSyncerFunc defines function that creates syncer for a builder
@@ -74,11 +71,6 @@ func newS3Syncer() (*s3Syncer, error) {
 	return &s3Syncer{
 		hub: hub,
 	}, nil
-}
-
-// GetRepository returns the name of S3 hub
-func (s *s3Syncer) GetRepository() string {
-	return fmt.Sprintf("s3://%v", defaults.HubBucket)
 }
 
 // SelectRuntime picks an appropriate runtime for the application that's
@@ -174,11 +166,6 @@ func NewPackSyncer(pack pack.PackageService, apps app.Applications, repo string)
 		apps: apps,
 		repo: repo,
 	}
-}
-
-// GetRepository returns the syncer's repository address
-func (s *packSyncer) GetRepository() string {
-	return s.repo
 }
 
 // SelectRuntime picks an appropriate runtime for the application that's

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -248,7 +248,8 @@ func (env *LocalEnvironment) GetLoginEntry(opsCenterURL string) (*users.LoginEnt
 				Password:     defaults.DistributionOpsCenterPassword,
 			}, nil
 		}
-		return nil, trace.NotFound("Please login to Ops Center")
+		return nil, trace.NotFound("Please login to Ops Center: %v",
+			opsCenterURL)
 	}
 	return entry, nil
 }
@@ -288,10 +289,12 @@ func (env *LocalEnvironment) SelectOpsCenter(opsURL string) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	if len(entries) == 0 {
-		return "", trace.AccessDenied("Please login to Ops Center")
+		return "", trace.AccessDenied("Please login to Ops Center: %v",
+			opsURL)
 	}
 	if len(entries) != 1 {
-		return "", trace.AccessDenied("Please login to Ops Center")
+		return "", trace.AccessDenied("Please login to Ops Center: %v",
+			opsURL)
 	}
 	return entries[0].OpsCenterURL, nil
 }
@@ -305,7 +308,8 @@ func (env *LocalEnvironment) SelectOpsCenterWithDefault(opsURL, defaultURL strin
 		if defaultURL != "" {
 			return defaultURL, nil
 		}
-		return "", trace.AccessDenied("Please login to Ops Center")
+		return "", trace.AccessDenied("Please login to Ops Center: %v",
+			opsURL)
 	}
 	return url, nil
 }


### PR DESCRIPTION
During one of recent refactorings a change was made that if `--state-dir` flag is explicitly provided to the tele build command, it is always used as a package source (which is used for building installer from pre-built state). However, some customers use `--state-dir` to store login information (`tele login --state-dir=...`) and still want to download packages from their Ops Center.

This PR restores the original behavior that if `--repository` flag is provided alongside `--state-dir`, then this repository is used as a package source.

Closes https://github.com/gravitational/gravity.e/issues/3816.
