### PR TITLE
Exit after operation failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ GRAVITY_LINKFLAGS = "$(VERSION_FLAGS) $(GOLFLAGS)"
 TELEPORT_TAG = 3.0.1
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
+TELEPORT_S3_BUCKET ?= teleport-v$(TELEPORT_TAG)-linux-amd64.tar.gz
+
 PLANET_TAG := 5.3.4-$(K8S_VER)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
@@ -187,7 +189,7 @@ build:
 	$(MAKE) -C build.assets build
 
 # 'install' uses the host's Golang to place output into $GOPATH/bin
-.PHONY:install
+.PHONY: install
 install:
 	go install -ldflags "$(VERSION_FLAGS)" ./tool/tele ./tool/gravity
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -12,7 +12,9 @@ LOCAL_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build
 # Path to the local gravity build assets directory used inside the container
 LOCAL_GRAVITY_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build/$(GRAVITY_VERSION)
 
+DOCKER_ARGS ?= --pull
 BBOX = gravity-buildbox:latest
+GOCACHE ?= $(HOME)/.cache/go-build
 
 GRAVITY_WEB_APP_DIR ?= $(abspath $(LOCALDIR)/../web)/
 
@@ -196,6 +198,8 @@ validate-deps: buildbox
 build-in-container: buildbox
 	docker run --rm=true -u $$(id -u) \
 		   -v $(TOP):$(SRCDIR) \
+		   -v $(GOCACHE):/gocache \
+		   -e "GOCACHE=/gocache" \
 		   -e "LOCAL_BUILDDIR=$(LOCAL_BUILDDIR)" \
 		   -e "LOCAL_GRAVITY_BUILDDIR=$(LOCAL_GRAVITY_BUILDDIR)" \
 		   -e "GRAVITY_PKG_PATH=$(GRAVITY_PKG_PATH)" \
@@ -458,7 +462,7 @@ clone-teleport:
 	cd $(TELEPORT_SRCDIR)/teleport && git fetch --all --tags && git checkout $(TELEPORT_REPOTAG)
 
 pull-teleport:
-	-$(AWS) s3 cp $(S3_OPTS) $(BUILD_BUCKET_URL)/teleport/$(TELEPORT_TAG) $(TELEPORT_OUT)
+	-$(AWS) s3 cp $(S3_OPTS) $(BUILD_BUCKET_URL)/teleport/$(TELEPORT_TAG)/$(TELEPORT_S3_BUCKET) $(TELEPORT_OUT)
 
 push-teleport: $(TELEPORT_OUT)
 	$(AWS) s3 cp $(S3_OPTS) $(TELEPORT_OUT) $(BUILD_BUCKET_URL)/teleport/$(TELEPORT_TAG)
@@ -554,4 +558,4 @@ buildbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg GRPC_GATEWAY_TAG=$(GRPC_GATEWAY_TAG) \
 		--build-arg VERSION_TAG=$(VERSION_TAG) \
-		--pull --tag $(BBOX) .
+		$(DOCKER_ARGS) --tag $(BBOX) .

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,6 +204,10 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
+	// UnattendedOperationEnvVar names the environment variable that specifies whether an operation
+	// should run in unattended mode
+	UnattendedOperationEnvVar = "GRAVITY_UNATTENDED_OPERATION"
+
 	// DockerRegistry is a default name for private docker registry
 	DockerRegistry = "leader.telekube.local:5000"
 

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,9 +204,9 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
-	// UnattendedOperationEnvVar names the environment variable that specifies whether an operation
-	// should run in unattended mode
-	UnattendedOperationEnvVar = "GRAVITY_UNATTENDED_OPERATION"
+	// ExitAfterErrorEnvVar names the environment variable that specifies whether the process should exit
+	// after a failed operation instead of waiting for user input
+	ExitAfterErrorEnvVar = "GRAVITY_EXIT_AFTER_ERROR"
 
 	// DockerRegistry is a default name for private docker registry
 	DockerRegistry = "leader.telekube.local:5000"

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -91,6 +91,10 @@ type PeerConfig struct {
 	JoinBackend storage.Backend
 	// Manual turns on manual plan execution
 	Manual bool
+	// Unattended executes the operation in unattended mode.
+	// In this mode, the process will exit immediately after the failed operation
+	// instead of waiting for user input
+	Unattended bool
 	// OperationID is the ID of existing join operation created via UI
 	OperationID string
 }
@@ -721,6 +725,9 @@ func (p *Peer) Wait() error {
 				return nil
 			}
 			if progress.State == ops.ProgressStateFailed {
+				if p.Unattended {
+					return trace.BadParameter("join operation failed")
+				}
 				p.Silent.Println(color.RedString("Failed to join the cluster"))
 				p.Silent.Printf("---\nAgent process will keep running so you can re-run certain steps.\n" +
 					"Once no longer needed, this process can be shutdown using Ctrl-C.\n")

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -91,10 +91,9 @@ type PeerConfig struct {
 	JoinBackend storage.Backend
 	// Manual turns on manual plan execution
 	Manual bool
-	// Unattended executes the operation in unattended mode.
-	// In this mode, the process will exit immediately after the failed operation
+	// ExitAfterError exits the process after the operation failure
 	// instead of waiting for user input
-	Unattended bool
+	ExitAfterError bool
 	// OperationID is the ID of existing join operation created via UI
 	OperationID string
 }
@@ -723,7 +722,7 @@ func (p *Peer) Wait() error {
 				return nil
 			}
 			if progress.State == ops.ProgressStateFailed {
-				if p.Unattended {
+				if p.ExitAfterError {
 					return trace.BadParameter("join operation failed")
 				}
 				p.Silent.Println(color.RedString("Failed to join the cluster"))

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -52,8 +52,7 @@ func (i *Installer) StartInteractiveInstall() error {
 	for {
 		select {
 		case <-i.Context.Done():
-			i.Warnf("Context is closing: %v.", i.Context.Err())
-			return nil
+			return trace.Wrap(i.Context.Err())
 		case tm := <-ticker.C:
 			if tm.IsZero() {
 				return trace.ConnectionProblem(nil, "timeout")
@@ -409,7 +408,7 @@ func (i *Installer) waitForAgents() error {
 	for {
 		select {
 		case <-i.Context.Done():
-			return trace.ConnectionProblem(i.Context.Err(), "context is closing")
+			return trace.Wrap(i.Context.Err())
 		case tm := <-ticker.C:
 			if tm.IsZero() {
 				return trace.ConnectionProblem(nil, "timed out waiting for agents to join")
@@ -500,7 +499,7 @@ func PollProgress(ctx context.Context, send func(Event), operator ops.Operator,
 	for {
 		select {
 		case <-ctx.Done():
-			send(Event{Error: trace.ConnectionProblem(ctx.Err(), "context is closing")})
+			return
 		case <-agentDoneCh:
 			log.Debug("Agent shut down.")
 			// avoid receiving on closed channel

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -201,6 +201,10 @@ type Config struct {
 	NewProcess process.NewGravityProcess
 	// Silent allows installer to output its progress
 	localenv.Silent
+	// Unattended executes the operation in unattended mode.
+	// In this mode, the process will exit immediately after the failed operation
+	// instead of waiting for user input
+	Unattended bool
 }
 
 // CheckAndSetDefaults checks the parameters and autodetects some defaults
@@ -438,6 +442,9 @@ func (i *Installer) Wait() error {
 					}
 					return nil
 				} else {
+					if i.Unattended {
+						return trace.BadParameter("install operation failed")
+					}
 					i.PrintStep(color.RedString("Installation failed in %v, "+
 						"check %v for details", i.timeSinceBeginning(i.OperationKey), i.UserLogFile))
 					i.printf("---\nInstaller process will keep running so you can inspect the operation plan using\n" +

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -201,10 +201,9 @@ type Config struct {
 	NewProcess process.NewGravityProcess
 	// Silent allows installer to output its progress
 	localenv.Silent
-	// Unattended executes the operation in unattended mode.
-	// In this mode, the process will exit immediately after the failed operation
+	// ExitAfterError exits the process after the operation failure
 	// instead of waiting for user input
-	Unattended bool
+	ExitAfterError bool
 }
 
 // CheckAndSetDefaults checks the parameters and autodetects some defaults
@@ -441,7 +440,7 @@ func (i *Installer) Wait() error {
 					}
 					return nil
 				} else {
-					if i.Unattended {
+					if i.ExitAfterError {
 						return trace.BadParameter("install operation failed")
 					}
 					i.PrintStep(color.RedString("Installation failed in %v, "+

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -406,8 +406,7 @@ func (i *Installer) Wait() error {
 	for {
 		select {
 		case <-i.Context.Done():
-			i.Debug("Operation context closed.")
-			return nil
+			return trace.Wrap(i.Context.Err())
 		case event := <-i.EventsC:
 			if event.Error != nil {
 				return trace.Wrap(event.Error)
@@ -814,7 +813,6 @@ func wait(ctx context.Context, cancel context.CancelFunc, p process.GravityProce
 	case err := <-errC:
 		return trace.Wrap(err)
 	case <-ctx.Done():
-		log.Debug("Operation context closed.")
-		return nil
+		return trace.Wrap(ctx.Err())
 	}
 }

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -351,9 +351,9 @@ type InstallCmd struct {
 	// Manual puts install operation in manual mode
 	Manual *bool
 	// Unattended executes the operation in unattended mode.
-	// In this mode, the installer will exit immediately after ther operation
+	// In this mode, the process will exit immediately after the failed operation
 	// instead of waiting for user input
-	Unattanded *bool
+	Unattended *bool
 	// ServiceUID is system user ID
 	ServiceUID *string
 	// ServiceGID is system user group ID
@@ -399,6 +399,10 @@ type JoinCmd struct {
 	Force *bool
 	// Complete marks join operation complete
 	Complete *bool
+	// Unattended executes the operation in unattended mode.
+	// In this mode, the process will exit immediately after the failed operation
+	// instead of waiting for user input
+	Unattended *bool
 	// OperationID is the ID of the operation created via UI
 	OperationID *string
 }

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -350,6 +350,10 @@ type InstallCmd struct {
 	Resume *bool
 	// Manual puts install operation in manual mode
 	Manual *bool
+	// Unattended executes the operation in unattended mode.
+	// In this mode, the installer will exit immediately after ther operation
+	// instead of waiting for user input
+	Unattanded *bool
 	// ServiceUID is system user ID
 	ServiceUID *string
 	// ServiceGID is system user group ID

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -350,10 +350,9 @@ type InstallCmd struct {
 	Resume *bool
 	// Manual puts install operation in manual mode
 	Manual *bool
-	// Unattended executes the operation in unattended mode.
-	// In this mode, the process will exit immediately after the failed operation
+	// ExitAfterError exits the process after the operation failure
 	// instead of waiting for user input
-	Unattended *bool
+	ExitAfterError *bool
 	// ServiceUID is system user ID
 	ServiceUID *string
 	// ServiceGID is system user group ID
@@ -399,10 +398,9 @@ type JoinCmd struct {
 	Force *bool
 	// Complete marks join operation complete
 	Complete *bool
-	// Unattended executes the operation in unattended mode.
-	// In this mode, the process will exit immediately after the failed operation
+	// ExitAfterError exits the process after the operation failure
 	// instead of waiting for user input
-	Unattended *bool
+	ExitAfterError *bool
 	// OperationID is the ID of the operation created via UI
 	OperationID *string
 }

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -108,6 +108,10 @@ type InstallConfig struct {
 	NodeTags []string
 	// NewProcess is used to launch gravity API server process
 	NewProcess process.NewGravityProcess
+	// Unattended executes the operation in unattended mode.
+	// In this mode, the process will exit immediately after the failed operation
+	// instead of waiting for user input
+	Unattended bool
 }
 
 // NewInstallConfig creates install config from the passed CLI args and flags
@@ -150,6 +154,7 @@ func NewInstallConfig(g *Application) InstallConfig {
 		ServiceUID: *g.InstallCmd.ServiceUID,
 		ServiceGID: *g.InstallCmd.ServiceGID,
 		NodeTags:   *g.InstallCmd.GCENodeTags,
+		Unattended: *g.InstallCmd.Unattended,
 	}
 }
 
@@ -339,6 +344,7 @@ func (i *InstallConfig) ToInstallerConfig(env *localenv.LocalEnvironment) (*inst
 		ServiceUser:   i.ServiceUser,
 		GCENodeTags:   i.NodeTags,
 		NewProcess:    i.NewProcess,
+		Unattended:    i.Unattended,
 	}, nil
 }
 

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -108,10 +108,9 @@ type InstallConfig struct {
 	NodeTags []string
 	// NewProcess is used to launch gravity API server process
 	NewProcess process.NewGravityProcess
-	// Unattended executes the operation in unattended mode.
-	// In this mode, the process will exit immediately after the failed operation
+	// ExitAfterError exits the process after the operation failure
 	// instead of waiting for user input
-	Unattended bool
+	ExitAfterError bool
 }
 
 // NewInstallConfig creates install config from the passed CLI args and flags
@@ -149,12 +148,12 @@ func NewInstallConfig(g *Application) InstallConfig {
 			StorageDriver: g.InstallCmd.DockerStorageDriver.value,
 			Args:          *g.InstallCmd.DockerArgs,
 		},
-		DNSConfig:  g.InstallCmd.DNSConfig(),
-		Manual:     *g.InstallCmd.Manual,
-		ServiceUID: *g.InstallCmd.ServiceUID,
-		ServiceGID: *g.InstallCmd.ServiceGID,
-		NodeTags:   *g.InstallCmd.GCENodeTags,
-		Unattended: *g.InstallCmd.Unattended,
+		DNSConfig:      g.InstallCmd.DNSConfig(),
+		Manual:         *g.InstallCmd.Manual,
+		ServiceUID:     *g.InstallCmd.ServiceUID,
+		ServiceGID:     *g.InstallCmd.ServiceGID,
+		NodeTags:       *g.InstallCmd.GCENodeTags,
+		ExitAfterError: *g.InstallCmd.ExitAfterError,
 	}
 }
 
@@ -310,41 +309,41 @@ func (i *InstallConfig) ToInstallerConfig(env *localenv.LocalEnvironment) (*inst
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &install.Config{
-		Context:       ctx,
-		Cancel:        cancel,
-		EventsC:       make(chan install.Event, 100),
-		AdvertiseAddr: advertiseAddr,
-		Resources:     resources,
-		AppPackage:    appPackage,
-		LocalPackages: env.Packages,
-		LocalApps:     env.Apps,
-		LocalBackend:  env.Backend,
-		Silent:        env.Silent,
-		SiteDomain:    i.SiteDomain,
-		StateDir:      i.ReadStateDir,
-		WriteStateDir: i.WriteStateDir,
-		UserLogFile:   i.UserLogFile,
-		SystemLogFile: i.SystemLogFile,
-		Token:         i.InstallToken,
-		CloudProvider: i.CloudProvider,
-		Flavor:        i.Flavor,
-		Role:          i.Role,
-		SystemDevice:  i.SystemDevice,
-		DockerDevice:  i.DockerDevice,
-		Mounts:        i.Mounts,
-		DNSOverrides:  *dnsOverrides,
-		DNSConfig:     i.DNSConfig,
-		Mode:          i.Mode,
-		PodCIDR:       i.PodCIDR,
-		ServiceCIDR:   i.ServiceCIDR,
-		VxlanPort:     i.VxlanPort,
-		Docker:        i.Docker,
-		Insecure:      i.Insecure,
-		Manual:        i.Manual,
-		ServiceUser:   i.ServiceUser,
-		GCENodeTags:   i.NodeTags,
-		NewProcess:    i.NewProcess,
-		Unattended:    i.Unattended,
+		Context:        ctx,
+		Cancel:         cancel,
+		EventsC:        make(chan install.Event, 100),
+		AdvertiseAddr:  advertiseAddr,
+		Resources:      resources,
+		AppPackage:     appPackage,
+		LocalPackages:  env.Packages,
+		LocalApps:      env.Apps,
+		LocalBackend:   env.Backend,
+		Silent:         env.Silent,
+		SiteDomain:     i.SiteDomain,
+		StateDir:       i.ReadStateDir,
+		WriteStateDir:  i.WriteStateDir,
+		UserLogFile:    i.UserLogFile,
+		SystemLogFile:  i.SystemLogFile,
+		Token:          i.InstallToken,
+		CloudProvider:  i.CloudProvider,
+		Flavor:         i.Flavor,
+		Role:           i.Role,
+		SystemDevice:   i.SystemDevice,
+		DockerDevice:   i.DockerDevice,
+		Mounts:         i.Mounts,
+		DNSOverrides:   *dnsOverrides,
+		DNSConfig:      i.DNSConfig,
+		Mode:           i.Mode,
+		PodCIDR:        i.PodCIDR,
+		ServiceCIDR:    i.ServiceCIDR,
+		VxlanPort:      i.VxlanPort,
+		Docker:         i.Docker,
+		Insecure:       i.Insecure,
+		Manual:         i.Manual,
+		ServiceUser:    i.ServiceUser,
+		GCENodeTags:    i.NodeTags,
+		NewProcess:     i.NewProcess,
+		ExitAfterError: i.ExitAfterError,
 	}, nil
 }
 

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -87,7 +87,7 @@ func startInstall(env *localenv.LocalEnvironment, i InstallConfig) error {
 
 	err = installer.Wait()
 	if utils.IsContextCancelledError(err) {
-		return nil
+		return trace.BadParameter("cancelled")
 	}
 	return trace.Wrap(err)
 }

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -84,7 +84,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.InstallCmd.Force = g.InstallCmd.Flag("force", "Force phase execution").Bool()
 	g.InstallCmd.Resume = g.InstallCmd.Flag("resume", "Resume installation from last failed step").Bool()
 	g.InstallCmd.Manual = g.InstallCmd.Flag("manual", "Manually execute install operation phases").Bool()
-	g.InstallCmd.Unattended = g.InstallCmd.Flag("unattended", "Exits after the operation without waiting for input").Bool()
+	g.InstallCmd.Unattended = g.InstallCmd.Flag("unattended", "Exits after the operation without waiting for input").
+		OverrideDefaultFromEnvar(constants.UnattendedOperationEnvVar).
+		Bool()
 	g.InstallCmd.ServiceUID = g.InstallCmd.Flag("service-uid",
 		fmt.Sprintf("Service user ID for planet. %q user will created and used if none specified", defaults.ServiceUser)).
 		Default(defaults.ServiceUserID).

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -84,8 +84,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.InstallCmd.Force = g.InstallCmd.Flag("force", "Force phase execution").Bool()
 	g.InstallCmd.Resume = g.InstallCmd.Flag("resume", "Resume installation from last failed step").Bool()
 	g.InstallCmd.Manual = g.InstallCmd.Flag("manual", "Manually execute install operation phases").Bool()
-	g.InstallCmd.Unattended = g.InstallCmd.Flag("unattended", "Exits after the operation without waiting for input").
-		OverrideDefaultFromEnvar(constants.UnattendedOperationEnvVar).
+	g.InstallCmd.ExitAfterError = g.InstallCmd.Flag("exit-after-error", "Exit after operation failure without waiting for input").
+		OverrideDefaultFromEnvar(constants.ExitAfterErrorEnvVar).
 		Bool()
 	g.InstallCmd.ServiceUID = g.InstallCmd.Flag("service-uid",
 		fmt.Sprintf("Service user ID for planet. %q user will created and used if none specified", defaults.ServiceUser)).
@@ -118,7 +118,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.JoinCmd.Force = g.JoinCmd.Flag("force", "Force phase execution").Bool()
 	g.JoinCmd.Complete = g.JoinCmd.Flag("complete", "Complete join operation").Bool()
 	g.JoinCmd.OperationID = g.JoinCmd.Flag("operation-id", "ID of the operation that was created via UI").Hidden().String()
-	g.JoinCmd.Unattended = g.JoinCmd.Flag("unattended", "Exits after the operation without waiting for input").Bool()
+	g.JoinCmd.ExitAfterError = g.JoinCmd.Flag("exit-after-error", "Exit after operation failure without waiting for input").
+		OverrideDefaultFromEnvar(constants.ExitAfterErrorEnvVar).
+		Bool()
 
 	g.AutoJoinCmd.CmdClause = g.Command("autojoin", "Use cloud provider data to join a node to existing cluster")
 	g.AutoJoinCmd.ClusterName = g.AutoJoinCmd.Arg("cluster-name", "Cluster name used for discovery").Required().String()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -84,6 +84,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.InstallCmd.Force = g.InstallCmd.Flag("force", "Force phase execution").Bool()
 	g.InstallCmd.Resume = g.InstallCmd.Flag("resume", "Resume installation from last failed step").Bool()
 	g.InstallCmd.Manual = g.InstallCmd.Flag("manual", "Manually execute install operation phases").Bool()
+	g.InstallCmd.Unattended = g.InstallCmd.Flag("unattended", "Exits after the operation without waiting for input").Bool()
 	g.InstallCmd.ServiceUID = g.InstallCmd.Flag("service-uid",
 		fmt.Sprintf("Service user ID for planet. %q user will created and used if none specified", defaults.ServiceUser)).
 		Default(defaults.ServiceUserID).
@@ -115,6 +116,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.JoinCmd.Force = g.JoinCmd.Flag("force", "Force phase execution").Bool()
 	g.JoinCmd.Complete = g.JoinCmd.Flag("complete", "Complete join operation").Bool()
 	g.JoinCmd.OperationID = g.JoinCmd.Flag("operation-id", "ID of the operation that was created via UI").Hidden().String()
+	g.JoinCmd.Unattended = g.JoinCmd.Flag("unattended", "Exits after the operation without waiting for input").Bool()
 
 	g.AutoJoinCmd.CmdClause = g.Command("autojoin", "Use cloud provider data to join a node to existing cluster")
 	g.AutoJoinCmd.ClusterName = g.AutoJoinCmd.Arg("cluster-name", "Cluster name used for discovery").Required().String()


### PR DESCRIPTION
This PR adds a knob to exit a failed installation/join operation necessary in automated environments (i.e. robotest or script-driven installation).

Also fixes an issue with teleport S3 location for `pull-teleport`.

Requires https://github.com/gravitational/gravity.e/pull/3829.
Fixes https://github.com/gravitational/gravity.e/issues/3397.
Fixes https://github.com/gravitational/gravity.e/issues/3790.