### PR TITLE
[5.2] split domain on host/port when parsing docker image reference.

### DIFF
--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -172,7 +172,11 @@ func parseImageNameTag(image string) (name, tag string, err error) {
 	domain := docker.Domain(named)
 	path := strings.Replace(docker.Path(named), "/", "-", -1)
 	if domain != "" {
-		path = fmt.Sprint(domain, "-", path)
+		host, port := utils.SplitHostPort(domain, "")
+		if port != "" {
+			host = fmt.Sprint(host, "-", port)
+		}
+		path = fmt.Sprint(host, "-", path)
 	}
 
 	return path, tag, nil

--- a/lib/app/service/docker_test.go
+++ b/lib/app/service/docker_test.go
@@ -17,46 +17,69 @@ limitations under the License.
 package service
 
 import (
+	"fmt"
+
 	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/loc"
 
 	. "gopkg.in/check.v1"
 )
 
-func (s *VendorSuite) TestParsesImageToNameTag(c *C) {
-	type result struct {
-		name, tag string
-	}
+func (s *VendorSuite) TestGeneratesProperPackageName(c *C) {
 	var testCases = []struct {
-		image   string
-		result  result
-		comment string
+		image        string
+		result       loc.Locator
+		visited      map[string]loc.Locator
+		randomSuffix func(string) string
+		comment      string
 	}{
 		{
 			image:   "foo:5.1.0",
-			result:  result{name: "foo", tag: "5.1.0"},
+			result:  loc.MustParseLocator("gravitational.io/foo:5.1.0"),
 			comment: "image reference w/o repository",
 		},
 		{
 			image:   "repo/foo:1.0.0",
-			result:  result{name: "repo-foo", tag: "1.0.0"},
+			result:  loc.MustParseLocator("gravitational.io/repo-foo:1.0.0"),
 			comment: "image reference with repository",
 		},
 		{
-			image:   "repo/foo:latest",
-			result:  result{name: "repo-foo", tag: "latest"},
-			comment: "literal tag",
+			image:   "repo.io/subrepo/foo:0.0.1",
+			result:  loc.MustParseLocator("gravitational.io/repo.io-subrepo-foo:0.0.1"),
+			comment: "nested repositories",
 		},
 		{
-			image:   "repo.io/subrepo/foo:latest",
-			result:  result{name: "repo.io-subrepo-foo", tag: "latest"},
-			comment: "nested repositories",
+			image:   "repo.io:123/subrepo/foo:0.0.1",
+			result:  loc.MustParseLocator("gravitational.io/repo.io-123-subrepo-foo:0.0.1"),
+			comment: "repository with a port",
+		},
+		{
+			image:  "repo.io:123/subrepo/foo:0.0.1",
+			result: loc.MustParseLocator("foo/bar:0.0.1"),
+			visited: map[string]loc.Locator{
+				"repo.io:123/subrepo/foo:0.0.1": loc.MustParseLocator("foo/bar:0.0.1"),
+			},
+			comment: "uses cached value",
+		},
+		{
+			image:  "planet-master:0.0.1",
+			result: loc.MustParseLocator("gravitational.io/planet-master-qux:0.0.1"),
+			randomSuffix: func(name string) string {
+				return fmt.Sprintf("%v-qux", name)
+			},
+			comment: "avoids collision with legacy name",
 		},
 	}
 
 	for _, testCase := range testCases {
-		name, tag, err := parseImageNameTag(testCase.image)
 		comment := Commentf(testCase.comment)
+		visited := testCase.visited
+		if visited == nil {
+			visited = make(map[string]loc.Locator)
+		}
+		generate := newRuntimePackage(visited, testCase.randomSuffix)
+		runtimePackage, err := generate(testCase.image)
 		c.Assert(err, IsNil, comment)
-		c.Assert(result{name: name, tag: tag}, compare.DeepEquals, testCase.result, comment)
+		c.Assert(*runtimePackage, compare.DeepEquals, testCase.result, comment)
 	}
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -401,7 +401,7 @@ func (v *vendorer) translateRuntimeImages(m *schema.Manifest) error {
 		m.SystemOptions.Dependencies.Runtime.Locator = *runtimePackage
 	}
 	imageToPackage := make(map[string]loc.Locator)
-	newPackageName := newRuntimePackage(imageToPackage)
+	newPackageName := newRuntimePackage(imageToPackage, nil)
 	for i, profile := range m.NodeProfiles {
 		if profile.SystemOptions == nil || profile.SystemOptions.BaseImage == "" {
 			continue
@@ -435,14 +435,16 @@ func (v *vendorer) translateRuntimeImages(m *schema.Manifest) error {
 // newRuntimePackage returns a generator to generate package names.
 // Generated package names are guaranteed to not collide with legacy runtime
 // package names and be unique within a single generator.
-func newRuntimePackage(imageToPackage map[string]loc.Locator) packageNameGeneratorFunc {
+func newRuntimePackage(imageToPackage map[string]loc.Locator, randomSuffix randomSuffix) packageNameGeneratorFunc {
 	generatedNames := make(map[string]struct{})
 	nonUnique := func(name string) bool {
 		_, exists := generatedNames[name]
 		return exists
 	}
-	randomSuffix := func(name string) string {
-		return fmt.Sprintf("%v-%v", name, utilrand.String(4))
+	if randomSuffix == nil {
+		randomSuffix = func(name string) string {
+			return fmt.Sprintf("%v-%v", name, utilrand.String(4))
+		}
 	}
 	var legacyPackages = []string{loc.LegacyPlanetMaster.Name, loc.LegacyPlanetNode.Name}
 	return func(image string) (runtimePackage *loc.Locator, err error) {
@@ -474,6 +476,8 @@ func newRuntimePackage(imageToPackage map[string]loc.Locator) packageNameGenerat
 		return runtimePackage, nil
 	}
 }
+
+type randomSuffix func(string) string
 
 type packageNameGeneratorFunc func(image string) (runtimePackage *loc.Locator, err error)
 

--- a/lib/app/service/vendor_test.go
+++ b/lib/app/service/vendor_test.go
@@ -190,7 +190,7 @@ func (*VendorSuite) TestGeneratesProperPackageNames(c *C) {
 	}
 
 	imageToPackage := make(map[string]loc.Locator)
-	newName := newRuntimePackage(imageToPackage)
+	newName := newRuntimePackage(imageToPackage, nil)
 	generated := make(map[string]struct{})
 	for _, testCase := range testCases {
 		loc, err := newName(testCase.image)


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity.e/issues/3828.