### PR TITLE
[5.2] Revert removal of update triggering from UI

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -13,6 +13,7 @@ LOCAL_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build
 LOCAL_GRAVITY_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build/$(GRAVITY_VERSION)
 
 BBOX = gravity-buildbox:latest
+DOCKER_ARGS ?= --pull
 
 GRAVITY_WEB_APP_DIR ?= $(abspath $(LOCALDIR)/../web)/
 
@@ -555,4 +556,4 @@ buildbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg GRPC_GATEWAY_TAG=$(GRPC_GATEWAY_TAG) \
 		--build-arg VERSION_TAG=$(VERSION_TAG) \
-		--pull --tag $(BBOX) .
+		$(DOCKER_ARGS) --tag $(BBOX) .

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -17,6 +17,7 @@ export ROBOTEST_VERSION=${ROBOTEST_VERSION:-'stable-gce'}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
+export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity
 export DEPLOY_TO=${DEPLOY_TO:-gce}
 export TAG=$(git rev-parse --short HEAD)
 export GCL_PROJECT_ID=${GCL_PROJECT_ID:-"kubeadm-167321"}

--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -86,7 +86,6 @@ func (b *planBuilder) AddBootstrapPhase(plan *storage.OperationPlan) {
 			Package:     &b.Application.Package,
 			Agent:       agent,
 			ServiceUser: &b.ServiceUser,
-			DNSConfig:   &b.DNSConfig,
 		},
 	})
 }

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -243,7 +243,6 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 			Package:     &s.appPackage,
 			Agent:       s.adminAgent,
 			ServiceUser: &s.serviceUser,
-			DNSConfig:   &s.dnsConfig,
 		},
 	}, phase)
 }

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fsm
 
 import (
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 
@@ -156,15 +157,6 @@ func RequireIfPresent(plan *storage.OperationPlan, phaseIDs ...string) []string 
 	return present
 }
 
-func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {
-	// add the phase itself
-	*result = append(*result, phase)
-	// as well as all its subphases and their subphases recursively
-	for i := range phase.Phases {
-		addPhases(&phase.Phases[i], result)
-	}
-}
-
 // GetOperationPlan returns resolved operation plan for the specified operation
 func GetOperationPlan(b storage.Backend, clusterName, operationID string) (*storage.OperationPlan, error) {
 	plan, err := b.GetOperationPlan(clusterName, operationID)
@@ -176,4 +168,22 @@ func GetOperationPlan(b storage.Backend, clusterName, operationID string) (*stor
 		return nil, trace.Wrap(err)
 	}
 	return ResolvePlan(*plan, ch), nil
+}
+
+// OperationKey returns an operation key for the specified operation plan
+func OperationKey(plan storage.OperationPlan) ops.SiteOperationKey {
+	return ops.SiteOperationKey{
+		AccountID:   plan.AccountID,
+		SiteDomain:  plan.ClusterName,
+		OperationID: plan.OperationID,
+	}
+}
+
+func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {
+	// add the phase itself
+	*result = append(*result, phase)
+	// as well as all its subphases and their subphases recursively
+	for i := range phase.Phases {
+		addPhases(&phase.Phases[i], result)
+	}
 }

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -325,7 +325,6 @@ func (i *Installer) GetFSM() (*fsm.FSM, error) {
 		LocalBackend:   i.LocalBackend,
 		Insecure:       i.Insecure,
 		UserLogFile:    i.UserLogFile,
-		DNSConfig:      i.DNSConfig,
 		ReportProgress: true,
 	})
 }

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -77,8 +77,6 @@ type FSMConfig struct {
 	UserLogFile string
 	// ReportProgress controls whether engine should report progress to Operator
 	ReportProgress bool
-	// DNSConfig specifies the DNS configuration to use
-	DNSConfig storage.DNSConfig
 }
 
 // Check validates install FSM config and sets some defaults

--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -63,7 +63,7 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 				config.Operator)
 
 		case strings.HasPrefix(p.Phase.ID, phases.LabelPhase):
-			client, err := httplib.GetUnprivilegedKubeClient(config.DNSConfig.Addr())
+			client, err := httplib.GetUnprivilegedKubeClient(p.Plan.DNSConfig.Addr())
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -73,7 +73,7 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 				client)
 
 		case p.Phase.ID == phases.RBACPhase:
-			client, err := httplib.GetClusterKubeClient(config.DNSConfig.Addr())
+			client, err := httplib.GetClusterKubeClient(p.Plan.DNSConfig.Addr())
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -50,9 +50,6 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 	if p.Phase.Data.Package == nil {
 		return nil, trace.BadParameter("application package is required: %#v", p.Phase.Data)
 	}
-	if p.Phase.Data.DNSConfig == nil {
-		return nil, trace.BadParameter("DNS configuration is required: %#v", p.Phase.Data)
-	}
 
 	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
@@ -94,7 +91,7 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		ExecutorParams:   p,
 		ServiceUser:      *serviceUser,
 		remote:           remote,
-		dnsConfig:        *p.Phase.Data.DNSConfig,
+		dnsConfig:        p.Plan.DNSConfig,
 	}, nil
 }
 

--- a/lib/install/plan.go
+++ b/lib/install/plan.go
@@ -71,6 +71,7 @@ func (i *Installer) GetOperationPlan(cluster ops.Site, op ops.SiteOperation) (*s
 		AccountID:     op.AccountID,
 		ClusterName:   op.SiteDomain,
 		Servers:       append(builder.Masters, builder.Nodes...),
+		DNSConfig:     cluster.DNSConfig,
 	}
 
 	switch i.Mode {

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -254,7 +254,6 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 					Package:     &s.installer.AppPackage,
 					Agent:       s.adminAgent,
 					ServiceUser: serviceUser,
-					DNSConfig:   &s.dnsConfig,
 				},
 			},
 			{
@@ -265,7 +264,6 @@ func (s *PlanSuite) verifyBootstrapPhase(c *check.C, phase storage.OperationPhas
 					Package:     &s.installer.AppPackage,
 					Agent:       s.regularAgent,
 					ServiceUser: serviceUser,
-					DNSConfig:   &s.dnsConfig,
 				},
 			},
 		},

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -60,8 +60,6 @@ type PlanBuilder struct {
 	RegularAgent storage.LoginEntry
 	// ServiceUser is the cluster system user
 	ServiceUser storage.OSUser
-	// DNSConfig specifies the custom cluster DNS configuration
-	DNSConfig storage.DNSConfig
 }
 
 // AddChecksPhase appends preflight checks phase to the provided plan
@@ -109,7 +107,6 @@ func (b *PlanBuilder) AddBootstrapPhase(plan *storage.OperationPlan) {
 				Package:     &b.Application.Package,
 				Agent:       agent,
 				ServiceUser: &b.ServiceUser,
-				DNSConfig:   &b.DNSConfig,
 			},
 			Step: 3,
 		})
@@ -525,7 +522,6 @@ func (i *Installer) GetPlanBuilder(cluster ops.Site, op ops.SiteOperation) (*Pla
 			UID:  strconv.Itoa(i.Config.ServiceUser.UID),
 			GID:  strconv.Itoa(i.Config.ServiceUser.GID),
 		},
-		DNSConfig: cluster.DNSConfig,
 	}, nil
 }
 

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -135,6 +135,7 @@ func newClusterEnvironment(args clusterEnvironmentArgs) (*ClusterEnvironment, er
 		Apps:     apps,
 		Users:    users,
 		StateDir: siteDir,
+		Local:    true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -358,7 +358,7 @@ type SSHSignResponse struct {
 // that does not uses any interfaces
 func (s *SSHSignResponse) ToRaw() (*SSHSignResponseRaw, error) {
 	raw := SSHSignResponseRaw{
-		Cert: s.Cert,
+		Cert:                   s.Cert,
 		TrustedHostAuthorities: make([]json.RawMessage, 0, len(s.TrustedHostAuthorities)),
 	}
 	for i := range s.TrustedHostAuthorities {
@@ -384,7 +384,7 @@ type SSHSignResponseRaw struct {
 // ToNative converts back to request that has all interfaces inside
 func (s *SSHSignResponseRaw) ToNative() (*SSHSignResponse, error) {
 	native := SSHSignResponse{
-		Cert: s.Cert,
+		Cert:                   s.Cert,
 		TrustedHostAuthorities: make([]teleservices.CertAuthority, 0, len(s.TrustedHostAuthorities)),
 	}
 	for i := range s.TrustedHostAuthorities {
@@ -1076,9 +1076,8 @@ type CreateSiteAppUpdateOperationRequest struct {
 	SiteDomain string `json:"site_domain"`
 	// App specifies a new application package in the "locator" form, e.g. gravitational.io/mattermost:1.2.3
 	App string `json:"package"`
-	// Manual specifies whether a manual update mode is requested.
-	// Deprecated.
-	Manual bool `json:"manual"`
+	// StartAgents specifies whether the operation will automatically start the update agents
+	StartAgents bool `json:"start_agents"`
 }
 
 // Check validates this request

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -292,7 +292,7 @@ func (s *site) createUpdateOperation(req ops.CreateSiteAppUpdateOperationRequest
 		Message:    "initializing the operation",
 	})
 
-	if req.Manual {
+	if !req.StartAgents {
 		return key, nil
 	}
 

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -268,15 +268,13 @@ func (s *site) createUpdateOperation(req ops.CreateSiteAppUpdateOperationRequest
 			return
 		}
 
+		log := log.WithField("operation", op.Key())
 		// Fail the operation and reset cluster state.
 		// It is important to complete the operation as subsequent same type operations
 		// will not be able to complete if there's an existing incomplete one
 		errReset := ops.FailOperation(op.Key(), s.service, trace.Unwrap(err).Error())
 		if errReset != nil {
-			log.WithFields(log.Fields{
-				"err":       errReset,
-				"operation": op.Key(),
-			}).Warn("Failed to fail operation.")
+			log.WithError(errReset).Warn("Failed to mark operation as failed.")
 		}
 
 		errReset = s.setSiteState(ops.SiteStateActive)

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -353,7 +353,7 @@ func (s *site) startUpdateAgent(ctx context.Context, opCtx *operationContext, up
 		// extract new gravity version
 		C("rm -rf %s", secretsHostDir).
 		C("mkdir -p %s", secretsHostDir).
-		C("%s package export --file-mask=%o %s %s --ops-url=%s --insecure",
+		C("%s package export --file-mask=%o %s %s --ops-url=%s --insecure --quiet",
 			constants.GravityBin, defaults.SharedExecutableMask,
 			gravityPackage.String(), agentExecPath, defaults.GravityServiceURL).
 		// distribute agents and upgrade process

--- a/lib/rpc/deploy.go
+++ b/lib/rpc/deploy.go
@@ -219,7 +219,7 @@ func deployAgentOnNode(ctx context.Context, req DeployAgentsRequest, node, nodeS
 		runCmd = fmt.Sprintf("%s agent --debug install", gravityHostPath)
 	}
 
-	err = utils.NewSSHCommands(utils.NewSSHRunner(ctx, nodeClient.Client)).
+	err = utils.NewSSHCommands(nodeClient.Client).
 		C("rm -rf %s", secretsHostDir).
 		C("mkdir -p %s", secretsHostDir).
 		WithRetries("%s enter -- --notty %s -- package unpack %s %s --debug --ops-url=%s --insecure",

--- a/lib/rpc/deploy.go
+++ b/lib/rpc/deploy.go
@@ -219,7 +219,7 @@ func deployAgentOnNode(ctx context.Context, req DeployAgentsRequest, node, nodeS
 		runCmd = fmt.Sprintf("%s agent --debug install", gravityHostPath)
 	}
 
-	err = utils.NewSSHCommands(nodeClient.Client).
+	err = utils.NewSSHCommands(utils.NewSSHRunner(ctx, nodeClient.Client)).
 		C("rm -rf %s", secretsHostDir).
 		C("mkdir -p %s", secretsHostDir).
 		WithRetries("%s enter -- --notty %s -- package unpack %s %s --debug --ops-url=%s --insecure",

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -43,6 +43,8 @@ type OperationPlan struct {
 	GravityPackage loc.Locator `json:"gravity_package"`
 	// CreatedAt is the plan creation timestamp
 	CreatedAt time.Time `json:"created_at"`
+	// DNSConfig specifies cluster DNS configuration
+	DNSConfig DNSConfig `json:"dns_config"`
 }
 
 // Check makes sure operation plan is valid
@@ -120,8 +122,6 @@ type OperationPhaseData struct {
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`
 	// Data is arbitrary text data to provide to a phase executor
 	Data string `json:"data,omitempty" yaml:"data,omitempty"`
-	// DNSConfig specifies custom cluster DNS configuration
-	DNSConfig *DNSConfig `json:"dns_config,omitempty" yaml:"dns_config,omitempty"`
 }
 
 // ElectionChange describes changes to make to cluster elections

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -251,21 +251,6 @@ func GetDNSConfig(backend Backend, fallback DNSConfig) (config *DNSConfig, err e
 	return config, nil
 }
 
-// GetClusterDNSConfig returns the DNS configuration from the cluster record.
-// Returns a copy of storage.LegacyDNSConfig if no cluster record is available
-func GetClusterDNSConfig(backend Backend) (*DNSConfig, error) {
-	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-	config := LegacyDNSConfig
-	if cluster != nil && !cluster.DNSConfig.IsEmpty() {
-		config = cluster.DNSConfig
-	}
-
-	return &config, nil
-}
-
 // DeepComparePhases compares the actual phase to the expected phase omitting
 // some insignificant fields like description or UI step number
 func DeepComparePhases(c *check.C, expected, actual OperationPhase) {

--- a/lib/update/phase_app.go
+++ b/lib/update/phase_app.go
@@ -41,12 +41,11 @@ import (
 
 // updatePhaseApp is the executor for the app update phase
 type updatePhaseApp struct {
-	log.FieldLogger
 	phaseApp
 }
 
 // NewUpdatePhaseApp returns a new app phase executor
-func NewUpdatePhaseApp(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase) (*updatePhaseApp, error) {
+func NewUpdatePhaseApp(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase, logger log.FieldLogger) (*updatePhaseApp, error) {
 	cluster, err := c.Operator.GetLocalSite()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -55,8 +54,8 @@ func NewUpdatePhaseApp(c FSMConfig, plan storage.OperationPlan, phase storage.Op
 		return nil, trace.NotFound("no package specified for phase %q", phase.ID)
 	}
 	return &updatePhaseApp{
-		FieldLogger: log.NewEntry(log.New()),
 		phaseApp: phaseApp{
+			FieldLogger:    logger,
 			Apps:           c.Apps,
 			Client:         c.Client,
 			GravityPackage: plan.GravityPackage,
@@ -113,18 +112,17 @@ func (p *updatePhaseApp) createBootstrapResources() error {
 
 // updatePhaseBeforeApp is an executor for application's pre-update hook
 type updatePhaseBeforeApp struct {
-	log.FieldLogger
 	phaseApp
 }
 
 // NewUpdatePhaseBeforeApp returns a new executor for running application pre-update hook
-func NewUpdatePhaseBeforeApp(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase) (*updatePhaseBeforeApp, error) {
+func NewUpdatePhaseBeforeApp(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase, logger log.FieldLogger) (*updatePhaseBeforeApp, error) {
 	if phase.Data.Package == nil {
 		return nil, trace.NotFound("no package specified for phase %q", phase.ID)
 	}
 	return &updatePhaseBeforeApp{
-		FieldLogger: log.NewEntry(log.New()),
 		phaseApp: phaseApp{
+			FieldLogger:    logger,
 			Apps:           c.Apps,
 			Client:         c.Client,
 			GravityPackage: plan.GravityPackage,
@@ -160,6 +158,7 @@ type phaseApp struct {
 	Servers []storage.Server
 	// ServiceUser is the user used for services and system storage
 	ServiceUser storage.OSUser
+	log.FieldLogger
 }
 
 // PreCheck makes sure this phase is being executed on a master node
@@ -187,34 +186,31 @@ func (p *phaseApp) runHooks(ctx context.Context, hooks ...schema.HookType) error
 		_, err := app.CheckHasAppHook(p.Apps, req)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				log.Debugf("%v does not have %v hook.", p.Package, hook)
+				p.Debugf("%v does not have %v hook.", p.Package, hook)
 				continue
 			}
 			return trace.Wrap(err)
 		}
+		p.Infof("Execute %v(%v) hook.", p.Package, hook)
 		reader, writer := io.Pipe()
 		defer writer.Close()
-		go streamHook(hook, reader)
+		go streamHook(hook, reader, p.FieldLogger)
 		_, err = app.StreamAppHook(ctx, p.Apps, req, writer)
 		if err != nil {
-			return trace.Wrap(err, "%v %s hook failed", p.Package, hook)
+			return trace.Wrap(err, "%v(%v) hook failed", p.Package, hook)
 		}
 	}
 	return nil
 }
 
-func streamHook(hook schema.HookType, reader io.ReadCloser) {
+func streamHook(hook schema.HookType, reader io.ReadCloser, logger log.FieldLogger) {
 	defer reader.Close()
 	scanner := bufio.NewScanner(reader)
-	logger := log.WithFields(log.Fields{
-		trace.Component: "hook",
-		"hook":          string(hook),
-	})
 	for scanner.Scan() {
 		logger.Info(scanner.Text())
 	}
 	err := scanner.Err()
-	if err != nil {
-		logger.Warnf("Failed to stream hook logs: %v.", err)
+	if err != nil && err != io.EOF {
+		logger.Warnf("Failed to stream logs for hook %v: %v.", hook, err)
 	}
 }

--- a/lib/update/phase_bootstrap.go
+++ b/lib/update/phase_bootstrap.go
@@ -81,7 +81,7 @@ type updatePhaseBootstrap struct {
 }
 
 // NewUpdatePhaseBootstrap creates a new bootstrap phase executor
-func NewUpdatePhaseBootstrap(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase, remote fsm.Remote) (fsm.PhaseExecutor, error) {
+func NewUpdatePhaseBootstrap(c FSMConfig, plan storage.OperationPlan, phase storage.OperationPhase, remote fsm.Remote, logger log.FieldLogger) (fsm.PhaseExecutor, error) {
 	if phase.Data == nil || phase.Data.Package == nil {
 		return nil, trace.NotFound("no application package specified for phase %v", phase)
 	}
@@ -127,7 +127,7 @@ func NewUpdatePhaseBootstrap(c FSMConfig, plan storage.OperationPlan, phase stor
 		Operation:        *operation,
 		GravityPath:      gravityPath,
 		ServiceUser:      cluster.ServiceUser,
-		FieldLogger:      log.NewEntry(log.New()),
+		FieldLogger:      logger,
 		remote:           remote,
 		runtimePackage:   *runtimePackage,
 		installedRuntime: *installedRuntime,
@@ -203,6 +203,7 @@ func (p *updatePhaseBootstrap) configureNode() error {
 }
 
 func (p *updatePhaseBootstrap) exportGravity(ctx context.Context) error {
+	p.Infof("Export gravity binary to %v.", p.GravityPath)
 	err := utils.CopyWithRetries(ctx, p.GravityPath, func() (io.ReadCloser, error) {
 		_, rc, err := p.Packages.ReadPackage(p.GravityPackage)
 		return rc, trace.Wrap(err)
@@ -223,6 +224,7 @@ func (p *updatePhaseBootstrap) updateDNSConfig() error {
 	}
 
 	err = p.HostLocalBackend.SetDNSConfig(dnsConfig)
+	p.Infof("Update cluster DNS configuration as %v.", dnsConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -230,6 +232,7 @@ func (p *updatePhaseBootstrap) updateDNSConfig() error {
 }
 
 func (p *updatePhaseBootstrap) pullSystemUpdates() error {
+	p.Info("Pull system updates.")
 	out, err := fsm.RunCommand(utils.PlanetCommandArgs(
 		filepath.Join(defaults.GravityUpdateDir, constants.GravityBin),
 		"--quiet", "--insecure", "system", "pull-updates",
@@ -240,11 +243,12 @@ func (p *updatePhaseBootstrap) pullSystemUpdates() error {
 	if err != nil {
 		return trace.Wrap(err, "failed to pull system updates: %s", out)
 	}
-	log.Debugf("Pulled system updates: %s.", out)
+	p.Debugf("Pulled system updates: %s.", out)
 	return nil
 }
 
 func (p *updatePhaseBootstrap) syncPlan() error {
+	p.Info("Sync operation plan.")
 	site, err := p.Backend.GetSite(p.Operation.SiteDomain)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/update/phase_checks.go
+++ b/lib/update/phase_checks.go
@@ -51,6 +51,7 @@ func NewUpdatePhaseChecks(
 	plan storage.OperationPlan,
 	phase storage.OperationPhase,
 	remote fsm.AgentRepository,
+	logger log.FieldLogger,
 ) (*updatePhaseChecks, error) {
 	if phase.Data.Package == nil {
 		return nil, trace.NotFound("no update application package specified for phase %v", phase)
@@ -63,7 +64,7 @@ func NewUpdatePhaseChecks(
 		return nil, trace.Wrap(err)
 	}
 	return &updatePhaseChecks{
-		FieldLogger:      log.NewEntry(log.New()),
+		FieldLogger:      logger,
 		apps:             c.Apps,
 		servers:          plan.Servers,
 		updatePackage:    *phase.Data.Package,
@@ -102,6 +103,7 @@ func (p *updatePhaseChecks) Execute(ctx context.Context) error {
 		dockerConfig.StorageDriver = dockerSchema.StorageDriver
 	}
 
+	p.Infof("Executing preflight checks on %v.", formatServers(p.servers))
 	err = validate(ctx, p.remote, p.servers, installedApp.Manifest, app.Manifest, dockerConfig)
 	return trace.Wrap(err, "failed to validate requirements")
 }

--- a/lib/update/phase_election.go
+++ b/lib/update/phase_election.go
@@ -64,12 +64,8 @@ func NewPhaseElectionChange(
 		return nil, trace.Wrap(err)
 	}
 
-	var dnsConfig storage.DNSConfig
-	if cluster != nil {
-		dnsConfig = cluster.DNSConfig
-	}
-	if dnsConfig.IsEmpty() {
-		dnsConfig = storage.LegacyDNSConfig
+	if cluster.DNSConfig.IsEmpty() {
+		return nil, trace.NotFound("cluster DNS configuration is missing")
 	}
 
 	return &phaseElectionChange{
@@ -78,7 +74,7 @@ func NewPhaseElectionChange(
 		ClusterName:    plan.ClusterName,
 		ElectionChange: *phase.Data.ElectionChange,
 		FieldLogger:    logger,
-		dnsConfig:      dnsConfig,
+		dnsConfig:      cluster.DNSConfig,
 		remote:         remote,
 	}, nil
 }

--- a/lib/update/phase_election.go
+++ b/lib/update/phase_election.go
@@ -53,6 +53,7 @@ func NewPhaseElectionChange(
 	phase storage.OperationPhase,
 	remote fsm.Remote,
 	operator ops.Operator,
+	logger logrus.FieldLogger,
 ) (*phaseElectionChange, error) {
 	if phase.Data == nil || phase.Data.ElectionChange == nil {
 		return nil, trace.BadParameter("no election status specified for phase %q", phase.ID)
@@ -76,13 +77,14 @@ func NewPhaseElectionChange(
 		Server:         *phase.Data.Server,
 		ClusterName:    plan.ClusterName,
 		ElectionChange: *phase.Data.ElectionChange,
-		FieldLogger:    logrus.NewEntry(logrus.New()),
+		FieldLogger:    logger,
 		dnsConfig:      dnsConfig,
 		remote:         remote,
 	}, nil
 }
 
 func (p *phaseElectionChange) waitForMasterMigration(rollback bool) error {
+	p.Info("Wait for new leader election.")
 	err := utils.Retry(defaults.RetryInterval, defaults.RetryAttempts, func() error {
 		leaderAddr, err := utils.ResolveAddr(constants.APIServerDomainName, p.dnsConfig.Addr())
 		if err != nil {

--- a/lib/update/phase_gc.go
+++ b/lib/update/phase_gc.go
@@ -29,14 +29,11 @@ import (
 )
 
 // NewGarbageCollectPhase returns a new executor for the garbage collection phase
-func NewGarbageCollectPhase(plan storage.OperationPlan, phase storage.OperationPhase, remote fsm.Remote) (*phaseGC, error) {
+func NewGarbageCollectPhase(plan storage.OperationPlan, phase storage.OperationPhase, remote fsm.Remote, logger log.FieldLogger) (*phaseGC, error) {
 	return &phaseGC{
-		FieldLogger: log.WithFields(log.Fields{
-			"phase":  phase.ID,
-			"server": phase.Data.Server.AdvertiseIP,
-		}),
-		Server: *phase.Data.Server,
-		remote: remote,
+		FieldLogger: logger,
+		Server:      *phase.Data.Server,
+		remote:      remote,
 	}, nil
 }
 
@@ -45,8 +42,8 @@ func NewGarbageCollectPhase(plan storage.OperationPlan, phase storage.OperationP
 // Clean up tasks include:
 //  * trimming the container journal
 func (r *phaseGC) Execute(ctx context.Context) error {
-	if err := trimJournalFiles(r.remote); err != nil {
-		r.Warnf("Failed to clean up journald journal files: %v.", err)
+	if err := trimJournalFiles(r.remote, r.FieldLogger); err != nil {
+		r.Warnf("Failed to clean up obsolete journal files: %v.", err)
 	}
 	return nil
 }
@@ -66,7 +63,8 @@ func (*phaseGC) PostCheck(context.Context) error {
 	return nil
 }
 
-func trimJournalFiles(remote fsm.Remote) error {
+func trimJournalFiles(remote fsm.Remote, logger log.FieldLogger) error {
+	logger.Info("Gabrage collect obsolete journal files.")
 	commands := [][]string{
 		// Force flush journal buffers and rotate files
 		utils.PlanetCommandArgs(defaults.JournalctlBin, "--flush", "--rotate"),

--- a/lib/update/phase_init.go
+++ b/lib/update/phase_init.go
@@ -101,15 +101,7 @@ func NewUpdatePhaseInit(c FSMConfig, plan storage.OperationPlan, phase storage.O
 		return nil, trace.Wrap(err, "failed to query installed application")
 	}
 
-	dnsConfig := cluster.DNSConfig
-	if dnsConfig.IsEmpty() {
-		existingDNS, err := getExistingDNSConfig(c.HostLocalPackages)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to determine existing cluster DNS configuration")
-		}
-		dnsConfig = *existingDNS
-	}
-	logger.Infof("Existing DNS configuration: %v.", dnsConfig)
+	logger.Infof("Existing DNS configuration: %v.", plan.DNSConfig)
 
 	existingDocker := checks.DockerConfigFromSchemaValue(installedApp.Manifest.SystemDocker())
 	checks.OverrideDockerConfig(&existingDocker, installOperation.InstallExpand.Vars.System.Docker)
@@ -127,7 +119,7 @@ func NewUpdatePhaseInit(c FSMConfig, plan storage.OperationPlan, phase storage.O
 		app:            *app,
 		installedApp:   *installedApp,
 		existingDocker: existingDocker,
-		existingDNS:    dnsConfig,
+		existingDNS:    plan.DNSConfig,
 	}, nil
 }
 

--- a/lib/update/phase_migration_test.go
+++ b/lib/update/phase_migration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 
 	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
 )
 
@@ -50,7 +51,7 @@ func (s *PhaseMigrationSuite) TestMigrateLinks(c *check.C) {
 	phase, err := NewPhaseMigrateLinks(
 		FSMConfig{Backend: s.backend},
 		storage.OperationPlan{ClusterName: cluster.Domain},
-		storage.OperationPhase{})
+		storage.OperationPhase{}, logrus.StandardLogger())
 	c.Assert(err, check.IsNil)
 
 	// insert a few links

--- a/lib/update/plan.go
+++ b/lib/update/plan.go
@@ -72,6 +72,7 @@ func InitOperationPlan(
 
 	dnsConfig := cluster.DNSConfig
 	if dnsConfig.IsEmpty() {
+		log.Info("Detecting DNS configuration.")
 		existingDNS, err := getExistingDNSConfig(localEnv.Packages)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to determine existing cluster DNS configuration")
@@ -273,6 +274,7 @@ func newOperationPlanFromParams(p newPlanParams) (*storage.OperationPlan, error)
 		AccountID:      p.operation.AccountID,
 		ClusterName:    p.operation.SiteDomain,
 		Servers:        p.servers,
+		DNSConfig:      p.dnsConfig,
 		GravityPackage: *gravityPackage,
 	}
 

--- a/lib/update/plan_test.go
+++ b/lib/update/plan_test.go
@@ -106,7 +106,7 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 	resolve(&plan)
 
 	// exercise
-	obtainedPlan, err := newOperationPlan(params)
+	obtainedPlan, err := newOperationPlanFromParams(params)
 	c.Assert(err, check.IsNil)
 	// Reset the capacity so the plans can be compared
 	obtainedPlan.Phases = resetCap(obtainedPlan.Phases)
@@ -145,7 +145,7 @@ func (s *PlanSuite) TestPlanWithoutRuntimeUpdate(c *check.C) {
 	resolve(&plan)
 
 	// exercise
-	obtainedPlan, err := newOperationPlan(params)
+	obtainedPlan, err := newOperationPlanFromParams(params)
 	c.Assert(err, check.IsNil)
 	// Reset the capacity so the plans can be compared
 	obtainedPlan.Phases = resetCap(obtainedPlan.Phases)

--- a/lib/update/utils.go
+++ b/lib/update/utils.go
@@ -17,12 +17,16 @@ limitations under the License.
 package update
 
 import (
+	"archive/tar"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"strconv"
 	"strings"
 
 	appservice "github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/loc"
@@ -123,7 +127,7 @@ func getRuntimePackage(manifest schema.Manifest, profile schema.NodeProfile, clu
 }
 
 func getExistingDNSConfig(packages pack.PackageService) (*storage.DNSConfig, error) {
-	_, configPackage, err := pack.FindRuntimePackageWithConfig(packages)
+	_, configPackage, err := pack.FindAnyRuntimePackageWithConfig(packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -132,21 +136,39 @@ func getExistingDNSConfig(packages pack.PackageService) (*storage.DNSConfig, err
 		return nil, trace.Wrap(err)
 	}
 	defer rc.Close()
-	var runtimeConfig runtimeConfig
-	err = json.NewDecoder(rc).Decode(&runtimeConfig)
+	var configBytes []byte
+	err = archive.TarGlob(tar.NewReader(rc), "", []string{"vars.json"}, func(_ string, r io.Reader) error {
+		configBytes, err = ioutil.ReadAll(r)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return archive.Abort
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	port := defaults.DNSPort
+	var runtimeConfig runtimeConfig
+	if configBytes != nil {
+		err = json.Unmarshal(configBytes, &runtimeConfig)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	dnsPort := defaults.DNSPort
 	if len(runtimeConfig.DNSPort) != 0 {
-		port, err = strconv.Atoi(runtimeConfig.DNSPort)
+		dnsPort, err = strconv.Atoi(runtimeConfig.DNSPort)
 		if err != nil {
 			return nil, trace.Wrap(err, "expected integer value but got %v", runtimeConfig.DNSPort)
 		}
 	}
+	var dnsAddrs []string
+	if runtimeConfig.DNSListenAddr != "" {
+		dnsAddrs = append(dnsAddrs, runtimeConfig.DNSListenAddr)
+	}
 	dnsConfig := &storage.DNSConfig{
-		Addrs: []string{runtimeConfig.DNSListenAddr},
-		Port:  port,
+		Addrs: dnsAddrs,
+		Port:  dnsPort,
 	}
 	if dnsConfig.IsEmpty() {
 		*dnsConfig = storage.LegacyDNSConfig

--- a/lib/update/utils.go
+++ b/lib/update/utils.go
@@ -173,6 +173,7 @@ func getExistingDNSConfig(packages pack.PackageService) (*storage.DNSConfig, err
 	if dnsConfig.IsEmpty() {
 		*dnsConfig = storage.LegacyDNSConfig
 	}
+	logrus.Infof("Detected DNS configuration: %v.", dnsConfig)
 	return dnsConfig, nil
 }
 

--- a/lib/update/utils.go
+++ b/lib/update/utils.go
@@ -17,6 +17,9 @@ limitations under the License.
 package update
 
 import (
+	"fmt"
+	"strings"
+
 	appservice "github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/loc"
@@ -113,4 +116,20 @@ func getRuntimePackage(manifest schema.Manifest, profile schema.NodeProfile, clu
 			profile.Name, clusterRole)
 	}
 	return runtimePackage, nil
+}
+
+func formatServers(servers []storage.Server) string {
+	var formats []string
+	for _, server := range servers {
+		formats = append(formats, formatServer(server))
+	}
+	return strings.Join(formats, ",")
+}
+
+func formatServer(server storage.Server) string {
+	return fmt.Sprintf("node(addr=%v, hostname=%v, role=%v, cluster_role=%v)",
+		server.AdvertiseIP,
+		server.Hostname,
+		server.Role,
+		server.ClusterRole)
 }

--- a/lib/utils/kubectl/kubectl.go
+++ b/lib/utils/kubectl/kubectl.go
@@ -155,7 +155,7 @@ func GetNodesAddr(ctx context.Context) ([]string, error) {
 		`jsonpath={.items[*].status.addresses[?(@.type=="InternalIP")].address}`))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
-	cmd.Stderr = utils.StderrLogger(log.StandardLogger().WithField("cmd", "kubectl get nodes"))
+	cmd.Stderr = utils.NewLoggingWriter(log.WithField("cmd", "kubectl get nodes"))
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/lib/utils/kubectl/kubectl.go
+++ b/lib/utils/kubectl/kubectl.go
@@ -155,7 +155,7 @@ func GetNodesAddr(ctx context.Context) ([]string, error) {
 		`jsonpath={.items[*].status.addresses[?(@.type=="InternalIP")].address}`))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
-	cmd.Stderr = utils.NewLoggingWriter(log.WithField("cmd", "kubectl get nodes"))
+	cmd.Stderr = utils.NewStderrLogger(log.WithField("cmd", "kubectl get nodes"))
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1540,9 +1540,10 @@ func (m *Handler) updateSiteApp(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.Wrap(err)
 	}
 	req := ops.CreateSiteAppUpdateOperationRequest{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p[0].Value,
-		App:        input.Package,
+		AccountID:   context.User.GetAccountID(),
+		SiteDomain:  p[0].Value,
+		App:         input.Package,
+		StartAgents: true,
 	}
 	log.Infof("got site update operation request: %v", req)
 	op, err := context.Operator.CreateSiteAppUpdateOperation(req)

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -493,7 +493,6 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams) err
 		LocalApps:     localApps,
 		LocalBackend:  localEnv.Backend,
 		Insecure:      localEnv.Insecure,
-		DNSConfig:     storage.DNSConfig(localEnv.DNS),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -663,7 +662,6 @@ func rollbackInstallPhase(localEnv *localenv.LocalEnvironment, p rollbackParams)
 		LocalApps:     localApps,
 		LocalBackend:  localEnv.Backend,
 		Insecure:      localEnv.Insecure,
-		DNSConfig:     storage.DNSConfig(localEnv.DNS),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -57,7 +57,7 @@ func initOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) error {
 			" or `gravity upgrade --manual` and retry.", secretsDir)
 	}
 
-	plan, err := update.InitOperationPlan(ctx, updateEnv, clusterEnv)
+	plan, err := update.InitOperationPlan(ctx, localEnv, updateEnv, clusterEnv)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/planet.go
+++ b/tool/gravity/cli/planet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	libstatus "github.com/gravitational/gravity/lib/status"
 	"github.com/gravitational/gravity/lib/storage"
@@ -36,7 +37,7 @@ import (
 // planetEnter is a shortcut that finds installed planet in this cluster
 // and enters it
 func planetEnter(env *localenv.LocalEnvironment, args []string) error {
-	planetPackage, planetConfigPackage, err := findAnyRuntimePackageWithConfig(env.Packages)
+	planetPackage, planetConfigPackage, err := pack.FindAnyRuntimePackageWithConfig(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -52,7 +53,7 @@ func planetShell(env *localenv.LocalEnvironment) error {
 
 // planetExec executes a command within a namespace of a planet container
 func planetExec(env *localenv.LocalEnvironment, tty bool, stdin bool, cmd string, extraArgs []string) error {
-	planetPackage, planetConfigPackage, err := findAnyRuntimePackageWithConfig(env.Packages)
+	planetPackage, planetConfigPackage, err := pack.FindAnyRuntimePackageWithConfig(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -70,7 +71,7 @@ func planetExec(env *localenv.LocalEnvironment, tty bool, stdin bool, cmd string
 }
 
 func getPlanetStatus(env *localenv.LocalEnvironment, args []string) error {
-	planetPackage, planetConfigPackage, err := findAnyRuntimePackageWithConfig(env.Packages)
+	planetPackage, planetConfigPackage, err := pack.FindAnyRuntimePackageWithConfig(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -97,7 +98,7 @@ func getPlanetStatus(env *localenv.LocalEnvironment, args []string) error {
 
 // planetVersion returns version of the currently installed planet
 func planetVersion(env *localenv.LocalEnvironment) (*semver.Version, error) {
-	locator, err := findAnyRuntimePackage(env.Packages)
+	locator, err := pack.FindAnyRuntimePackage(env.Packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -257,7 +257,7 @@ func deployUpdateAgents(ctx context.Context, localEnv, updateEnv *localenv.Local
 
 	// Operation plan initialization requires access to TLS RPC credentials
 	// generated above
-	plan, err := update.InitOperationPlan(ctx, updateEnv, req.clusterEnv)
+	plan, err := update.InitOperationPlan(ctx, localEnv, updateEnv, req.clusterEnv)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -231,13 +231,13 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	defer localEnv.Close()
 
 	// create an environment used during upgrades
-	var upgradeEnv *localenv.LocalEnvironment
+	var updateEnv *localenv.LocalEnvironment
 	if g.isUpgradeCommand(cmd) {
-		upgradeEnv, err = g.UpgradeEnv()
+		updateEnv, err = g.UpgradeEnv()
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer upgradeEnv.Close()
+		defer updateEnv.Close()
 	}
 
 	// create an environment where join-specific data is stored
@@ -314,7 +314,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return updateCheck(localEnv, *g.UpdateCheckCmd.App)
 	case g.UpdateTriggerCmd.FullCommand():
 		return updateTrigger(localEnv,
-			upgradeEnv,
+			updateEnv,
 			*g.UpdateTriggerCmd.App,
 			*g.UpdateTriggerCmd.Manual)
 	case g.UpgradeCmd.FullCommand():
@@ -322,7 +322,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.UpgradeCmd.Phase = fsm.RootPhase
 		}
 		if *g.UpgradeCmd.Phase != "" {
-			return executeUpgradePhase(localEnv, upgradeEnv,
+			return executeUpgradePhase(localEnv, updateEnv,
 				upgradePhaseParams{
 					phaseID:          *g.UpgradeCmd.Phase,
 					force:            *g.UpgradeCmd.Force,
@@ -331,15 +331,15 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 				})
 		}
 		if *g.UpgradeCmd.Complete {
-			return completeUpgrade(localEnv, upgradeEnv)
+			return completeUpgrade(localEnv, updateEnv)
 		}
 		return updateTrigger(localEnv,
-			upgradeEnv,
+			updateEnv,
 			*g.UpgradeCmd.App,
 			*g.UpgradeCmd.Manual)
 	case g.RollbackCmd.FullCommand():
 		return rollbackOperationPhase(localEnv,
-			upgradeEnv,
+			updateEnv,
 			joinEnv,
 			rollbackParams{
 				phaseID:          *g.RollbackCmd.Phase,
@@ -349,12 +349,12 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			})
 	case g.PlanCmd.FullCommand():
 		if *g.PlanCmd.Init {
-			return initOperationPlan(localEnv, upgradeEnv)
+			return initOperationPlan(localEnv, updateEnv)
 		}
 		if *g.PlanCmd.Sync {
-			return syncOperationPlan(localEnv, upgradeEnv)
+			return syncOperationPlan(localEnv, updateEnv)
 		}
-		return displayOperationPlan(localEnv, upgradeEnv, joinEnv, *g.PlanCmd.OperationID, *g.PlanCmd.Output)
+		return displayOperationPlan(localEnv, updateEnv, joinEnv, *g.PlanCmd.OperationID, *g.PlanCmd.Output)
 	case g.LeaveCmd.FullCommand():
 		return leave(localEnv, leaveConfig{
 			force:     *g.LeaveCmd.Force,
@@ -736,11 +736,11 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.ResourceGetCmd.Format,
 			*g.ResourceGetCmd.User)
 	case g.RPCAgentDeployCmd.FullCommand():
-		return rpcAgentDeploy(localEnv, *g.RPCAgentDeployCmd.Args)
+		return rpcAgentDeploy(localEnv, updateEnv, *g.RPCAgentDeployCmd.Args)
 	case g.RPCAgentInstallCmd.FullCommand():
 		return rpcAgentInstall(localEnv, *g.RPCAgentInstallCmd.Args)
 	case g.RPCAgentRunCmd.FullCommand():
-		return rpcAgentRun(localEnv, upgradeEnv,
+		return rpcAgentRun(localEnv, updateEnv,
 			*g.RPCAgentRunCmd.Args)
 	case g.RPCAgentShutdownCmd.FullCommand():
 		return rpcAgentShutdown(localEnv)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -50,7 +50,7 @@ func updateCheck(env *localenv.LocalEnvironment, appPackage string) error {
 
 func updateTrigger(
 	localEnv *localenv.LocalEnvironment,
-	upgradeEnv *localenv.LocalEnvironment,
+	updateEnv *localenv.LocalEnvironment,
 	appPackage string,
 	manual bool,
 ) error {
@@ -132,7 +132,7 @@ func updateTrigger(
 	}
 
 	ctx := context.TODO()
-	err = deployUpdateAgents(ctx, localEnv, upgradeEnv, req)
+	err = deployUpdateAgents(ctx, localEnv, updateEnv, req)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -93,6 +93,7 @@ func updateTrigger(
 		AccountID:  cluster.AccountID,
 		SiteDomain: cluster.Domain,
 		App:        app.Package.String(),
+		Manual:     true,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -93,7 +93,6 @@ func updateTrigger(
 		AccountID:  cluster.AccountID,
 		SiteDomain: cluster.Domain,
 		App:        app.Package.String(),
-		Manual:     true,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -138,6 +138,8 @@ func (g *Application) isUpgradeCommand(cmd string) bool {
 		return true
 	case g.RPCAgentRunCmd.FullCommand():
 		return len(*g.RPCAgentRunCmd.Args) > 0
+	case g.RPCAgentDeployCmd.FullCommand():
+		return len(*g.RPCAgentDeployCmd.Args) > 0
 	}
 	return false
 }


### PR DESCRIPTION
This PR reverts the removal of code that triggers update from UI. I accidentally removed it when working on another issue thinking it would not be needed.

I also found a couple of issues in update when it was triggered from UI:
  - set of remote command executed to prepare and spawn the update engine would not create the agent directory (this was synced from lib/rpc/deploy.go)
  - `agent deploy upgrade` command would erroneously use the last (unfinished) update operation from local backend as the backend sync was missing

Additionally, this adds proper logging to update operation (like install) using the `fms.Logger`.