### PR TITLE
[5.3.x] Fix panic in upgrade complete.

### DIFF
--- a/tool/gravity/cli/upgrade.go
+++ b/tool/gravity/cli/upgrade.go
@@ -142,6 +142,9 @@ func completeUpgrade(localEnv, updateEnv *localenv.LocalEnvironment) error {
 			Packages:        clusterEnv.Packages,
 			ClusterPackages: clusterEnv.ClusterPackages,
 			Apps:            clusterEnv.Apps,
+			Client:          clusterEnv.Client,
+			Operator:        clusterEnv.Operator,
+			Users:           clusterEnv.Users,
 			LocalBackend:    updateEnv.Backend,
 			Remote:          runner,
 		})


### PR DESCRIPTION
Backport https://github.com/gravitational/gravity/pull/151.