### PR TITLE
fixed old link in quickstart

### DIFF
--- a/docs/5.x/quickstart.md
+++ b/docs/5.x/quickstart.md
@@ -20,7 +20,7 @@ Gravity system.
 
 
 Gravity is a Linux-based toolkit. By default it supports 64-bit versions of the
-following Linux distributions as [specified here](/pack/#distributions)
+following Linux distributions as [specified here](/requirements/#distributions)
 
 If you have a need to support a Linux distribution not listed above,
 Gravitational offers Implementation Services that may be able to assist you.


### PR DESCRIPTION
We were linking to an old URL for the list of linux distros supported.