### PR TITLE
Update docs on `runtimeenvironment` resource, 'gravity plan'

### DIFF
--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -9,7 +9,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 5.5.0-alpha.6 | No  | January, 15th 2019   | -                    | 1.12.3             | 3.0.1            |
 | 5.4.2         | No  | January, 8th 2019    | -                    | 1.13.0             | 2.4.10           |
-| 5.3.7         | No  | January, 17th 2019    | -                    | 1.12.3             | 2.4.10           |
+| 5.3.8         | No  | January, 25th 2019    | -                    | 1.12.3             | 2.4.10           |
 | 5.2.5         | Yes | January, 8th 2019    | October, 15th, 2019  | 1.11.5             | 2.4.10           |
 | 5.0.28        | Yes | January, 7th 2019    | April, 13th 2019     | 1.9.12-gravitational | 2.4.10         |
 | 4.68.0        | Yes | January, 17th 2019   | November, 16th 2018  | 1.7.18-gravitational | 2.3.5          |
@@ -70,6 +70,12 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 !!! warning
     Teleport 2.4.10 includes fixes for a security vulnerability. Please see
     [Teleport Announcements](https://gravitational.zendesk.com/hc/en-us/articles/360015185614-Teleport-3-1-2-3-0-3-2-7-7-2-6-10) for more information.
+
+### 5.3.8
+
+#### Improvements
+
+* Add support for creating Gravity resources during install.
 
 ### 5.3.7
 

--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -71,6 +71,12 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     Teleport 2.4.10 includes fixes for a security vulnerability. Please see
     [Teleport Announcements](https://gravitational.zendesk.com/hc/en-us/articles/360015185614-Teleport-3-1-2-3-0-3-2-7-7-2-6-10) for more information.
 
+### 5.3.7
+
+#### Improvements
+
+* New resource type `runtime_environment`. See [Configuring Runtime Environment Variables](/cluster#configuring-runtime-environment-variables) for details.
+
 ### 5.3.6
 
 #### Bugfixes

--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -81,7 +81,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 #### Improvements
 
-* New resource type `runtime_environment`. See [Configuring Runtime Environment Variables](/cluster#configuring-runtime-environment-variables) for details.
+* New resource type `runtimeenvironment`. See [Configuring Runtime Environment Variables](/cluster#configuring-runtime-environment-variables) for details.
 
 ### 5.3.6
 

--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Releases
 
-Every major gravity version `x.0.0` has it's long term support release, e.g. for `3.0.0` version
+Every major Gravity version `x.0.0` has it's long term support release, e.g. for `3.0.0` version
 LTS starts with `3.51.0` with minor backwards compatible changes added over time until the end of support cycle.
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |

--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -9,7 +9,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 5.5.0-alpha.6 | No  | January, 15th 2019   | -                    | 1.12.3             | 3.0.1            |
 | 5.4.2         | No  | January, 8th 2019    | -                    | 1.13.0             | 2.4.10           |
-| 5.3.6         | No  | January, 8th 2019    | -                    | 1.12.3             | 2.4.10           |
+| 5.3.7         | No  | January, 17th 2019    | -                    | 1.12.3             | 2.4.10           |
 | 5.2.5         | Yes | January, 8th 2019    | October, 15th, 2019  | 1.11.5             | 2.4.10           |
 | 5.0.28        | Yes | January, 7th 2019    | April, 13th 2019     | 1.9.12-gravitational | 2.4.10         |
 | 4.68.0        | Yes | January, 17th 2019   | November, 16th 2018  | 1.7.18-gravitational | 2.3.5          |

--- a/docs/5.x/cli.md
+++ b/docs/5.x/cli.md
@@ -23,7 +23,7 @@ The typical Gravity workflow is as follows:
 `tele` is the Gravity CLI client and can run on macOS and Linux. By using `tele` on your laptop you can:
 
 * Package Kubernetes applications into self-installing tarballs ("Application Bundles").
-* Publish Applications Bundles into the Ops Center.
+* Publish Application Bundles into the Ops Center.
 * Manage the Gravity Clusters in the Ops Center.
 
 See more details in [Packaging & Deployment](pack.md) section.
@@ -37,7 +37,7 @@ To achieve this, `tsh` uses the Ops Center as an "SSH bastion" or "jump host".
 The `tsh` tool is a part of Gravitational Teleport, an [open source SSH server and
 client](https://gravitational.com/teleport) developed and supported by
 Gravitational. Teleport can be used outside of Gravity, but the supplied `tsh`
-client is tighly integrated with other Gravity tools, for example `tele login`.
+client is tightly integrated with other Gravity tools, for example `tele login`.
 
 See more details in [Remote Management](manage.md) section
 

--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -1234,7 +1234,7 @@ Resource Name             | Resource Description
 `alert`                   | cluster monitoring alert
 `alerttarget`             | cluster monitoring alert target
 `smtp`                    | cluster monitoring SMTP configuration
-`runtime_environment`     | cluster runtime environment variables
+`runtimeenvironment`     | cluster runtime environment variables
 
 ### Configuring OpenID Connect
 
@@ -1979,11 +1979,11 @@ environment (set up during installation or update).
 If you need to make changes to the runtime environment, i.e. introduce new environment variables
 like `HTTP_PROXY`, this resource will allow you to do that.
 
-To add a new environment variable, `HTTP_PROXY`, create the file with following contents:
+To add a new environment variable, `HTTP_PROXY`, create a file with following contents:
 
 [envars.yaml]
 ```yaml
-kind: runtime_environment
+kind: runtimeenvironment
 version: v1
 spec:
   HTTP_PROXY: "example.com:8001"
@@ -2026,7 +2026,7 @@ See [Managing an Ongoing Operation](/cluster/#managing-an-ongoing-operation) for
 To view the currently configured runtime environment variables:
 
 ```bash
-$ gravity resource get runtime_environment
+$ gravity resource get runtimeenvironment
 Environment
 -----------
 HTTP_PROXY=example.com:8081
@@ -2035,7 +2035,7 @@ HTTP_PROXY=example.com:8081
 To remove the configured runtime environment variables, run:
 
 ```bash
-$ gravity resource rm runtime_environment
+$ gravity resource rm runtimeenvironment
 ```
 
 !!! warning

--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -99,8 +99,8 @@ The full list of `gravity` commands:
 |-----------|--------------------------------------------------------------------|
 | status    | show the status of the cluster and the application running in it   |
 | update    | manage application updates on a Gravity Cluster                    |
-| upgrade   | manage the application upgrade operation for a Gravity Cluster     |
-| plan      | manage (active) operation plan                                     |
+| upgrade   | manage the cluster upgrade operation for a Gravity Cluster         |
+| plan      | manage operation plan                                              |
 | rollback  | roll back the upgrade operation for a Gravity Cluster              |
 | join      | add a new node to the cluster                                      |
 | autojoin  | join the cluster using cloud provider for discovery                |
@@ -616,7 +616,7 @@ Phase                    Description                                            
 
 The command is aliased as `gravity plan display`.
 The plan lists all steps, top to bottom, in the order in which they will be executed.
-Each step (phase), has a state which explains whether it has already ran or whether it failed.
+Each step (phase), has a state which explains whether it has already run or whether it failed.
 Also, steps can explicitly or implicitly depend on other steps.
 The commands will make sure a particular phase cannot be executed before its requirements have not run.
 
@@ -1973,7 +1973,7 @@ See (Kapacitor Integration)[/monitoring/#kapacitor-integration] about details on
 
 ### Configuring Runtime Environment Variables
 
-As you already know, in a Gravity cluster, each node is running a runtime container that hosts Kubernetes.
+In a Gravity cluster, each node is running a runtime container that hosts Kubernetes.
 All services (including Kubernetes native services like API server or kubelet) execute with the predefined
 environment (set up during installation or update).
 If you need to make changes to the runtime environment post-install or post-update - i.e. introduce new environment variables
@@ -1986,7 +1986,7 @@ To add a new environment variable, `HTTP_PROXY`, create the file with following 
 kind: runtime_environment
 version: v1
 spec:
-  "HTTP_PROXY": "example.com:8001"
+  HTTP_PROXY: "example.com:8001"
 ```
 
 and then create the resource with:
@@ -2022,7 +2022,7 @@ To view the currently configured runtime environment variables:
 $ gravity resource get runtime_environment
 Environment
 -----------
-HTTP_PROXY=example.con:8081
+HTTP_PROXY=example.com:8081
 ```
 
 To remove the configured runtime environment variables, run:

--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -1976,7 +1976,7 @@ See (Kapacitor Integration)[/monitoring/#kapacitor-integration] about details on
 In a Gravity cluster, each node is running a runtime container that hosts Kubernetes.
 All services (including Kubernetes native services like API server or kubelet) execute with the predefined
 environment (set up during installation or update).
-If you need to make changes to the runtime environment post-install or post-update - i.e. introduce new environment variables
+If you need to make changes to the runtime environment, i.e. introduce new environment variables
 like `HTTP_PROXY`, this resource will allow you to do that.
 
 To add a new environment variable, `HTTP_PROXY`, create the file with following contents:
@@ -1989,7 +1989,14 @@ spec:
   HTTP_PROXY: "example.com:8001"
 ```
 
-and then create the resource with:
+To install a cluster with the new runtime environment, specify the resources file as an argument
+to the `install` command:
+
+```bsh
+$ sudo gravity install --cluster=<cluster-name> --config=envars.yaml
+```
+
+On an installed cluster, create the resource with:
 
 ```bash
 $ sudo gravity resource create -f envars.yaml

--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -641,7 +641,7 @@ $ sudo gravity plan execute --phase=/masters
 
 will execute all steps of the `/masters` node in the order listed.
 
-Sometimes it is necessary to force execution of a particular step although it has already ran.
+Sometimes it is necessary to force execution of a particular step although it has already run.
 To do this, add `--force` flag to the command line:
 
 ```bash

--- a/docs/5.x/guides.md
+++ b/docs/5.x/guides.md
@@ -5,7 +5,7 @@ this technology, and we've been blogging about it along the way.
 
 ## Troubleshooting
 
-* [Troubleshooting Kuberentes Networking](https://gravitational.com/blog/troubleshooting-kubernetes-networking/)
+* [Troubleshooting Kubernetes Networking](https://gravitational.com/blog/troubleshooting-kubernetes-networking/)
   we go over some of the networking problems we have encountered in the wild
   and offers easy ways to troubleshoot/discover them. Here we offer some advice
   on how to avoid the failures and achieve more robust deployments.

--- a/docs/5.x/installation.md
+++ b/docs/5.x/installation.md
@@ -107,7 +107,7 @@ Flag      | Description
 `--cluster` | _(Optional)_ Name of the cluster. Auto-generated if not set.
 `--cloud-provider` | _(Optional)_ Enable cloud provider integration: `generic` (no cloud provider integration), `aws` or `gce`. Autodetected if not set.
 `--flavor` | _(Optional)_ Application flavor. See [Application Manifest](pack/#application-manifest) for details.
-`--config` | _(Optional)_ File with Kubernetes resources to create in the cluster during installation.
+`--config` | _(Optional)_ File with Kubernetes/Gravity resources to create in the cluster during installation.
 `--pod-network-cidr` | _(Optional)_ CIDR range Kubernetes will be allocating node subnets and pod IPs from. Must be a minimum of /16 so Kubernetes is able to allocate /24 to each node. Defaults to `10.244.0.0/16`.
 `--service-cidr` | _(Optional)_ CIDR range Kubernetes will be allocating service IPs from. Defaults to `10.100.0.0/16`.
 `--wizard` | _(Optional)_ Start the installation wizard.

--- a/docs/5.x/installation.md
+++ b/docs/5.x/installation.md
@@ -242,7 +242,7 @@ overlay network to work properly.
 * Instances must be assigned a [network tag](https://cloud.google.com/vpc/docs/add-remove-network-tags)
 matching the name of the cluster. It is required to ensure that created load
 balancers discover proper instances.
-* Cloud API access scopes must include RW permissions for Compute Engine.
+* Cloud API access scopes must include read/write permissions for Compute Engine.
 
 Once the nodes have been properly configured, copy the installer tarball and
 launch installation as described above:

--- a/docs/5.x/instance.md
+++ b/docs/5.x/instance.md
@@ -4,7 +4,7 @@
 
 ### Create instance
 
-Choose debian image from community images:
+Choose a debian image from community images:
 
 ![deploy](images/instance.png)
 
@@ -37,7 +37,7 @@ Create DNS entry and set it up to the elastic IP
 
 ### Manual prep
 
-If everythign is OK, you should be able to log in:
+If everything is OK, you should be able to log in:
 
 ssh -i ~/.ssh/ops.pem admin@<instance-ip>
 
@@ -104,7 +104,7 @@ git clone git@github.com:gravitational/ops.git
 * Launch provisioning script:
 
 You will be asked to enter GPG password to decrypt secrets in github.
-The password to decrypt GPG keys is in lastpass ("GPG Provisioning Key)", so get it before launching provisioning script.
+The password to decrypt GPG keys is in LastPass ("GPG Provisioning Key)", so get it before launching provisioning script.
 
 ```bsh
 cd $GOPATH/src/github.com/gravitational/gravity/deploy
@@ -118,7 +118,7 @@ Open:
 
 https://console.developers.google.com/apis/credentials?project=teleport-1263&authuser=1
 
-Add a new OIDC hook for new opscenter
+Add a new OIDC hook for the new Ops Center
 
 ![deploy](images/oidc.png)
 

--- a/docs/5.x/manage.md
+++ b/docs/5.x/manage.md
@@ -70,7 +70,7 @@ To provision a new Gravity Cluster on AWS:
 
 1. Declare the Cluster Spec in a YAML file, for example `cluster.yaml`
 2. Execute `$ tele create cluster.yaml`
-3. Optional: provisioning of a cluster can be customzied with user-supplied
+3. Optional: provisioning of a cluster can be customized with user-supplied
    scripts based on tools like [Terraform](https://www.terraform.io/) or
    [Cloud Formation](https://aws.amazon.com/cloudformation/).
 
@@ -187,7 +187,7 @@ either in a separate YAML file as shown above, or inline.
 
 **Hook Parameters**
 
-All provisioning hooks implemented as Kubernetes jobs and their parameters are passed either as an environment
+All provisioning hooks are implemented as Kubernetes jobs and their parameters are passed either as an environment
 variables (env) or as a Kubernetes secret mounted as a file.
 
 The following parameters are common for all cloud providers:

--- a/docs/5.x/monitoring.md
+++ b/docs/5.x/monitoring.md
@@ -64,7 +64,7 @@ create a custom dashboard, which can then be exported.
 
 ## Metrics collection
 
-All default metrics collected by heapster go into the `k8s` database in InfluxDB. All other applications that collect
+All default metrics collected by Heapster go into the `k8s` database in InfluxDB. All other applications that collect
 metrics should submit them into the same database in order for proper retention policies to be enforced.
 
 ## Retention policies
@@ -76,7 +76,7 @@ By default InfluxDB has 3 pre-configured retention policies:
 * long = 52w
 
 The `default` retention policy is supposed to store high-precision metrics (for example, all default metrics collected
-by heapster with 10s interval). The `default` policy is default for `k8s` database which means that metrics that do not
+by Heapster with 10s interval). The `default` policy is default for `k8s` database which means that metrics that do not
 specify retention policy explicitly go in there. The other two policies - `medium` and `long` are intended to store
 metric rollups and should not be used directly.
 
@@ -245,11 +245,11 @@ Following table shows the alerts Gravity ships with by default:
 | Filesystem | High inode usage | Triggers a warning, when > 90% used, with > 95% used, triggers a critical error |
 | System | Uptime | Triggers a warning when a node's uptime is less than 5min |
 | System | Kernel parameters | Triggers an error if a parameter is not set. See [value matrix](/requirements/#kernel-module-matrix) for details. |
-| Etcd | Etcd instance health | Triggers an error when an etcd master is down longer than 5min |
+| Etcd | Etcd instance health | Triggers an error when an Etcd master is down longer than 5min |
 | Etcd | Etcd latency check | Triggers a warning, when follower <-> leader latency exceeds 500ms, then an error when it exceeds 1s over a period of 1min |
 | Docker | Docker daemon health | Triggers an error when docker daemon is down |
 | InfluxDB | InfluxDB instance health | Triggers an error when InfluxDB is inaccessible |
 | Kubernetes | Kubernetes node readiness | Triggers an error when the node is not ready |
 
-Kapacitor will also trigger an email for each of the events listed above if stmp resource has been
+Kapacitor will also trigger an email for each of the events listed above if SMTP resource has been
 configured (see [configuration](/monitoring/#configuration) for details).

--- a/docs/5.x/opscenter.md
+++ b/docs/5.x/opscenter.md
@@ -73,9 +73,9 @@ for information on how to configure Ops Center management endpoints.
 
 ## Upgrading Ops Center
 
-Log into a root terminal on the OpsCenter server.
+Log into a root terminal on the Ops Center server.
 
-Update the tele binary:
+Update the `tele` binary:
 
 ```bsh
 $ curl -LO https://get.gravitational.io/telekube/bin/{VERSION}/linux/x86_64/tele

--- a/docs/5.x/opscenter.md
+++ b/docs/5.x/opscenter.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The Gravity Ops Center is a multi-cluster control plane available in the Enterprise version of Gravity. It reduces the operational overhead of managing multiple Gravity Clusters and Applications Bundles by allowing users to:
+The Gravity Ops Center is a multi-cluster control plane available in the Enterprise version of Gravity. It reduces the operational overhead of managing multiple Gravity Clusters and Application Bundles by allowing users to:
 
 * Publish Application Bundles and manage their versions.
 * Download and install Application Bundles, i.e. quickly creating Kubernetes clusters.

--- a/docs/5.x/overview.md
+++ b/docs/5.x/overview.md
@@ -26,7 +26,7 @@ There are two primary use cases for Gravity:
 1. **On-Premise Deployments of K8s Applications:** Software vendors (including
    SaaS applications) often need to deploy and remotely update complex
    software in private data centers or public cloud accounts, like AWS, owned
-   by their customers.  
+   by their customers.
 
 2. **Reducing Operational Overhead:** Ops teams supporting many distributed
    product teams are often tasked with providing Kubernetes-as-a-Service 
@@ -37,7 +37,7 @@ There are two primary use cases for Gravity:
 For these use cases, Gravity is used to create an Application Bundle that includes the Kubernetes binaries,
 their dependencies, a private Docker registry for autonomous operation, a
 monitoring system and an SSH bastion for remotely managing the cluster either
-via simple SSH or via Kubernetes API. These components are customizeable by the user and additional componenets may be included.
+via simple SSH or via Kubernetes API. These components are customizable by the user and additional components may be included.
 
 In other words, a Gravity Application Bundle is a _self-contained, downloadable
 Kubernetes appliance_ which enables true application portability across any

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -15,7 +15,7 @@ Gravity works with Kubernetes applications. This means the following prerequisit
 
 ## Getting Started
 
-Any Linux or macOS laptop can be used to package and publish Kubernetes
+Any Linux or MacOS laptop can be used to package and publish Kubernetes
 applications using Gravity. To get started, you need to download and
 install the Gravity SDK tools:
 
@@ -128,7 +128,7 @@ that do not depend on the host OS. Containerized builds are also easier to autom
 
 The example below builds a Docker image called `tele-buildbox`. This image will contain `tele` tool and can be used to create Gravity packages.
 
-#### Build Docker image with Tele
+#### Build Docker Image With `tele`
 
 First, build docker image `tele-buildbox` with `tele` inside:
 
@@ -165,9 +165,9 @@ tele push ${OPS_URL}
 
 To run this build under Docker:
 
-* Expose a OPS_TOKEN and TELE_FLAGS environment variables
+* Expose a `OPS_TOKEN` and `TELE_FLAGS` environment variables
 * Use host networking
-* Expose the Docker socket into the container to allow tele to pull container images referenced in the manifest
+* Expose the Docker socket into the container to allow `tele` to pull container images referenced in the manifest
 
 The script below assumes that `build.sh` is located in the same working directory as the application:
 
@@ -244,17 +244,17 @@ Gravity was designed with the goal of being compatible with existing, standard
 Kubernetes applications. The Application Manifest is _the only Gravity-specific artifact_ you
 will have to create and maintain.
 
-The file format was designed to mimic a Kubernete
+The file format was designed to mimic a Kubernetes
 resource as much as possible and several Kubernetes concepts are used
 for efficiency:
 
-1. Kubernetes [Config Maps](http://kubernetes.io/docs/user-guide/configmap/)
+1. Kubernetes [ConfigMaps](http://kubernetes.io/docs/user-guide/configmap/)
    are used to manage the application configuration.
 
 2. The custom Installation Wizard steps are implemented as regular
    [Kubernetes Services](http://kubernetes.io/docs/user-guide/services/).
 
-3. Application lifecycle hooks like _install_, _uninstall_ or _update_ are implemented as
+3. Application life cycle hooks like _install_, _uninstall_ or _update_ are implemented as
    [Kubernetes Jobs](http://kubernetes.io/docs/user-guide/jobs/).
 
 Additionally, the Application Manifest is designed to be as small as possible in an effort to promote
@@ -648,7 +648,7 @@ specifying OS distribution requirements for a node profile.
 
 ## Application Hooks
 
-"Application Hooks" are Kubernetes jobs that run at different points in the application lifecycle or in
+"Application Hooks" are Kubernetes jobs that run at different points in the application life cycle or in
 response to certain events happening in the cluster.
 
 Each hook job has access to the "Application Resources" which are mounted under
@@ -802,7 +802,7 @@ correct image references.
 The Gravity graphical installer supports plugging in custom screens after the main
 installation phase (such as installing Kubernetes and system dependencies) has successfully completed.
 
-A "Custom Installation Screen" is just a web application running inside the deployed Kuberneted cluster
+A "Custom Installation Screen" is just a web application running inside the deployed Kubernetes cluster
 and reachable via a Kubernetes service. Enabling a Custom Installation Screen allows the user to perform
 actions specific to an Gravity Cluster upon successful install (for example, configuring an application or
 launch a database migration).
@@ -813,7 +813,7 @@ the user to that endpoint after the installation. Bandwagon presents users with 
 can enter login and password to provision a local Gravity Cluster user and choose whether to enable or disable
 remote support.
 
-Bandwagon is [open source](https://github.com/gravitational/bandwagon) on Github and can be used as an
+Bandwagon is [open source](https://github.com/gravitational/bandwagon) on GitHub and can be used as an
 example of how to implement your own custom installer screen.
 
 To enable Bandwagon, add this to your Application Manifest:
@@ -838,7 +838,7 @@ installer:
 
 ## Service User
 Gravity uses a special user for running system services inside the environment container called `planet`.
-Historically, this user has had a hardcoded UID `1000` on host hence rendering user management
+Historically, this user has had a hard-coded UID `1000` on host hence rendering user management
 inflexible and cumbersome.
 
 Starting with LTS 4.54, Gravity allows this user to be configured in offline installation.
@@ -865,7 +865,7 @@ root$ ./gravity install <options> --service-uid=1001
 Then agents connecting from every other node in the cluster will use (and create if not
 existing) the same user ID.
 
-Service user can also be used for running unprivileged services inside the kubernetes cluster.
+Service user can also be used for running unprivileged services inside the Kubernetes cluster.
 To run a specific Pod (or just a container) under the service user, use `-1` as a user ID
 which will be translated to the corresponding service user ID:
 
@@ -888,7 +888,7 @@ spec:
       runAsUser: -1   # to use for a single container
 ```
 
-Only resources stored as .yaml files are subject to automatic translation.
+Only resources stored as YAML files are subject to automatic translation.
 If an application hook uses custom resource provisioning, it might need to perform conversion manually.
 
 The value of the effective service user ID is stored in the `GRAVITY_SERVICE_USER` environment variable which is made

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -15,7 +15,7 @@ Gravity works with Kubernetes applications. This means the following prerequisit
 
 ## Getting Started
 
-Any Linux or MacOS laptop can be used to package and publish Kubernetes
+Any Linux or Mac OS laptop can be used to package and publish Kubernetes
 applications using Gravity. To get started, you need to download and
 install the Gravity SDK tools:
 
@@ -128,7 +128,7 @@ that do not depend on the host OS. Containerized builds are also easier to autom
 
 The example below builds a Docker image called `tele-buildbox`. This image will contain `tele` tool and can be used to create Gravity packages.
 
-#### Build Docker Image With `tele`
+#### Build Docker Image With Tele
 
 First, build docker image `tele-buildbox` with `tele` inside:
 

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -15,7 +15,7 @@ Gravity works with Kubernetes applications. This means the following prerequisit
 
 ## Getting Started
 
-Any Linux or Mac OS laptop can be used to package and publish Kubernetes
+Any Linux or macOS laptop can be used to package and publish Kubernetes
 applications using Gravity. To get started, you need to download and
 install the Gravity SDK tools:
 

--- a/docs/5.x/quickstart.md
+++ b/docs/5.x/quickstart.md
@@ -320,7 +320,7 @@ Cluster:		friendlypoincare4048
 
 If a single node cluster is not enough, you can add additional nodes to it:
 
-1. Copy `gravity` binary from the boostrapping node above to another host which
+1. Copy `gravity` binary from the bootstrapping node above to another host which
    is about to be added to the cluster.  Let's assume its IP is `10.5.5.29`.
 2. Execute `gravity join` command as shown below. Note that this command will
    "think" in silence for a few seconds before dumping any output.
@@ -357,7 +357,7 @@ Now you have a two-node Kubernetes cluster with Mattermost running inside.
 The next step is to create a new Kubernetes user:
 
 ```bash
-# execute this on the K8s master node (running on 10.5.5.28 in our example) 
+# execute this on the K8s master node (running on 10.5.5.28 in our example)
 # to create a user "ekontsevoy"
 $ gravity users add --roles=@teleadmin ekontsevoy
 
@@ -369,7 +369,7 @@ https://10.5.5.28:3009/web/newuser/e5b5422da69ff44d41f92e3ce6167659a7fee10e1023a
 Now click on the printed URL and select a password. You are now inside the K8s management UI
 for your cluster. You can bookmark the following URL to access it in the future: `https://https://10.5.5.28:32009/web/`
 
-You will also see that this cluster is running Mattermost inside, accessible as a Kubernetes service 
+You will also see that this cluster is running Mattermost inside, accessible as a Kubernetes service
 on port `32010`, i.e. it's accessible using IP addresses of both machines in the cluster:
 
 * `http://10.5.5.28:32010/`
@@ -383,9 +383,9 @@ application into a private network.
 
 To launch a web installer, you will need:
 
-* The application bundle `mattermost.tar` which we have prepared earlier. 
+* The application bundle `mattermost.tar` which we have prepared earlier.
 * A Linux computer with a graphical interface, connected to the same network
-  with the target Linux nodes. 
+  with the target Linux nodes.
 
 First, untar `mattermost.tar` and execute the `install` script. This command
 launches an HTTP server which serves a web UI and acts as a bootstrapping agent
@@ -423,10 +423,10 @@ approach is quite similar to how virtual machines/instances are treated by
 using disk images in virtualized environments.
 
 This dramatically lowers the operational overhead of running multiple Kubernetes
-cluters within an organization, allows complex SaaS applications to be converted
+clusters within an organization, allows complex SaaS applications to be converted
 into downloadable Kubernetes appliances and dramatically simplifies implementing
-compliance in organizations by publishing Kubernetes images pre-configured and 
+compliance in organizations by publishing Kubernetes images pre-configured and
 approved by the security and compliance teams.
 
-If you need additional guidance with packaging your Kubernetes clusters into 
+If you need additional guidance with packaging your Kubernetes clusters into
 Gravity appliances, our implementation services team can help (info@gravitational.com).

--- a/docs/5.x/requirements.md
+++ b/docs/5.x/requirements.md
@@ -309,18 +309,18 @@ to be able to provision required infrastructure on your AWS account.
 
 ## Etcd Disk
 
-Gravity Clusters make high use of etcd, both for the Kubernetes cluster and for
-the application's own bookeeping with respect to e.g. deployed clusters' health
+Gravity Clusters make high use of Etcd, both for the Kubernetes cluster and for
+the application's own bookkeeping with respect to e.g. deployed clusters' health
 and reachability. As a result, it is helpful to have a reliable, performance
 isolated disk.
 
 To achieve this, by default, Gravity looks for a disk mounted at
 `/var/lib/gravity/planet/etcd`. We recommend you mount a dedicated disk there,
-ext4 formatted with at least 50GiB of free space. A reasonably high perfomance
-SSD is prefered. On AWS, we recommend an io1 class EBS volume with at least
+`ext4` formatted with at least 50GiB of free space. A reasonably high performance
+SSD is preferred. On AWS, we recommend an `io1` class EBS volume with at least
 1500 provisioned IOPS.
 
-If your etcd disk is `xvdf`, you can have the following `/etc/fstab` entry to
+If your Etcd disk is `xvdf`, you can have the following `/etc/fstab` entry to
 make sure it's mounted upon machine startup:
 
 ```

--- a/docs/5.x/terraform.md
+++ b/docs/5.x/terraform.md
@@ -1,11 +1,11 @@
 # Terraform Provider (OSS)
 
-The gravity terraform provider is used to support terraform management of opensource gravity clusters. The provider needs to be configured with a valid token in order to manage a cluster.
+The Gravity terraform provider is used to support terraform management of open-source Gravity clusters. The provider needs to be configured with a valid token in order to manage a cluster.
 
 ## Getting Started
 
 ### Install the Gravity provider
-The terraform provider will be automatically installed when getting the gravity tools.
+The terraform provider will be automatically installed when getting the Gravity tools.
 
 ```bsh
 curl https://get.gravitational.io/telekube/install/5.2.5 | bash
@@ -52,7 +52,7 @@ The following arguments are supported:
     - local: Use local database for users / accounts.
     - oidc: Use OpenID Connect service as an identity provider.
     - saml: Use SAML service as an identity provider.
-    - github: Use github as an identity provider.
+    - github: Use GitHub as an identity provider.
 * `second_factor` - Whether to enable second factor authentication when using local identity provider.
     - off: Second factor authentication is disabled on the cluster.
     - otp: Use TOTP based second factor authentication.
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `u2f_facets` - (Optional) A list of facets for U2F authentication. See [the teleport documents](https://gravitational.com/teleport/docs/admin-guide/#fido-u2f) for more information.
 
 ## gravity_github
-Configures the cluster to allow authentication using github as an identity provider.
+Configures the cluster to allow authentication using GitHub as an identity provider.
 
 ### Example Usage
 ```bsh
@@ -85,12 +85,12 @@ resource "gravity_github" "test" {
 The following arguments are supported:
 
 * `name` - The name of the connector. This name must be unique.
-* `client_id` - Github OAuth app client ID to use.
-* `client_secret` - Github OAuth app client secret.
+* `client_id` - GitHub OAuth app client ID to use.
+* `client_secret` - GitHub OAuth app client secret.
 * `redirect_url` - URL that the cluster can be reached at for OAuth callback.
 * `display` - Human readable display name that will be presented to users on the web interface when logging in.
 * `teams_to_logins` - One or more maps of organization/team/logins to allow on the cluster.
-    - organization - The github organization a user belongs to.
+    - organization - The GitHub organization a user belongs to.
     - team - The team within the organization that the user belongs to.
     - logins - A list of allowed logins for this organization/team on the cluster.
 
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 * `name` - A name to use for the forwarder.
 * `address` - The IP address or hostname and port to send logs to in the format `<host>:<port>`.
-* `protocol` - Which transpor protocol to use for log forwarding.
+* `protocol` - Which transport protocol to use for log forwarding.
     - tcp - Use TCP transport.
     - udp - Use UDP transport.
 
@@ -141,8 +141,8 @@ EOF
 ### Argument Reference
 The following arguments are supported:
 
-* `cert` - The certificate chain in pem format, with the full trust chain.
-* `private_key` - The private key which matches the certificate in pem format.
+* `cert` - The certificate chain in PEM format, with the full trust chain.
+* `private_key` - The private key which matches the certificate in PEM format.
 
 ## gravity_token
 A token is a static secret that can be used to login to a cluster as a user.
@@ -193,12 +193,12 @@ The following arguments are supported:
 
 
 # Terraform Provider (Enterprise)
-The gravity enterprise terraform provider is used to support terraform management of resources only available in the enterprise version of gravity. This provider should be used in conjunction with the opensource gravity provider to manage a gravity cluster.
+The Gravity enterprise terraform provider is used to support terraform management of resources only available in the enterprise version of Gravity. This provider should be used in conjunction with the open-source Gravity provider to manage a Gravity cluster.
 
 ## Getting Started
 
 ### Install the Gravity Enterprise provider
-The terraform provider will be automatically installed when getting the gravity tools.
+The terraform provider will be automatically installed when getting the Gravity tools.
 
 ```bsh
 curl https://get.gravitational.io/telekube/install/5.2.5 | bash
@@ -256,7 +256,7 @@ The following arguments are supported:
 * `agents_advertise_addr` - (Optional) Endpoint used by remote clusters to connect to Ops Center as a trusted cluster.
 
 ## gravityenterprise_oidc
-A gravity enterprise cluster can be configured to use Open ID connect as an identity provider and authenticate users.
+A Gravity enterprise cluster can be configured to use Open ID connect as an identity provider and authenticate users.
 
 ### Example Usage
 ```bsh
@@ -281,12 +281,12 @@ The following arguments are supported:
 
 * `name` - The name of the connector.
 * `display` - (Optional) The display name of the connector as shown in the UI.
-* `redirect_url` - The url on the gravity cluster that will process the OpenID callback. Should be in the format https://<cluster-hostname>/portalapi/v1/oidc/callback.
+* `redirect_url` - The URL on the Gravity cluster that will process the OpenID callback. Should be in the format https://<cluster-hostname>/portalapi/v1/oidc/callback.
 * `acr` - Authentication Context Class Reference value. The meaning of the ACR value is context-specific and varies for identity providers.
 * `identity_provider` - (Optional)
 * `client_id` - Is the client-id used by the identity provider.
 * `client_secret` - Is the secret used to authenticate with the identity provider.
-* `issuer_url` - Is the url of the identity provider to direct users to.
+* `issuer_url` - Is the URL of the identity provider to direct users to.
 * `scope` - Is a list of additional scopes set by the provider.
 * `claims_to_roles` - Is a dictionary of claim to role mappings. Can be passed multiple times.
     - `claim` - OIDC claim name.
@@ -323,11 +323,11 @@ The following arguments are supported:
 
 * `name` - The name of the role.
 * `max_ttl` - The maximum TTL of a login session through this role. See https://golang.org/pkg/time/#ParseDuration for the format. Default: "24h0m0s".
-* `port_forwarding` - Enable port forwarding for tsh sessions. Default: false
-* `forward_agent` - Enable ssh agent forwarding for tsh sessions. Default: false
+* `port_forwarding` - Enable port forwarding for `tsh` sessions. Default: false
+* `forward_agent` - Enable ssh agent forwarding for `tsh` sessions. Default: false
 * `allow` - Map of allowed conditions for this role.
     - `logins` - List of logins that the user can login as.
-    - `node_labels` - Map of key=value pairs that identify nodes user is able to access via tsh.
+    - `node_labels` - Map of key=value pairs that identify nodes user is able to access via `tsh`.
     - `rule` - A map of rules to apply to the condition. Multiple rules can be created.
         - `resources` - A list of resources that this rule applies to:
             - cluster_auth_preference - type of authentication for this cluster.
@@ -359,7 +359,7 @@ The following arguments are supported:
             - assignKubernetesGroups - assigns specified kubernetes groups to the role.
 * `deny` - Map of deny conditions for this role.
     - `logins` - List of logins that the user can login as.
-    - `node_labels` - Map of key=value pairs that identify nodes user is able to access via tsh.
+    - `node_labels` - Map of key=value pairs that identify nodes user is able to access via `tsh`.
     - `rule` - A map of rules to apply to the condition. Multiple rules can be created.
         - `resources` - A list of resources that this rule applies to:
             - cluster_auth_preference - type of authentication for this cluster.
@@ -416,11 +416,11 @@ The following arguments are supported:
 * `issuer` - A unique name (usually a URL) that the identity provider uses for SAML 2.0
 * `sso` - URL of the identity provider SSO service.
 * `cert` - The identity provider certificate.
-* `acs` - The callback url on the gravity cluster. Format https://<host>/portalapi/v1/saml/callback.
+* `acs` - The callback URL on the Gravity cluster. Format https://<host>/portalapi/v1/saml/callback.
 * `audience` - (Optional) Uniquely identifies our service provider.
 * `service_provider_issuer` - (Optional) is the issuer of the service provider
-* `entity_descriptor` - (Optional) - Inline entity descriptor xml configuration.
-* `entity_descriptor_url` - (Optional) Fetch entity descriptor XML from the provided url.
+* `entity_descriptor` - (Optional) - Inline entity descriptor XML configuration.
+* `entity_descriptor_url` - (Optional) Fetch entity descriptor XML from the provided URL.
 * `atributes_to_roles` -  Is a dictionary of claim to role mappings. Can be passed multiple times.
     - `name` - claim name.
     - `value` - claim value to match.
@@ -430,7 +430,7 @@ The following arguments are supported:
 * `identity_provider` - (Optional) is the external identity provider.
 
 ## gravityenterprise_trusted_cluster
-Trusted clusters allows connecting a standalone gravity enterprise cluster to an Ops Center.
+Trusted clusters allows connecting a standalone Gravity enterprise cluster to an Ops Center.
 
 ### Example Usage
 ```bsh

--- a/docs/5.x/workshops.md
+++ b/docs/5.x/workshops.md
@@ -16,13 +16,13 @@ An introduction to [Docker](https://www.docker.com/) and its basic concepts
 
 #### Computer and OS
 
-This workshop is written for Mac OS X but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for macOS but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 #### Docker
 
 For Linux: follow instructions provided [here](https://docs.docker.com/engine/installation/linux/).
 
-If you have Mac OS X (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
+If you have macOS (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
 
 *Older docker package for OSes older than Yosemite -- Docker Toolbox located [here](https://www.docker.com/products/docker-toolbox).*
 
@@ -750,7 +750,7 @@ This is an introduction to Kubernetes and basic Kubernetes concepts. We will set
 
 ### Requirements
 
-This workshop is written for Mac OS X or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for macOS or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 In addition, you will need to install:
 
@@ -763,7 +763,7 @@ In addition, you will need to install:
 
 For Linux: follow instructions provided [here](https://docs.docker.com/engine/installation/linux/).
 
-If you have Mac OS X (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
+If you have macOS (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
 
 *Older docker package for OSes older than Yosemite -- Docker Toolbox located [here](https://www.docker.com/products/docker-toolbox).*
 
@@ -775,7 +775,7 @@ Get latest stable version from https://www.virtualbox.org/wiki/Downloads
 
 #### Kubectl
 
-For Mac OS X:
+For macOS:
 
 ```bsh
 $ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.8/bin/darwin/amd64/kubectl \
@@ -795,7 +795,7 @@ Xcode will install essential console utilities for us. You can install it from t
 
 #### Minikube
 
-For Mac OS X:
+For macOS:
 
 ```
 $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-darwin-amd64 \
@@ -821,7 +821,7 @@ minikube ssh
 docker run -p 5000:5000 --name registry -d registry:2
 ```
 
-**Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
+**Notice for macOS users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
 1. Get minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:
@@ -1880,7 +1880,7 @@ of Kubernetes deployments and we will take a look at some common mistakes to avo
 
 ### Requirements
 
-You will need Mac OS X or a Linux OS with at least `7GB RAM` and `8GB free disk space` available.
+You will need macOS or a Linux OS with at least `7GB RAM` and `8GB free disk space` available.
 
 * docker
 * VirtualBox
@@ -1891,7 +1891,7 @@ You will need Mac OS X or a Linux OS with at least `7GB RAM` and `8GB free disk 
 
 For Linux: follow instructions provided [here](https://docs.docker.com/engine/installation/linux/).
 
-If you have Mac OS X (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
+If you have macOS (Yosemite or newer), please download Docker for Mac [here](https://download.docker.com/mac/stable/Docker.dmg).
 
 *Older docker package for OSes older than Yosemite -- Docker Toolbox located [here](https://www.docker.com/products/docker-toolbox).*
 
@@ -1903,7 +1903,7 @@ Get latest stable version from https://www.virtualbox.org/wiki/Downloads
 
 #### Kubectl
 
-For Mac OS X:
+For macOS:
 
     curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.8/bin/darwin/amd64/kubectl \
         && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
@@ -1919,7 +1919,7 @@ Xcode will install essential console utilities for us. You can install it from t
 
 #### Minikube
 
-For Mac OS X:
+For macOS:
 
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-darwin-amd64 \
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
@@ -1941,7 +1941,7 @@ minikube ssh
 docker run -p 5000:5000 --name registry -d registry:2
 ```
 
-**Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
+**Notice for macOS users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
 1. Get minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:

--- a/docs/5.x/workshops.md
+++ b/docs/5.x/workshops.md
@@ -1,6 +1,6 @@
 # Introduction
 
-These are a series of workshops typically delivered by the Gravitational services team. You can also find them with all the resources needed [on Github](https://github.com/gravitational/workshop).
+These are a series of workshops typically delivered by the Gravitational services team. You can also find them with all the resources needed [on GitHub](https://github.com/gravitational/workshop).
 
 We have published three different workshops that you can work through separately or together. They require an intermediate level of knowledge of Linux computer systems. Each workshop should take a 2 to 3 hours to complete.
 
@@ -16,7 +16,7 @@ An introduction to [Docker](https://www.docker.com/) and its basic concepts
 
 #### Computer and OS
 
-This workshop is written for Mac OSX but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for MacOS X but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 #### Docker
 
@@ -28,7 +28,7 @@ If you have Mac OS X (Yosemite or newer), please download Docker for Mac [here](
 
 #### Xcode and local tools
 
-Xcode will install essential console utilities for us. You can install it from AppStore.
+Xcode will install essential console utilities for us. You can install it from the App Store.
 
 ### Introduction
 
@@ -40,7 +40,7 @@ Docker is as easy as Linux! To prove that let us write classic "Hello, World" in
 $ docker run busybox echo "hello world"
 ```
 
-Docker containers are just as simple as linux processes, but they also provide many more features that we are going to explore.
+Docker containers are just as simple as Linux processes, but they also provide many more features that we are going to explore.
 
 Let's review the structure of the command:
 
@@ -51,7 +51,7 @@ echo "hello world" # command to run
 ```
 
 Container image supplies environment - binaries with shell for example that is running the command, so you are not using
-host operating system shell, but the shell from busybox package when executing Docker run.
+host operating system shell, but the shell from `busybox` package when executing Docker run.
 
 #### Sneak peek into container environment
 
@@ -72,7 +72,7 @@ My terminal prints out something like this:
 As you can see, the process runs in a very limited and isolated environment, and the PID of the process is 1, so it does not see all other processes
 running on your machine.
 
-#### Adding envrionment variables
+#### Adding Environment Variables
 
 Let's see what environment variables we have:
 
@@ -83,7 +83,7 @@ HOSTNAME=0a0169cdec9a
 ```
 
 The environment is different from your host environment.
-We can extend environment by passing explicit enviornment variable flag to `docker run`:
+We can extend environment by passing explicit environment variable flag to `docker run`:
 
 ```bsh
 $ docker run -e HELLO=world busybox env
@@ -172,11 +172,11 @@ Press `Ctrl-C` to stop the running container.
 
 ![docker-settings](images/containers.png)
 
-A Docker container is a set of linux processes that run isolated from the rest of the processes. Multiple linux subsystems help to create a container concept.
+A Docker container is a set of Linux processes that run isolated from the rest of the processes. Multiple Linux subsystems help to create a container concept.
 
 **Namespaces**
 
-Namespaces create isolated stacks of linux primitives for a running process.
+Namespaces create isolated stacks of Linux primitives for a running process.
 
 * NET namespace creates a separate networking stack for the container, with its own routing tables and devices
 * PID namespace is used to assign isolated process IDs that are separate from host OS. For example, this is important if we want to send signals to a running
@@ -193,7 +193,7 @@ Kernel feature that limits, accounts for, and isolates the resource usage (CPU, 
 
 **Capabilities**
 
-Capabilitites provide enhanced permission checks on the running process, and can limit the interface configuration, even for a root user - for example (`CAP_NET_ADMIN`)
+Capabilities provide enhanced permission checks on the running process, and can limit the interface configuration, even for a root user - for example (`CAP_NET_ADMIN`)
 
 You can find a lot of additional low level detail [here](http://crosbymichael.com/creating-containers-part-1.html).
 
@@ -226,7 +226,7 @@ eea49c9314db        library/python:3.3   "python -m http.serve"   3 seconds ago 
 
 * Container ID - auto generated unique running id.
 * Container image - image name.
-* Command - linux process running as the PID 1 in the container.
+* Command - Linux process running as the PID 1 in the container.
 * Names - user friendly name of the container, we have named our container with `--name=simple1` flag.
 
 We can use `logs` to view logs of a running container:
@@ -345,7 +345,7 @@ hello                                         latest              4dce466cf3de  
 * Size - the size of our image is just 34 bytes.
 
 **NOTE:** Docker images are very different from virtual image formats. Because Docker does not boot any operating system, but simply runs
-linux process in isolation, we don't need any kernel, drivers or libraries to ship with the image, so it could be as tiny as several bytes!
+Linux process in isolation, we don't need any kernel, drivers or libraries to ship with the image, so it could be as tiny as several bytes!
 
 
 **Running the image**
@@ -414,7 +414,7 @@ $ docker run hello:v2 /hello.sh
 hello, world v2!
 ```
 
-**Entry point**
+**Entrypoint**
 
 We can improve our image by supplying `entrypoint`:
 
@@ -424,14 +424,14 @@ $ cd docker/busybox-entrypoint
 $ docker build -t hello:v3 .
 ```
 
-Entrypoint remembers the command to be executed on start, even if you don't supply the arguments:
+`ENTRYPOINT` remembers the command to be executed on start, even if you don't supply the arguments:
 
 ```bsh
 $ docker run hello:v3
 hello, world !
 ```
 
-What happens if you pass flags? they will be executed as arugments:
+What happens if you pass flags? They will be executed as arguments:
 
 ```bsh
 $ docker run hello:v3 woo
@@ -545,7 +545,7 @@ Let's update the script.sh
 $ cp script2.sh script.sh
 ```
 
-They are only differrent by one letter, but this makes a difference:
+They are only different by one letter, but this makes a difference:
 
 
 ```bsh
@@ -576,7 +576,7 @@ Successfully built d0ec3cfed6f7
 
 
 Docker executes every command in a special container. It detects the fact that the content has (or has not) changed,
-and instead of re-exectuing the command, uses cached value isntead. This helps to speed up builds, but sometimes introduces problems.
+and instead of re-executing the command, uses cached value instead. This helps to speed up builds, but sometimes introduces problems.
 
 **NOTE:** You can always turn caching off by using the `--no-cache=true` option for the `docker build` command.
 
@@ -584,7 +584,7 @@ Docker images are composed of layers:
 
 ![images](https://docs.docker.com/engine/userguide/storagedriver/images/image-layers.jpg)
 
-Every layer is a the result of the execution of a command in the Dockerfile.
+Every layer is the result of execution of a command in the Dockerfile.
 
 **RUN command**
 
@@ -750,14 +750,14 @@ This is an introduction to Kubernetes and basic Kubernetes concepts. We will set
 
 ### Requirements
 
-This workshop is written for Mac OSX or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for MacOS X or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 In addition, you will need to install:
 
-* docker
+* Docker
 * VirtualBox
 * kubectl
-* minikube
+* Minikube
 
 #### Docker
 
@@ -791,7 +791,7 @@ $ curl -O https://storage.googleapis.com/kubernetes-release/release/v1.3.8/bin/l
 
 #### Xcode and local tools
 
-Xcode will install essential console utilities for us. You can install it from AppStore.
+Xcode will install essential console utilities for us. You can install it from the App Store.
 
 #### Minikube
 
@@ -809,7 +809,7 @@ $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/min
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 ```
 
-Also, you can install drivers for various VM providers to optimize your minikube VM performance.
+Also, you can install drivers for various VM providers to optimize your Minikube VM performance.
 Instructions can be found here: https://github.com/kubernetes/minikube/blob/master/DRIVERS.md.
 
 To run a cluster:
@@ -823,7 +823,7 @@ docker run -p 5000:5000 --name registry -d registry:2
 
 **Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
-1. Get minikube VM IP via calling `minikube ip`
+1. Get Minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:
 
 ![docker-settings](images/macos-docker-settings.jpg)
@@ -841,8 +841,8 @@ $ kubectl expose deployment my-nginx --type=LoadBalancer --port=80
 Now let's explore what just happened.
 
 * [Pods](http://kubernetes.io/docs/user-guide/pods/) are a building block
-of the infrastructure. In essense this is a group of containers sharing the same networking and host
-linux namespaces. They are used to group related processes together. Our `run` command resulted in several running pods:
+of the infrastructure. In essence this is a group of containers sharing the same networking and host
+Linux namespaces. They are used to group related processes together. Our `run` command resulted in several running pods:
 
 
 ```
@@ -921,7 +921,7 @@ that's rarely necessary.
 
 ### Pod Containers
 
-In our Nginx pod there's only one running container `my-nginx`, however as we've mentioned before we can have multiple
+In our NGINX pod there's only one running container `my-nginx`, however as we've mentioned before we can have multiple
 containers running in single Pod.
 
 Our container exposes Port 80. Thanks to overlay network every container can expose the same port on the same machine, and they won't collide.
@@ -940,7 +940,7 @@ If there's just one container, we can omit the container name within the pod:
 $ kubectl exec -ti my-nginx-3800858182-auusv /bin/
 ```
 
-Let's explore our nginx container a bit:
+Let's explore our NGINX container a bit:
 
 ```
 $ ps uax
@@ -950,17 +950,17 @@ root       265  0.2  0.0  20224  1912 ?        Ss   20:24   0:00 /bin/
 root       270  0.0  0.0  17492  1144 ?        R+   20:25   0:00 ps uax
 ```
 
-as you see, our container has it's own separate PID namespace - nginx process is actually `PID 1`.
+as you see, our container has it's own separate PID namespace - NGINX process is actually `PID 1`.
 
 ```
 $ ls -l /var/run/secrets/kubernetes.io/serviceaccount/
 ```
 
-K8s also mounted special volume in our container `serviceaccount` with access credentials to talk to K8s API process.
-K8s uses this techinque a lot to mount configuration and secrets into a running container. We will explore this in more detail
+Kubernetes also mounted special volume in our container `serviceaccount` with access credentials to talk to Kubernetes API process.
+Kubernetes uses this technique a lot to mount configuration and secrets into a running container. We will explore this in more detail
 a bit later.
 
-We don't need to always run interactive sessions within container, e.g. we can execute commmand without attaching PTY:
+We don't need to always run interactive sessions within container, e.g. we can execute command without attaching PTY:
 
 ```
 $ kubectl exec my-nginx-3800858182-auusv -- /bin/ls -l
@@ -989,10 +989,10 @@ drwxr-xr-x.   1 root root   90 May  4 02:38 var
 **Note:** when calling exec, don't forget `--`. You don't need to escape or join command arguments passed to exec really, `kubectl` will simply
 send everything after `--` as is.
 
-### Deployments and Replicasets
+### Deployments and ReplicaSets
 
-So k8s created 2 Pods for us and that's it? Not really, it's a bit more advanced system and it really thought through the deployment lifecycle.
-K8s created a deployment with replicaset of 2 pods:
+So Kubernetes created 2 Pods for us and that's it? Not really, it's a bit more advanced system and it really thought through the deployment life cycle.
+Kubernetes created a deployment with ReplicaSet of 2 pods:
 
 ```
 $ kubectl get deployments
@@ -1009,7 +1009,7 @@ my-nginx-3800858182   2         2         1h
 Whoa! Lot's of stuff! Let's go through it one by one:
 
 [Deployment](http://kubernetes.io/docs/user-guide/deployments) is a special declarative state of your [Pods](http://kubernetes.io/docs/user-guide/pods) and [ReplicaSets](http://kubernetes.io/docs/user-guide/replicasets).
-You simply declare the desire state of your deployment and K8s converges the current state to it.
+You simply declare the desire state of your deployment and Kubernetes converges the current state to it.
 
 Every time you update the deployment, it kicks off the update procedure using whatever update strategy you've selected for it.
 
@@ -1042,7 +1042,7 @@ Events tell us what happened to this deployment in the past. We'll dig a little 
 
 ### Services
 
-Pods, Replicasets and Deployments and all done with one command! But that's not all. We need a scalable way to access our services, so k8s team came up with
+Pods, ReplicaSets and Deployments and all done with one command! But that's not all. We need a scalable way to access our services, so k8s team came up with
 [Services](http://kubernetes.io/docs/user-guide/services)
 
 Services provide special Virtual IPs load balancing traffic to the set of pods in a replica sets.
@@ -1053,7 +1053,7 @@ kubernetes   10.100.0.1     <none>        443/TCP   2h
 my-nginx     10.100.68.75   <none>        80/TCP    1h
 ```
 
-As you see there are two services - one is a system service `kubernetes` that points to k8s API. Another one is `my-nginx` service, pointing to our Pods in a replica sets.
+As you see there are two services - one is a system service `kubernetes` that points to Kubernetes API. Another one is `my-nginx` service, pointing to our Pods in a replica sets.
 
 Let's dig a little deeper into services:
 
@@ -1071,7 +1071,7 @@ Session Affinity:	None
 No events.
 ```
 
-`ClusterIP` type of the service means that it's an internal IP managed by k8s and not reachable outside. You can create outher types of services that play nicely with AWS/GCE and Azure `LoadBalancer`, we'll
+`ClusterIP` type of the service means that it's an internal IP managed by Kubernetes and not reachable outside. You can create other types of services that play nicely with AWS/GCE and Azure `LoadBalancer`, we'll
 dig into that some other time though. Meanwhile, let's notice that there are 2 endpoints:
 
 ```
@@ -1111,8 +1111,8 @@ curl http://10.100.68.75
 working. Further configuration is required.</p>
 ```
 
-It works! Wait, so you need to hardcode this VIP in your configuration? What if it changes from environment to environment?
-Thankfully, k8s team thought about this as well, and we can simply do:
+It works! Wait, so you need to hard-code this VIP in your configuration? What if it changes from environment to environment?
+Thankfully, Kubernetes team thought about this as well, and we can simply do:
 
 ```
 $ kubectl run -i -t --rm cli --image=tutum/curl --restart=Never
@@ -1121,11 +1121,11 @@ $ curl http://my-nginx
 ...
 ```
 
-K8s is integrated with [SkyDNS](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns) service
+Kubernetes is integrated with [SkyDNS](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns) service
 that watches the services and pods and sets up appropriate `A` records. Our `sandbox` local DNS server is simply configured to
-point to the DNS service provided by k8s.
+point to the DNS service provided by Kubernetes.
 
-That's very similar how K8s manages discovery in containers as well. Let's login into one of the nginx boxes and
+That's very similar how Kubernetes manages discovery in containers as well. Let's login into one of the NGINX boxes and
 discover `/etc/resolv.conf` there:
 
 
@@ -1138,13 +1138,13 @@ search default.svc.cluster.local svc.cluster.local cluster.local hsd1.ca.comcast
 options ndots:5
 ```
 
-As you see, `resolv.conf` is set up to point to the DNS resolution service managed by K8s.
+As you see, `resolv.conf` is set up to point to the DNS resolution service managed by Kubernetes.
 
 ### Back to Deployments
 
 The power of Deployments comes from ability to do smart upgrades and rollbacks in case if something goes wrong.
 
-Let's update our deployment of nginx to the newer version.
+Let's update our deployment of NGINX to the newer version.
 
 ```
 $ cat my-nginx-new.yaml
@@ -1183,7 +1183,7 @@ $ kubectl apply -f my-nginx-new.yaml
 ```
 
 
-We can see that a new replicaset has been created
+We can see that a new ReplicaSet has been created
 
 ```
 $ kubectl get rs
@@ -1194,7 +1194,7 @@ my-nginx-3800858182   0         0         2h
 ```
 
 If we look at the events section of the deployment we will see how it performed rolling update
-scaling up new replicaset and scaling down old replicaset:
+scaling up new ReplicaSet and scaling down old ReplicaSet:
 
 
 ```
@@ -1352,9 +1352,9 @@ REVISION	CHANGE-CAUSE
 
 Well, our `nginx`es are up and running, let's make sure they actually do something useful by configuring them to say `hello, kubernetes!`
 
-[ConfigMap](http://kubernetes.io/docs/user-guide/configmap/) is a special K8s resource that maps to configuration files or environment variables inside a Pod.
+[ConfigMap](http://kubernetes.io/docs/user-guide/configmap/) is a special Kubernetes resource that maps to configuration files or environment variables inside a Pod.
 
-Lets create configmap from a directory. Our `conf.d` contains a `default.conf` file:
+Lets create ConfigMap from a directory. Our `conf.d` contains a `default.conf` file:
 
 ```
 $ cat conf.d/default.conf
@@ -1368,7 +1368,7 @@ server {
 }
 ```
 
-We can convert the whole directory into configmap:
+We can convert the whole directory into ConfigMap:
 
 ```
 $ kubectl create configmap my-nginx-v1 --from-file=conf.d
@@ -1388,7 +1388,7 @@ default.conf:	125 bytes
 
 ```
 
-Every file is now it's own property, e.g. `default.conf`. Now, the trick is to mount this config map in the `/etc/nginx/conf.d/`
+Every file is now it's own property, e.g. `default.conf`. Now, the trick is to mount this ConfigMap in the `/etc/nginx/conf.d/`
 of our nginxes. We will use new deployment for this purpose:
 
 
@@ -1428,12 +1428,12 @@ spec:
            name: my-nginx-v1
 ```
 
-Notice that we've introduced `volumes` section that tells k8s to attach volumes to the pods. One special volume type we support is `configMap` that
-is created on the fly from the configmap resource `my-nginx-v1` that we've just created.
+Notice that we've introduced `volumes` section that tells Kubernetes to attach volumes to the pods. One special volume type we support is `configMap` that
+is created on the fly from the ConfigMap resource `my-nginx-v1` that we've just created.
 
 Another part of our config is `volumeMounts` that are specified for each container and tell it where to mount the volume.
 
-Let's apply our config map:
+Let's apply our ConfigMap:
 
 ```
 $ kubectl apply -f my-nginx-configmap.yaml
@@ -1448,7 +1448,7 @@ my-nginx-3885498220-0c6h0   1/1       Running   0          39s
 my-nginx-3885498220-9q61s   1/1       Running   0          38s
 ```
 
-Out of curiosity, let's login into one of them and see ourselves the mounted configmap:
+Out of curiosity, let's login into one of them and see ourselves the mounted ConfigMap:
 
 ```
 $ kubectl exec -ti my-nginx-3885498220-0c6h0 /bin/
@@ -1463,7 +1463,7 @@ server {
 }
 ```
 
-and finally, let's see it all in action:
+And finally, let's see it all in action:
 
 ```
 $ kubectl run -i -t --rm cli --image=tutum/curl --restart=Never
@@ -1473,9 +1473,9 @@ hello, Kubernetes!
 
 ### Connecting services
 
-Let's deploy a bit more complicated stack. In this excercise we will deploy [Mattermost](http://www.mattermost.org) - an alternative to Slack that can run
+Let's deploy a bit more complicated stack. In this exercise we will deploy [Mattermost](http://www.mattermost.org) - an alternative to Slack that can run
 on your infrastructure. We will build our own containers and configuration, push it to the registry and
-Mattermost stack is composed of a worker process that connects to a running postgres instance.
+Mattermost stack is composed of a worker process that connects to a running PostgreSQL instance.
 
 **Build container**
 
@@ -1501,19 +1501,19 @@ Mattermost's worker expects configuration to be mounted at:
 $ cat mattermost/worker-config/config.json
 ```
 
-If we examine config closely, we will notice that mattermost expects a connector
-string to postgres:
+If we examine config closely, we will notice that Mattermost expects a connector
+string to PostgreSQL:
 
 ```
    "DataSource": "postgres://postgres:mattermost@postgres:5432/postgres?sslmode=disable"
    "DataSourceReplicas": ["postgres://postgres:mattermost@postgres:5432/postgres?sslmode=disable"]
 ```
 
-Here's where k8s power comes into play. We don't need to provide hardcoded IPs, we can simply make sure that
-there's a `postres` service pointing to our Postgres DB running somewhere in the cluster.
+Here's where Kubernetes power comes into play. We don't need to provide hard-coded IPs, we can simply make sure that
+there's a `postres` service pointing to our PostgreSQL DB running somewhere in the cluster.
 
 
-Let us create config map based on this file:
+Let us create ConfigMap based on this file:
 
 ```
 $ kubectl create configmap mattermost-v1 --from-file=mattermost/worker-config
@@ -1530,7 +1530,7 @@ config.json:	2951 bytes
 
 **Starting Up Postgres**
 
-Let's create a single Pod running posgres and point our service to it:
+Let's create a single Pod running PostgreSQL and point our service to it:
 
 ```
 $ kubectl create -f mattermost/postgres.yaml
@@ -1539,7 +1539,7 @@ NAME                        READY     STATUS    RESTARTS   AGE
 mattermost-database         1/1       Running   0          12m
 ```
 
-Let's check out the logs of our postgres:
+Let's check out the logs of our PostgreSQL:
 
 ```
 $ kubectl logs mattermost-database
@@ -1558,13 +1558,13 @@ selecting default max_connections ... 100
 selecting default shared_buffers ... 128MB
 ```
 
-**Note** Our `mattermost-database` is a special snowflake, in real production systems we must create a proper replicaset
+**Note** Our `mattermost-database` is a special snowflake, in real production systems we must create a proper ReplicaSet
 for the stateful service, what is slightly more complicated than this sample.
 
 
 **Creating Postgres Service**
 
-Let's create postrges service:
+Let's create PostgreSQL service:
 
 ```
 $ kubectl create -f mattermost/postgres-service.yaml
@@ -1645,7 +1645,7 @@ spec:
 $ kubectl create -f mattermost/worker.yaml --record
 ```
 
-Let's check out the status of the deployment to see if everything is allright:
+Let's check out the status of the deployment to see if everything is alright:
 
 ```
 $ kubectl describe deployments/mattermost-worker
@@ -1670,7 +1670,7 @@ Events:
 
 **Creating mattermost service**
 
-Our last touch is to create mattermost service and check how it all works together:
+Our last touch is to create Mattermost service and check how it all works together:
 
 ```
 $ kubectl create -f mattermost/worker-service.yaml
@@ -1751,10 +1751,10 @@ Notice this:
 NodePort:		http	32321/TCP
 ```
 
-Here we see that on my Vagrant every node in the system should have `IP:32321` resolve to the mattermost web app.
+Here we see that on my Vagrant every node in the system should have `IP:32321` resolve to the Mattermost web app.
 On your Vagrant the port most likely will be different!
 
-So on my computer I can now open mattermost app using one of the nodes IP:
+So on my computer I can now open Mattermost app using one of the nodes IP:
 
 
 ![mattermost](images/mattermost.png)
@@ -1768,12 +1768,12 @@ $ minikube addons enable ingress
 ```
 
 An Ingress is a collection of rules that allow inbound connections to reach the cluster services.
-It can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
-The difference between service and ingress (in K8S terminology) is that service allows you to provide access on OSI L3, and ingress
+It can be configured to give services externally-reachable URLs, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+The difference between service and ingress (in Kubernetes terminology) is that service allows you to provide access on OSI L3, and ingress
 works on L7. E.g. while accessing HTTP server service can provide only load-balancing and HA, unlike ingres which could be used to split
 traffic on HTTP location basis, etc.
 
-First, we need to create to 2 different nginx deployments, configmaps and services for them:
+First, we need to create to 2 different NGINX deployments, ConfigMaps and services for them:
 
 ```
 $ kubectl create configmap cola-nginx --from-file=ingress/conf-cola
@@ -1796,7 +1796,7 @@ Now we have two different deployments and services, assume we need to route user
 requests from `/cola` to `cola-nginx` service (backed by `cola-nginx` deployment)
 and `/pepsi` to `pepsi-nginx` service.
 
-This can be acheived using following ingress resource:
+This can be achieved using following ingress resource:
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -1831,10 +1831,10 @@ Notice annotations:
 * `ingress.kubernetes.io/rewrite-target: /` -- sets request's location to `/` instead of specified in `path`.
 * `ingress.kubernetes.io/ssl-redirect: "false"` -- disables HTTP to HTTPS redirect, enabled by default.
 
-Ingress is implemented inside `kube-system` namespace using any kind of configurable proxy. E.g. in minikube
-ingress uses nginx. Simply speaking there's special server which reacts to ingress resource creation/deletion/alteration
-and updates configuration of neighboured nginx. This *ingress controller* application started using
-ReplicationController resource inside minikube, but could be run as usual K8S application (DS, Deployment, etc),
+Ingress is implemented inside `kube-system` namespace using any kind of configurable proxy. E.g. in Minikube
+ingress uses NGINX. Simply speaking there's special server which reacts to ingress resource creation/deletion/alteration
+and updates configuration of neighboured NGINX. This *ingress controller* application started using
+ReplicationController resource inside Minikube, but could be run as usual Kubernetes application (DS, Deployment, etc),
 on special set of "edge router" nodes for improved security.
 
 ```
@@ -1867,8 +1867,8 @@ More details on ingress features and use cases [here](https://kubernetes.io/docs
 
 ### Recap
 
-We've learned several quite important concepts like Services, Pods, Replicasets and
-Configmaps. But that's just a small part of what Kubernetes can do. You can read much more on [Kubernetes website](http://kubernetes.io).
+We've learned several quite important concepts like Services, Pods, ReplicaSet and
+ConfigMaps. But that's just a small part of what Kubernetes can do. You can read much more on [Kubernetes website](http://kubernetes.io).
 
 
 ## Kubernetes Production Patterns
@@ -1880,12 +1880,12 @@ of Kubernetes deployments and we will take a look at some common mistakes to avo
 
 ### Requirements
 
-You will need Mac OSX or a Linux OS with at least `7GB RAM` and `8GB free disk space` available.
+You will need Mac OS X or a Linux OS with at least `7GB RAM` and `8GB free disk space` available.
 
-* docker
+* Docker
 * VirtualBox
 * kubectl
-* minikube
+* Minikube
 
 #### Docker
 
@@ -1915,7 +1915,7 @@ For Linux:
 
 #### Xcode and local tools
 
-Xcode will install essential console utilities for us. You can install it from AppStore.
+Xcode will install essential console utilities for us. You can install it from the App Store.
 
 #### Minikube
 
@@ -1929,7 +1929,7 @@ For Linux:
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-linux-amd64 \
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
-Also, you can install drivers for various VM providers to optimize your minikube VM performance.
+Also, you can install drivers for various VM providers to optimize your Minikube VM performance.
 Instructions can be found here: https://github.com/kubernetes/minikube/blob/master/DRIVERS.md.
 
 To run a cluster:
@@ -1943,14 +1943,14 @@ docker run -p 5000:5000 --name registry -d registry:2
 
 **Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
-1. Get minikube VM IP via calling `minikube ip`
+1. Get Minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:
 
 ![docker-settings](images/macos-docker-settings.jpg)
 
 ### Anti-Pattern: Mixing build environment and runtime environment
 
-Let's take a look at this dockerfile
+Let's take a look at this Dockerfile
 
 ```Dockerfile
 FROM ubuntu:14.04
@@ -1960,7 +1960,7 @@ RUN apt-get install gcc
 RUN gcc hello.c -o /hello
 ```
 
-It compiles and runs simple helloworld program:
+It compiles and runs simple "Hello, World" program:
 
 ```
 $ cd prod/build
@@ -1986,7 +1986,7 @@ Which leads us to the second problem:
 
 **Security**
 
-We distribute the whole build toolchain in addition to that we ship the source code of the image:
+We distribute the whole build tool chain in addition to that we ship the source code of the image:
 
 ```
 $ docker run --entrypoint=cat prod /build/hello.c
@@ -2010,7 +2010,7 @@ $ cd prod/build-fix
 $ docker build -f build.dockerfile -t buildbox .
 ```
 
-**NOTE:** We have used new `-f` flag to specify dockerfile we are going to use.
+**NOTE:** We have used new `-f` flag to specify Dockerfile we are going to use.
 
 Now we have a `buildbox` image that contains our build environment. We can use it to compile the C program now:
 
@@ -2023,7 +2023,7 @@ We have not used `docker build` this time, but mounted the source code and run t
 **NOTE:** Docker will soon support this pattern natively by introducing [build stages](https://github.com/docker/docker/pull/32063) into the build process.
 
 
-We can now use much simpler (and smaller) dockerfile to run our image:
+We can now use much simpler (and smaller) Dockerfile to run our image:
 
 ```Dockerfile
 FROM quay.io/gravitational/debian-tall:0.0.1
@@ -2047,7 +2047,7 @@ prod                                          latest              b2c197180350  
 
 **Orphans**
 
-It is quite easy to leave orphaned processes running in backround. Let's take an image we have build in the previous example:
+It is quite easy to leave orphaned processes running in background. Let's take an image we have build in the previous example:
 
 ```
 docker run busybox sleep 10000
@@ -2419,7 +2419,7 @@ our frontend has to make two requests to the backend:
 * Fetch current mail from the database
 
 If the weather service is down, user still would like to review the email, so weather service
-is auxillary, while current mail service is critical.
+is auxiliary, while current mail service is critical.
 
 Here is our frontend, weather and mail services written in python:
 
@@ -2524,7 +2524,7 @@ service "mail" configured
 service "weather" configured
 ```
 
-Check that everyting is running smoothly:
+Check that everything is running smoothly:
 
 ```
 $ kubectl run -i -t --rm cli --image=tutum/curl --restart=Never
@@ -2740,7 +2740,7 @@ service "weather" configured
 ```
 
 
-Circuit breaker will detect service outage and auxillary weather service will not bring our mail service down any more:
+Circuit breaker will detect service outage and auxiliary weather service will not bring our mail service down any more:
 
 ```
 $ curl http://frontend
@@ -2762,10 +2762,10 @@ $ curl http://frontend
 
 ### Production Pattern: Sidecar For Rate and Connection Limiting
 
-In the previous example we have used a sidecar pattern - a special proxy local to the Pod, that adds additional logic to the service, such as error deteciton, TLS termination
+In the previous example we have used a sidecar pattern - a special proxy local to the Pod, that adds additional logic to the service, such as error detection, TLS termination
 and other features.
 
-Here is an example of sidecar nginx proxy that adds rate and connection limits:
+Here is an example of sidecar NGINX proxy that adds rate and connection limits:
 
 ```
 $ cd prod/sidecar

--- a/docs/5.x/workshops.md
+++ b/docs/5.x/workshops.md
@@ -16,7 +16,7 @@ An introduction to [Docker](https://www.docker.com/) and its basic concepts
 
 #### Computer and OS
 
-This workshop is written for MacOS X but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for Mac OS X but should mostly work with Linux as well. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 #### Docker
 
@@ -750,14 +750,14 @@ This is an introduction to Kubernetes and basic Kubernetes concepts. We will set
 
 ### Requirements
 
-This workshop is written for MacOS X or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
+This workshop is written for Mac OS X or Linux. You will need a machine with at least `7GB RAM` and `8GB free disk space` available.
 
 In addition, you will need to install:
 
-* Docker
+* docker
 * VirtualBox
 * kubectl
-* Minikube
+* minikube
 
 #### Docker
 
@@ -809,7 +809,7 @@ $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/min
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 ```
 
-Also, you can install drivers for various VM providers to optimize your Minikube VM performance.
+Also, you can install drivers for various VM providers to optimize your minikube VM performance.
 Instructions can be found here: https://github.com/kubernetes/minikube/blob/master/DRIVERS.md.
 
 To run a cluster:
@@ -823,7 +823,7 @@ docker run -p 5000:5000 --name registry -d registry:2
 
 **Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
-1. Get Minikube VM IP via calling `minikube ip`
+1. Get minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:
 
 ![docker-settings](images/macos-docker-settings.jpg)
@@ -921,7 +921,7 @@ that's rarely necessary.
 
 ### Pod Containers
 
-In our NGINX pod there's only one running container `my-nginx`, however as we've mentioned before we can have multiple
+In our nginx pod there's only one running container `my-nginx`, however as we've mentioned before we can have multiple
 containers running in single Pod.
 
 Our container exposes Port 80. Thanks to overlay network every container can expose the same port on the same machine, and they won't collide.
@@ -940,7 +940,7 @@ If there's just one container, we can omit the container name within the pod:
 $ kubectl exec -ti my-nginx-3800858182-auusv /bin/
 ```
 
-Let's explore our NGINX container a bit:
+Let's explore our nginx container a bit:
 
 ```
 $ ps uax
@@ -950,7 +950,7 @@ root       265  0.2  0.0  20224  1912 ?        Ss   20:24   0:00 /bin/
 root       270  0.0  0.0  17492  1144 ?        R+   20:25   0:00 ps uax
 ```
 
-as you see, our container has it's own separate PID namespace - NGINX process is actually `PID 1`.
+as you see, our container has it's own separate PID namespace - nginx process is actually `PID 1`.
 
 ```
 $ ls -l /var/run/secrets/kubernetes.io/serviceaccount/
@@ -1125,7 +1125,7 @@ Kubernetes is integrated with [SkyDNS](https://github.com/kubernetes/kubernetes/
 that watches the services and pods and sets up appropriate `A` records. Our `sandbox` local DNS server is simply configured to
 point to the DNS service provided by Kubernetes.
 
-That's very similar how Kubernetes manages discovery in containers as well. Let's login into one of the NGINX boxes and
+That's very similar how Kubernetes manages discovery in containers as well. Let's login into one of the nginx boxes and
 discover `/etc/resolv.conf` there:
 
 
@@ -1144,7 +1144,7 @@ As you see, `resolv.conf` is set up to point to the DNS resolution service manag
 
 The power of Deployments comes from ability to do smart upgrades and rollbacks in case if something goes wrong.
 
-Let's update our deployment of NGINX to the newer version.
+Let's update our deployment of nginx to the newer version.
 
 ```
 $ cat my-nginx-new.yaml
@@ -1670,7 +1670,7 @@ Events:
 
 **Creating mattermost service**
 
-Our last touch is to create Mattermost service and check how it all works together:
+Our last touch is to create mattermost service and check how it all works together:
 
 ```
 $ kubectl create -f mattermost/worker-service.yaml
@@ -1751,10 +1751,10 @@ Notice this:
 NodePort:		http	32321/TCP
 ```
 
-Here we see that on my Vagrant every node in the system should have `IP:32321` resolve to the Mattermost web app.
+Here we see that on my Vagrant every node in the system should have `IP:32321` resolve to the mattermost web app.
 On your Vagrant the port most likely will be different!
 
-So on my computer I can now open Mattermost app using one of the nodes IP:
+So on my computer I can now open mattermost app using one of the nodes IP:
 
 
 ![mattermost](images/mattermost.png)
@@ -1773,7 +1773,7 @@ The difference between service and ingress (in Kubernetes terminology) is that s
 works on L7. E.g. while accessing HTTP server service can provide only load-balancing and HA, unlike ingres which could be used to split
 traffic on HTTP location basis, etc.
 
-First, we need to create to 2 different NGINX deployments, ConfigMaps and services for them:
+First, we need to create to 2 different nginx deployments, ConfigMaps and services for them:
 
 ```
 $ kubectl create configmap cola-nginx --from-file=ingress/conf-cola
@@ -1831,10 +1831,10 @@ Notice annotations:
 * `ingress.kubernetes.io/rewrite-target: /` -- sets request's location to `/` instead of specified in `path`.
 * `ingress.kubernetes.io/ssl-redirect: "false"` -- disables HTTP to HTTPS redirect, enabled by default.
 
-Ingress is implemented inside `kube-system` namespace using any kind of configurable proxy. E.g. in Minikube
-ingress uses NGINX. Simply speaking there's special server which reacts to ingress resource creation/deletion/alteration
-and updates configuration of neighboured NGINX. This *ingress controller* application started using
-ReplicationController resource inside Minikube, but could be run as usual Kubernetes application (DS, Deployment, etc),
+Ingress is implemented inside `kube-system` namespace using any kind of configurable proxy. E.g. in minikube
+ingress uses nginx. Simply speaking there's special server which reacts to ingress resource creation/deletion/alteration
+and updates configuration of neighboured nginx. This *ingress controller* application started using
+ReplicationController resource inside minikube, but could be run as usual Kubernetes application (DS, Deployment, etc),
 on special set of "edge router" nodes for improved security.
 
 ```
@@ -1882,10 +1882,10 @@ of Kubernetes deployments and we will take a look at some common mistakes to avo
 
 You will need Mac OS X or a Linux OS with at least `7GB RAM` and `8GB free disk space` available.
 
-* Docker
+* docker
 * VirtualBox
 * kubectl
-* Minikube
+* minikube
 
 #### Docker
 
@@ -1929,7 +1929,7 @@ For Linux:
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.12.2/minikube-linux-amd64 \
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
-Also, you can install drivers for various VM providers to optimize your Minikube VM performance.
+Also, you can install drivers for various VM providers to optimize your minikube VM performance.
 Instructions can be found here: https://github.com/kubernetes/minikube/blob/master/DRIVERS.md.
 
 To run a cluster:
@@ -1943,7 +1943,7 @@ docker run -p 5000:5000 --name registry -d registry:2
 
 **Notice for Mac OS X users:** you need to allow your docker daemon to work with your local insecure registry. It could be achieved via adding VM address to Docker for Mac.
 
-1. Get Minikube VM IP via calling `minikube ip`
+1. Get minikube VM IP via calling `minikube ip`
 2. Add obtained IP with port 5000 (specified above in `docker run` command) to Docker insecure registries:
 
 ![docker-settings](images/macos-docker-settings.jpg)
@@ -2765,7 +2765,7 @@ $ curl http://frontend
 In the previous example we have used a sidecar pattern - a special proxy local to the Pod, that adds additional logic to the service, such as error detection, TLS termination
 and other features.
 
-Here is an example of sidecar NGINX proxy that adds rate and connection limits:
+Here is an example of sidecar nginx proxy that adds rate and connection limits:
 
 ```
 $ cd prod/sidecar


### PR DESCRIPTION
Also ran everything through a spellchecker, hence multiple typos fixed.

I will update the upgrade section (remove mostly as it now duplicates information from the new `Managing an ongoing Operation` section that describes the updated `gravity plan`) once I've forward ported the `runtime_environment` implementation.

I also feel that all operation-related content should probably go into a separate file, like `operations.md`. 
