### PR TITLE
[5.3]: fix a typo and make `name` optional in `gravity resource rm`

### DIFF
--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gravitational/version"
 )
 
-// Modules allows to customize certain behavioral aspects of Telekube
+// Modules allows to customize certain behavioral aspects of Gravity
 type Modules interface {
 	// ProcessModes returns a list of modes gravity process can run in
 	ProcessModes() []string
@@ -39,8 +39,11 @@ type Modules interface {
 	DefaultAuthPreference(processMode string) (teleservices.AuthPreference, error)
 	// SupportedResources returns a list of resources that can be created/viewed
 	SupportedResources() []string
-	// SupportedResourcesToRemoves returns a list of resources that can be removed
+	// SupportedResourcesToRemove returns a list of resources that can be removed
 	SupportedResourcesToRemove() []string
+	// CanonicalKind translates the specified kind r to canonical form.
+	// Returns an empty string if no canonical form exists
+	CanonicalKind(kind string) string
 	// SupportedConnectors returns a list of supported auth connector kinds
 	SupportedConnectors() []string
 	// Version returns the gravity version
@@ -106,6 +109,12 @@ func (m *defaultModules) SupportedConnectors() []string {
 		teleservices.KindOIDCConnector,
 		teleservices.KindGithubConnector,
 	}
+}
+
+// CanonicalKind translates the specified kind r to canonical form.
+// Returns an empty string if no canonical form exists
+func (m *defaultModules) CanonicalKind(kind string) string {
+	return storage.CanonicalKind(kind)
 }
 
 // Version returns the gravity version

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -41,7 +41,7 @@ type Modules interface {
 	SupportedResources() []string
 	// SupportedResourcesToRemove returns a list of resources that can be removed
 	SupportedResourcesToRemove() []string
-	// CanonicalKind translates the specified kind r to canonical form.
+	// CanonicalKind translates the specified kind to canonical form.
 	// Returns an empty string if no canonical form exists
 	CanonicalKind(kind string) string
 	// SupportedConnectors returns a list of supported auth connector kinds
@@ -111,7 +111,7 @@ func (m *defaultModules) SupportedConnectors() []string {
 	}
 }
 
-// CanonicalKind translates the specified kind r to canonical form.
+// CanonicalKind translates the specified kind to canonical form.
 // Returns an empty string if no canonical form exists
 func (m *defaultModules) CanonicalKind(kind string) string {
 	return storage.CanonicalKind(kind)

--- a/lib/ops/opshandler/resources.go
+++ b/lib/ops/opshandler/resources.go
@@ -223,8 +223,12 @@ func (h *WebHandler) getGithubConnectors(w http.ResponseWriter, r *http.Request,
    DELETE /portal/v1/accounts/:account_id/sites/:site_domain/github/connectors/:id
 */
 func (h *WebHandler) deleteGithubConnector(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
-	err := ctx.Identity.DeleteGithubConnector(p.ByName("id"))
+	name := p.ByName("id")
+	err := ctx.Identity.DeleteGithubConnector(name)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound("GitHub connector %q not found", name)
+		}
 		return trace.Wrap(err)
 	}
 	roundtrip.ReplyJSON(w, http.StatusOK, message("Github connector deleted"))

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -74,8 +74,7 @@ func (r *Resources) Create(req resources.CreateRequest) error {
 	if err := req.Check(); err != nil {
 		return trace.Wrap(err)
 	}
-	kind := modules.Get().CanonicalKind(req.Resource.Kind)
-	switch kind {
+	switch req.Resource.Kind {
 	case teleservices.KindGithubConnector:
 		conn, err := teleservices.GetGithubConnectorMarshaler().Unmarshal(req.Resource.Raw)
 		if err != nil {
@@ -223,8 +222,7 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 	if err := req.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	kind := modules.Get().CanonicalKind(req.Kind)
-	switch kind {
+	switch req.Kind {
 	case teleservices.KindGithubConnector, teleservices.KindAuthConnector:
 		if req.Name != "" {
 			connector, err := r.Operator.GetGithubConnector(r.cluster.Key(), req.Name, req.WithSecrets)

--- a/lib/ops/resources/resources.go
+++ b/lib/ops/resources/resources.go
@@ -83,7 +83,7 @@ type ListRequest struct {
 }
 
 // Check validates the request
-func (r ListRequest) Check() error {
+func (r *ListRequest) Check() error {
 	if r.Kind == "" {
 		return trace.BadParameter("resource kind is mandatory")
 	}
@@ -92,6 +92,7 @@ func (r ListRequest) Check() error {
 	if !utils.StringInSlice(resources, kind) {
 		return trace.BadParameter("unknown resource kind %q", r.Kind)
 	}
+	r.Kind = kind
 	return nil
 }
 
@@ -108,7 +109,7 @@ type RemoveRequest struct {
 }
 
 // Check validates the request
-func (r RemoveRequest) Check() error {
+func (r *RemoveRequest) Check() error {
 	if r.Kind == "" {
 		return trace.BadParameter("resource kind is mandatory")
 	}
@@ -125,6 +126,7 @@ func (r RemoveRequest) Check() error {
 			return trace.BadParameter("resource name is mandatory")
 		}
 	}
+	r.Kind = kind
 	return nil
 }
 

--- a/lib/ops/resources/resources.go
+++ b/lib/ops/resources/resources.go
@@ -88,7 +88,7 @@ func (r ListRequest) Check() error {
 		return trace.BadParameter("resource kind is mandatory")
 	}
 	kind := modules.Get().CanonicalKind(r.Kind)
-	resources := modules.Get().SupportedResourcesToRemove()
+	resources := modules.Get().SupportedResources()
 	if !utils.StringInSlice(resources, kind) {
 		return trace.BadParameter("unknown resource kind %q", r.Kind)
 	}

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -58,7 +58,7 @@ const (
 	KindRuntimeEnvironment = "runtime_environment"
 )
 
-// CanonicalKind translates the specified kind r to canonical form.
+// CanonicalKind translates the specified kind to canonical form.
 // Returns an empty string if no canonical form exists
 func CanonicalKind(kind string) string {
 	switch kind {
@@ -93,6 +93,7 @@ func CanonicalKind(kind string) string {
 var SupportedGravityResources = []string{
 	teleservices.KindClusterAuthPreference,
 	teleservices.KindGithubConnector,
+	teleservices.KindAuthConnector,
 	teleservices.KindUser,
 	KindToken,
 	KindLogForwarder,

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -58,6 +58,36 @@ const (
 	KindRuntimeEnvironment = "runtime_environment"
 )
 
+// CanonicalKind translates the specified kind r to canonical form.
+// Returns an empty string if no canonical form exists
+func CanonicalKind(kind string) string {
+	switch kind {
+	case teleservices.KindGithubConnector:
+		return teleservices.KindGithubConnector
+	case teleservices.KindAuthConnector, "auth":
+		return teleservices.KindAuthConnector
+	case teleservices.KindUser, "users":
+		return teleservices.KindUser
+	case KindToken, "tokens":
+		return KindToken
+	case KindLogForwarder, "logforwarders":
+		return KindLogForwarder
+	case KindTLSKeyPair, "tlskeypairs", "tls":
+		return KindTLSKeyPair
+	case teleservices.KindClusterAuthPreference, "authpreference", "cap":
+		return teleservices.KindClusterAuthPreference
+	case KindSMTPConfig, "smtps":
+		return KindSMTPConfig
+	case KindAlert, "alerts":
+		return KindAlert
+	case KindAlertTarget, "alerttargets":
+		return KindAlertTarget
+	case KindRuntimeEnvironment, "environments", "env":
+		return KindRuntimeEnvironment
+	}
+	return ""
+}
+
 // SupportedGravityResources is a list of resources supported by
 // "gravity resource create/get" subcommands
 var SupportedGravityResources = []string{
@@ -74,7 +104,7 @@ var SupportedGravityResources = []string{
 }
 
 // SupportedGravityResourcesToRemove is a list of resources supported by
-// "gravity resource remove" subcommand
+// "gravity resource rm" subcommand
 var SupportedGravityResourcesToRemove = []string{
 	teleservices.KindGithubConnector,
 	teleservices.KindUser,

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -263,7 +263,7 @@ const (
 The operation might take several minutes to complete depending on the cluster size.
 
 The operation will start automatically once you approve it.
-If want to review the operation plan first or execute it manually step by step,
+If you want to review the operation plan first or execute it manually step by step,
 run the operation in manual mode by specifying '--manual' flag.
 
 Are you sure?`

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -658,7 +658,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// remove one or many resources
 	g.ResourceRemoveCmd.CmdClause = g.ResourceCmd.Command("rm", fmt.Sprintf("Remove a configuration resource, e.g. gravity resource rm oidc google. Supported resources are: %v", modules.Get().SupportedResourcesToRemove()))
 	g.ResourceRemoveCmd.Kind = g.ResourceRemoveCmd.Arg("kind", fmt.Sprintf("resource kind, one of %v", modules.Get().SupportedResourcesToRemove())).Required().String()
-	g.ResourceRemoveCmd.Name = g.ResourceRemoveCmd.Arg("name", "resource name, e.g. github").Required().String()
+	g.ResourceRemoveCmd.Name = g.ResourceRemoveCmd.Arg("name", "resource name, e.g. github").String()
 	g.ResourceRemoveCmd.Force = g.ResourceRemoveCmd.Flag("force", "Do not return errors if a resource is not found").Short('f').Bool()
 	g.ResourceRemoveCmd.User = g.ResourceRemoveCmd.Flag("user", "user to remove resource for, defaults to currently logged in user").String()
 	g.ResourceRemoveCmd.Manual = g.ResourceRemoveCmd.Flag("manual", "manually execute operation phases").Short('m').Bool()

--- a/tool/gravity/cli/resources.go
+++ b/tool/gravity/cli/resources.go
@@ -101,7 +101,7 @@ func CreateResource(
 
 // RemoveResource deletes resource by name
 func RemoveResource(env *localenv.LocalEnvironment, factory LocalEnvironmentFactory, kind string, name string, force bool, user string, manual, confirmed bool) error {
-	if kind := modules.Get().CanonicalKind(kind); kind == storage.KindRuntimeEnvironment {
+	if modules.Get().CanonicalKind(kind) == storage.KindRuntimeEnvironment {
 		if checkRunningAsRoot() != nil {
 			return trace.BadParameter("updating cluster runtime environment variables requires root privileges.\n" +
 				"Please run this command as root")

--- a/tool/gravity/cli/resources.go
+++ b/tool/gravity/cli/resources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops/resources"
 	"github.com/gravitational/gravity/lib/ops/resources/gravity"
 	"github.com/gravitational/gravity/lib/storage"
@@ -100,7 +101,7 @@ func CreateResource(
 
 // RemoveResource deletes resource by name
 func RemoveResource(env *localenv.LocalEnvironment, factory LocalEnvironmentFactory, kind string, name string, force bool, user string, manual, confirmed bool) error {
-	if kind == storage.KindRuntimeEnvironment {
+	if kind := modules.Get().CanonicalKind(kind); kind == storage.KindRuntimeEnvironment {
 		if checkRunningAsRoot() != nil {
 			return trace.BadParameter("updating cluster runtime environment variables requires root privileges.\n" +
 				"Please run this command as root")


### PR DESCRIPTION
 * Handle alternative resource names in modules interface.
 * Make 'name' flag optional for 'gravity resource rm'
 * Fix typo in a message banner

Complimentary PR: https://github.com/gravitational/gravity.e/pull/3903