### PR TITLE
Remove cni interface in system uninstall.

### DIFF
--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -1039,7 +1039,7 @@ func removeInterfaces(env *localenv.LocalEnvironment) error {
 	}
 
 	for _, iface := range ifaces {
-		if utils.HasOneOfPrefixes(iface.Name, "docker", "flannel") {
+		if utils.HasOneOfPrefixes(iface.Name, "docker", "flannel", "cni") {
 			env.PrintStep("Removing network interface %q", iface.Name)
 			out := &bytes.Buffer{}
 			if err := utils.Exec(exec.Command("ip", "link", "del", iface.Name), out); err != nil {


### PR DESCRIPTION
Otherwise reusing the same node fails unless the cni0 interface is deleted manually.