### PR TITLE
Set overlay driver as default in application manifest

### DIFF
--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -525,7 +525,8 @@ systemOptions:
 
   # Docker section allows to customize docker
   docker:
-    # Storage backend used, supported: "devicemapper" (default), "overlay", "overlay2"
+    # Storage backend used, supported: "devicemapper", "overlay" (default), "overlay2"
+    # Note: devicemapper is no longer available from gravity 5.3.4 or later.
     storageDriver: overlay
     # List of additional command line args to provide to docker daemon
     args: ["--log-level=DEBUG"]

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -525,8 +525,7 @@ systemOptions:
 
   # Docker section allows to customize docker
   docker:
-    # Storage backend used, supported: "devicemapper", "overlay", "overlay2" (default)
-    # Note: devicemapper is no longer available from gravity 5.3.4 or later.
+    # Storage backend used, supported: "devicemapper" (pre 5.3), "overlay", "overlay2" (default)
     storageDriver: overlay
     # List of additional command line args to provide to docker daemon
     args: ["--log-level=DEBUG"]

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -525,7 +525,7 @@ systemOptions:
 
   # Docker section allows to customize docker
   docker:
-    # Storage backend used, supported: "devicemapper", "overlay" (default), "overlay2"
+    # Storage backend used, supported: "devicemapper", "overlay", "overlay2" (default)
     # Note: devicemapper is no longer available from gravity 5.3.4 or later.
     storageDriver: overlay
     # List of additional command line args to provide to docker daemon

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -525,7 +525,7 @@ systemOptions:
 
   # Docker section allows to customize docker
   docker:
-    # Storage backend used, supported: "devicemapper" (pre 5.3), "overlay", "overlay2" (default)
+    # Storage backend used, supported: "overlay", "overlay2" (default)
     storageDriver: overlay
     # List of additional command line args to provide to docker daemon
     args: ["--log-level=DEBUG"]

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -204,7 +204,7 @@ func dockerConfigWithDefaults(config *Docker) Docker {
 	}
 	docker := *config
 	if docker.StorageDriver == "" {
-		docker.StorageDriver = constants.DockerStorageDriverDevicemapper
+		docker.StorageDriver = constants.DockerStorageDriverOverlay
 	}
 	if docker.Capacity == 0 {
 		docker.Capacity = defaultDockerCapacity
@@ -1073,7 +1073,7 @@ var (
 	defaultDockerCapacity = utils.MustParseCapacity(defaults.DockerDeviceCapacity)
 	// defaultDocker is the default docker settings
 	defaultDocker = Docker{
-		StorageDriver: constants.DockerStorageDriverDevicemapper,
+		StorageDriver: constants.DockerStorageDriverOverlay,
 		Capacity:      defaultDockerCapacity,
 	}
 

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -204,7 +204,7 @@ func dockerConfigWithDefaults(config *Docker) Docker {
 	}
 	docker := *config
 	if docker.StorageDriver == "" {
-		docker.StorageDriver = constants.DockerStorageDriverOverlay
+		docker.StorageDriver = constants.DockerStorageDriverOverlay2
 	}
 	if docker.Capacity == 0 {
 		docker.Capacity = defaultDockerCapacity
@@ -1073,7 +1073,7 @@ var (
 	defaultDockerCapacity = utils.MustParseCapacity(defaults.DockerDeviceCapacity)
 	// defaultDocker is the default docker settings
 	defaultDocker = Docker{
-		StorageDriver: constants.DockerStorageDriverOverlay,
+		StorageDriver: constants.DockerStorageDriverOverlay2,
 		Capacity:      defaultDockerCapacity,
 	}
 


### PR DESCRIPTION
Use overlay as the default storage driver. I don't know if overlay2 would be a better default, or if overlay is more likely to support a wider range of systems.

Updates https://github.com/gravitational/gravity/issues/211
Updates https://github.com/gravitational/gravity.e/issues/3913

Requires backport to 5.3.x/5.4.x.