### PR TITLE
Set overlay driver as default in application manifest (#212)

### DIFF
--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -524,7 +524,7 @@ systemOptions:
 
   # Docker section allows to customize docker
   docker:
-    # Storage backend used, supported: "devicemapper" (default), "overlay", "overlay2"
+    # Storage backend used, supported: "overlay", "overlay2" (default)
     storageDriver: overlay
     # List of additional command line args to provide to docker daemon
     args: ["--log-level=DEBUG"]

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -186,7 +186,7 @@ func dockerConfigWithDefaults(config *Docker) Docker {
 	}
 	docker := *config
 	if docker.StorageDriver == "" {
-		docker.StorageDriver = constants.DockerStorageDriverDevicemapper
+		docker.StorageDriver = constants.DockerStorageDriverOverlay2
 	}
 	if docker.Capacity == 0 {
 		docker.Capacity = defaultDockerCapacity
@@ -1051,7 +1051,7 @@ var (
 	defaultDockerCapacity = utils.MustParseCapacity(defaults.DockerDeviceCapacity)
 	// defaultDocker is the default docker settings
 	defaultDocker = Docker{
-		StorageDriver: constants.DockerStorageDriverDevicemapper,
+		StorageDriver: constants.DockerStorageDriverOverlay2,
 		Capacity:      defaultDockerCapacity,
 	}
 


### PR DESCRIPTION
Backport: https://github.com/gravitational/gravity/pull/212

* Set overlay driver as default in application manifest

https://github.com/gravitational/gravity/issues/211
https://github.com/gravitational/gravity.e/issues/3913

* use overlay2 as the default

* minimize the note about device mapper support

* minimize the note about device mapper support