### PR TITLE
[5.3] avoid panic in agent

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -143,7 +143,7 @@ type Peer struct {
 	// Only set after the agent has been started
 	agentDoneCh <-chan struct{}
 	// agent is this peer's RPC agent
-	agent rpcserver.Server
+	agent *rpcserver.PeerServer
 }
 
 // NewPeer returns new cluster peer client


### PR DESCRIPTION
If an interface is used, the it becomes trickier to deal with empty vs nil interface here:
```go
 	// Since getAgent returns a pointer, and if it's a nil, p.agent will be
	// set to (*rpserver.PeerServer(nil), nil) as the interface
	// value which makes p.agent != nil
	p.agent, err = p.getAgent(*ctx)
	if err != nil {
		return trace.Wrap(err)
	}
```
Updates https://github.com/gravitational/gravity.e/issues/3916.