### PR TITLE
Do not filter unrecognized resources

### DIFF
--- a/lib/app/resources/decode.go
+++ b/lib/app/resources/decode.go
@@ -56,14 +56,6 @@ L:
 // DecodeOption is a functional argument for decoding
 type DecodeOption func(*universalDecoder)
 
-// SkipUnrecognized returns "continue" error if decoding failed with
-// unrecognized object error
-func SkipUnrecognized() DecodeOption {
-	return func(d *universalDecoder) {
-		d.skipUnrecognized = true
-	}
-}
-
 type encoding int
 
 const (
@@ -149,8 +141,8 @@ func (r *universalDecoder) Decode() (runtime.Object, error) {
 	}
 	object, err := runtime.Decode(r.Decoder, unk.Raw)
 	if err != nil {
-		if r.skipUnrecognized && runtime.IsNotRegisteredError(trace.Unwrap(err)) {
-			return nil, utils.Continue("skipping unrecognized object: %v", err)
+		if runtime.IsNotRegisteredError(trace.Unwrap(err)) {
+			return &unk, nil
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/resources/resourcefiles.go
+++ b/lib/app/resources/resourcefiles.go
@@ -103,7 +103,7 @@ func NewResourceFile(path string) (*ResourceFile, error) {
 	defer file.Close()
 
 	// decode the contents of the resource file into an object
-	resource, err := Decode(file, SkipUnrecognized())
+	resource, err := Decode(file)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/resources/resourcefiles_test.go
+++ b/lib/app/resources/resourcefiles_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/gravitational/gravity/lib/compare"
 
 	. "gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type ResourceFilesSuite struct {
@@ -90,6 +91,62 @@ func (s *ResourceFilesSuite) TestResourceFiles(c *C) {
 	c.Assert(err, IsNil)
 	sort.Strings(images)
 	c.Assert(images, DeepEquals, rewrittenImages)
+
+	// verify that no resources were dropped
+	c.Assert(headers(rFiles), compare.DeepEquals, []runtime.TypeMeta{
+		{
+			Kind:       "Bundle",
+			APIVersion: "bundle.gravitational.io/v2",
+		},
+		{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "CronJob",
+			APIVersion: "batch/v2alpha1",
+		},
+		{
+			Kind:       "CronTab",
+			APIVersion: "stable.example.com/v1",
+		},
+		{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1beta1",
+		},
+		{
+			Kind:       "DaemonSet",
+			APIVersion: "extensions/v1beta1",
+		},
+		{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "ReplicationController",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "ReplicationController",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		{
+			Kind:       "SystemApplication",
+			APIVersion: "bundle.gravitational.io/v2",
+		},
+	})
 }
 
 func (s *ResourceFilesSuite) TestForEachObjectInFile(c *C) {
@@ -123,7 +180,7 @@ func (s *ResourceFilesSuite) TestForEachObjectInFile(c *C) {
 func prepareResourceFiles(c *C) (files []*os.File) {
 	dir := c.MkDir()
 
-	for _, resource := range []string{resources1, resources2, manifest1, manifest2} {
+	for _, resource := range []string{resources1, resources2, manifest1, manifest2, unrecognizedResource} {
 		file, err := ioutil.TempFile(dir, "resourcefilestest")
 		c.Assert(err, IsNil)
 		_, err = file.Write([]byte(resource))

--- a/lib/app/resources/utils.go
+++ b/lib/app/resources/utils.go
@@ -98,7 +98,7 @@ func renderResourceTemplate(path string, serviceUser systeminfo.User) error {
 		os.Remove(tmp.Name())
 	}()
 
-	res, err := Decode(in, SkipUnrecognized())
+	res, err := Decode(in)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -707,7 +707,7 @@ func resourceFromChart(path string) (*resources.Resource, error) {
 		return nil, trace.Wrap(err)
 	}
 	log.WithField("path", path).Debug(string(out))
-	return resources.Decode(bytes.NewReader(out), resources.SkipUnrecognized())
+	return resources.Decode(bytes.NewReader(out))
 }
 
 // resourcesFromPath collects resource files in root for further processing.


### PR DESCRIPTION
Do not filter unrecognized resources - instead, pass them through as `Unknown`s.

Fixes https://github.com/gravitational/gravity.e/issues/3923.