### PR TITLE
Installer UX.

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -324,7 +324,8 @@ func (p *Peer) checkAndSetServerProfile(app ops.Application) error {
 			return nil
 		}
 	}
-	return trace.NotFound("server role %q is not found", p.Role)
+	return utils.Abort(trace.BadParameter(
+		"specified node role %q is not defined in the application manifest", p.Role))
 }
 
 // runLocalChecks makes sure node satisfies system requirements

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -397,10 +397,10 @@ func (i *Installer) canContinue(report *ops.AgentReport) bool {
 		i.sendMessage(color.YellowString("Node %q on %v has left",
 			server.Role, utils.ExtractHost(server.AdvertiseAddr)))
 	}
-	// Save the current agent report so we can compare against it next iteration.
+	// Save the current agent report so we can compare against it on next iteration.
 	i.agentReport = report
 	// See if the current agent report satisfies the selected flavor.
-	needed, extra := report.Check(i.flavor)
+	needed, extra := report.MatchFlavor(i.flavor)
 	if len(needed) == 0 && len(extra) == 0 {
 		i.sendMessage(color.GreenString("All agents have connected!"))
 		return true

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -17,12 +17,15 @@ limitations under the License.
 package install
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"strconv"
+	"text/tabwriter"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -288,7 +291,6 @@ func (i *Installer) createAdminAgent() error {
 // StartOperation inializes installation plan, instantiates the install
 // FSM engine and launches the operation (plan execution)
 func (i *Installer) StartOperation() error {
-	i.Info("Starting installation.")
 	i.sendMessage("Starting the installation")
 	if err := i.createAdminAgent(); err != nil {
 		return trace.Wrap(err, "failed to create cluster admin agent")
@@ -298,7 +300,6 @@ func (i *Installer) StartOperation() error {
 	}
 	// in the manual mode do not launch FSM
 	if i.Manual {
-		i.Info("Manual install mode, not starting automatic plan execution.")
 		i.sendMessage(`Installation was started in manual mode
 Inspect the operation plan using "gravity plan" and execute plan phases manually on respective nodes using "gravity install --phase=<phase-id>"
 After all phases have completed successfully, shutdown this installer process using Ctrl-C`)
@@ -358,6 +359,7 @@ func (i *Installer) send(e Event) {
 }
 
 func (i *Installer) sendMessage(format string, args ...interface{}) {
+	i.Infof(format, args...)
 	i.send(Event{Progress: &ops.ProgressEntry{Message: fmt.Sprintf(format, args...)}})
 }
 
@@ -365,35 +367,60 @@ func (i *Installer) PollProgress(agentDoneCh <-chan struct{}) {
 	PollProgress(i.Context, i.send, i.Operator, i.OperationKey, agentDoneCh)
 }
 
-func (i *Installer) canContinue(servers []checks.ServerInfo) bool {
-	profiles := make(map[string]int)
-	for _, node := range i.flavor.Nodes {
-		profiles[node.Profile] = node.Count
+// formatProfiles outputs a table with information about node profiles
+// that need to join in order for installation to proceed.
+func (i *Installer) formatProfiles(profiles map[string]int) string {
+	var buf bytes.Buffer
+	w := new(tabwriter.Writer)
+	w.Init(&buf, 0, 8, 1, '\t', 0)
+	fmt.Fprintf(w, "Role\tNodes\tCommand\n")
+	fmt.Fprintf(w, "----\t-----\t-------\n")
+	for role, nodes := range profiles {
+		fmt.Fprintf(w, "%v\t%v\t%v\n", role, nodes,
+			fmt.Sprintf("gravity join %v --token=%v --role=%v",
+				i.AdvertiseAddr, i.Token.Token, role))
 	}
-	for _, s := range servers {
-		counter := profiles[s.Role]
-		counter -= 1
-		profiles[s.Role] = counter
+	w.Flush()
+	return buf.String()
+}
+
+// canContinue returns true if the installation can commence based on the
+// provided agent report and false if not all agents have joined yet.
+func (i *Installer) canContinue(report *ops.AgentReport) bool {
+	// See if any new nodes have joined or left since previous agent report.
+	joined, left := report.Diff(i.agentReport)
+	for _, server := range joined {
+		i.sendMessage(color.GreenString("Successfully added %q node on %v",
+			server.Role, utils.ExtractHost(server.AdvertiseAddr)))
 	}
-	for role, counter := range profiles {
-		if counter > 0 {
-			i.send(Event{
-				Progress: &ops.ProgressEntry{
-					Message: fmt.Sprintf(
-						"Still waiting for %v nodes of role %q", counter, role),
-				},
-			})
-			log.Infof("Still waiting for %v nodes of role %q.", counter, role)
-			return false
-		}
+	for _, server := range left {
+		i.sendMessage(color.YellowString("Node %q on %v has left",
+			server.Role, utils.ExtractHost(server.AdvertiseAddr)))
 	}
-	i.send(Event{
-		Progress: &ops.ProgressEntry{
-			Message: "All agents have connected!",
-		},
-	})
-	log.Info("All agents have connected!")
-	return true
+	// Save the current agent report so we can compare against it next iteration.
+	i.agentReport = report
+	// See if the current agent report satisfies the selected flavor.
+	needed, extra := report.Check(i.flavor)
+	if len(needed) == 0 && len(extra) == 0 {
+		i.sendMessage(color.GreenString("All agents have connected!"))
+		return true
+	}
+	// If there were no changes compared to previous report, do not
+	// output anything.
+	if len(joined) == 0 && len(left) == 0 {
+		return false
+	}
+	// Dump the table with remaining nodes that need to join.
+	i.sendMessage(fmt.Sprintf("Please execute the following join commands on target nodes:\n%v",
+		i.formatProfiles(needed)))
+	// If there are any extra agents with roles we don't expect for
+	// the selected flavor, they need to leave.
+	for _, server := range extra {
+		i.sendMessage(color.RedString("Node %q on %v is not a part of the flavor, shut it down",
+			server.Role, utils.ExtractHost(server.AdvertiseAddr)))
+	}
+	// We can't proceed yet.
+	return false
 }
 
 func (i *Installer) waitForAgents() error {
@@ -418,7 +445,7 @@ func (i *Installer) waitForAgents() error {
 				log.Warningf("Failed to get agent report: %v.", err)
 				continue
 			}
-			if !i.canContinue(report.Servers) {
+			if !i.canContinue(report) {
 				continue
 			}
 			log.Infof("Installation can proceed! %v", report)

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -466,9 +466,8 @@ func (i *Installer) printf(format string, args ...interface{}) {
 }
 
 func (i *Installer) printPostInstallMessage() {
-	message := modules.Get().PostInstallMessage()
-	if message != "" {
-		i.printf("\n%v\n", message)
+	if m, ok := modules.Get().(modules.Messager); ok {
+		i.printf("\n%v\n", m.PostInstallMessage())
 	}
 }
 

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -106,7 +106,10 @@ type Installer struct {
 	Cluster *ops.Site
 	// engine allows to customize installer behavior
 	engine Engine
+	// flavor stores the selected install flavor
 	flavor *schema.Flavor
+	// agentReport stores the last agent report
+	agentReport *ops.AgentReport
 }
 
 // SetFlavor sets the flavor that will be installed
@@ -429,20 +432,20 @@ func (i *Installer) Wait() error {
 					i.PrintStep(color.GreenString("Installation succeeded in %v",
 						i.timeSinceBeginning(i.OperationKey)))
 					if i.Mode == constants.InstallModeInteractive {
-						i.printf("---\nInstaller process will keep running so the installation can be finished by\n" +
-							"completing necessary post install actions in the installer UI if the installed\n" +
-							"application requires it. Once no longer needed, this process can be shutdown\n" +
-							"using Ctrl-C.\n")
+						i.printf("\nInstaller process will keep running so the installation can be finished by\n" +
+							"completing necessary post-install actions in the installer UI if the installed\n" +
+							"application requires it.\n")
+						i.printf(color.YellowString("\nOnce no longer needed, press Ctrl-C to shutdown this process.\n"))
 						return wait(i.Context, i.Cancel, i.Process)
 					}
 					return nil
 				} else {
 					i.PrintStep(color.RedString("Installation failed in %v, "+
-						"check %v for details", i.timeSinceBeginning(i.OperationKey), i.UserLogFile))
-					i.printf("---\nInstaller process will keep running so you can inspect the operation plan using\n" +
+						"check %v and %v for details", i.timeSinceBeginning(i.OperationKey), i.UserLogFile, i.SystemLogFile))
+					i.printf("\nInstaller process will keep running so you can inspect the operation plan using\n" +
 						"`gravity plan` command, see what failed and continue plan execution manually\n" +
-						"using `gravity install --phase=<phase-id>` command after fixing the problem.\n" +
-						"Once no longer needed, this process can be shutdown using Ctrl-C.\n")
+						"using `gravity install --phase=<phase-id>` command after fixing the problem.\n")
+					i.printf(color.YellowString("\nOnce no longer needed, press Ctrl-C to shutdown this process.\n"))
 					return wait(i.Context, i.Cancel, i.Process)
 				}
 			}

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -139,6 +139,7 @@ func newClusterEnvironment(args clusterEnvironmentArgs) (*ClusterEnvironment, er
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	operator.SetKubeClient(args.client)
 
 	clusterPackages, err := ClusterPackages()
 	if err != nil {

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -48,7 +48,11 @@ type Modules interface {
 	Version() Version
 	// TeleRepository returns the default repository for tele package cache
 	TeleRepository() string
-	// PostInstallMessage returns a message that gets printed to CLI after successful installation
+}
+
+// Messager provides methods for various informational messages
+type Messager interface {
+	// PostInstallMessage returns a message that gets printed to console after successful installation
 	PostInstallMessage() string
 }
 
@@ -127,8 +131,8 @@ func (m *defaultModules) TeleRepository() string {
 	return fmt.Sprintf("s3://%v", defaults.HubBucket)
 }
 
-// PostInstallMessage returns message that gets printed in CLI after
-// successful installation
+// PostInstallMessage returns message that gets printed to console after
+// successful installation.
 func (m *defaultModules) PostInstallMessage() string {
 	return `Congratulations!
 The cluster is up and running. Please take a look at "cluster management" section:

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -48,6 +48,8 @@ type Modules interface {
 	Version() Version
 	// TeleRepository returns the default repository for tele package cache
 	TeleRepository() string
+	// PostInstallMessage returns a message that gets printed to CLI after successful installation
+	PostInstallMessage() string
 }
 
 // Set sets the modules interface
@@ -123,6 +125,14 @@ func (m *defaultModules) Version() Version {
 // TeleRepository returns the default repository for tele package cache
 func (m *defaultModules) TeleRepository() string {
 	return fmt.Sprintf("s3://%v", defaults.HubBucket)
+}
+
+// PostInstallMessage returns message that gets printed in CLI after
+// successful installation
+func (m *defaultModules) PostInstallMessage() string {
+	return `Congratulations!
+The cluster is up and running. Please take a look at "cluster management" section:
+https://gravitational.com/gravity/docs/cluster/`
 }
 
 // Version represents gravity version

--- a/lib/ops/agents.go
+++ b/lib/ops/agents.go
@@ -92,17 +92,17 @@ func (s *AgentReport) Has(advertiseAddr string) bool {
 }
 
 // Diff returns added/removed servers this agent report has compared to
-// the provided report.
-func (s *AgentReport) Diff(another *AgentReport) (added, removed []checks.ServerInfo) {
-	if another == nil {
+// the provided previous report.
+func (s *AgentReport) Diff(previous *AgentReport) (added, removed []checks.ServerInfo) {
+	if previous == nil {
 		return s.Servers, nil
 	}
 	for _, server := range s.Servers {
-		if !another.Has(server.AdvertiseAddr) {
+		if !previous.Has(server.AdvertiseAddr) {
 			added = append(added, server)
 		}
 	}
-	for _, server := range another.Servers {
+	for _, server := range previous.Servers {
 		if !s.Has(server.AdvertiseAddr) {
 			removed = append(removed, server)
 		}
@@ -110,11 +110,11 @@ func (s *AgentReport) Diff(another *AgentReport) (added, removed []checks.Server
 	return
 }
 
-// Check verifies if agents from this report satisfy the provided flavor.
+// MatchFlavor verifies if agents from this report satisfy the provided flavor.
 //
 // Returns number/roles of agents that still need to join as well as any
 // extra servers that are not a part of the flavor.
-func (s *AgentReport) Check(flavor *schema.Flavor) (needed map[string]int, extra []checks.ServerInfo) {
+func (s *AgentReport) MatchFlavor(flavor *schema.Flavor) (needed map[string]int, extra []checks.ServerInfo) {
 	needed = make(map[string]int)
 	for _, node := range flavor.Nodes {
 		needed[node.Profile] = node.Count

--- a/lib/ops/agents.go
+++ b/lib/ops/agents.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/gravitational/gravity/lib/checks"
+	"github.com/gravitational/gravity/lib/schema"
 
 	"github.com/gravitational/trace"
 )
@@ -78,4 +79,55 @@ func (r *RawAgentReport) FromTransport() (*AgentReport, error) {
 func (s *AgentReport) String() string {
 	return fmt.Sprintf(
 		"AgentReport(Message=%v, Servers=%v)", s.Message, len(s.Servers))
+}
+
+// Has returns true if this agent report contains server with the provided IP.
+func (s *AgentReport) Has(advertiseAddr string) bool {
+	for _, server := range s.Servers {
+		if server.AdvertiseAddr == advertiseAddr {
+			return true
+		}
+	}
+	return false
+}
+
+// Diff returns added/removed servers this agent report has compared to
+// the provided report.
+func (s *AgentReport) Diff(another *AgentReport) (added, removed []checks.ServerInfo) {
+	if another == nil {
+		return s.Servers, nil
+	}
+	for _, server := range s.Servers {
+		if !another.Has(server.AdvertiseAddr) {
+			added = append(added, server)
+		}
+	}
+	for _, server := range another.Servers {
+		if !s.Has(server.AdvertiseAddr) {
+			removed = append(removed, server)
+		}
+	}
+	return
+}
+
+// Check verifies if agents from this report satisfy the provided flavor.
+//
+// Returns number/roles of agents that still need to join as well as any
+// extra servers that are not a part of the flavor.
+func (s *AgentReport) Check(flavor *schema.Flavor) (needed map[string]int, extra []checks.ServerInfo) {
+	needed = make(map[string]int)
+	for _, node := range flavor.Nodes {
+		needed[node.Profile] = node.Count
+	}
+	for _, server := range s.Servers {
+		if _, ok := needed[server.Role]; ok {
+			needed[server.Role] -= 1
+			if needed[server.Role] == 0 {
+				delete(needed, server.Role)
+			}
+		} else {
+			extra = append(extra, server)
+		}
+	}
+	return
 }

--- a/lib/ops/agents_test.go
+++ b/lib/ops/agents_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import (
+	"testing"
+
+	"github.com/gravitational/gravity/lib/checks"
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/rpc/proto"
+	"github.com/gravitational/gravity/lib/schema"
+
+	check "gopkg.in/check.v1"
+)
+
+func TestOps(t *testing.T) { check.TestingT(t) }
+
+type AgentReportSuite struct{}
+
+var _ = check.Suite(&AgentReportSuite{})
+
+func (s *AgentReportSuite) TestDiff(c *check.C) {
+	server1 := serverInfo("192.168.1.1", "node")
+	server2 := serverInfo("192.168.1.2", "node")
+	server3 := serverInfo("192.168.1.3", "node")
+
+	report1 := &AgentReport{
+		Servers: []checks.ServerInfo{server1, server2},
+	}
+	report2 := &AgentReport{
+		Servers: []checks.ServerInfo{server1, server3},
+	}
+
+	added, removed := report1.Diff(nil)
+	c.Assert(added, compare.DeepEquals, []checks.ServerInfo{server1, server2})
+	c.Assert(removed, check.IsNil)
+
+	added, removed = report2.Diff(report1)
+	c.Assert(added, compare.DeepEquals, []checks.ServerInfo{server3})
+	c.Assert(removed, compare.DeepEquals, []checks.ServerInfo{server2})
+}
+
+func (s *AgentReportSuite) TestCheck(c *check.C) {
+	server1 := serverInfo("192.168.1.1", "worker")
+	server2 := serverInfo("192.168.1.3", "db")
+	server3 := serverInfo("192.168.1.4", "api")
+
+	report := &AgentReport{
+		Servers: []checks.ServerInfo{server1, server2, server3},
+	}
+
+	needed, extra := report.Check(&schema.Flavor{
+		Nodes: []schema.FlavorNode{
+			{Profile: "worker", Count: 3},
+			{Profile: "db", Count: 2},
+		},
+	})
+	c.Assert(needed, compare.DeepEquals, map[string]int{"worker": 2, "db": 1})
+	c.Assert(extra, compare.DeepEquals, []checks.ServerInfo{server3})
+}
+
+func serverInfo(addr, role string) checks.ServerInfo {
+	return checks.ServerInfo{
+		RuntimeConfig: proto.RuntimeConfig{
+			AdvertiseAddr: addr,
+			Role:          role,
+		},
+	}
+}

--- a/lib/ops/agents_test.go
+++ b/lib/ops/agents_test.go
@@ -63,7 +63,7 @@ func (s *AgentReportSuite) TestCheck(c *check.C) {
 		Servers: []checks.ServerInfo{server1, server2, server3},
 	}
 
-	needed, extra := report.Check(&schema.Flavor{
+	needed, extra := report.MatchFlavor(&schema.Flavor{
 		Nodes: []schema.FlavorNode{
 			{Profile: "worker", Count: 3},
 			{Profile: "db", Count: 2},

--- a/lib/ops/opsservice/endpoints.go
+++ b/lib/ops/opsservice/endpoints.go
@@ -47,6 +47,13 @@ func (o *Operator) GetKubeClient() (*kubernetes.Clientset, error) {
 	return o.kubeClient, nil
 }
 
+// SetKubeClient sets Kubernetes client for this operator.
+func (o *Operator) SetKubeClient(client *kubernetes.Clientset) {
+	o.kubeMutex.Lock()
+	defer o.kubeMutex.Unlock()
+	o.kubeClient = client
+}
+
 // GetApplicationEndpoints returns a list of application endpoints for a deployed site
 func (o *Operator) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, error) {
 	site, err := o.openSite(key)

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -522,9 +522,12 @@ func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
 	}
 
 	// expand token is used when joining nodes to the cluster
-	expandToken, err := users.CryptoRandomToken(defaults.ProvisioningTokenBytes)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	expandToken := r.InstallToken
+	if expandToken == "" {
+		expandToken, err = users.CryptoRandomToken(defaults.ProvisioningTokenBytes)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	b := o.backend()

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"time"
 
@@ -59,6 +60,28 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 	if token != nil {
 		status.Token = *token
+	}
+
+	// Collect application endpoints.
+	endpoints, err := operator.GetApplicationEndpoints(cluster.Key())
+	if err != nil {
+		return status, trace.Wrap(err)
+	}
+	// Right now only 1 application is supported, in the future there
+	// will be many application each with its own endpoints.
+	status.Endpoints.Applications = append(status.Endpoints.Applications,
+		ApplicationEndpoints{
+			Application: cluster.App.Package,
+			Endpoints:   endpoints,
+		})
+
+	// For cluster endpoints, they point to gravity-site service on master nodes.
+	masters := cluster.ClusterState.Servers.Masters()
+	for _, master := range masters {
+		status.Endpoints.Cluster.AuthGateway = append(status.Endpoints.Cluster.AuthGateway,
+			fmt.Sprintf("%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
+		status.Endpoints.Cluster.UI = append(status.Endpoints.Cluster.UI,
+			fmt.Sprintf("https://%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
 	}
 
 	// FIXME: have status extension accept the operator/environment
@@ -150,8 +173,79 @@ type Cluster struct {
 	Operation *ClusterOperation `json:"operation,omitempty"`
 	// ActiveOperations is a list of operations currently active in the cluster
 	ActiveOperations []*ClusterOperation `json:"active_operations,omitempty"`
+	// Endpoints contains cluster and application endpoints.
+	Endpoints Endpoints `json:"endpoints"`
 	// Extension is a cluster status extension
 	Extension `json:",inline,omitempty"`
+}
+
+// Endpoints contains information about cluster and application endpoints.
+type Endpoints struct {
+	// Applications contains endpoints for installed applications.
+	Applications ApplicationsEndpoints `json:"applications,omitempty"`
+	// Cluster contains system cluster endpoints.
+	Cluster ClusterEndpoints `json:"cluster"`
+}
+
+// ClusterEndpoints describes system cluster endpoints.
+type ClusterEndpoints struct {
+	// AuthGateway contains addresses that users should specify via --proxy
+	// flag to tsh commands (essentially, address of gravity-site service)
+	AuthGateway []string `json:"auth_gateway"`
+	// UI contains URLs of the cluster control panel.
+	UI []string `json:"ui"`
+}
+
+// WriteTo writes cluster endpoints to the provided writer.
+func (e ClusterEndpoints) WriteTo(w io.Writer) (n int64, err error) {
+	fprintf(&n, w, "Cluster endpoints:\n")
+	fprintf(&n, w, "    * Authentication gateway:\n")
+	for _, e := range e.AuthGateway {
+		fprintf(&n, w, "        - %v\n", e)
+	}
+	fprintf(&n, w, "    * Cluster management URL:\n")
+	for _, e := range e.UI {
+		fprintf(&n, w, "        - %v\n", e)
+	}
+	return n, nil
+}
+
+// ApplicationsEndpoints contains endpoints for multiple applications.
+type ApplicationsEndpoints []ApplicationEndpoints
+
+// ApplicationEndpoints contains endpoints for a single application.
+type ApplicationEndpoints struct {
+	// Application is the application locator.
+	Application loc.Locator `json:"application"`
+	// Endpoints is a list of application endpoints.
+	Endpoints []ops.Endpoint `json:"endpoints"`
+}
+
+// WriteTo writes all application endpoints to the provided writer.
+func (e ApplicationsEndpoints) WriteTo(w io.Writer) (n int64, err error) {
+	if len(e) == 0 {
+		return 0, nil
+	}
+	fprintf(&n, w, "Application endpoints:\n")
+	for _, app := range e {
+		fprintf(&n, w, "    * %v:%v:\n", app.Application.Name, app.Application.Version)
+		for _, ep := range app.Endpoints {
+			fprintf(&n, w, "        - %v:\n", ep.Name)
+			for _, addr := range ep.Addresses {
+				fprintf(&n, w, "            - %v\n", addr)
+			}
+		}
+	}
+	return n, nil
+}
+
+func fprintf(n *int64, w io.Writer, format string, a ...interface{}) {
+	written, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		logrus.Errorf(err.Error())
+		return
+	}
+	*n += int64(written)
 }
 
 // Key returns key structure that identifies this operation

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -86,6 +86,12 @@ func URLSplitHostPort(in, defaultPort string) (string, string, error) {
 	return host, port, nil
 }
 
+// ExtractHost returns only the host part from the provided address.
+func ExtractHost(addr string) string {
+	host, _ := SplitHostPort(addr, "")
+	return host
+}
+
 // SplitHostPort extracts host name without port from host
 func SplitHostPort(in, defaultPort string) (host string, port string) {
 	parts := strings.SplitN(in, ":", 2)

--- a/lib/utils/parse_test.go
+++ b/lib/utils/parse_test.go
@@ -215,3 +215,9 @@ func (s ParseSuite) TestParseZoneOverride(c *check.C) {
 		c.Assert(ns, check.Equals, testCase.outNs, testCase.comment)
 	}
 }
+
+func (s *ParseSuite) TestExtractHost(c *check.C) {
+	c.Assert(ExtractHost("localhost:3023"), check.Equals, "localhost")
+	c.Assert(ExtractHost("127.0.0.1:8080"), check.Equals, "127.0.0.1")
+	c.Assert(ExtractHost("example.com"), check.Equals, "example.com")
+}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -50,6 +50,8 @@ func status(env *localenv.LocalEnvironment, printOptions printOptions) error {
 	if err == nil {
 		err = printStatus(operator, clusterStatus{*status, nil}, printOptions)
 		return trace.Wrap(err)
+	} else {
+		log.Errorf(trace.DebugReport(err))
 	}
 
 	if printOptions.operationID != "" {
@@ -266,7 +268,7 @@ func printStatusText(cluster clusterStatus) {
 		if cluster.Cluster != nil {
 			domain = cluster.Cluster.Domain
 		}
-		fmt.Fprintf(w, "Cluster:\t%v\n", unknownFallback(domain))
+		fmt.Fprintf(w, "Cluster nodes:\t%v\n", unknownFallback(domain))
 		printAgentStatus(*cluster.Agent, w)
 	}
 
@@ -298,6 +300,7 @@ func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 		fmt.Fprintf(w, "Last completed operation:\n")
 		printOperation(cluster.Operation, w)
 	}
+	cluster.Endpoints.Cluster.WriteTo(w)
 }
 
 func printOperation(operation *statusapi.ClusterOperation, w io.Writer) {


### PR DESCRIPTION
This PR implements a number of UX improvements for the installer, mostly cosmetic stuff:

* When installing a multi-node flavor, installer outputs a table with required join commands that should be run on other nodes. (And re-prints the table every time a new node joins/leaves).
* In a multi-node install scenario, previously when you specified incorrect "role" to the join command, it would just spin until timeout. I've now made it exit with appropriate error message immediately.
* If a customer specified `--token` to the install command, the same token becomes the join token.
* Extend status command to collect cluster/application endpoints information and print it after successful installation as well as in `gravity status`.
* Added some post-install messages, adjusted colors to make some things more prominent.

Closes https://github.com/gravitational/gravity.e/issues/3912, closes https://github.com/gravitational/gravity.e/issues/3891.