### PR TITLE
Allow excluding certain applications from install.

### DIFF
--- a/assets/site-app/images/hook/entrypoint.sh
+++ b/assets/site-app/images/hook/entrypoint.sh
@@ -17,7 +17,10 @@ if [ $1 = "update" ]; then
     echo "Creating or updating configmap"
     rig configmap gravity-site --resource-namespace=kube-system --from-file=/var/lib/gravity/resources/config
     if [ -n "$MANUAL_UPDATE" ]; then
-      rig upsert -f /var/lib/gravity/resources/site.yaml --debug
+        rig upsert -f /var/lib/gravity/resources/site.yaml --debug
+        if kubectl get namespaces/monitoring > /dev/null 2>&1; then
+            rig upsert -f /var/lib/gravity/resources/monitoring.yaml --debug
+        fi
     fi
 
     # Check to see if the Ops Center ConfigMap has already been created.

--- a/assets/site-app/images/site/init.sh
+++ b/assets/site-app/images/site/init.sh
@@ -31,3 +31,8 @@ fi
 
 # create daemon set with app
 /usr/local/bin/kubectl apply -f /var/lib/gravity/resources/site.yaml
+
+# create monitoring rbac policies if monitoring namespace exists
+if /usr/local/bin/kubectl get namespaces/monitoring > /dev/null 2>&1; then
+    /usr/local/bin/kubectl apply -f /var/lib/gravity/resources/monitoring.yaml
+fi

--- a/assets/site-app/resources/monitoring.yaml
+++ b/assets/site-app/resources/monitoring.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gravity-site
+  namespace: monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gravity-site
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gravity-site
+subjects:
+- kind: ServiceAccount
+  name: gravity-site
+  namespace: kube-system

--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -51,47 +51,6 @@ subjects:
   name: gravity-site
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gravity-site
-  namespace: monitoring
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: gravity-site
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: gravity-site
-subjects:
-- kind: ServiceAccount
-  name: gravity-site
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gravity-site

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1034,6 +1034,13 @@ var (
 	// BandwagonServiceName is the name of the default setup endpoint service
 	BandwagonServiceName = "bandwagon"
 
+	// LoggingAppName is the name of the logging application
+	LoggingAppName = "logging-app"
+	// MonitoringAppName is the name of the monitoring application
+	MonitoringAppName = "monitoring-app"
+	// TillerAppName is the name of the tiller application
+	TillerAppName = "tiller-app"
+
 	// KubeletArgs is a list of default command line options for kubelet
 	KubeletArgs = []string{
 		`--eviction-hard="nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%"`,

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -612,16 +612,8 @@ func splitServers(servers []storage.Server, app app.Application) (masters []stor
 // skipDependency returns true if the dependency package specified by dep
 // should be skipped when installing the provided application
 func (b *PlanBuilder) skipDependency(dep loc.Locator) bool {
-	// rbac-app is installed separately
 	if dep.Name == constants.BootstrapConfigPackage {
-		return true
+		return true // rbac-app is installed separately
 	}
-	// do not install bandwagon unless the app uses it in its post-install
-	if dep.Name == defaults.BandwagonPackageName {
-		setup := b.Application.Manifest.SetupEndpoint()
-		if setup == nil || setup.ServiceName != defaults.BandwagonServiceName {
-			return true
-		}
-	}
-	return false
+	return schema.ShouldSkipApp(b.Application.Manifest, dep)
 }

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -572,6 +572,7 @@ const manifestSchema = `
             },
             "logs": {"$ref": "#/definitions/onOff"},
             "monitoring": {"$ref": "#/definitions/onOff"},
+            "catalog": {"$ref": "#/definitions/onOff"},
             "kubernetes": {"$ref": "#/definitions/onOff"},
             "configuration": {"$ref": "#/definitions/onOff"}
           }


### PR DESCRIPTION
This PR allows to exclude certain applications (logging/monitoring/tiller) from installation. It is controller by their respective "extensions" field in the manifest. We already had it for logs and monitoring but it only affected UI tabs display - now it also skips respective system apps during install/upgrade. I also added a "catalog" field to it which does the same for tiller app. Closes https://github.com/gravitational/gravity.e/issues/3928.

Note: I had to move monitoring-related rbac resources out of site.yaml and create them separately b/c there may be no monitoring namespace anymore (if monitoring app is excluded).