### PR TITLE
update gravity-site healthz endpoint to more reliably indicate problems

### DIFF
--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -874,6 +874,10 @@ func (p *Process) ReportHealth(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		started := time.Now()
 		_, err := p.backend.GetAccounts()
+
+		// TODO(knisbet) This should really be reported through proper metrics collection
+		// for now we just log it. On a good system, worse case scenario is about 15ms
+		// so give some margin, but log if etcd is slightly on the slow side above 25ms.
 		elapsed := time.Now().Sub(started)
 		if elapsed > 25*time.Millisecond {
 			log.WithField("elapsed", elapsed).Error("Backend is slow.")

--- a/vendor/github.com/gravitational/teleport/lib/utils/tls.go
+++ b/vendor/github.com/gravitational/teleport/lib/utils/tls.go
@@ -122,7 +122,7 @@ func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 		NotAfter:              notAfter,
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	// collect IP addresses localhost resolves to and add them to the cert. template:


### PR DESCRIPTION
Updates healthz processing, so that:
- Generate a timeout if the backend is slow/unresponsive instead of waiting until the client has timed out
- Log slow backend requests
- Removed sending raw backend error messages to clients (this endpoint allows unauthenticated access)


Extra:
- Set server cipher selection, to avoid a bug that's tripped me up a couple times, where the curl in planet can't communicate using http2 to the gravity-site server
- Update cipher selection to be stricter recommendations, using teleport defaults