### PR TITLE
AuthGateway resource.

### DIFF
--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -140,6 +140,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: GRAVITY_CONFIG
             valueFrom:
               configMapKeyRef:

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -316,6 +316,10 @@ const (
 	// certificate is updated
 	ClusterCertificateUpdatedEvent = "ClusterCertificateUpdated"
 
+	// AuthGatewayConfigUpdatedEvent is broadcasted when config map with
+	// auth gateway configuration gets updated.
+	AuthGatewayConfigUpdatedEvent = "AuthGatewayConfigUpdated"
+
 	// MaxInteractiveSessionTTL is a max time for an interactive session
 	MaxInteractiveSessionTTL = 20 * time.Hour
 
@@ -339,6 +343,10 @@ const (
 
 	// EnvPodIP is environment variable that contains pod IP address
 	EnvPodIP = "POD_IP"
+	// EnvPodName is environment variable with the pod name
+	EnvPodName = "POD_NAME"
+	// EnvPodNamespace is environment variable with the pod namespace
+	EnvPodNamespace = "POD_NAMESPACE"
 
 	// EnvCloudProvider sets cloud provider name
 	EnvCloudProvider = "CLOUD_PROVIDER"
@@ -534,6 +542,9 @@ const (
 
 	// ResourceSpecKey specifies the name of the key with raw resource specification
 	ResourceSpecKey = "spec"
+
+	// AuthGatewayConfigMaps is the name of config map with auth gateway configuration.
+	AuthGatewayConfigMap = "auth-gateway"
 
 	// LVMSystemDir specifies the default location where lvm2 keeps state and configuration data
 	LVMSystemDir = "/etc/lvm"

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -316,10 +316,6 @@ const (
 	// certificate is updated
 	ClusterCertificateUpdatedEvent = "ClusterCertificateUpdated"
 
-	// AuthGatewayConfigUpdatedEvent is broadcasted when config map with
-	// auth gateway configuration gets updated.
-	AuthGatewayConfigUpdatedEvent = "AuthGatewayConfigUpdated"
-
 	// MaxInteractiveSessionTTL is a max time for an interactive session
 	MaxInteractiveSessionTTL = 20 * time.Hour
 
@@ -543,7 +539,7 @@ const (
 	// ResourceSpecKey specifies the name of the key with raw resource specification
 	ResourceSpecKey = "spec"
 
-	// AuthGatewayConfigMaps is the name of config map with auth gateway configuration.
+	// AuthGatewayConfigMap is the name of config map with auth gateway configuration.
 	AuthGatewayConfigMap = "auth-gateway"
 
 	// LVMSystemDir specifies the default location where lvm2 keeps state and configuration data

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -971,3 +971,19 @@ func (o *OperatorACL) DeleteGithubConnector(key SiteKey, name string) error {
 	}
 	return o.operator.DeleteGithubConnector(key, name)
 }
+
+// UpsertAuthGateway updates auth gateway configuration.
+func (o *OperatorACL) UpsertAuthGateway(key SiteKey, gw storage.AuthGateway) error {
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	return o.operator.UpsertAuthGateway(key, gw)
+}
+
+// GetAuthGateway returns auth gateway configuration.
+func (o *OperatorACL) GetAuthGateway(key SiteKey) (storage.AuthGateway, error) {
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return o.operator.GetAuthGateway(key)
+}

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1725,4 +1725,8 @@ type Identity interface {
 	GetGithubConnectors(key SiteKey, withSecrets bool) ([]teleservices.GithubConnector, error)
 	// DeleteGithubConnector deletes a Github connector by name
 	DeleteGithubConnector(key SiteKey, name string) error
+	// UpsertAuthGateway updates auth gateway configuration
+	UpsertAuthGateway(SiteKey, storage.AuthGateway) error
+	// GetAuthGateway returns auth gateway configuration
+	GetAuthGateway(SiteKey) (storage.AuthGateway, error)
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -1388,6 +1388,32 @@ func (c *Client) DeleteGithubConnector(key ops.SiteKey, name string) error {
 	return trace.Wrap(err)
 }
 
+// UpsertAuthGateway updates auth gateway configuration.
+func (c *Client) UpsertAuthGateway(key ops.SiteKey, gw storage.AuthGateway) error {
+	bytes, err := storage.MarshalAuthGateway(gw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = c.PostJSON(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "authgateway"),
+		&UpsertResourceRawReq{
+			Resource: bytes,
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// GetAuthGateway returns auth gateway configuration.
+func (c *Client) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
+	response, err := c.Get(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "authgateway"),
+		url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return storage.UnmarshalAuthGateway(response.Bytes())
+}
+
 // PostJSON issues HTTP POST request to the server with the provided JSON data
 func (c *Client) PostJSON(endpoint string, data interface{}) (*roundtrip.Response, error) {
 	return telehttplib.ConvertResponse(c.Client.PostJSON(endpoint, data))

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -266,6 +266,10 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/authentication/preference", h.needsAuth(h.upsertClusterAuthPreference))
 	h.GET("/portal/v1/accounts/:account_id/sites/:site_domain/authentication/preference", h.needsAuth(h.getClusterAuthPreference))
 
+	// auth gateway settings
+	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/authgateway", h.needsAuth(h.upsertAuthGateway))
+	h.GET("/portal/v1/accounts/:account_id/sites/:site_domain/authgateway", h.needsAuth(h.getAuthGateway))
+
 	return h, nil
 }
 

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -822,3 +822,13 @@ func (r *Router) DeleteGithubConnector(key ops.SiteKey, name string) error {
 	}
 	return client.DeleteGithubConnector(key, name)
 }
+
+// UpsertAuthGateway updates auth gateway configuration.
+func (r *Router) UpsertAuthGateway(key ops.SiteKey, gw storage.AuthGateway) error {
+	return r.Local.UpsertAuthGateway(key, gw)
+}
+
+// GetAuthGateway returns auth gateway configuration.
+func (r *Router) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
+	return r.Local.GetAuthGateway(key)
+}

--- a/lib/ops/opsservice/authgateway.go
+++ b/lib/ops/opsservice/authgateway.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/users"
+
+	"github.com/gravitational/trace"
+	"k8s.io/client-go/kubernetes"
+)
+
+// UpsertAuthGateway updates auth gateway configuration.
+func (o *Operator) UpsertAuthGateway(key ops.SiteKey, gw storage.AuthGateway) error {
+	// Updating auth gateway configuration may trigger gravity-site
+	// restart so allow to create it only on active clusters (to avoid
+	// interrupting an operation for example).
+	cluster, err := o.GetLocalSite()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if cluster.State != ops.SiteStateActive {
+		return trace.BadParameter("auth gateway configuration can be updated "+
+			"on active clusters only, the cluster is currently %v", cluster.State)
+	}
+	client, err := o.GetKubeClient()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return UpsertAuthGateway(client, o.users(), gw)
+}
+
+// UpsertAuthGateway updates auth gateway configuration.
+func UpsertAuthGateway(client *kubernetes.Clientset, identity users.Identity, gw storage.AuthGateway) error {
+	if authPreference := gw.GetAuthPreference(); authPreference != nil {
+		err := identity.SetAuthPreference(authPreference)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	// If the resource already exists, update only those fields that were
+	// set in the new resource instead of replacing the whole thing.
+	current, err := GetAuthGateway(client, identity)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	if current != nil {
+		gw.ApplyTo(current)
+	} else {
+		current = gw
+	}
+	data, err := storage.MarshalAuthGateway(current)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return updateConfigMap(client.Core().ConfigMaps(defaults.KubeSystemNamespace),
+		constants.AuthGatewayConfigMap, defaults.KubeSystemNamespace, string(data), nil)
+}
+
+// GetAuthGateway returns auth gateway configuration
+func (o *Operator) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
+	client, err := o.GetKubeClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return GetAuthGateway(client, o.users())
+}
+
+// GetAuthGateway returns auth gateway configuration
+func GetAuthGateway(client *kubernetes.Clientset, identity users.Identity) (storage.AuthGateway, error) {
+	data, err := getConfigMap(client.Core().ConfigMaps(defaults.KubeSystemNamespace),
+		constants.AuthGatewayConfigMap)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	gw, err := storage.UnmarshalAuthGateway([]byte(data))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Use auth preference value from the database in case it was set
+	// independently of auth gateway resource via separate auth preference
+	// resource, which is obsolete. Once dedicated auth preference resource
+	// is removed, auth gateway will become a sole source of truth and this
+	// will no longer be needed.
+	authPreference, err := identity.GetAuthPreference()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	gw.SetAuthPreference(authPreference)
+	return gw, nil
+}

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1011,7 +1011,6 @@ type planetConfig struct {
 // for the provided server.
 func (s *site) getPrincipals(node *ProvisionedServer) []string {
 	principals := []string{
-		s.domainName,
 		node.AdvertiseIP,
 		node.Hostname,
 	}

--- a/lib/ops/opsservice/monitoring.go
+++ b/lib/ops/opsservice/monitoring.go
@@ -104,7 +104,7 @@ func (o *Operator) UpdateAlert(key ops.SiteKey, alert storage.Alert) error {
 		constants.MonitoringType: constants.MonitoringTypeAlert,
 	}
 	return updateConfigMap(client.Core().ConfigMaps(defaults.MonitoringNamespace),
-		alert.GetName(), string(data), labels)
+		alert.GetName(), defaults.MonitoringNamespace, string(data), labels)
 }
 
 // DeleteAlert deletes the specified monitoring alert
@@ -180,7 +180,7 @@ func (o *Operator) UpdateAlertTarget(key ops.SiteKey, target storage.AlertTarget
 		constants.MonitoringType: constants.MonitoringTypeAlertTarget,
 	}
 	return updateConfigMap(client.Core().ConfigMaps(defaults.MonitoringNamespace),
-		constants.AlertTargetConfigMap, string(data), labels)
+		constants.AlertTargetConfigMap, defaults.MonitoringNamespace, string(data), labels)
 }
 
 // DeleteAlertTarget deletes the cluster monitoring alert target
@@ -211,11 +211,11 @@ func getConfigMap(client corev1.ConfigMapInterface, name string) (string, error)
 	return data, nil
 }
 
-func updateConfigMap(client corev1.ConfigMapInterface, name, data string, labels map[string]string) error {
+func updateConfigMap(client corev1.ConfigMapInterface, name, namespace, data string, labels map[string]string) error {
 	config := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: defaults.MonitoringNamespace,
+			Namespace: namespace,
 			Labels:    labels,
 		},
 		Data: map[string]string{

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -512,3 +512,65 @@ func (c alertTargetCollection) Resources() (resources []teleservices.UnknownReso
 }
 
 type alertTargetCollection []storage.AlertTarget
+
+type authGatewayCollection struct {
+	item storage.AuthGateway
+}
+
+// Resources returns the resources collection in the generic format
+func (c *authGatewayCollection) Resources() (resources []teleservices.UnknownResource, err error) {
+	resource, err := utils.ToUnknownResource(c.item)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	resources = append(resources, *resource)
+	return resources, nil
+}
+
+// WriteText serializes auth gateway config in human-friendly text format
+func (c *authGatewayCollection) WriteText(w io.Writer) error {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	common.PrintTableHeader(t, []string{"Parameter", "Value"})
+	fmt.Fprintf(t, "Max Connections:\t%v\n", c.item.GetMaxConnections())
+	fmt.Fprintf(t, "Max Users:\t%v\n", c.item.GetMaxUsers())
+	if c.item.GetClientIdleTimeout() != nil {
+		fmt.Fprintf(t, "Client Idle Timeout:\t%v\n", c.item.GetClientIdleTimeout().Value())
+	} else {
+		fmt.Fprintf(t, "Client Idle Timeout:\tnever\n")
+	}
+	if c.item.GetDisconnectExpiredCert() != nil {
+		fmt.Fprintf(t, "Disconnect Expired Cert:\t%v\n", c.item.GetDisconnectExpiredCert().Value())
+	} else {
+		fmt.Fprintf(t, "Disconnect Expired Cert:\tno\n")
+	}
+	if ap := c.item.GetAuthPreference(); ap != nil {
+		fmt.Fprintf(t, "Authentication:\ttype: %v, second factor: %v\n", ap.GetType(), ap.GetSecondFactor())
+	}
+	fmt.Fprintf(t, "SSH Public Addrs:\t%v\n", formatList(c.item.GetSSHPublicAddrs()))
+	fmt.Fprintf(t, "Kubernetes Public Addrs:\t%v\n", formatList(c.item.GetKubernetesPublicAddrs()))
+	fmt.Fprintf(t, "Web Public Addrs:\t%v\n", formatList(c.item.GetWebPublicAddrs()))
+	_, err := io.WriteString(w, t.String())
+	return trace.Wrap(err)
+}
+
+func formatList(list []string) string {
+	if len(list) == 0 {
+		return "-"
+	}
+	return strings.Join(list, ", ")
+}
+
+// WriteJSON serializes collection into JSON format
+func (c *authGatewayCollection) WriteJSON(w io.Writer) error {
+	return utils.WriteJSON(c, w)
+}
+
+// WriteYAML serializes collection into YAML format
+func (c *authGatewayCollection) WriteYAML(w io.Writer) error {
+	return utils.WriteYAML(c, w)
+}
+
+// ToMarshal returns object that should be marshaled.
+func (c *authGatewayCollection) ToMarshal() interface{} {
+	return c.item
+}

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -518,13 +518,12 @@ type authGatewayCollection struct {
 }
 
 // Resources returns the resources collection in the generic format
-func (c *authGatewayCollection) Resources() (resources []teleservices.UnknownResource, err error) {
+func (c *authGatewayCollection) Resources() ([]teleservices.UnknownResource, error) {
 	resource, err := utils.ToUnknownResource(c.item)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	resources = append(resources, *resource)
-	return resources, nil
+	return []teleservices.UnknownResource{*resource}, nil
 }
 
 // WriteText serializes auth gateway config in human-friendly text format
@@ -543,8 +542,8 @@ func (c *authGatewayCollection) WriteText(w io.Writer) error {
 	} else {
 		fmt.Fprintf(t, "Disconnect Expired Cert:\tno\n")
 	}
-	if ap := c.item.GetAuthPreference(); ap != nil {
-		fmt.Fprintf(t, "Authentication:\ttype: %v, second factor: %v\n", ap.GetType(), ap.GetSecondFactor())
+	if auth := c.item.GetAuthentication(); auth != nil {
+		fmt.Fprintf(t, "Authentication:\ttype: %v, second factor: %v\n", auth.Type, auth.SecondFactor)
 	}
 	fmt.Fprintf(t, "SSH Public Addrs:\t%v\n", formatList(c.item.GetSSHPublicAddrs()))
 	fmt.Fprintf(t, "Kubernetes Public Addrs:\t%v\n", formatList(c.item.GetKubernetesPublicAddrs()))

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops/resources"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/fatih/color"
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
 )
@@ -160,6 +161,9 @@ func (r *Resources) Create(req resources.CreateRequest) error {
 		}
 		r.Println("Updated TLS keypair")
 	case teleservices.KindClusterAuthPreference:
+		r.Println(color.YellowString("Cluster auth preference resource is " +
+			"obsolete and will be removed in a future release. Please use " +
+			"auth gateway resource instead."))
 		cap, err := teleservices.GetAuthPreferenceMarshaler().Unmarshal(req.Resource.Raw)
 		if err != nil {
 			return trace.Wrap(err)
@@ -207,6 +211,18 @@ func (r *Resources) Create(req resources.CreateRequest) error {
 			return trace.Wrap(err)
 		}
 		r.Printf("Updated monitoring alert target %q\n", target.GetName())
+	case storage.KindAuthGateway:
+		r.Println(color.YellowString("Note: gravity-site pods may restart " +
+			"in order for the changes to take effect."))
+		gw, err := storage.UnmarshalAuthGateway(req.Resource.Raw)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		err = r.Operator.UpsertAuthGateway(r.cluster.Key(), gw)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		r.Println("Updated auth gateway configuration")
 	case "":
 		return trace.BadParameter("missing resource kind")
 	default:
@@ -298,11 +314,23 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		keyPair := storage.NewTLSKeyPair(cert.Certificate, cert.PrivateKey)
 		return &tlsKeyPairCollection{keyPairs: []storage.TLSKeyPair{keyPair}}, nil
 	case teleservices.KindClusterAuthPreference, "authpreference", "cap":
+		r.Println(color.YellowString("Cluster auth preference resource is " +
+			"obsolete and will be removed in a future release. Please use " +
+			"auth gateway resource instead."))
 		authPreference, err := r.Operator.GetClusterAuthPreference(r.cluster.Key())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return clusterAuthPreferenceCollection{authPreference}, nil
+	case storage.KindAuthGateway:
+		gw, err := r.Operator.GetAuthGateway(r.cluster.Key())
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return nil, trace.NotFound("auth gateway resource not found")
+			}
+			return nil, trace.Wrap(err)
+		}
+		return &authGatewayCollection{gw}, nil
 	case storage.KindSMTPConfig, "smtps":
 		config, err := r.Operator.GetSMTPConfig(r.cluster.Key())
 		if err != nil {

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -163,7 +163,7 @@ func (r *Resources) Create(req resources.CreateRequest) error {
 	case teleservices.KindClusterAuthPreference:
 		r.Println(color.YellowString("Cluster auth preference resource is " +
 			"obsolete and will be removed in a future release. Please use " +
-			"auth gateway resource instead."))
+			"auth gateway resource instead: https://gravitational.com/gravity/docs/cluster/#configuring-cluster-authentication-gateway."))
 		cap, err := teleservices.GetAuthPreferenceMarshaler().Unmarshal(req.Resource.Raw)
 		if err != nil {
 			return trace.Wrap(err)
@@ -212,8 +212,6 @@ func (r *Resources) Create(req resources.CreateRequest) error {
 		}
 		r.Printf("Updated monitoring alert target %q\n", target.GetName())
 	case storage.KindAuthGateway:
-		r.Println(color.YellowString("Note: gravity-site pods may restart " +
-			"in order for the changes to take effect."))
 		gw, err := storage.UnmarshalAuthGateway(req.Resource.Raw)
 		if err != nil {
 			return trace.Wrap(err)
@@ -316,7 +314,7 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 	case teleservices.KindClusterAuthPreference, "authpreference", "cap":
 		r.Println(color.YellowString("Cluster auth preference resource is " +
 			"obsolete and will be removed in a future release. Please use " +
-			"auth gateway resource instead."))
+			"auth gateway resource instead: https://gravitational.com/gravity/docs/cluster/#configuring-cluster-authentication-gateway."))
 		authPreference, err := r.Operator.GetClusterAuthPreference(r.cluster.Key())
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -276,7 +276,12 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 
 	process.Infof("Process ID: %v.", processID)
 
-	process.teleportConfig, err = process.buildTeleportConfig()
+	process.authGatewayConfig, err = process.getOrInitAuthGatewayConfig()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	process.teleportConfig, err = process.buildTeleportConfig(process.authGatewayConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1258,10 +1263,6 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		}
 
 		if err := p.startAuthGatewayWatch(p.context, client); err != nil {
-			return trace.Wrap(err)
-		}
-
-		if err := p.startWatchingAuthGatewayEvents(p.context, client); err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -104,6 +104,7 @@ type Process struct {
 	leader         storage.Leader
 	packages       pack.PackageService
 	cfg            processconfig.Config
+	tcfg           telecfg.FileConfig
 	identity       users.Identity
 	mode           string
 	teleportConfig *service.Config
@@ -129,6 +130,10 @@ type Process struct {
 	handlers Handlers
 	// rpcCreds holds generated RPC agents credentials
 	rpcCreds rpcCredentials
+	// authGatewayConfig is the current auth gateway configuration (basically,
+	// a config that gets applied on top of teleport's config the process
+	// was started with)
+	authGatewayConfig storage.AuthGateway
 }
 
 // Handlers combines all the process' web and API Handlers
@@ -253,6 +258,7 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 		packages:       packages,
 		backend:        backend,
 		cfg:            cfg,
+		tcfg:           tcfg,
 		mode:           cfg.Mode,
 		identity:       identity,
 		clusterObjects: clusterObjects,
@@ -270,43 +276,7 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 
 	process.Infof("Process ID: %v.", processID)
 
-	telecfgFromImport, err := process.getTeleportConfigFromImportState()
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to query teleport config from import")
-	}
-
-	if telecfgFromImport != nil {
-		// Reset reverse tunnel from import configuration.
-		// See https://github.com/gravitational/gravity/issues/2927
-		telecfgFromImport.Auth.ReverseTunnels = nil
-
-		tcfg = *telecfgFromImport
-	}
-	if err := processconfig.MergeTeleConfigFromEnv(&tcfg); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// bootstrap reverse tunnels to Ops Centers from enabled trusted clusters
-	tunnels, err := reverseTunnelsFromTrustedClusters(backend)
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	tcfg.Auth.ReverseTunnels = append(tcfg.Auth.ReverseTunnels, tunnels...)
-
-	process.teleportConfig = service.MakeDefaultConfig()
-	process.teleportConfig.DataDir = tcfg.DataDir
-
-	if err := telecfg.ApplyFileConfig(&tcfg, process.teleportConfig); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	process.teleportConfig.Auth.StorageConfig.Params["path"] = tcfg.DataDir
-	if len(process.teleportConfig.AuthServers) == 0 && process.teleportConfig.Auth.Enabled {
-		process.teleportConfig.AuthServers = append(process.teleportConfig.AuthServers, process.teleportConfig.Auth.SSHAddr)
-	}
-
-	process.teleportConfig.Auth.Preference, err = process.getAuthPreference()
+	process.teleportConfig, err = process.buildTeleportConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -315,17 +285,6 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 		process.Warn("Enabling Teleport insecure dev mode!")
 		telelib.SetInsecureDevMode(true)
 	}
-
-	// Teleport will be using Gravity backend implementation
-	process.teleportConfig.Identity = process.identity
-	process.teleportConfig.Trust = process.identity
-	process.teleportConfig.Presence = process.backend
-	process.teleportConfig.Provisioner = process.identity
-	process.teleportConfig.Proxy.DisableWebInterface = true
-	process.teleportConfig.Proxy.DisableWebService = true
-	process.teleportConfig.Access = process.identity
-	process.teleportConfig.Console = logrus.StandardLogger().Writer()
-	process.teleportConfig.ClusterConfiguration = process.identity
 
 	process.Infof("Teleport config: %#v.", process.teleportConfig)
 	process.Infof("Gravity config: %#v.", cfg)
@@ -1295,6 +1254,18 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		}
 
 		if err := p.startCertificateWatch(p.context, client); err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := p.startAuthGatewayWatch(p.context, client); err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := p.startWatchingAuthGatewayEvents(p.context, client); err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := p.startWatchingReloadEvents(p.context, client); err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
+	"github.com/gravitational/gravity/lib/processconfig"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/service"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// buildTeleportConfig build configuration object that will be used to
+// start embedded Teleport services.
+func (p *Process) buildTeleportConfig() (*service.Config, error) {
+	configFromImport, err := p.getTeleportConfigFromImportState()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// If we're running inside Kubernetes, Teleport configuration is stored
+	// in a package that's available in what we call "import state".
+	fileConfig := p.tcfg
+	if configFromImport != nil {
+		fileConfig = *configFromImport
+	}
+	err = processconfig.MergeTeleConfigFromEnv(&fileConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Apply user-defined configuration on top of the file config. This is
+	// what users configure via AuthGateway resource.
+	p.authGatewayConfig, err = p.getOrInitAuthGatewayConfig()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	if p.authGatewayConfig != nil {
+		p.authGatewayConfig.ApplyToTeleportConfig(&fileConfig)
+	}
+	fileConfig.Auth.ReverseTunnels, err = reverseTunnelsFromTrustedClusters(p.backend)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	serviceConfig := service.MakeDefaultConfig()
+	err = config.ApplyFileConfig(&fileConfig, serviceConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	serviceConfig.Auth.StorageConfig.Params["path"] = fileConfig.DataDir
+	if len(serviceConfig.AuthServers) == 0 && serviceConfig.Auth.Enabled {
+		serviceConfig.AuthServers = append(serviceConfig.AuthServers, serviceConfig.Auth.SSHAddr)
+	}
+	// Teleport will be using Gravity backend implementation.
+	serviceConfig.Identity = p.identity
+	serviceConfig.Trust = p.identity
+	serviceConfig.Presence = p.backend
+	serviceConfig.Provisioner = p.identity
+	serviceConfig.Proxy.DisableWebInterface = true
+	serviceConfig.Proxy.DisableWebService = true
+	serviceConfig.Access = p.identity
+	serviceConfig.Console = logrus.StandardLogger().Writer()
+	serviceConfig.ClusterConfiguration = p.identity
+	return serviceConfig, nil
+}
+
+// getOrInitAuthGatewayConfig returns auth gateway configuration.
+//
+// If it's not found, it's first initialized with default values.
+func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
+	if !p.inKubernetes() {
+		return nil, nil
+	}
+	client, err := tryGetPrivilegedKubeClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authGateway, err := opsservice.GetAuthGateway(client, p.identity)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	if authGateway != nil {
+		p.Debug("Auth gateway config resource is already initialized.")
+		return authGateway, nil
+	}
+	// Auth gateway resource does not exist, initialize it with default
+	// values taken from Teleport config.
+	p.Info("Initializing auth gateway config resource.")
+	authPreference, err := p.getAuthPreference()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authGateway = storage.DefaultAuthGateway()
+	authGateway.SetAuthPreference(authPreference)
+	// Initially the local cluster name is set as a principal.
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authGateway.SetPublicAddrs([]string{cluster.Domain})
+	err = opsservice.UpsertAuthGateway(client, p.identity, authGateway)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return authGateway, nil
+}
+
+func (p *Process) getAuthGatewayConfig() (storage.AuthGateway, error) {
+	client, err := tryGetPrivilegedKubeClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return opsservice.GetAuthGateway(client, p.identity)
+}

--- a/lib/process/watch.go
+++ b/lib/process/watch.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	libkube "github.com/gravitational/gravity/lib/kubernetes"
+	"github.com/gravitational/gravity/lib/processconfig"
 
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/trace"
@@ -96,4 +98,151 @@ func (p *Process) watchCertificate(ctx context.Context, client *kubernetes.Clien
 			return nil
 		}
 	}
+}
+
+// startAuthGatewayWatch launches watcher that monitors config map with
+// auth gateway configuration.
+func (p *Process) startAuthGatewayWatch(ctx context.Context, client *kubernetes.Clientset) error {
+	go func() {
+		for {
+			err := p.watchAuthGateway(ctx, client)
+			if err != nil {
+				p.Errorf("Failed to start auth gateway config watch: %v.", trace.DebugReport(err))
+			}
+			select {
+			case <-time.After(time.Second):
+			case <-ctx.Done():
+				p.Debug("Auth gateway config watcher stopped.")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// watchAuthGateway watches changes to the auth gateway config map.
+func (p *Process) watchAuthGateway(ctx context.Context, client *kubernetes.Clientset) error {
+	p.Debug("Restarting auth gateway config watch.")
+	watcher, err := client.Core().ConfigMaps(defaults.KubeSystemNamespace).Watch(metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", constants.AuthGatewayConfigMap).String(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Stop()
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				p.Debugf("Watcher channel closed: %v.", event)
+				return nil
+			}
+			if event.Type != watch.Modified && event.Type != watch.Deleted {
+				p.Debugf("Ignoring event: %v.", event.Type)
+				continue
+			}
+			configMap, ok := event.Object.(*v1.ConfigMap)
+			if !ok {
+				p.Warningf("Expected ConfigMap, got: %T %v.", event.Object, event.Object)
+				continue
+			}
+			if configMap.Name != constants.AuthGatewayConfigMap {
+				p.Debugf("Ignoring ConfigMap change: %v.", configMap.Name)
+				continue
+			}
+			p.Debugf("Detected ConfigMap change: %v.", configMap.Name)
+			p.BroadcastEvent(service.Event{
+				Name: constants.AuthGatewayConfigUpdatedEvent,
+			})
+		case <-ctx.Done():
+			p.Debug("Stopping auth gateway config watcher.")
+			return nil
+		}
+	}
+}
+
+// startWatchingAuthGatewayEvents launches watcher that monitors auth
+// gateway configuration change events and appropriately updates
+// Teleport configuration.
+func (p *Process) startWatchingAuthGatewayEvents(ctx context.Context, client *kubernetes.Clientset) error {
+	go func() {
+		eventsCh := make(chan service.Event)
+		p.WaitForEvent(ctx, constants.AuthGatewayConfigUpdatedEvent, eventsCh)
+		p.Infof("Started watching %v events.", constants.AuthGatewayConfigUpdatedEvent)
+		for {
+			select {
+			case event := <-eventsCh:
+				if event.Name != constants.AuthGatewayConfigUpdatedEvent {
+					p.Warnf("Expected %v event, got: %#v.", constants.AuthGatewayConfigUpdatedEvent, event)
+					continue
+				}
+				p.Infof("Received event: %#v.", event)
+				authGatewayConfig, err := p.getAuthGatewayConfig()
+				if err != nil {
+					p.Errorf(trace.DebugReport(err))
+					continue
+				}
+				if authGatewayConfig.PrincipalsChanged(p.authGatewayConfig) {
+					// Teleport principals got updated. Don't restart right
+					// away, but update its config so it can regenerate
+					// identities for its services.
+					p.Infof("Auth gateway principals changed.")
+					config, err := p.buildTeleportConfig()
+					if err != nil {
+						p.Errorf(trace.DebugReport(err))
+						continue
+					}
+					// Replacing principals in config will result in Teleport
+					// regenerating identities (asynchonously) and then
+					// sending reload event which will be caught below.
+					processconfig.ReplacePublicAddrs(p.teleportProcess().Config, config)
+				} else if authGatewayConfig.SettingsChanged(p.authGatewayConfig) {
+					// Principals didn't change but some of the Teleport
+					// settings changed so we can reload right away.
+					p.Infof("Auth gateway settings changed.")
+					p.BroadcastEvent(service.Event{
+						Name: service.TeleportReloadEvent,
+					})
+				} else {
+					// Neither principals nor other settings changed, nothing
+					// to do (maybe auth preference changed which is also a
+					// part auth gateway resource).
+					p.Infof("Auth gateway principals/settings didn't change.")
+				}
+			case <-ctx.Done():
+				p.Infof("Stopped watching %v events.", constants.AuthGatewayConfigUpdatedEvent)
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// startWatchingReloadEvents launches watcher that listens for reload events
+// and restarts the process.
+func (p *Process) startWatchingReloadEvents(ctx context.Context, client *kubernetes.Clientset) error {
+	go func() {
+		eventsCh := make(chan service.Event)
+		p.WaitForEvent(ctx, service.TeleportReloadEvent, eventsCh)
+		p.Infof("Started watching %v events.", service.TeleportReloadEvent)
+		for {
+			select {
+			case event := <-eventsCh:
+				if event.Name != service.TeleportReloadEvent {
+					p.Warnf("Expected %v event, got: %#v.", service.TeleportReloadEvent, event)
+					continue
+				}
+				p.Infof("Received event: %#v.", event)
+				err := libkube.DeleteSelf(client, p.FieldLogger)
+				if err != nil {
+					p.Errorf("Failed to restart the pod: %v.", trace.DebugReport(err))
+					continue
+				}
+			case <-ctx.Done():
+				p.Infof("Stopped watching %v events.", service.TeleportReloadEvent)
+				return
+			}
+		}
+	}()
+	return nil
 }

--- a/lib/process/watch.go
+++ b/lib/process/watch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	libkube "github.com/gravitational/gravity/lib/kubernetes"
 	"github.com/gravitational/gravity/lib/processconfig"
+	"github.com/gravitational/gravity/lib/storage"
 
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/trace"
@@ -38,13 +39,15 @@ import (
 // and notifies the process' "certificateCh" when the change happens
 func (p *Process) startCertificateWatch(ctx context.Context, client *kubernetes.Clientset) error {
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			err := p.watchCertificate(ctx, client)
 			if err != nil {
 				p.Errorf("Failed to start certificate watch: %v.", trace.DebugReport(err))
 			}
 			select {
-			case <-time.After(time.Second):
+			case <-ticker.C:
 			case <-ctx.Done():
 				p.Debug("Certificate watcher stopped.")
 				return
@@ -101,16 +104,19 @@ func (p *Process) watchCertificate(ctx context.Context, client *kubernetes.Clien
 }
 
 // startAuthGatewayWatch launches watcher that monitors config map with
-// auth gateway configuration.
+// auth gateway configuration and updates Teleport configuration
+// appropriately.
 func (p *Process) startAuthGatewayWatch(ctx context.Context, client *kubernetes.Clientset) error {
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			err := p.watchAuthGateway(ctx, client)
 			if err != nil {
 				p.Errorf("Failed to start auth gateway config watch: %v.", trace.DebugReport(err))
 			}
 			select {
-			case <-time.After(time.Second):
+			case <-ticker.C:
 			case <-ctx.Done():
 				p.Debug("Auth gateway config watcher stopped.")
 				return
@@ -120,7 +126,8 @@ func (p *Process) startAuthGatewayWatch(ctx context.Context, client *kubernetes.
 	return nil
 }
 
-// watchAuthGateway watches changes to the auth gateway config map.
+// watchAuthGateway observes changes to the auth gateway config map and
+// updates Teleport configuration appropriately.
 func (p *Process) watchAuthGateway(ctx context.Context, client *kubernetes.Clientset) error {
 	p.Debug("Restarting auth gateway config watch.")
 	watcher, err := client.Core().ConfigMaps(defaults.KubeSystemNamespace).Watch(metav1.ListOptions{
@@ -143,17 +150,26 @@ func (p *Process) watchAuthGateway(ctx context.Context, client *kubernetes.Clien
 			}
 			configMap, ok := event.Object.(*v1.ConfigMap)
 			if !ok {
-				p.Warningf("Expected ConfigMap, got: %T %v.", event.Object, event.Object)
+				p.Warningf("Expected ConfigMap, got: %[1]T %[1]v.", event.Object)
 				continue
 			}
 			if configMap.Name != constants.AuthGatewayConfigMap {
 				p.Debugf("Ignoring ConfigMap change: %v.", configMap.Name)
 				continue
 			}
-			p.Debugf("Detected ConfigMap change: %v.", configMap.Name)
-			p.BroadcastEvent(service.Event{
-				Name: constants.AuthGatewayConfigUpdatedEvent,
-			})
+			p.Infof("Detected ConfigMap change: %v.", configMap.Name)
+			authGatewayConfig, err := p.getAuthGatewayConfig()
+			if err != nil {
+				p.Errorf("Failed to retrieve auth gateway config: %v.",
+					trace.DebugReport(err))
+				return trace.Wrap(err)
+			}
+			err = p.reloadAuthGatewayConfig(authGatewayConfig)
+			if err != nil {
+				p.Errorf("Failed to reload auth gateway config: %v.",
+					trace.DebugReport(err))
+				continue
+			}
 		case <-ctx.Done():
 			p.Debug("Stopping auth gateway config watcher.")
 			return nil
@@ -161,60 +177,40 @@ func (p *Process) watchAuthGateway(ctx context.Context, client *kubernetes.Clien
 	}
 }
 
-// startWatchingAuthGatewayEvents launches watcher that monitors auth
-// gateway configuration change events and appropriately updates
-// Teleport configuration.
-func (p *Process) startWatchingAuthGatewayEvents(ctx context.Context, client *kubernetes.Clientset) error {
-	go func() {
-		eventsCh := make(chan service.Event)
-		p.WaitForEvent(ctx, constants.AuthGatewayConfigUpdatedEvent, eventsCh)
-		p.Infof("Started watching %v events.", constants.AuthGatewayConfigUpdatedEvent)
-		for {
-			select {
-			case event := <-eventsCh:
-				if event.Name != constants.AuthGatewayConfigUpdatedEvent {
-					p.Warnf("Expected %v event, got: %#v.", constants.AuthGatewayConfigUpdatedEvent, event)
-					continue
-				}
-				p.Infof("Received event: %#v.", event)
-				authGatewayConfig, err := p.getAuthGatewayConfig()
-				if err != nil {
-					p.Errorf(trace.DebugReport(err))
-					continue
-				}
-				if authGatewayConfig.PrincipalsChanged(p.authGatewayConfig) {
-					// Teleport principals got updated. Don't restart right
-					// away, but update its config so it can regenerate
-					// identities for its services.
-					p.Infof("Auth gateway principals changed.")
-					config, err := p.buildTeleportConfig()
-					if err != nil {
-						p.Errorf(trace.DebugReport(err))
-						continue
-					}
-					// Replacing principals in config will result in Teleport
-					// regenerating identities (asynchonously) and then
-					// sending reload event which will be caught below.
-					processconfig.ReplacePublicAddrs(p.teleportProcess().Config, config)
-				} else if authGatewayConfig.SettingsChanged(p.authGatewayConfig) {
-					// Principals didn't change but some of the Teleport
-					// settings changed so we can reload right away.
-					p.Infof("Auth gateway settings changed.")
-					p.BroadcastEvent(service.Event{
-						Name: service.TeleportReloadEvent,
-					})
-				} else {
-					// Neither principals nor other settings changed, nothing
-					// to do (maybe auth preference changed which is also a
-					// part auth gateway resource).
-					p.Infof("Auth gateway principals/settings didn't change.")
-				}
-			case <-ctx.Done():
-				p.Infof("Stopped watching %v events.", constants.AuthGatewayConfigUpdatedEvent)
-				return
-			}
+// reloadAuthGatewayConfig compares the provided auth gateway configuration
+// with the configuration the process is currently started with and makes a
+// decision on whether the configuration should be updated and/or the process
+// restarted in order for the changes to take effect.
+func (p *Process) reloadAuthGatewayConfig(authGatewayConfig storage.AuthGateway) error {
+	if authGatewayConfig.PrincipalsChanged(p.authGatewayConfig) {
+		// Teleport principals got updated. Don't restart right
+		// away, but update its config so it can regenerate
+		// identities for its services.
+		p.Info("Auth gateway principals changed.")
+		config, err := p.buildTeleportConfig(authGatewayConfig)
+		if err != nil {
+			return trace.Wrap(err)
 		}
-	}()
+		// Replacing principals in config will result in Teleport
+		// regenerating identities (asynchonously) and then
+		// sending reload event which will be caught below.
+		processconfig.ReplacePublicAddrs(p.teleportProcess().Config, config)
+	} else if authGatewayConfig.SettingsChanged(p.authGatewayConfig) {
+		// Principals didn't change but some of the Teleport
+		// settings changed so we can reload right away.
+		p.Info("Auth gateway settings changed.")
+		p.BroadcastEvent(service.Event{
+			Name: service.TeleportReloadEvent,
+		})
+	} else {
+		// Neither principals nor other settings changed, nothing
+		// to do (maybe auth preference changed which is also a
+		// part of auth gateway resource).
+		p.Info("Auth gateway principals/settings didn't change.")
+	}
+	// Update gateway config information on the process so we can compare
+	// with it if/when next change happens.
+	p.authGatewayConfig = authGatewayConfig
 	return nil
 }
 

--- a/lib/processconfig/merge.go
+++ b/lib/processconfig/merge.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/teleport/lib/service"
 
 	"github.com/gravitational/configure"
 	telecfg "github.com/gravitational/teleport/lib/config"
@@ -99,4 +100,13 @@ func MergeTeleConfig(into, from *telecfg.FileConfig) error {
 		into.Proxy.CertFile = from.Proxy.CertFile
 	}
 	return nil
+}
+
+// ReplacePublicAddrs replaces public addresses of all services in the
+// specified config from the provided config.
+func ReplacePublicAddrs(into, from *service.Config) {
+	into.Auth.PublicAddrs = from.Auth.PublicAddrs
+	into.Proxy.SSHPublicAddrs = from.Proxy.SSHPublicAddrs
+	into.Proxy.PublicAddrs = from.Proxy.PublicAddrs
+	into.Proxy.Kube.PublicAddrs = from.Proxy.Kube.PublicAddrs
 }

--- a/lib/storage/authgateway.go
+++ b/lib/storage/authgateway.go
@@ -1,0 +1,561 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/utils"
+
+	teleconfig "github.com/gravitational/teleport/lib/config"
+	teledefaults "github.com/gravitational/teleport/lib/defaults"
+	teleservices "github.com/gravitational/teleport/lib/services"
+	teleutils "github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// AuthGateway defines a resource that controls embedded Teleport configuration.
+type AuthGateway interface {
+	// Resource provides common resource methods.
+	teleservices.Resource
+	// CheckAndSetDefaults validates the resource and fills in some defaults.
+	CheckAndSetDefaults() error
+	// GetMaxConnections returns maximum allowed connections number.
+	GetMaxConnections() int64
+	// GetMaxUsers returns maximum allowed users number.
+	GetMaxUsers() int
+	// GetConnectionLimits returns all configured connection limits.
+	GetConnectionLimits() *ConnectionLimits
+	// SetConnectionLimits sets connection limits on the resource.
+	SetConnectionLimits(ConnectionLimits)
+	// GetClientIdleTimeout returns idle timeout for SSH sessions.
+	GetClientIdleTimeout() *teleservices.Duration
+	// SetClientIdleTimeout sets idle timeout setting on the resource.
+	SetClientIdleTimeout(teleservices.Duration)
+	// GetDisconnectExpiredCert returns whether ongoing SSH session will be
+	// disconnected immediately upon certificate expiration.
+	GetDisconnectExpiredCert() *teleservices.Bool
+	// SetDisconnectExpiredCert sets expired cert policy setting on the resource.
+	SetDisconnectExpiredCert(teleservices.Bool)
+	// GetAuthPreference returns authentication preference setting.
+	GetAuthPreference() teleservices.AuthPreference
+	// SetAuthPreference sets authentication preference setting.
+	SetAuthPreference(teleservices.AuthPreference)
+	// GetSSHPublicAddrs returns SSH public addresses.
+	GetSSHPublicAddrs() []string
+	// SetSSHPublicAddrs sets SSH public addresses on the resource.
+	SetSSHPublicAddrs([]string)
+	// GetKubernetesPublicAddrs returns Kubernetes public addresses.
+	GetKubernetesPublicAddrs() []string
+	// SetKubernetesPublicAddrs sets Kubernetes public addresses on the resource.
+	SetKubernetesPublicAddrs([]string)
+	// GetWebPublicAddrs returns web service public addresses.
+	GetWebPublicAddrs() []string
+	// SetWebPublicAddrs sets web service public addresses on the resource.
+	SetWebPublicAddrs([]string)
+	// GetPublicAddrs returns public addresses set for all services.
+	GetPublicAddrs() []string
+	// SetPublicAddrs sets public addresses that apply to all services.
+	SetPublicAddrs([]string)
+	// ApplyTo applies auth gateway settings to the provided auth gateway resource.
+	ApplyTo(AuthGateway)
+	// ApplyToTeleportConfig applies auth gateway settings to the provided Teleport config.
+	ApplyToTeleportConfig(*teleconfig.FileConfig)
+	// PrincipalsChanged returns true if list of principals is difference b/w two auth gateway configs.
+	PrincipalsChanged(AuthGateway) bool
+	// SettingsChanged returns true is connection settings changed b/w two auth gateway configs.
+	SettingsChanged(AuthGateway) bool
+}
+
+// NewAuthGateway creates a new auth gateway resource for the provided spec.
+func NewAuthGateway(spec AuthGatewaySpecV2) AuthGateway {
+	return &AuthGatewayV2{
+		Kind:    KindAuthGateway,
+		Version: teleservices.V2,
+		Metadata: teleservices.Metadata{
+			Name:      KindAuthGateway,
+			Namespace: teledefaults.Namespace,
+		},
+		Spec: spec,
+	}
+}
+
+// DefaultAuthGateway returns auth gateway resource with default parameters.
+func DefaultAuthGateway() AuthGateway {
+	var maxConnections int64 = teledefaults.LimiterMaxConnections
+	maxUsers := teledefaults.LimiterMaxConcurrentUsers
+	clientIdleTimeout := teleservices.NewDuration(0)
+	disconnectExpiredCert := teleservices.NewBool(false)
+	return NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxConnections: &maxConnections,
+			MaxUsers:       &maxUsers,
+		},
+		ClientIdleTimeout:     &clientIdleTimeout,
+		DisconnectExpiredCert: &disconnectExpiredCert,
+	})
+}
+
+// AuthGatewayV2 defines the auth gateway resource.
+type AuthGatewayV2 struct {
+	// Kind is the resource kind.
+	Kind string `json:"kind"`
+	// Version is the resource version.
+	Version string `json:"version"`
+	// Metadata is the resource metadata.
+	Metadata teleservices.Metadata `json:"metadata"`
+	// Spec is the resource specification.
+	Spec AuthGatewaySpecV2 `json:"spec"`
+}
+
+// AuthGatewaySpecV2 defines the auth gateway resource specification.
+type AuthGatewaySpecV2 struct {
+	// ConnectionLimits describes configured connection limits.
+	ConnectionLimits *ConnectionLimits `json:"connection_limits,omitempty"`
+	// ClientIdleTimeout is the idle session timeout.
+	ClientIdleTimeout *teleservices.Duration `json:"client_idle_timeout,omitempty"`
+	// DisconnectExpiredCert is whether expired certificate interrupts session.
+	DisconnectExpiredCert *teleservices.Bool `json:"disconnect_expired_cert,omitempty"`
+	// Authentication is authentication preferences.
+	Authentication *teleservices.AuthPreferenceSpecV2 `json:"authentication,omitempty"`
+	// PublicAddr sets public addresses for all Teleport services.
+	PublicAddr *[]string `json:"public_addr,omitempty"`
+	// SSHPublicAddr sets public addresses for proxy SSH service.
+	SSHPublicAddr *[]string `json:"ssh_public_addr,omitempty"`
+	// KubernetesPublicAddr sets public addresses for Kubernetes proxy service.
+	KubernetesPublicAddr *[]string `json:"kubernetes_public_addr,omitempty"`
+	// WebPublicAddr sets public addresses for web service.
+	WebPublicAddr *[]string `json:"web_public_addr,omitempty"`
+}
+
+// ConnectionLimits defines connection limits setting on auth gateway resource.
+type ConnectionLimits struct {
+	// MaxConnections is the maximum number of connections to auth/proxy services.
+	MaxConnections *int64 `json:"max_connections,omitempty"`
+	// MaxUsers is the maximum number of simultaneously connected users.
+	MaxUsers *int `json:"max_users,omitempty"`
+}
+
+// String returns the object's string representation.
+func (l ConnectionLimits) String() string {
+	var parts []string
+	if l.MaxConnections != nil {
+		parts = append(parts, fmt.Sprintf("MaxConnections=%v", *l.MaxConnections))
+	}
+	if l.MaxUsers != nil {
+		parts = append(parts, fmt.Sprintf("MaxUsers=%v", *l.MaxUsers))
+	}
+	return fmt.Sprintf("ConnectionLimits(%v)", strings.Join(parts, ","))
+}
+
+// PrincipalsChanged returns true if a list of principals is different between
+// this and provided auth gateway configurations.
+//
+// "Principals" are hostname parts of public addresses of different services
+// that get encoded as SAN extensions (Subject Alternative Names) into their
+// respective certificates.
+func (gw *AuthGatewayV2) PrincipalsChanged(other AuthGateway) bool {
+	if principalsChanged(gw.GetSSHPublicAddrs(), other.GetSSHPublicAddrs()) {
+		return true
+	}
+	if principalsChanged(gw.GetKubernetesPublicAddrs(), other.GetKubernetesPublicAddrs()) {
+		return true
+	}
+	if principalsChanged(gw.GetWebPublicAddrs(), other.GetWebPublicAddrs()) {
+		return true
+	}
+	return false
+}
+
+func principalsChanged(old, new []string) bool {
+	oldSet := utils.NewStringSetFromSlice(utils.Hosts(old))
+	newSet := utils.NewStringSetFromSlice(utils.Hosts(new))
+	return len(oldSet.Diff(newSet)) > 0
+}
+
+// SettingsChanged returns true if connection settings are different between
+// this and provided auth gateway configuration.
+func (gw *AuthGatewayV2) SettingsChanged(other AuthGateway) bool {
+	if gw.GetMaxConnections() != other.GetMaxConnections() {
+		return true
+	}
+	if gw.GetMaxUsers() != other.GetMaxUsers() {
+		return true
+	}
+	if gw.GetClientIdleTimeout() != nil && other.GetClientIdleTimeout() == nil ||
+		gw.GetClientIdleTimeout() == nil && other.GetClientIdleTimeout() != nil ||
+		gw.GetClientIdleTimeout() != nil && other.GetClientIdleTimeout() != nil &&
+			gw.GetClientIdleTimeout().Value() != other.GetClientIdleTimeout().Value() {
+		return true
+	}
+	if gw.GetDisconnectExpiredCert() != nil && other.GetDisconnectExpiredCert() == nil ||
+		gw.GetDisconnectExpiredCert() == nil && other.GetDisconnectExpiredCert() != nil ||
+		gw.GetDisconnectExpiredCert() != nil && other.GetDisconnectExpiredCert() != nil &&
+			gw.GetDisconnectExpiredCert().Value() != other.GetDisconnectExpiredCert().Value() {
+		return true
+	}
+	return false
+}
+
+// ApplyTo applies auth gateway settings to the provided other auth gateway.
+//
+// Only non-nil settings are applied.
+func (gw *AuthGatewayV2) ApplyTo(other AuthGateway) {
+	if v := gw.GetConnectionLimits(); v != nil {
+		other.SetConnectionLimits(*v)
+	}
+	if v := gw.GetClientIdleTimeout(); v != nil {
+		other.SetClientIdleTimeout(*v)
+	}
+	if v := gw.GetDisconnectExpiredCert(); v != nil {
+		other.SetDisconnectExpiredCert(*v)
+	}
+	if v := gw.GetAuthPreference(); v != nil {
+		other.SetAuthPreference(v)
+	}
+	if gw.Spec.PublicAddr != nil {
+		other.SetSSHPublicAddrs(*gw.Spec.PublicAddr)
+		other.SetKubernetesPublicAddrs(*gw.Spec.PublicAddr)
+		other.SetWebPublicAddrs(*gw.Spec.PublicAddr)
+	}
+	if gw.Spec.SSHPublicAddr != nil {
+		other.SetSSHPublicAddrs(*gw.Spec.SSHPublicAddr)
+	}
+	if gw.Spec.KubernetesPublicAddr != nil {
+		other.SetKubernetesPublicAddrs(*gw.Spec.KubernetesPublicAddr)
+	}
+	if gw.Spec.WebPublicAddr != nil {
+		other.SetWebPublicAddrs(*gw.Spec.WebPublicAddr)
+	}
+}
+
+// Apply applies auth gateway settings to the provided config.
+func (gw *AuthGatewayV2) ApplyToTeleportConfig(config *teleconfig.FileConfig) {
+	if gw.Spec.ConnectionLimits != nil {
+		config.Global.Limits.MaxConnections = *gw.Spec.ConnectionLimits.MaxConnections
+		config.Global.Limits.MaxUsers = *gw.Spec.ConnectionLimits.MaxUsers
+	}
+	if gw.Spec.ClientIdleTimeout != nil {
+		config.Auth.ClientIdleTimeout = *gw.Spec.ClientIdleTimeout
+	}
+	if gw.Spec.DisconnectExpiredCert != nil {
+		config.Auth.DisconnectExpiredCert = *gw.Spec.DisconnectExpiredCert
+	}
+	if gw.Spec.Authentication != nil {
+		var u2f *teleconfig.UniversalSecondFactor
+		if gw.Spec.Authentication.U2F != nil {
+			u2f = &teleconfig.UniversalSecondFactor{
+				AppID:  gw.Spec.Authentication.U2F.AppID,
+				Facets: gw.Spec.Authentication.U2F.Facets,
+			}
+		}
+		config.Auth.Authentication = &teleconfig.AuthenticationConfig{
+			Type:          gw.Spec.Authentication.Type,
+			SecondFactor:  gw.Spec.Authentication.SecondFactor,
+			ConnectorName: gw.Spec.Authentication.ConnectorName,
+			U2F:           u2f,
+		}
+	}
+	config.Auth.PublicAddr = append(config.Auth.PublicAddr,
+		gw.GetSSHPublicAddrs()...)
+	config.Proxy.SSHPublicAddr = append(config.Proxy.SSHPublicAddr,
+		gw.GetSSHPublicAddrs()...)
+	config.Proxy.PublicAddr = append(config.Proxy.PublicAddr,
+		gw.GetWebPublicAddrs()...)
+	config.Proxy.Kube.PublicAddr = append(config.Proxy.Kube.PublicAddr,
+		gw.GetKubernetesPublicAddrs()...)
+}
+
+// GetMaxConnections returns max connections setting.
+func (gw *AuthGatewayV2) GetMaxConnections() int64 {
+	if gw.Spec.ConnectionLimits != nil {
+		if gw.Spec.ConnectionLimits.MaxConnections != nil {
+			return *gw.Spec.ConnectionLimits.MaxConnections
+		}
+	}
+	return 0
+}
+
+// GetMaxUsers returns max users setting.
+func (gw *AuthGatewayV2) GetMaxUsers() int {
+	if gw.Spec.ConnectionLimits != nil {
+		if gw.Spec.ConnectionLimits.MaxUsers != nil {
+			return *gw.Spec.ConnectionLimits.MaxUsers
+		}
+	}
+	return 0
+}
+
+// GetConnectionLimits returns connection limit settings.
+func (gw *AuthGatewayV2) GetConnectionLimits() *ConnectionLimits {
+	return gw.Spec.ConnectionLimits
+}
+
+// SetConnectionLimits sets connection limits settings on the resource.
+func (gw *AuthGatewayV2) SetConnectionLimits(value ConnectionLimits) {
+	if gw.Spec.ConnectionLimits == nil {
+		gw.Spec.ConnectionLimits = &ConnectionLimits{}
+	}
+	if value.MaxConnections != nil {
+		gw.Spec.ConnectionLimits.MaxConnections = value.MaxConnections
+	}
+	if value.MaxUsers != nil {
+		gw.Spec.ConnectionLimits.MaxUsers = value.MaxUsers
+	}
+}
+
+// GetClientIdleTimeout returns the client idle timeout setting.
+func (gw *AuthGatewayV2) GetClientIdleTimeout() *teleservices.Duration {
+	return gw.Spec.ClientIdleTimeout
+}
+
+// SetClientIdleTimeout sets the client idle timeout setting on the resource.
+func (gw *AuthGatewayV2) SetClientIdleTimeout(value teleservices.Duration) {
+	gw.Spec.ClientIdleTimeout = &value
+}
+
+// GetDisconnectExpiredCert returns the expired certificate policy setting.
+func (gw *AuthGatewayV2) GetDisconnectExpiredCert() *teleservices.Bool {
+	return gw.Spec.DisconnectExpiredCert
+}
+
+// SetDisconnectExpiredCert sets the expired certificate policy setting on the resource.
+func (gw *AuthGatewayV2) SetDisconnectExpiredCert(value teleservices.Bool) {
+	gw.Spec.DisconnectExpiredCert = &value
+}
+
+// GetAuthPreference returns the authentication preference settings.
+func (gw *AuthGatewayV2) GetAuthPreference() teleservices.AuthPreference {
+	if gw.Spec.Authentication != nil {
+		// It never returns an error.
+		authPreference, _ := teleservices.NewAuthPreference(*gw.Spec.Authentication)
+		return authPreference
+	}
+	return nil
+}
+
+// SetAuthPreference sets the authentication preference settings on the resource.
+func (gw *AuthGatewayV2) SetAuthPreference(authPreference teleservices.AuthPreference) {
+	// It only returns trace.NotFound() error.
+	u2f, _ := authPreference.GetU2F()
+	gw.Spec.Authentication = &teleservices.AuthPreferenceSpecV2{
+		Type:          authPreference.GetType(),
+		SecondFactor:  authPreference.GetSecondFactor(),
+		ConnectorName: authPreference.GetConnectorName(),
+		U2F:           u2f,
+	}
+}
+
+// GetPublicAddrs returns public addresses for all services.
+func (gw *AuthGatewayV2) GetPublicAddrs() []string {
+	if gw.Spec.SSHPublicAddr != nil {
+		return *gw.Spec.SSHPublicAddr
+	}
+	return nil
+}
+
+// SetPublicAddrs sets public addresses for all services.
+func (gw *AuthGatewayV2) SetPublicAddrs(value []string) {
+	gw.Spec.PublicAddr = &value
+}
+
+// GetSSHPublicAddrs returns public addresses for proxy SSH service.
+func (gw *AuthGatewayV2) GetSSHPublicAddrs() []string {
+	if gw.Spec.SSHPublicAddr != nil {
+		return *gw.Spec.SSHPublicAddr
+	}
+	if gw.Spec.PublicAddr != nil {
+		return *gw.Spec.PublicAddr
+	}
+	return nil
+}
+
+// SetSSHPublicAddrs sets proxy SSH service public addresses.
+func (gw *AuthGatewayV2) SetSSHPublicAddrs(value []string) {
+	gw.Spec.SSHPublicAddr = &value
+}
+
+// GetKubernetesPublicAddrs returns public addresses for Kubernetes proxy service.
+func (gw *AuthGatewayV2) GetKubernetesPublicAddrs() []string {
+	if gw.Spec.KubernetesPublicAddr != nil {
+		return *gw.Spec.KubernetesPublicAddr
+	}
+	if gw.Spec.PublicAddr != nil {
+		return *gw.Spec.PublicAddr
+	}
+	return nil
+}
+
+// SetKubernetesPublicAddrs sets Kubernetes proxy service public addresses.
+func (gw *AuthGatewayV2) SetKubernetesPublicAddrs(value []string) {
+	gw.Spec.KubernetesPublicAddr = &value
+}
+
+// GetWebPublicAddrs returns proxy web service public addresses.
+func (gw *AuthGatewayV2) GetWebPublicAddrs() (addrs []string) {
+	if gw.Spec.WebPublicAddr != nil {
+		return *gw.Spec.WebPublicAddr
+	}
+	if gw.Spec.PublicAddr != nil {
+		return *gw.Spec.PublicAddr
+	}
+	return nil
+}
+
+// SetWebPublicAddrs sets proxy web service public addresses.
+func (gw *AuthGatewayV2) SetWebPublicAddrs(value []string) {
+	gw.Spec.WebPublicAddr = &value
+}
+
+// CheckAndSetDefaults validates the resource and fills in some defaults.
+func (gw *AuthGatewayV2) CheckAndSetDefaults() error {
+	if gw.Metadata.Name == "" {
+		gw.Metadata.Name = KindAuthGateway
+	}
+	err := gw.Metadata.CheckAndSetDefaults()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// GetName returns the resource name.
+func (gw *AuthGatewayV2) GetName() string {
+	return gw.Metadata.Name
+}
+
+// SetName sets the resource name.
+func (gw *AuthGatewayV2) SetName(name string) {
+	gw.Metadata.Name = name
+}
+
+// GetMetadata returns the resource metadata.
+func (gw *AuthGatewayV2) GetMetadata() teleservices.Metadata {
+	return gw.Metadata
+}
+
+// SetExpiry sets the resource expiration time.
+func (gw *AuthGatewayV2) SetExpiry(expires time.Time) {
+	gw.Metadata.SetExpiry(expires)
+}
+
+// Expires returns the resource expiration time.
+func (gw *AuthGatewayV2) Expiry() time.Time {
+	return gw.Metadata.Expiry()
+}
+
+// SetTTL sets the resource TTL.
+func (gw *AuthGatewayV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+	gw.Metadata.SetTTL(clock, ttl)
+}
+
+// String returns the object's string representation.
+func (gw AuthGatewayV2) String() string {
+	var parts []string
+	if gw.Spec.ConnectionLimits != nil {
+		parts = append(parts, fmt.Sprintf("%s", *gw.Spec.ConnectionLimits))
+	}
+	if gw.Spec.ClientIdleTimeout != nil {
+		parts = append(parts, fmt.Sprintf("ClientIdleTimeout=%s", gw.Spec.ClientIdleTimeout.Value()))
+	}
+	if gw.Spec.DisconnectExpiredCert != nil {
+		parts = append(parts, fmt.Sprintf("DisconnectExpiredCert=%v", gw.Spec.DisconnectExpiredCert.Value()))
+	}
+	if gw.Spec.Authentication != nil {
+		parts = append(parts, fmt.Sprintf("%s", gw.GetAuthPreference()))
+	}
+	if gw.Spec.PublicAddr != nil {
+		parts = append(parts, fmt.Sprintf("PublicAddr=%v", strings.Join(*gw.Spec.PublicAddr, ",")))
+	}
+	if gw.Spec.SSHPublicAddr != nil {
+		parts = append(parts, fmt.Sprintf("SSHPublicAddr=%v", strings.Join(*gw.Spec.SSHPublicAddr, ",")))
+	}
+	if gw.Spec.KubernetesPublicAddr != nil {
+		parts = append(parts, fmt.Sprintf("KubernetesPublicAddr=%v", strings.Join(*gw.Spec.KubernetesPublicAddr, ",")))
+	}
+	if gw.Spec.WebPublicAddr != nil {
+		parts = append(parts, fmt.Sprintf("WebPublicAddr=%v", strings.Join(*gw.Spec.WebPublicAddr, ",")))
+	}
+	return fmt.Sprintf("AuthGatewayV2(%s)", strings.Join(parts, ","))
+}
+
+// UnmarshalAuthGateway unmarshals auth gateway resource from the provided JSON data.
+func UnmarshalAuthGateway(data []byte) (AuthGateway, error) {
+	jsonData, err := teleutils.ToJSON(data)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var header teleservices.ResourceHeader
+	err = json.Unmarshal(jsonData, &header)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	switch header.Version {
+	case teleservices.V2:
+		var gw AuthGatewayV2
+		err := teleutils.UnmarshalWithSchema(GetAuthGatewaySchema(), &gw, jsonData)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		err = gw.CheckAndSetDefaults()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &gw, nil
+	}
+	return nil, trace.BadParameter("%v resource version %q is not supported",
+		KindAuthGateway, header.Version)
+}
+
+// MarshalAuthGateway marshals provided auth gateway resource to JSON.
+func MarshalAuthGateway(gw AuthGateway, opts ...teleservices.MarshalOption) ([]byte, error) {
+	return json.Marshal(gw)
+}
+
+// GetAuthGatewaySchema returns the full auth gateway resource schema.
+func GetAuthGatewaySchema() string {
+	return fmt.Sprintf(teleservices.V2SchemaTemplate, MetadataSchema,
+		AuthGatewaySpecV2Schema, "")
+}
+
+// AuthGatewaySpecV2Schema defines the auth gateway spec schema.
+var AuthGatewaySpecV2Schema = fmt.Sprintf(`{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "connection_limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_connections": {"type": "number"},
+        "max_users": {"type": "number"}
+      }
+    },
+    "authentication": %v,
+    "client_idle_timeout": {"type": "string"},
+    "disconnect_expired_cert": {"type": "boolean"},
+    "public_addr": {"type": "array", "items": {"type": "string"}},
+    "ssh_public_addr": {"type": "array", "items": {"type": "string"}},
+    "kubernetes_public_addr": {"type": "array", "items": {"type": "string"}},
+    "web_public_addr": {"type": "array", "items": {"type": "string"}}
+  }
+}`, fmt.Sprintf(teleservices.AuthPreferenceSpecSchemaTemplate, ""))

--- a/lib/storage/authgateway.go
+++ b/lib/storage/authgateway.go
@@ -160,7 +160,10 @@ type ConnectionLimits struct {
 }
 
 // Check validates the limits settings.
-func (l ConnectionLimits) Check() error {
+func (l *ConnectionLimits) Check() error {
+	if l == nil {
+		return nil
+	}
 	if l.MaxConnections != nil && *l.MaxConnections < 0 {
 		return trace.BadParameter("max connections can't be negative")
 	}
@@ -464,11 +467,9 @@ func (gw *AuthGatewayV1) CheckAndSetDefaults() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if gw.Spec.ConnectionLimits != nil {
-		err := gw.Spec.ConnectionLimits.Check()
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	err = gw.Spec.ConnectionLimits.Check()
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	if gw.Spec.Authentication != nil {
 		auth, err := gw.GetAuthPreference()

--- a/lib/storage/authgateway_test.go
+++ b/lib/storage/authgateway_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"time"
+
+	"github.com/gravitational/gravity/lib/compare"
+	teleconfig "github.com/gravitational/teleport/lib/config"
+	teleservices "github.com/gravitational/teleport/lib/services"
+	teleutils "github.com/gravitational/teleport/lib/utils"
+	check "gopkg.in/check.v1"
+)
+
+type AuthGatewaySuite struct{}
+
+var _ = check.Suite(&AuthGatewaySuite{})
+
+func (s *AuthGatewaySuite) TestResourceParsing(c *check.C) {
+	spec := `kind: authgateway
+version: v2
+spec:
+  connection_limits:
+    max_connections: 2000
+    max_users: 20
+  authentication:
+    type: oidc
+    second_factor: "off"
+    connector_name: google
+  client_idle_timeout: 60s
+  disconnect_expired_cert: true
+  public_addr: ["example.com"]
+  ssh_public_addr: ["ssh.example.com"]
+  kubernetes_public_addr: ["k8s.example.com"]
+  web_public_addr: ["web.example.com"]
+`
+	gw, err := UnmarshalAuthGateway([]byte(spec))
+	c.Assert(err, check.IsNil)
+	c.Assert(gw, compare.DeepEquals, NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxConnections: int64p(2000),
+			MaxUsers:       intp(20),
+		},
+		Authentication: &teleservices.AuthPreferenceSpecV2{
+			Type:          "oidc",
+			SecondFactor:  "off",
+			ConnectorName: "google",
+		},
+		ClientIdleTimeout:     durp(60 * time.Second),
+		DisconnectExpiredCert: teleservices.NewBoolOption(true),
+		PublicAddr:            &[]string{"example.com"},
+		SSHPublicAddr:         &[]string{"ssh.example.com"},
+		KubernetesPublicAddr:  &[]string{"k8s.example.com"},
+		WebPublicAddr:         &[]string{"web.example.com"},
+	}))
+}
+
+func (s *AuthGatewaySuite) TestPrincipalsChanged(c *check.C) {
+	testCases := []struct {
+		gw1, gw2 AuthGateway
+		result   bool
+	}{
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				PublicAddr: &[]string{"example.com"},
+			}),
+			result: true,
+		},
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				PublicAddr: &[]string{"example.com"},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				SSHPublicAddr: &[]string{"ssh.example.com"},
+			}),
+			result: true,
+		},
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				PublicAddr: &[]string{"example.com"},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				SSHPublicAddr:        &[]string{"example.com"},
+				KubernetesPublicAddr: &[]string{"example.com"},
+				WebPublicAddr:        &[]string{"example.com"},
+			}),
+			result: false,
+		},
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				PublicAddr: &[]string{"example.com"},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				SSHPublicAddr:        &[]string{"example.com"},
+				KubernetesPublicAddr: &[]string{"example.com"},
+			}),
+			result: true,
+		},
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				KubernetesPublicAddr: &[]string{"k8s.example.com:3036"},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				KubernetesPublicAddr: &[]string{"k8s.example.com:3027"},
+			}),
+			result: false,
+		},
+	}
+	for _, tc := range testCases {
+		c.Assert(tc.gw1.PrincipalsChanged(tc.gw2), check.Equals, tc.result,
+			check.Commentf("Test case %s/%s/%v failed.", tc.gw1, tc.gw2, tc.result))
+	}
+}
+
+func (s *AuthGatewaySuite) TestSettingsChanged(c *check.C) {
+	testCases := []struct {
+		gw1, gw2 AuthGateway
+		result   bool
+	}{
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				ConnectionLimits: &ConnectionLimits{
+					MaxConnections: int64p(1000),
+					MaxUsers:       intp(10),
+				},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				ConnectionLimits: &ConnectionLimits{
+					MaxConnections: int64p(1500),
+					MaxUsers:       intp(10),
+				},
+			}),
+			result: true,
+		},
+		{
+			gw1: NewAuthGateway(AuthGatewaySpecV2{
+				SSHPublicAddr: &[]string{"example.com"},
+			}),
+			gw2: NewAuthGateway(AuthGatewaySpecV2{
+				SSHPublicAddr: &[]string{"ssh.example.com"},
+			}),
+			result: false,
+		},
+	}
+	for _, tc := range testCases {
+		c.Assert(tc.gw1.SettingsChanged(tc.gw2), check.Equals, tc.result,
+			check.Commentf("Test case %s/%s/%v failed.", tc.gw1, tc.gw2, tc.result))
+	}
+}
+
+func (s *AuthGatewaySuite) TestApplyTo(c *check.C) {
+	gw1 := NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxConnections: int64p(1000),
+			MaxUsers:       intp(10),
+		},
+		SSHPublicAddr: &[]string{"ssh.example.com"},
+	})
+	gw2 := NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxUsers: intp(5),
+		},
+		PublicAddr: &[]string{"example.com"},
+	})
+	gw2.ApplyTo(gw1)
+	c.Assert(gw1, compare.DeepEquals, NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxConnections: int64p(1000),
+			MaxUsers:       intp(5),
+		},
+		SSHPublicAddr:        &[]string{"example.com"},
+		KubernetesPublicAddr: &[]string{"example.com"},
+		WebPublicAddr:        &[]string{"example.com"},
+	}))
+}
+
+func (s *AuthGatewaySuite) TestApplyToTeleportConfig(c *check.C) {
+	gw := NewAuthGateway(AuthGatewaySpecV2{
+		ConnectionLimits: &ConnectionLimits{
+			MaxConnections: int64p(1000),
+			MaxUsers:       intp(10),
+		},
+		ClientIdleTimeout: durp(60 * time.Second),
+		Authentication: &teleservices.AuthPreferenceSpecV2{
+			Type:         "oidc",
+			SecondFactor: "off",
+		},
+		PublicAddr:           &[]string{"example.com"},
+		KubernetesPublicAddr: &[]string{"k8s.example.com"},
+	})
+	var config teleconfig.FileConfig
+	gw.ApplyToTeleportConfig(&config)
+	c.Assert(config, compare.DeepEquals, teleconfig.FileConfig{
+		Global: teleconfig.Global{
+			Limits: teleconfig.ConnectionLimits{
+				MaxConnections: 1000,
+				MaxUsers:       10,
+			},
+		},
+		Auth: teleconfig.Auth{
+			ClientIdleTimeout: teleservices.NewDuration(60 * time.Second),
+			Authentication: &teleconfig.AuthenticationConfig{
+				Type:         "oidc",
+				SecondFactor: "off",
+			},
+			PublicAddr: teleutils.Strings([]string{"example.com"}),
+		},
+		Proxy: teleconfig.Proxy{
+			PublicAddr:    teleutils.Strings([]string{"example.com"}),
+			SSHPublicAddr: teleutils.Strings([]string{"example.com"}),
+			Kube: teleconfig.Kube{
+				PublicAddr: teleutils.Strings([]string{"k8s.example.com"}),
+			},
+		},
+	})
+}
+
+func int64p(i int64) *int64 {
+	return &i
+}
+
+func intp(i int) *int {
+	return &i
+}
+
+func durp(d time.Duration) *teleservices.Duration {
+	v := teleservices.NewDuration(d)
+	return &v
+}

--- a/lib/storage/authgateway_test.go
+++ b/lib/storage/authgateway_test.go
@@ -131,35 +131,46 @@ func (s *AuthGatewaySuite) TestPrincipalsChanged(c *check.C) {
 }
 
 func (s *AuthGatewaySuite) TestResourceValidation(c *check.C) {
-	specs := []string{
-		// Invalid connections limit.
-		`kind: authgateway
+	tests := []struct {
+		desc string
+		spec string
+	}{
+		{
+			desc: "Invalid connections limit",
+			spec: `kind: authgateway
 version: v1
 spec:
   connection_limits:
     max_connections: -10`,
-		// Invalid users limit.
-		`kind: authgateway
+		},
+		{
+			desc: "Invalid users limit",
+			spec: `kind: authgateway
 version: v1
 spec:
   connection_limits:
     max_users: abc`,
-		// Invalid auth preference.
-		`kind: authgateway
+		},
+		{
+			desc: "Invalid auth preference",
+			spec: `kind: authgateway
 version: v1
 spec:
   authentication:
     type: g00gle
     second_factor: "off"`,
-		// Invalid principal (empty address).
-		`kind: authgateway
+		},
+		{
+			desc: "Invalid principal (empty address)",
+			spec: `kind: authgateway
 version: v1
 spec:
   ssh_public_addr: [""]`,
+		},
 	}
-	for _, spec := range specs {
-		_, err := UnmarshalAuthGateway([]byte(spec))
-		c.Assert(err, check.NotNil, check.Commentf("Test case %q failed.", spec))
+	for _, t := range tests {
+		_, err := UnmarshalAuthGateway([]byte(t.spec))
+		c.Assert(err, check.NotNil, check.Commentf("Test case %q failed.", t.desc))
 	}
 }
 

--- a/lib/storage/cluster_test.go
+++ b/lib/storage/cluster_test.go
@@ -29,10 +29,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func TestClusterParsing(t *testing.T) { TestingT(t) }
+func TestStorageResources(t *testing.T) { TestingT(t) }
 
-type ClusterSuite struct {
-}
+type ClusterSuite struct{}
 
 var _ = Suite(&ClusterSuite{})
 

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -54,6 +54,8 @@ const (
 	KindSystemInfo = "systeminfo"
 	// KindEndpoints defines the Ops Center endpoints resource type
 	KindEndpoints = "endpoints"
+	// KindAuthGateway defines the auth gateway resource type
+	KindAuthGateway = "authgateway"
 )
 
 // SupportedGravityResources is a list of resources supported by
@@ -68,6 +70,7 @@ var SupportedGravityResources = []string{
 	KindAlert,
 	KindAlertTarget,
 	KindTLSKeyPair,
+	KindAuthGateway,
 }
 
 // SupportedGravityResourcesToRemove is a list of resources supported by
@@ -82,3 +85,25 @@ var SupportedGravityResourcesToRemove = []string{
 	KindAlertTarget,
 	KindTLSKeyPair,
 }
+
+// MetadataSchema is a copy of teleport/lib/services.MetadataSchema but with
+// optional 'name' property because some Gravity resources do not require it
+const MetadataSchema = `{
+  "type": "object",
+  "additionalProperties": false,
+  "default": {},
+  "properties": {
+    "name": {"type": "string"},
+    "namespace": {"type": "string", "default": "default"},
+    "description": {"type": "string"},
+    "expires": {"type": "string"},
+    "id": {"type": "integer"},
+    "labels": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+         "^[a-zA-Z/.0-9_*-]+$":  {"type": "string"}
+      }
+    }
+  }
+}`

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -94,7 +94,7 @@ const MetadataSchema = `{
   "default": {},
   "properties": {
     "name": {"type": "string"},
-    "namespace": {"type": "string", "default": "default"},
+    "namespace": {"type": "string"},
     "description": {"type": "string"},
     "expires": {"type": "string"},
     "id": {"type": "integer"},

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -101,6 +101,15 @@ func SplitHostPort(in, defaultPort string) (host string, port string) {
 	return parts[0], defaultPort
 }
 
+// Hosts returns a list of hosts from the provided host:port addresses
+func Hosts(addrs []string) (hosts []string) {
+	for _, addr := range addrs {
+		host, _ := SplitHostPort(addr, "")
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
 // ParseHostPort parses the provided address as host:port
 func ParseHostPort(in string) (host string, port int32, err error) {
 	host, portS, err := net.SplitHostPort(in)

--- a/lib/utils/parse_test.go
+++ b/lib/utils/parse_test.go
@@ -221,3 +221,8 @@ func (s *ParseSuite) TestExtractHost(c *check.C) {
 	c.Assert(ExtractHost("127.0.0.1:8080"), check.Equals, "127.0.0.1")
 	c.Assert(ExtractHost("example.com"), check.Equals, "example.com")
 }
+
+func (s *ParseSuite) TestHosts(c *check.C) {
+	c.Assert(Hosts([]string{"example.com", "localhost:3023", "127.0.0.1:443"}),
+		check.DeepEquals, []string{"example.com", "localhost", "127.0.0.1"})
+}

--- a/lib/utils/stringset.go
+++ b/lib/utils/stringset.go
@@ -67,3 +67,19 @@ func (s StringSet) Has(item string) (exists bool) {
 	_, exists = s[item]
 	return exists
 }
+
+// Diff returns difference between this and provided set.
+func (s StringSet) Diff(another StringSet) StringSet {
+	diff := NewStringSet()
+	for item := range s {
+		if !another.Has(item) {
+			diff.Add(item)
+		}
+	}
+	for item := range another {
+		if !s.Has(item) {
+			diff.Add(item)
+		}
+	}
+	return diff
+}

--- a/lib/utils/stringset_test.go
+++ b/lib/utils/stringset_test.go
@@ -44,3 +44,9 @@ func (s *StringSetSuite) TestEverything(c *check.C) {
 	set.AddSlice([]string{"bad", "santa"})
 	c.Assert(set.Slice(), check.DeepEquals, []string{"1", "2", "3", "bad", "one", "santa"})
 }
+
+func (s *StringSetSuite) TestDiff(c *check.C) {
+	set1 := NewStringSetFromSlice([]string{"1", "2", "3"})
+	set2 := NewStringSetFromSlice([]string{"2", "3", "4"})
+	c.Assert(set1.Diff(set2).Slice(), check.DeepEquals, []string{"1", "4"})
+}

--- a/lib/utils/units.go
+++ b/lib/utils/units.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dustin/go-humanize"
+	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
 )
 
@@ -142,4 +144,10 @@ func BoolValue(v *bool) bool {
 // BoolPtr returns a pointer to a bool with value v
 func BoolPtr(v bool) *bool {
 	return &v
+}
+
+// DurationPtr returns a pointer to the provided duration value
+func DurationPtr(v time.Duration) *teleservices.Duration {
+	d := teleservices.NewDuration(v)
+	return &d
 }


### PR DESCRIPTION
This PR adds support for the `authgateway` resource which basically allows to tweak various configuration parameters of embedded Teleport.

I have removed documentation for the `cluster_auth_preference` resource because it is obsoleted by auth gateway. The actual resource support is still there for backward compatibility (and prints a warning when used).

Closes https://github.com/gravitational/gravity.e/issues/3918.
