### PR TITLE
[5.4] 'gravity plan' consistency update and minor bug fixes throughout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ properties([
            defaultValue: '1',
            description: 'How many times to repeat each test.'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'stable-gce',
+           defaultValue: 'dima',
            description: 'Robotest tag to use.'),
     choice(choices: ["true", "false"].join("\n"),
            defaultValue: 'true',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ properties([
            defaultValue: '1',
            description: 'How many times to repeat each test.'),
     string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'dima',
+           defaultValue: 'stable-gce',
            description: 'Robotest tag to use.'),
     choice(choices: ["true", "false"].join("\n"),
            defaultValue: 'true',

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,7 +204,7 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
-	// BlockingOperationEnvVar specifies whether to execute an operation in foreground
+	// BlockingOperationEnvVar specifies whether to wait for operation to complete
 	BlockingOperationEnvVar = "GRAVITY_BLOCKING_OPERATION"
 
 	// DockerRegistry is a default name for private docker registry

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,6 +204,9 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
+	// BlockingOperationEnvVar specifies whether to execute an operation in foreground
+	BlockingOperationEnvVar = "GRAVITY_BLOCKING_OPERATION"
+
 	// DockerRegistry is a default name for private docker registry
 	DockerRegistry = "leader.telekube.local:5000"
 

--- a/lib/environ/environ.go
+++ b/lib/environ/environ.go
@@ -132,7 +132,7 @@ func (r *Updater) GetPlan() (*storage.OperationPlan, error) {
 }
 
 func (r *Updater) executePlan(ctx context.Context, machine *libfsm.FSM, force bool) error {
-	progress := utils.NewProgress(ctx, "Updating envars", -1, false)
+	progress := utils.NewProgress(ctx, "Updating cluster runtime environment variables", -1, false)
 	defer progress.Stop()
 
 	planErr := machine.ExecutePlan(ctx, progress, force)
@@ -193,7 +193,7 @@ func (r *Config) checkAndSetDefaults() error {
 		return trace.BadParameter("cluster package service is required")
 	}
 	if r.FieldLogger == nil {
-		r.FieldLogger = log.WithField(trace.Component, "envars:updater")
+		r.FieldLogger = log.WithField(trace.Component, "environ:updater")
 	}
 	return nil
 }

--- a/lib/environ/internal/fsm/builder.go
+++ b/lib/environ/internal/fsm/builder.go
@@ -210,8 +210,8 @@ func (r phaseBuilder) node(server storage.Server, id, format string) phase {
 // enable - the list of servers to enable election on
 // disable - the list of servers to disable election on
 // server - The server the phase should be executed on, and used to name the phase
-// key - is the identifier of the phase (combined with server.Hostname)
-// msg - is a format string used to describe the phase
+// id - is the identifier of the phase (combined with server.Hostname)
+// format - is a format string used to describe the phase
 func setLeaderElection(enable, disable []storage.Server, server storage.Server, id, format string) phase {
 	return phase{
 		ID:          id,

--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -257,7 +257,7 @@ func (b *planBuilder) AddPostHookPhase(plan *storage.OperationPlan) {
 
 // AddElectPhase appends phase that enables leader election to the plan
 func (b *planBuilder) AddElectPhase(plan *storage.OperationPlan) {
-	plan.Phases = append(plan.Phases, storage.OperationPhase{
+	phase := storage.OperationPhase{
 		ID:          ElectPhase,
 		Description: "Enable leader election on the joined node",
 		Data: &storage.OperationPhaseData{
@@ -265,7 +265,11 @@ func (b *planBuilder) AddElectPhase(plan *storage.OperationPlan) {
 			ExecServer: &b.JoiningNode,
 		},
 		Requires: []string{installphases.WaitPhase},
-	})
+	}
+	if !b.JoiningNode.IsMaster() {
+		phase.Description = "Disable leader election on the joined node"
+	}
+	plan.Phases = append(plan.Phases, phase)
 }
 
 func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {

--- a/lib/expand/phases/elect.go
+++ b/lib/expand/phases/elect.go
@@ -59,7 +59,11 @@ type electExecutor struct {
 func (p *electExecutor) Execute(ctx context.Context) error {
 	p.Progress.NextStep("Enabling leader elections")
 	// TODO use etcd client?
-	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "leader", "resume",
+	cmd := "resume"
+	if !p.Phase.Data.Server.IsMaster() {
+		cmd = "pause"
+	}
+	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "leader", cmd,
 		fmt.Sprintf("--public-ip=%v", p.Phase.Data.Server.AdvertiseIP),
 		fmt.Sprintf("--election-key=/planet/cluster/%v/election", p.Plan.ClusterName),
 		fmt.Sprintf("--etcd-cafile=%v", defaults.Secret(defaults.RootCertFilename)),
@@ -68,7 +72,7 @@ func (p *electExecutor) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err, "failed to enable leader election: %s", out)
 	}
-	p.Info("Enabled leader election.")
+	p.Info("Reset leader election.")
 	return nil
 }
 

--- a/lib/expand/plan.go
+++ b/lib/expand/plan.go
@@ -105,10 +105,9 @@ func (p *Peer) getOperationPlan(ctx operationContext) (*storage.OperationPlan, e
 		builder.AddPostHookPhase(plan)
 	}
 
-	// if added a master node, make sure it participates in leader election
-	if builder.JoiningNode.IsMaster() {
-		builder.AddElectPhase(plan)
-	}
+	// Enabele/disable leader election depending on the cluster role
+	// of the joining node
+	builder.AddElectPhase(plan)
 
 	fillSteps(plan)
 	return plan, nil

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -170,9 +170,9 @@ func GetOperationPlan(b storage.Backend, clusterName, operationID string) (*stor
 	return ResolvePlan(*plan, ch), nil
 }
 
-// SetOperationState returns the handler to set operation state both in the given operator
+// OperationStateSetter returns the handler to set operation state both in the given operator
 // as well as the specified backend
-func SetOperationState(key ops.SiteOperationKey, operator ops.Operator, backend storage.Backend) ops.OperationStateFunc {
+func OperationStateSetter(key ops.SiteOperationKey, operator ops.Operator, backend storage.Backend) ops.OperationStateFunc {
 	return func(key ops.SiteOperationKey, req ops.SetOperationStateRequest) error {
 		err := operator.SetOperationState(key, req)
 		if err != nil {

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -170,6 +170,31 @@ func GetOperationPlan(b storage.Backend, clusterName, operationID string) (*stor
 	return ResolvePlan(*plan, ch), nil
 }
 
+// SetOperationState returns the handler to set operation state both in the given operator
+// as well as the specified backend
+func SetOperationState(key ops.SiteOperationKey, operator ops.Operator, backend storage.Backend) ops.OperationStateFunc {
+	return func(key ops.SiteOperationKey, req ops.SetOperationStateRequest) error {
+		err := operator.SetOperationState(key, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		op, err := operator.GetSiteOperation(key)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		backendOp, err := backend.GetSiteOperation(key.SiteDomain, key.OperationID)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		backendOp.State = op.State
+		_, err = backend.UpdateSiteOperation(*backendOp)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return nil
+	}
+}
+
 func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {
 	// add the phase itself
 	*result = append(*result, phase)

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -223,7 +223,7 @@ func (c *Config) CheckAndSetDefaults() (err error) {
 		return trace.BadParameter("missing AdvertiseAddr")
 	}
 	if c.LocalClusterClient == nil {
-		return trace.BadParameter("missing LocalClient")
+		return trace.BadParameter("missing LocalClusterClient")
 	}
 	if !utils.StringInSlice(modules.Get().InstallModes(), c.Mode) {
 		return trace.BadParameter("invalid Mode %q", c.Mode)

--- a/lib/ops/constants.go
+++ b/lib/ops/constants.go
@@ -127,8 +127,8 @@ const (
 	OperationGarbageCollectInProgress = "gc_in_progress"
 
 	// environment variables update operation
-	OperationUpdateEnvars           = "operation_update_envars"
-	OperationUpdateEnvarsInProgress = "update_envars_in_progress"
+	OperationUpdateEnvars           = "operation_update_runtime_environ"
+	OperationUpdateEnvarsInProgress = "update_runtime_environ_in_progress"
 
 	// common operation states
 	OperationStateCompleted = "completed"

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -117,7 +117,7 @@ type Operator interface {
 	Install
 	Updates
 	Identity
-	EnvironmentVariables
+	RuntimeEnvironment
 }
 
 // Accounts represents a collection of accounts in the portal
@@ -456,8 +456,8 @@ type Certificates interface {
 	DeleteClusterCertificate(SiteKey) error
 }
 
-// EnvironmentVariables manages runtime environment variables in cluster
-type EnvironmentVariables interface {
+// RuntimeEnvironment manages runtime environment variables in cluster
+type RuntimeEnvironment interface {
 	// CreateUpdateEnvarsOperation creates a new operation to update cluster runtime environment variables
 	CreateUpdateEnvarsOperation(CreateUpdateEnvarsOperationRequest) (*SiteOperationKey, error)
 	// GetClusterEnvironmentVariables retrieves the cluster runtime environment variables
@@ -953,9 +953,10 @@ func (s *SiteOperation) String() string {
 	case OperationGarbageCollect:
 		typeS = "garbage collect"
 	case OperationUpdateEnvars:
-		typeS = "update cluster envars"
+		typeS = "update runtime cluster environment variables"
 	}
-	return fmt.Sprintf("operation(%v, cluster=%v, state=%s)", typeS, s.SiteDomain, s.State)
+	return fmt.Sprintf("operation(%v(%v), cluster=%v, state=%s, created=%v)",
+		typeS, s.ID, s.SiteDomain, s.State, s.Created.Format(constants.HumanDateFormat))
 }
 
 // SiteOperationKey identifies key to retrieve an opertaion

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -326,6 +326,10 @@ func (s *site) packages() pack.PackageService {
 	return s.service.cfg.Packages
 }
 
+func (s *site) apps() appservice.Applications {
+	return s.service.cfg.Apps
+}
+
 func (s *site) clock() timetools.TimeProvider {
 	return s.service.cfg.Clock
 }

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -299,7 +299,7 @@ func (s *site) createUpdateOperation(req ops.CreateSiteAppUpdateOperationRequest
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	updateApp, err := s.service.cfg.Apps.GetApp(*updatePackage)
+	updateApp, err := s.apps().GetApp(*updatePackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -375,8 +375,9 @@ func (s *site) startUpdateAgent(ctx context.Context, opCtx *operationContext, up
 		C("%s package export --file-mask=%o %s %s --ops-url=%s --insecure --quiet",
 			constants.GravityBin, defaults.SharedExecutableMask,
 			gravityPackage.String(), agentExecPath, defaults.GravityServiceURL).
+		C("%s update init-plan", agentExecPath).
 		// distribute agents and upgrade process
-		C("%s agent deploy upgrade", agentExecPath).
+		C("%s agent deploy --leader=upgrade --node=sync-plan", agentExecPath).
 		WithLogger(s.WithField("node", master.HostName())).
 		WithOutput(opCtx.recorder).
 		Run(ctx)

--- a/lib/ops/utils.go
+++ b/lib/ops/utils.go
@@ -291,6 +291,14 @@ type OperationStateSetter interface {
 	SetOperationState(SiteOperationKey, SetOperationStateRequest) error
 }
 
+// SetOperationState implements the OperationStateSetter by invoking this handler
+func (r OperationStateFunc) SetOperationState(key SiteOperationKey, req SetOperationStateRequest) error {
+	return r(key, req)
+}
+
+// OperationStateFunc is a function handler for setting the operation state
+type OperationStateFunc func(SiteOperationKey, SetOperationStateRequest) error
+
 // VerifyLicense verifies the provided license
 func VerifyLicense(packages pack.PackageService, license string) error {
 	parsed, err := licenseapi.ParseLicense(license)
@@ -310,7 +318,7 @@ func VerifyLicense(packages pack.PackageService, license string) error {
 
 // GetExpandOperation returns the first available expand operation from
 // the provided backend
-func GetExpandOperation(backend storage.Backend) (*storage.SiteOperation, error) {
+func GetExpandOperation(backend storage.Backend) (*SiteOperation, error) {
 	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -321,7 +329,7 @@ func GetExpandOperation(backend storage.Backend) (*storage.SiteOperation, error)
 	}
 	for _, operation := range operations {
 		if operation.Type == OperationExpand {
-			return &operation, nil
+			return (*SiteOperation)(&operation), nil
 		}
 	}
 	return nil, trace.NotFound("expand operation not found")

--- a/lib/rpc/deploy.go
+++ b/lib/rpc/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -60,7 +59,7 @@ type DeployAgentsRequest struct {
 
 	// LeaderParams defines which parameters to pass to the leader agent process.
 	// The leader agent would be driving the update in case of the automatic update operation.
-	LeaderParams []string
+	LeaderParams string
 
 	// Leader is the node where the leader agent should be launched
 	//
@@ -68,7 +67,7 @@ type DeployAgentsRequest struct {
 	Leader *storage.Server
 
 	// NodeParams defines which parameters to pass to the regular agent process.
-	NodeParams []string
+	NodeParams string
 }
 
 // Check validates the request to deploy agents
@@ -216,12 +215,10 @@ func deployAgentOnNode(ctx context.Context, req DeployAgentsRequest, node, nodeS
 	var runCmd string
 	if leader {
 		runCmd = fmt.Sprintf("%s agent --debug install %s",
-			gravityHostPath,
-			strings.Join(req.LeaderParams, " "))
+			gravityHostPath, req.LeaderParams)
 	} else {
 		runCmd = fmt.Sprintf("%s agent --debug install %s",
-			gravityHostPath,
-			strings.Join(req.NodeParams, " "))
+			gravityHostPath, req.NodeParams)
 	}
 
 	err = utils.NewSSHCommands(nodeClient.Client).

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -125,6 +125,14 @@ func FromPlanetAgent(ctx context.Context, servers []storage.Server) (*Agent, err
 	}, nil
 }
 
+// IsDegraded returns whether the cluster is in degraded state
+func (r Status) IsDegraded() bool {
+	return (r.Cluster == nil ||
+		r.Cluster.State == ops.SiteStateDegraded ||
+		r.Agent == nil ||
+		r.Agent.GetSystemStatus() != pb.SystemStatus_Running)
+}
+
 // Status describes the status of the cluster as a whole
 type Status struct {
 	// Cluster describes the operational status of the cluster

--- a/lib/storage/environment.go
+++ b/lib/storage/environment.go
@@ -139,6 +139,7 @@ func UnmarshalEnvironmentVariables(data []byte) (EnvironmentVariables, error) {
 		// Set namespace explicitly - schema default is ignored in json.Unmarshal
 		// as teleservices.Metadata.Namespace is missing the json serialization tag
 		env.Metadata.Namespace = defaults.KubeSystemNamespace
+		env.Metadata.Name = constants.ClusterEnvironmentMap
 		if env.Metadata.Expires != nil {
 			teleutils.UTC(env.Metadata.Expires)
 		}
@@ -168,6 +169,7 @@ const EnvironmentSpecSchema = `{
     "kind": {"type": "string"},
     "version": {"type": "string", "default": "v1"},
     "metadata": {
+      "default": {},
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/lib/storage/environment_test.go
+++ b/lib/storage/environment_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/defaults"
+
+	teleservices "github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+	. "gopkg.in/check.v1"
+)
+
+type EnvS struct{}
+
+var _ = Suite(&EnvS{})
+
+func (*EnvS) TestParsesEnvironment(c *C) {
+	testCases := []struct {
+		in      string
+		env     *EnvironmentV1
+		error   error
+		comment string
+	}{
+		{
+			in:      `{}`,
+			error:   trace.BadParameter("failed to validate: name: name is required"),
+			comment: "chokes on empty json",
+		},
+		{
+			in:      `{"kind": "runtimeenvironment"}`,
+			error:   trace.BadParameter("failed to validate: name: name is required"),
+			comment: "invalid with missing required fields",
+		},
+		{
+			in: `{"kind": "runtimeenvironment", "metadata": {"name": "foo"}, "version": "v1", "spec": {"data": {"foo": "bar"}}}`,
+			env: &EnvironmentV1{
+				Kind:    KindRuntimeEnvironment,
+				Version: "v1",
+				Metadata: teleservices.Metadata{
+					Name:      constants.ClusterEnvironmentMap,
+					Namespace: defaults.KubeSystemNamespace,
+				},
+				Spec: EnvironmentSpec{
+					KeyValues: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			comment: "overrides metadata.name and metadata.namespace",
+		},
+		{
+			in: `{"kind": "runtimeenvironment", "metadata": {"name": "foo"}, "version": "v1", "spec": {"data": null}}`,
+			env: &EnvironmentV1{
+				Kind:    KindRuntimeEnvironment,
+				Version: "v1",
+				Metadata: teleservices.Metadata{
+					Name:      constants.ClusterEnvironmentMap,
+					Namespace: defaults.KubeSystemNamespace,
+				},
+			},
+			comment: "missing (empty) spec is ok",
+		},
+		{
+			in: `kind: runtimeenvironment
+version: v1
+spec:
+  data:
+    foo: bar
+    HTTP_PROXY: "example.com:8081"
+`,
+			env: &EnvironmentV1{
+				Kind:    KindRuntimeEnvironment,
+				Version: "v1",
+				Metadata: teleservices.Metadata{
+					Name:      constants.ClusterEnvironmentMap,
+					Namespace: defaults.KubeSystemNamespace,
+				},
+				Spec: EnvironmentSpec{
+					KeyValues: map[string]string{
+						"foo":        "bar",
+						"HTTP_PROXY": "example.com:8081",
+					},
+				},
+			},
+			comment: "parses the correct spec",
+		},
+	}
+	for _, tc := range testCases {
+		comment := Commentf(tc.comment)
+		env, err := UnmarshalEnvironmentVariables([]byte(tc.in))
+		if tc.error != nil {
+			c.Assert(err, FitsTypeOf, tc.error, comment)
+			continue
+		}
+		c.Assert(err, IsNil, comment)
+		c.Assert(env, compare.DeepEquals, tc.env, comment)
+
+		bytes, err := MarshalEnvironment(env)
+		c.Assert(err, IsNil, comment)
+
+		env2, err := UnmarshalEnvironmentVariables([]byte(bytes))
+		c.Assert(err, IsNil, comment)
+		c.Assert(env2, compare.DeepEquals, env, comment)
+	}
+}

--- a/lib/storage/environment_test.go
+++ b/lib/storage/environment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ func (*EnvS) TestParsesEnvironment(c *C) {
 		{
 			in:      `{}`,
 			error:   trace.BadParameter("failed to validate: name: name is required"),
-			comment: "chokes on empty json",
+			comment: "fails for empty json",
 		},
 		{
 			in:      `{"kind": "runtimeenvironment"}`,

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -124,7 +124,7 @@ func GetOperations(backend Backend) ([]SiteOperation, error) {
 	return operations, nil
 }
 
-// GetOperationByID returns the last operation for the local cluster
+// GetOperationByID returns the operation with the given ID for the local cluster
 func GetOperationByID(backend Backend, operationID string) (*SiteOperation, error) {
 	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
 	if err != nil {

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -100,20 +100,41 @@ func GetClusterLoginEntry(backend Backend) (*LoginEntry, error) {
 
 // GetLastOperation returns the last operation for the local cluster
 func GetLastOperation(backend Backend) (*SiteOperation, error) {
-	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	operations, err := backend.GetSiteOperations(cluster.Domain)
+	operations, err := GetOperations(backend)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if len(operations) == 0 {
 		return nil, trace.NotFound("no operations found")
 	}
-
 	return &(operations[0]), nil
+}
+
+// GetOperations returns all operations for the local cluster
+// sorted by time in descending order (with most recent operation first)
+func GetOperations(backend Backend) ([]SiteOperation, error) {
+	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	operations, err := backend.GetSiteOperations(cluster.Domain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return operations, nil
+}
+
+// GetOperationByID returns the last operation for the local cluster
+func GetOperationByID(backend Backend, operationID string) (*SiteOperation, error) {
+	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	operation, err := backend.GetSiteOperation(cluster.Domain, operationID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return operation, nil
 }
 
 // GetLocalServers returns local cluster state servers

--- a/lib/update/automatic.go
+++ b/lib/update/automatic.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/rpc"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/utils/kubectl"
 
@@ -35,7 +37,10 @@ func AutomaticUpgrade(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
+	operation, err := storage.GetLastOperation(updateEnv.Backend)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	creds, err := fsm.GetClientCredentials()
 	if err != nil {
 		return trace.Wrap(err)
@@ -52,6 +57,7 @@ func AutomaticUpgrade(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 		Apps:              clusterEnv.Apps,
 		Client:            clusterEnv.Client,
 		Operator:          clusterEnv.Operator,
+		Operation:         (*ops.SiteOperation)(operation),
 		Users:             clusterEnv.Users,
 		Remote:            runner,
 	}

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -124,7 +124,7 @@ func (f *fsmUpdateEngine) Complete(fsmErr error) error {
 		return trace.Wrap(err)
 	}
 
-	stateSetter := fsm.SetOperationState(opKey, f.Operator, f.LocalBackend)
+	stateSetter := fsm.OperationStateSetter(opKey, f.Operator, f.LocalBackend)
 	completed := fsm.IsCompleted(plan)
 	if completed {
 		err = ops.CompleteOperation(opKey, stateSetter)

--- a/lib/update/fsm.go
+++ b/lib/update/fsm.go
@@ -55,6 +55,8 @@ type FSMConfig struct {
 	Client *kubernetes.Clientset
 	// Operator is the local cluster operator
 	Operator ops.Operator
+	// Operation specifies the upgrade operation to work with
+	Operation *ops.SiteOperation
 	// Users is the cluster identity service
 	Users users.Identity
 	// Spec is used to retrieve a phase executor, allows
@@ -95,6 +97,9 @@ func NewFSM(ctx context.Context, c FSMConfig) (*fsm.FSM, error) {
 func (c *FSMConfig) checkAndSetDefaults() error {
 	if c.Backend == nil {
 		return trace.BadParameter("parameter Backend must be set")
+	}
+	if c.Operation == nil {
+		return trace.BadParameter("parameter Operation must be set")
 	}
 	if c.Spec == nil {
 		c.Spec = fsmSpec(*c)

--- a/lib/update/fsm_test.go
+++ b/lib/update/fsm_test.go
@@ -80,7 +80,7 @@ func (s *FSMSuite) TestFSMBasic(c *check.C) {
 		"/phase2": storage.OperationPhaseStateUnstarted,
 	})
 
-	s.engine.plan = &plan
+	s.engine.plan = plan
 	ctx := context.TODO()
 
 	// phase2 requires phase1 to be completed first
@@ -123,7 +123,7 @@ func (s *FSMSuite) TestFSMExecuteSubphase(c *check.C) {
 		},
 	}
 
-	s.engine.plan = &plan
+	s.engine.plan = plan
 
 	err := s.fsm.ExecutePhase(context.TODO(), fsm.Params{
 		PhaseID: "/phase1/sub1",
@@ -150,7 +150,7 @@ func (s *FSMSuite) TestFSMExecutePhaseWithSubphases(c *check.C) {
 		},
 	}
 
-	s.engine.plan = &plan
+	s.engine.plan = plan
 
 	err := s.fsm.ExecutePhase(context.TODO(), fsm.Params{
 		PhaseID: "/phase1",

--- a/lib/update/phase_system.go
+++ b/lib/update/phase_system.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// updatePhaseNode is the executor for the update master/node update phase
+// updatePhaseSystem is the executor for the update master/node update phase
 type updatePhaseSystem struct {
 	// OperationID is the id of the current update operation
 	OperationID string

--- a/lib/update/plan.go
+++ b/lib/update/plan.go
@@ -341,7 +341,7 @@ func newOperationPlanFromParams(p newPlanParams) (*storage.OperationPlan, error)
 		if updateEtcd {
 			etcdPhase := *builder.etcdPlan(leadMaster.Server, masters[1:].asServers(), nodes.asServers(),
 				currentVersion, desiredVersion)
-			// This does not depened on previous on purposes - when the etcd block is executed,
+			// This does not depend on previous on purposes - when the etcd block is executed,
 			// remote agents might be able to sync the plan before the shutdown of etcd instances
 			// has begun
 			root.Add(etcdPhase)

--- a/lib/update/plan.go
+++ b/lib/update/plan.go
@@ -29,16 +29,13 @@ import (
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
-	rpcclient "github.com/gravitational/gravity/lib/rpc/client"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
-	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/utils"
 
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -46,14 +43,16 @@ import (
 func InitOperationPlan(
 	ctx context.Context,
 	localEnv, updateEnv *localenv.LocalEnvironment,
-	clusterEnv *localenv.ClusterEnvironment) (*storage.OperationPlan, error) {
-	operation, err := storage.GetLastOperation(clusterEnv.Backend)
+	clusterEnv *localenv.ClusterEnvironment,
+	opKey ops.SiteOperationKey,
+) (*storage.OperationPlan, error) {
+	operation, err := storage.GetOperationByID(clusterEnv.Backend, opKey.OperationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if operation.Type != ops.OperationUpdate {
-		return nil, trace.BadParameter("%q does not support plans", operation.Type)
+		return nil, trace.BadParameter("expected update operation but got %q", operation.Type)
 	}
 
 	plan, err := clusterEnv.Backend.GetOperationPlan(operation.SiteDomain, operation.ID)
@@ -135,38 +134,12 @@ func SyncOperationPlan(src storage.Backend, dst storage.Backend) error {
 	return trace.Wrap(syncChangelog(src, dst, plan.ClusterName, plan.OperationID))
 }
 
-// SyncOperationPlanToCluster runs gravity plan --sync on each cluster member, to force syncronization from etcd
-// to the local store
-func SyncOperationPlanToCluster(ctx context.Context, plan storage.OperationPlan, clientCreds credentials.TransportCredentials) error {
-	ctx, cancel := context.WithTimeout(ctx, defaults.AgentRequestTimeout)
-	defer cancel()
-
-	logger := log.WithFields(log.Fields{
-		trace.Component: "fsm:sync",
-	})
-
-	for _, server := range plan.Servers {
-		err := systeminfo.HasInterface(server.AdvertiseIP)
-		if err == nil {
-			continue
-		}
-		addr := defaults.GravityRPCAgentAddr(server.AdvertiseIP)
-		clt, err := rpcclient.New(ctx, rpcclient.Config{ServerAddr: addr, Credentials: clientCreds})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		err = clt.GravityCommand(ctx, logger, nil, "plan", "--sync")
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	return nil
-}
-
 // newOperationPlan generates a new plan for the provided operation
-func newOperationPlan(env *localenv.ClusterEnvironment, dnsConfig storage.DNSConfig, op storage.SiteOperation) (*storage.OperationPlan, error) {
+func newOperationPlan(
+	env *localenv.ClusterEnvironment,
+	dnsConfig storage.DNSConfig,
+	operation storage.SiteOperation,
+) (*storage.OperationPlan, error) {
 	if env.Client == nil {
 		return nil, trace.BadParameter("Kubernetes client is required")
 	}
@@ -199,7 +172,7 @@ func newOperationPlan(env *localenv.ClusterEnvironment, dnsConfig storage.DNSCon
 		return nil, trace.Wrap(err)
 	}
 
-	updatePackage, err := op.Update.Package()
+	updatePackage, err := operation.Update.Package()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -212,7 +185,7 @@ func newOperationPlan(env *localenv.ClusterEnvironment, dnsConfig storage.DNSCon
 		return nil, trace.Wrap(err)
 	}
 
-	links, err := env.Backend.GetOpsCenterLinks(op.SiteDomain)
+	links, err := env.Backend.GetOpsCenterLinks(operation.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -222,7 +195,7 @@ func newOperationPlan(env *localenv.ClusterEnvironment, dnsConfig storage.DNSCon
 	}
 
 	plan, err := newOperationPlanFromParams(newPlanParams{
-		operation:        op,
+		operation:        operation,
 		servers:          servers,
 		installedRuntime: *installedRuntime,
 		installedApp:     *installedApp,

--- a/lib/vacuum/vacuum.go
+++ b/lib/vacuum/vacuum.go
@@ -192,6 +192,9 @@ func (r *Config) checkAndSetDefaults() error {
 	if r.Operator == nil {
 		return trace.BadParameter("cluster operator service is required")
 	}
+	if r.Operation == nil {
+		return trace.BadParameter("cluster operation is required")
+	}
 	if len(r.Servers) == 0 {
 		return trace.BadParameter("at least a single server is required")
 	}
@@ -217,7 +220,7 @@ type Config struct {
 	LocalPackages libpack.PackageService
 	// Operator is the cluster operator service
 	Operator ops.Operator
-	// Operation references a potentially active garbage collection operation
+	// Operation references the garbage collection operation to work with
 	Operation *ops.SiteOperation
 	// Servers is the list of cluster servers
 	Servers []storage.Server

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -68,10 +68,8 @@ type Application struct {
 	RemoveCmd RemoveCmd
 	// PlanCmd manages an operation plan
 	PlanCmd PlanCmd
-	// PlanInitCmd creates a new update operation plan
-	PlanInitCmd PlanInitCmd
-	// PlanSyncCmd synchronizes operation plan between local and cluster backends
-	PlanSyncCmd PlanSyncCmd
+	// UpdatePlanInitCmd creates a new update operation plan
+	UpdatePlanInitCmd UpdatePlanInitCmd
 	// PlanDisplayCmd displays plan of an operation
 	PlanDisplayCmd PlanDisplayCmd
 	// PlanExecuteCmd executes a phase of an active operation
@@ -457,16 +455,6 @@ type PlanCmd struct {
 	SkipVersionCheck *bool
 }
 
-// PlanInitCmd creates a new update operation plan
-type PlanInitCmd struct {
-	*kingpin.CmdClause
-}
-
-// PlanSyncCmd synchronizes operation plan between local and cluster backends
-type PlanSyncCmd struct {
-	*kingpin.CmdClause
-}
-
 // PlanDisplayCmd displays plan of a specific operation
 type PlanDisplayCmd struct {
 	*kingpin.CmdClause
@@ -580,6 +568,11 @@ type UpdateSystemCmd struct {
 	WithStatus *bool
 	// RuntimePackage specifies the runtime package to update to
 	RuntimePackage *loc.Locator
+}
+
+// UpdatePlanInitCmd creates a new update operation plan
+type UpdatePlanInitCmd struct {
+	*kingpin.CmdClause
 }
 
 // UpgradeCmd launches app upgrade
@@ -1143,8 +1136,10 @@ type RPCAgentCmd struct {
 // RPCAgentDeployCmd deploys RPC agents on cluster nodes
 type RPCAgentDeployCmd struct {
 	*kingpin.CmdClause
-	// Args is additional arguments to the agent
-	Args *[]string
+	// LeaderArgs is additional arguments to the leader agent
+	LeaderArgs *string
+	// NodeArgs is additional arguments to the regular agent
+	NodeArgs *string
 }
 
 // RPCAgentShutdownCmd requests RPC agents to shut down
@@ -1411,6 +1406,8 @@ type GarbageCollectCmd struct {
 	Phase *string
 	// PhaseTimeout is the phase execution timeout
 	PhaseTimeout *time.Duration
+	// OperationID specifies the ID of the operation to work with
+	OperationID *string
 	// Resume is whether to resume a failed garbage collection
 	Resume *bool
 	// Manual is whether the operation is not executed automatically

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -541,6 +541,9 @@ type UpdateTriggerCmd struct {
 	App *string
 	// Manual starts operation in manual mode
 	Manual *bool
+	// Block controls whether to wait for the operation to finish.
+	// If false, this enables to run the operation unattended
+	Block *bool
 }
 
 // UpdateUploadCmd uploads new app version to local cluster
@@ -582,6 +585,9 @@ type UpgradeCmd struct {
 	App *string
 	// Manual starts upgrade in manual mode
 	Manual *bool
+	// Block controls whether to wait for the operation to finish.
+	// If false, this enables to run the operation unattended
+	Block *bool
 	// Phase is upgrade operation phase to execute
 	Phase *string
 	// Timeout is phase execution timeout

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -118,7 +118,7 @@ func getLastOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, o
 		return nil, trace.NotFound("no operation found")
 	}
 	if len(operations) == 1 && operationID != "" {
-		log.WithField("operation", operations[0]).Info("Fetched an operation by ID.")
+		log.WithField("operation", operations[0]).Debug("Fetched operation by ID.")
 		return &operations[0], nil
 	}
 	log.Infof("Multiple operations found: \n%v\n, please specify operation with --operation-id.\n"+
@@ -132,7 +132,7 @@ func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.WithField("operations", oplist(operations).String()).Info("Fetched backend operations.")
+	log.WithField("operations", oplist(operations).String()).Debug("Fetched backend operations.")
 	if len(operations) == 0 {
 		if operationID != "" {
 			return nil, trace.NotFound("no operation with ID %v found", operationID)
@@ -140,7 +140,7 @@ func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment,
 		return nil, trace.NotFound("no operation found")
 	}
 	if len(operations) == 1 && operationID != "" {
-		log.WithField("operation", operations[0]).Info("Fetched an operation by ID.")
+		log.WithField("operation", operations[0]).Debug("Fetched an operation by ID.")
 		return &operations[0], nil
 	}
 	op, err := getActiveOperationFromList(operations)
@@ -202,7 +202,7 @@ func (r *backendOperations) List(localEnv, updateEnv, joinEnv *localenv.LocalEnv
 		if wizardEnv != nil && wizardEnv.Operator != nil {
 			op, err := ops.GetWizardOperation(wizardEnv.Operator)
 			if err == nil {
-				log.Info("Fetched install operation from wizard environment.")
+				log.Debug("Fetched install operation from wizard environment.")
 				r.operations[op.ID] = (ops.SiteOperation)(*op)
 			} else {
 				log.WithError(err).Warn("Failed to query install operation.")

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -110,7 +110,7 @@ func getLastOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, o
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.WithField("operations", oplist(operations).String()).Info("Fetched backend operations.")
+	log.WithField("operations", oplist(operations).String()).Debug("Fetched backend operations.")
 	if len(operations) == 0 {
 		if operationID != "" {
 			return nil, trace.NotFound("no operation with ID %v found", operationID)
@@ -140,7 +140,7 @@ func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment,
 		return nil, trace.NotFound("no operation found")
 	}
 	if len(operations) == 1 && operationID != "" {
-		log.WithField("operation", operations[0]).Debug("Fetched an operation by ID.")
+		log.WithField("operation", operations[0]).Debug("Fetched operation by ID.")
 		return &operations[0], nil
 	}
 	op, err := getActiveOperationFromList(operations)

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cli
 
 import (
-	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,6 +33,10 @@ import (
 type PhaseParams struct {
 	// PhaseID is the ID of the phase to execute
 	PhaseID string
+	// OperationID specifies the operation to work with.
+	// If unspecified, last operation is used.
+	// Some commands will require the last operation to also be active
+	OperationID string
 	// Force allows to force phase execution
 	Force bool
 	// Timeout is phase execution timeout
@@ -41,41 +45,41 @@ type PhaseParams struct {
 	SkipVersionCheck bool
 }
 
-func executePhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string, params PhaseParams) error {
-	op, err := getActiveOperation(localEnv, updateEnv, joinEnv, operationID)
+func executePhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, params PhaseParams) error {
+	op, err := getActiveOperation(localEnv, updateEnv, joinEnv, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	switch op.Type {
 	case ops.OperationInstall:
-		return executeInstallPhase(localEnv, params)
+		return executeInstallPhase(localEnv, params, op)
 	case ops.OperationExpand:
-		return executeJoinPhase(localEnv, joinEnv, params)
+		return executeJoinPhase(localEnv, joinEnv, params, op)
 	case ops.OperationUpdate:
-		return executeUpgradePhase(localEnv, updateEnv, params)
+		return executeUpgradePhase(localEnv, updateEnv, params, op)
 	case ops.OperationUpdateEnvars:
-		return executeEnvarsPhase(localEnv, updateEnv, params)
+		return executeEnvarsPhase(localEnv, updateEnv, params, *op)
 	case ops.OperationGarbageCollect:
-		return executeGarbageCollectPhase(localEnv, params)
+		return executeGarbageCollectPhase(localEnv, params, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan execution", op.Type)
 	}
 }
 
-func rollbackPhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string, params PhaseParams) error {
-	op, err := getActiveOperation(localEnv, updateEnv, joinEnv, operationID)
+func rollbackPhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, params PhaseParams) error {
+	op, err := getActiveOperation(localEnv, updateEnv, joinEnv, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	switch op.Type {
 	case ops.OperationInstall:
-		return rollbackInstallPhase(localEnv, params)
+		return rollbackInstallPhase(localEnv, params, op)
 	case ops.OperationExpand:
-		return rollbackJoinPhase(localEnv, joinEnv, params)
+		return rollbackJoinPhase(localEnv, joinEnv, params, op)
 	case ops.OperationUpdate:
-		return rollbackUpgradePhase(localEnv, updateEnv, params)
+		return rollbackUpgradePhase(localEnv, updateEnv, params, *op)
 	case ops.OperationUpdateEnvars:
-		return rollbackEnvarsPhase(localEnv, updateEnv, params)
+		return rollbackEnvarsPhase(localEnv, updateEnv, params, *op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan rollback", op.Type)
 	}
@@ -88,47 +92,56 @@ func completeOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironme
 	}
 	switch op.Type {
 	case ops.OperationInstall:
-		return completeInstallPlan(localEnv)
+		// There's only one install operation
+		return completeInstallPlan(localEnv, op)
 	case ops.OperationExpand:
-		return completeJoinPlan(localEnv, joinEnv)
+		return completeJoinPlan(localEnv, joinEnv, op)
 	case ops.OperationUpdate:
-		return completeUpdatePlan(localEnv, updateEnv)
+		return completeUpdatePlan(localEnv, updateEnv, *op)
 	case ops.OperationUpdateEnvars:
-		return completeEnvarsPlan(localEnv, updateEnv)
+		return completeEnvarsPlan(localEnv, updateEnv, *op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan completion", op.Type)
 	}
 }
 
 func getLastOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (*ops.SiteOperation, error) {
-	operations := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+	operations, err := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	log.WithField("operations", oplist(operations).String()).Info("Fetched backend operations.")
 	if len(operations) == 0 {
 		if operationID != "" {
 			return nil, trace.NotFound("no operation with ID %v found", operationID)
 		}
 		return nil, trace.NotFound("no operation found")
 	}
-	op, err := getActiveOperationFromList(operations)
-	if err != nil {
-		log.WithError(err).Warn("Failed to find active operation, will fall back to last completed.")
+	if len(operations) == 1 && operationID != "" {
+		log.WithField("operation", operations[0]).Info("Fetched an operation by ID.")
+		return &operations[0], nil
 	}
-	if op == nil {
-		if len(operations) != 1 {
-			return nil, trace.BadParameter("multiple operations found: \n%v\n, please specify operation with --operation-id",
-				formatOperations(operations))
-		}
-		op = &operations[0]
-	}
-	return op, nil
+	log.Infof("Multiple operations found: \n%v\n, please specify operation with --operation-id.\n"+
+		"Displaying the most recent operation.",
+		oplist(operations))
+	return &operations[0], nil
 }
 
 func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (*ops.SiteOperation, error) {
-	operations := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+	operations, err := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	log.WithField("operations", oplist(operations).String()).Info("Fetched backend operations.")
 	if len(operations) == 0 {
 		if operationID != "" {
 			return nil, trace.NotFound("no operation with ID %v found", operationID)
 		}
 		return nil, trace.NotFound("no operation found")
+	}
+	if len(operations) == 1 && operationID != "" {
+		log.WithField("operation", operations[0]).Info("Fetched an operation by ID.")
+		return &operations[0], nil
 	}
 	op, err := getActiveOperationFromList(operations)
 	if err != nil {
@@ -138,63 +151,104 @@ func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment,
 }
 
 // getBackendOperations returns the list of operation from the specified backends
-func getBackendOperations(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (result []ops.SiteOperation) {
-	// operationID -> operation
-	operations := make(map[string]ops.SiteOperation)
-	var clusterOperation *ops.SiteOperation
-	isOngoingInstallOperation := func() bool {
-		return clusterOperation == nil ||
-			(clusterOperation.Type == ops.OperationInstall && !clusterOperation.IsCompleted())
+// in descending order (sorted by creation time)
+func getBackendOperations(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (result []ops.SiteOperation, err error) {
+	b := newBackendOperations()
+	err = b.List(localEnv, updateEnv, joinEnv)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	getBackendOperation := func(backend storage.Backend, ctx string) *ops.SiteOperation {
-		op, err := storage.GetLastOperation(backend)
-		if err == nil {
-			if _, exists := operations[op.ID]; !exists {
-				operations[op.ID] = (ops.SiteOperation)(*op)
-			}
-		} else {
-			log.WithFields(logrus.Fields{
-				"context":       ctx,
-				logrus.ErrorKey: err,
-			}).Debug("Failed to query operation.")
+	for _, op := range b.operations {
+		if operationID == "" || operationID == op.ID {
+			result = append(result, op)
 		}
-		return (*ops.SiteOperation)(op)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Created.After(result[j].Created)
+	})
+	return result, nil
+}
+
+func newBackendOperations() backendOperations {
+	return backendOperations{
+		operations: make(map[string]ops.SiteOperation),
+	}
+}
+
+func (r *backendOperations) List(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment) error {
 	clusterEnv, err := localEnv.NewClusterEnvironmentWithTimeout(1 * time.Second)
 	if err != nil {
 		log.WithError(err).Debug("Failed to create cluster environment.")
 	}
 	if clusterEnv != nil {
-		clusterOperation = getBackendOperation(clusterEnv.Backend, "cluster")
+		err = r.init(clusterEnv.Backend)
+		if err != nil {
+			log.WithError(err).Warn("Failed to query cluster operations.")
+		}
 	}
 	if updateEnv != nil {
-		getBackendOperation(updateEnv.Backend, "update")
+		r.getOperationAndUpdateCache(updateEnv.Backend, log.WithField("context", "update"))
 	}
 	if joinEnv != nil {
-		getBackendOperation(joinEnv.Backend, "expand")
+		r.getOperationAndUpdateCache(joinEnv.Backend, log.WithField("context", "expand"))
 	}
 	// Only fetch operation from remote (install) environment if the install operation is ongoing
 	// or we failed to fetch the operation details from the cluster
-	if isOngoingInstallOperation() {
+	if r.isActiveInstallOperation() {
 		wizardEnv, err := localenv.NewRemoteEnvironment()
 		if err != nil {
-			log.WithError(err).Debug("Failed to create wizard environment.")
+			log.WithError(err).Warn("Failed to create wizard environment.")
 		}
 		if wizardEnv != nil && wizardEnv.Operator != nil {
 			op, err := ops.GetWizardOperation(wizardEnv.Operator)
 			if err == nil {
-				operations[op.ID] = (ops.SiteOperation)(*op)
+				log.Info("Fetched install operation from wizard environment.")
+				r.operations[op.ID] = (ops.SiteOperation)(*op)
 			} else {
-				log.WithError(err).Debug("Failed to query install operation.")
+				log.WithError(err).Warn("Failed to query install operation.")
 			}
 		}
 	}
-	for _, op := range operations {
-		if operationID == "" || operationID == op.ID {
-			result = append(result, op)
-		}
+	return nil
+}
+
+func (r *backendOperations) init(clusterBackend storage.Backend) error {
+	clusterOperations, err := storage.GetOperations(clusterBackend)
+	if err != nil {
+		return trace.Wrap(err, "failed to query cluster operations")
 	}
-	return result
+	if len(clusterOperations) == 0 {
+		return nil
+	}
+	// Initialize the operation state from the list of existing cluster operations
+	for _, op := range clusterOperations {
+		r.operations[op.ID] = (ops.SiteOperation)(op)
+	}
+	r.clusterOperation = (*ops.SiteOperation)(&clusterOperations[0])
+	r.operations[r.clusterOperation.ID] = *r.clusterOperation
+	return nil
+}
+
+func (r *backendOperations) getOperationAndUpdateCache(backend storage.Backend, logger logrus.FieldLogger) *ops.SiteOperation {
+	op, err := storage.GetLastOperation(backend)
+	if err == nil {
+		// Operation from the backend takes precedence over the existing operation (from cluster state)
+		r.operations[op.ID] = (ops.SiteOperation)(*op)
+	} else {
+		logger.WithError(err).Warn("Failed to query operation.")
+	}
+	return (*ops.SiteOperation)(op)
+}
+
+func (r backendOperations) isActiveInstallOperation() bool {
+	// FIXME: continue using wizard as source of truth as operation state
+	// replicated in etcd is reported completed before it actually is
+	return r.clusterOperation == nil || (r.clusterOperation.Type == ops.OperationInstall)
+}
+
+type backendOperations struct {
+	operations       map[string]ops.SiteOperation
+	clusterOperation *ops.SiteOperation
 }
 
 func getActiveOperationFromList(operations []ops.SiteOperation) (*ops.SiteOperation, error) {
@@ -206,10 +260,12 @@ func getActiveOperationFromList(operations []ops.SiteOperation) (*ops.SiteOperat
 	return nil, trace.NotFound("no active operations found")
 }
 
-func formatOperations(operations []ops.SiteOperation) string {
-	var formats []string
-	for _, op := range operations {
-		formats = append(formats, fmt.Sprintf("operation(id=%v, type=%v)", op.ID, op.Type))
+func (r oplist) String() string {
+	var ops []string
+	for _, op := range r {
+		ops = append(ops, op.String())
 	}
-	return strings.Join(formats, "\n")
+	return strings.Join(ops, "\n")
 }
+
+type oplist []ops.SiteOperation

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -163,6 +163,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpdateTriggerCmd.CmdClause = g.UpdateCmd.Command("trigger", "Trigger an update operation for given application").Hidden()
 	g.UpdateTriggerCmd.App = g.UpdateTriggerCmd.Arg("app", "Application version to update to, in the 'name:version' or 'name' (for latest version) format. If unspecified, currently installed application is updated").String()
 	g.UpdateTriggerCmd.Manual = g.UpdateTriggerCmd.Flag("manual", "Manual operation. Do not trigger automatic update").Short('m').Bool()
+	g.UpdateTriggerCmd.Block = g.UpdateTriggerCmd.Flag("block", "Wait for operation to finish (default). Use --no-block to run the operation unattended instead").
+		OverrideDefaultFromEnvar(constants.BlockingOperationEnvVar).
+		Default("true").
+		Bool()
 
 	g.UpdatePlanInitCmd.CmdClause = g.UpdateCmd.Command("init-plan", "Initialize operation plan").Hidden()
 
@@ -170,6 +174,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpgradeCmd.CmdClause = g.Command("upgrade", "Trigger an update operation for given application").Hidden()
 	g.UpgradeCmd.App = g.UpgradeCmd.Arg("app", "Application version to update to, in the 'name:version' or 'name' (for latest version) format. If unspecified, currently installed application is updated").String()
 	g.UpgradeCmd.Manual = g.UpgradeCmd.Flag("manual", "Manual upgrade mode").Short('m').Bool()
+	g.UpgradeCmd.Block = g.UpgradeCmd.Flag("block", "Wait for operation to finish (default). Use --no-block to run the operation unattended instead").
+		OverrideDefaultFromEnvar(constants.BlockingOperationEnvVar).
+		Default("true").
+		Bool()
 	g.UpgradeCmd.Phase = g.UpgradeCmd.Flag("phase", "Operation phase to execute").String()
 	g.UpgradeCmd.Timeout = g.UpgradeCmd.Flag("timeout", "Phase execution timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 	g.UpgradeCmd.Force = g.UpgradeCmd.Flag("force", "Force phase execution even if pre-conditions are not satisfied").Bool()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -136,9 +136,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. It not specified, the last operation will be used").Hidden().String()
 	g.PlanCmd.SkipVersionCheck = g.PlanCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 
-	g.PlanInitCmd.CmdClause = g.PlanCmd.Command("init", "Initialize operation plan")
-	g.PlanSyncCmd.CmdClause = g.PlanCmd.Command("sync", "Sync the operation plan from etcd to local store")
-
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation").Default()
 	g.PlanDisplayCmd.Output = common.Format(g.PlanDisplayCmd.Flag("output", "Output format for the plan, text, json or yaml").Short('o').Default(string(constants.EncodingText)))
 
@@ -166,6 +163,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpdateTriggerCmd.CmdClause = g.UpdateCmd.Command("trigger", "Trigger an update operation for given application").Hidden()
 	g.UpdateTriggerCmd.App = g.UpdateTriggerCmd.Arg("app", "Application version to update to, in the 'name:version' or 'name' (for latest version) format. If unspecified, currently installed application is updated").String()
 	g.UpdateTriggerCmd.Manual = g.UpdateTriggerCmd.Flag("manual", "Manual operation. Do not trigger automatic update").Short('m').Bool()
+
+	g.UpdatePlanInitCmd.CmdClause = g.UpdateCmd.Command("init-plan", "Initialize operation plan").Hidden()
 
 	// upgrade is aliased to "update trigger"
 	g.UpgradeCmd.CmdClause = g.Command("upgrade", "Trigger an update operation for given application").Hidden()
@@ -488,7 +487,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.RPCAgentCmd.CmdClause = g.Command("agent", "RPC agent")
 
 	g.RPCAgentDeployCmd.CmdClause = g.RPCAgentCmd.Command("deploy", "deploy RPC agents across cluster nodes, and run specified execution function").Hidden()
-	g.RPCAgentDeployCmd.Args = g.RPCAgentDeployCmd.Arg("arg", "additional arguments").Strings()
+	g.RPCAgentDeployCmd.LeaderArgs = g.RPCAgentDeployCmd.Flag("leader", "additional arguments to leader node agent").String()
+	g.RPCAgentDeployCmd.NodeArgs = g.RPCAgentDeployCmd.Flag("node", "additional arguments to regular node agent").String()
 
 	g.RPCAgentShutdownCmd.CmdClause = g.RPCAgentCmd.Command("shutdown", "request agents to shut down").Hidden()
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -95,8 +95,6 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.RPCAgentInstallCmd.FullCommand(),
 		g.RPCAgentRunCmd.FullCommand(),
 		g.PlanCmd.FullCommand(),
-		g.PlanInitCmd.FullCommand(),
-		g.PlanSyncCmd.FullCommand(),
 		g.PlanDisplayCmd.FullCommand(),
 		g.PlanExecuteCmd.FullCommand(),
 		g.PlanRollbackCmd.FullCommand(),
@@ -119,6 +117,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.JoinCmd.FullCommand(),
 		g.AutoJoinCmd.FullCommand(),
 		g.UpdateTriggerCmd.FullCommand(),
+		g.UpdatePlanInitCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
 		g.RPCAgentRunCmd.FullCommand(),
 		g.LeaveCmd.FullCommand(),
@@ -174,9 +173,8 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.SystemServiceUninstallCmd.FullCommand(),
 		g.EnterCmd.FullCommand(),
 		g.PlanetEnterCmd.FullCommand(),
+		g.UpdatePlanInitCmd.FullCommand(),
 		g.PlanCmd.FullCommand(),
-		g.PlanInitCmd.FullCommand(),
-		g.PlanSyncCmd.FullCommand(),
 		g.PlanDisplayCmd.FullCommand(),
 		g.PlanExecuteCmd.FullCommand(),
 		g.PlanRollbackCmd.FullCommand(),
@@ -295,7 +293,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 				PhaseID: *g.InstallCmd.Phase,
 				Force:   *g.InstallCmd.Force,
 				Timeout: *g.InstallCmd.PhaseTimeout,
-			})
+			}, nil)
 		}
 		return startInstall(localEnv, NewInstallConfig(g))
 	case g.JoinCmd.FullCommand():
@@ -304,10 +302,11 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		}
 		if *g.JoinCmd.Phase != "" {
 			return executeJoinPhase(localEnv, joinEnv, PhaseParams{
-				PhaseID: *g.JoinCmd.Phase,
-				Force:   *g.JoinCmd.Force,
-				Timeout: *g.JoinCmd.PhaseTimeout,
-			})
+				PhaseID:     *g.JoinCmd.Phase,
+				Force:       *g.JoinCmd.Force,
+				Timeout:     *g.JoinCmd.PhaseTimeout,
+				OperationID: *g.JoinCmd.OperationID,
+			}, nil)
 		}
 		return Join(localEnv, joinEnv, NewJoinConfig(g))
 	case g.AutoJoinCmd.FullCommand():
@@ -327,6 +326,8 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			updateEnv,
 			*g.UpdateTriggerCmd.App,
 			*g.UpdateTriggerCmd.Manual)
+	case g.UpdatePlanInitCmd.FullCommand():
+		return initUpdateOperationPlan(localEnv, updateEnv)
 	case g.UpgradeCmd.FullCommand():
 		if *g.UpgradeCmd.Resume {
 			*g.UpgradeCmd.Phase = fsm.RootPhase
@@ -338,43 +339,38 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 					Force:            *g.UpgradeCmd.Force,
 					Timeout:          *g.UpgradeCmd.Timeout,
 					SkipVersionCheck: *g.UpgradeCmd.SkipVersionCheck,
-				},
-			)
+				}, nil)
 		}
 		return updateTrigger(localEnv,
 			updateEnv,
 			*g.UpgradeCmd.App,
 			*g.UpgradeCmd.Manual)
-	case g.PlanInitCmd.FullCommand():
-		return initOperationPlan(localEnv, updateEnv)
-	case g.PlanSyncCmd.FullCommand():
-		return syncOperationPlan(localEnv, updateEnv)
 	case g.PlanExecuteCmd.FullCommand():
 		return executePhase(localEnv, updateEnv, joinEnv,
-			*g.PlanCmd.OperationID,
 			PhaseParams{
 				PhaseID:          *g.PlanExecuteCmd.Phase,
 				Force:            *g.PlanExecuteCmd.Force,
 				Timeout:          *g.PlanExecuteCmd.PhaseTimeout,
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
+				OperationID:      *g.PlanCmd.OperationID,
 			})
 	case g.PlanResumeCmd.FullCommand():
 		return executePhase(localEnv, updateEnv, joinEnv,
-			*g.PlanCmd.OperationID,
 			PhaseParams{
 				PhaseID:          fsm.RootPhase,
 				Force:            *g.PlanResumeCmd.Force,
 				Timeout:          *g.PlanResumeCmd.PhaseTimeout,
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
+				OperationID:      *g.PlanCmd.OperationID,
 			})
 	case g.PlanRollbackCmd.FullCommand():
 		return rollbackPhase(localEnv, updateEnv, joinEnv,
-			*g.PlanCmd.OperationID,
 			PhaseParams{
 				PhaseID:          *g.PlanRollbackCmd.Phase,
 				Force:            *g.PlanRollbackCmd.Force,
 				Timeout:          *g.PlanRollbackCmd.PhaseTimeout,
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
+				OperationID:      *g.PlanCmd.OperationID,
 			})
 	case g.PlanDisplayCmd.FullCommand():
 		return displayOperationPlan(localEnv, updateEnv, joinEnv,
@@ -704,10 +700,11 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		}
 		if phase != "" {
 			return executeGarbageCollectPhase(localEnv, PhaseParams{
-				PhaseID: phase,
-				Timeout: *g.GarbageCollectCmd.PhaseTimeout,
-				Force:   *g.GarbageCollectCmd.Force,
-			})
+				PhaseID:     phase,
+				Timeout:     *g.GarbageCollectCmd.PhaseTimeout,
+				Force:       *g.GarbageCollectCmd.Force,
+				OperationID: *g.GarbageCollectCmd.OperationID,
+			}, nil)
 		}
 		return garbageCollect(localEnv, *g.GarbageCollectCmd.Manual, *g.GarbageCollectCmd.Confirmed)
 	case g.SystemGCJournalCmd.FullCommand():
@@ -772,7 +769,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.ResourceGetCmd.Format,
 			*g.ResourceGetCmd.User)
 	case g.RPCAgentDeployCmd.FullCommand():
-		return rpcAgentDeploy(localEnv, updateEnv, *g.RPCAgentDeployCmd.Args)
+		return rpcAgentDeploy(localEnv, updateEnv,
+			*g.RPCAgentDeployCmd.LeaderArgs,
+			*g.RPCAgentDeployCmd.NodeArgs)
 	case g.RPCAgentInstallCmd.FullCommand():
 		return rpcAgentInstall(localEnv, *g.RPCAgentInstallCmd.Args)
 	case g.RPCAgentRunCmd.FullCommand():

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -325,7 +325,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return updateTrigger(localEnv,
 			updateEnv,
 			*g.UpdateTriggerCmd.App,
-			*g.UpdateTriggerCmd.Manual)
+			*g.UpdateTriggerCmd.Manual,
+			*g.UpdateTriggerCmd.Block,
+		)
 	case g.UpdatePlanInitCmd.FullCommand():
 		return initUpdateOperationPlan(localEnv, updateEnv)
 	case g.UpgradeCmd.FullCommand():
@@ -344,7 +346,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return updateTrigger(localEnv,
 			updateEnv,
 			*g.UpgradeCmd.App,
-			*g.UpgradeCmd.Manual)
+			*g.UpgradeCmd.Manual,
+			*g.UpgradeCmd.Block,
+		)
 	case g.PlanExecuteCmd.FullCommand():
 		return executePhase(localEnv, updateEnv, joinEnv,
 			PhaseParams{

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -253,7 +253,7 @@ func printStatusText(cluster clusterStatus) {
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
 	if cluster.Cluster != nil {
-		if isClusterDegrated(cluster) {
+		if cluster.Status.IsDegraded() {
 			fmt.Fprintf(w, "Cluster status:\t%v\n", color.RedString("degraded"))
 		} else {
 			fmt.Fprintf(w, "Cluster status:\t%v\n", color.GreenString(cluster.State))
@@ -366,13 +366,6 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgRed).SprintFunc()(probe))
 		}
 	}
-}
-
-func isClusterDegrated(status clusterStatus) bool {
-	return (status.Cluster == nil ||
-		status.Cluster.State == ops.SiteStateDegraded ||
-		status.Agent == nil ||
-		status.Agent.GetSystemStatus() != pb.SystemStatus_Running)
 }
 
 func unknownFallback(text string) string {

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	appservice "github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
@@ -52,7 +53,7 @@ func updateTrigger(
 	localEnv *localenv.LocalEnvironment,
 	updateEnv *localenv.LocalEnvironment,
 	appPackage string,
-	manual bool,
+	manual, block bool,
 ) error {
 	clusterEnv, err := localEnv.NewClusterEnvironment()
 	if err != nil {
@@ -119,6 +120,10 @@ func updateTrigger(
 		proxy:        proxy,
 		nodeParams:   constants.RPCAgentSyncPlanFunction,
 	}
+	unattended := !block && !manual
+	if unattended {
+		req.leaderParams = constants.RPCAgentUpgradeFunction
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.AgentDeployTimeout)
 	defer cancel()
@@ -130,6 +135,17 @@ func updateTrigger(
 	_, err = deployAgents(ctx, req)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	if unattended {
+		if localEnv.Silent {
+			// FIXME: keep the legacy behavior of reporting the operation ID in quiet mode.
+			// This is still used by robotest to fetch the operation ID
+			fmt.Println(opKey.OperationID)
+		}
+		localEnv.Printf("update operation (%v) has been started.\nCluster is updating in background.\n",
+			opKey.OperationID)
+		return nil
 	}
 
 	if !manual {
@@ -160,7 +176,6 @@ $ gravity upgrade --complete
 To abort an unsuccessful operation, rollback all completed/failed phases and
 run the same command. The operation will be marked as "failed" and the cluster
 will be returned to the "active" state.`)
-
 	return nil
 }
 

--- a/tool/gravity/cli/upgrade.go
+++ b/tool/gravity/cli/upgrade.go
@@ -23,26 +23,14 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
-	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/update"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 )
 
-func executeAutomaticUpgrade(ctx context.Context, localEnv, upgradeEnv *localenv.LocalEnvironment, args []string) error {
-	return trace.Wrap(update.AutomaticUpgrade(ctx, localEnv, upgradeEnv))
-}
-
-// upgradePhaseParams combines parameters for an upgrade phase execution/rollback
-type upgradePhaseParams struct {
-	// PhaseParams specifies generic phase execution configuration
-	PhaseParams
-	// skipVersionCheck allows to override gravity version compatibility check
-	skipVersionCheck bool
-}
-
-func executeUpgradePhase(localEnv, upgradeEnv *localenv.LocalEnvironment, p PhaseParams) error {
+func executeUpgradePhase(localEnv, upgradeEnv *localenv.LocalEnvironment, p PhaseParams, operation *ops.SiteOperation) error {
 	clusterEnv, err := localEnv.NewClusterEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
@@ -70,6 +58,7 @@ func executeUpgradePhase(localEnv, upgradeEnv *localenv.LocalEnvironment, p Phas
 		Apps:              clusterEnv.Apps,
 		Client:            clusterEnv.Client,
 		Operator:          clusterEnv.Operator,
+		Operation:         operation,
 		Users:             clusterEnv.Users,
 		Remote:            runner,
 	}, fsm.Params{
@@ -81,7 +70,7 @@ func executeUpgradePhase(localEnv, upgradeEnv *localenv.LocalEnvironment, p Phas
 	return trace.Wrap(err)
 }
 
-func rollbackUpgradePhase(localEnv, updateEnv *localenv.LocalEnvironment, p PhaseParams) error {
+func rollbackUpgradePhase(localEnv, updateEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	clusterEnv, err := localEnv.NewClusterEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
@@ -109,6 +98,7 @@ func rollbackUpgradePhase(localEnv, updateEnv *localenv.LocalEnvironment, p Phas
 		Apps:              clusterEnv.Apps,
 		Client:            clusterEnv.Client,
 		Operator:          clusterEnv.Operator,
+		Operation:         &operation,
 		Users:             clusterEnv.Users,
 		Remote:            runner,
 	}, fsm.Params{
@@ -120,7 +110,7 @@ func rollbackUpgradePhase(localEnv, updateEnv *localenv.LocalEnvironment, p Phas
 	return trace.Wrap(err)
 }
 
-func completeUpdatePlan(localEnv, updateEnv *localenv.LocalEnvironment) error {
+func completeUpdatePlan(localEnv, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
 	clusterEnv, err := localEnv.NewClusterEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,6 +130,7 @@ func completeUpdatePlan(localEnv, updateEnv *localenv.LocalEnvironment) error {
 			Apps:            clusterEnv.Apps,
 			Client:          clusterEnv.Client,
 			Operator:        clusterEnv.Operator,
+			Operation:       &operation,
 			Users:           clusterEnv.Users,
 			LocalBackend:    updateEnv.Backend,
 			Remote:          runner,
@@ -161,24 +152,4 @@ func completeUpdatePlan(localEnv, updateEnv *localenv.LocalEnvironment) error {
 
 	localEnv.Println("cluster has been activated")
 	return nil
-}
-
-func getUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) (*storage.OperationPlan, error) {
-	clusterEnv, err := localEnv.NewClusterEnvironment()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	fsm, err := update.NewFSM(context.TODO(),
-		update.FSMConfig{
-			Backend:      clusterEnv.Backend,
-			LocalBackend: updateEnv.Backend,
-		})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	plan, err := fsm.GetPlan()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return plan, nil
 }

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -140,20 +140,20 @@ func (g *Application) isJoinCommand(cmd string) bool {
 func (g *Application) isUpdateCommand(cmd string) bool {
 	switch cmd {
 	case g.PlanCmd.FullCommand(),
-		g.PlanInitCmd.FullCommand(),
-		g.PlanSyncCmd.FullCommand(),
 		g.PlanDisplayCmd.FullCommand(),
 		g.PlanExecuteCmd.FullCommand(),
 		g.PlanRollbackCmd.FullCommand(),
 		g.PlanResumeCmd.FullCommand(),
 		g.PlanCompleteCmd.FullCommand(),
+		g.UpdatePlanInitCmd.FullCommand(),
 		g.UpdateTriggerCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand():
 		return true
 	case g.RPCAgentRunCmd.FullCommand():
 		return len(*g.RPCAgentRunCmd.Args) > 0
 	case g.RPCAgentDeployCmd.FullCommand():
-		return len(*g.RPCAgentDeployCmd.Args) > 0
+		return len(*g.RPCAgentDeployCmd.LeaderArgs) > 0 ||
+			len(*g.RPCAgentDeployCmd.NodeArgs) > 0
 	}
 	return false
 }
@@ -164,8 +164,6 @@ func (g *Application) isExpandCommand(cmd string) bool {
 	switch cmd {
 	case g.JoinCmd.FullCommand(), g.AutoJoinCmd.FullCommand(),
 		g.PlanCmd.FullCommand(),
-		g.PlanInitCmd.FullCommand(),
-		g.PlanSyncCmd.FullCommand(),
 		g.PlanDisplayCmd.FullCommand(),
 		g.PlanExecuteCmd.FullCommand(),
 		g.PlanRollbackCmd.FullCommand(),


### PR DESCRIPTION
This PR is a followup to https://github.com/gravitational/gravity/pull/249.
It fixes the issues spotted after merging the changes that have been introduced in 5.3.x since the split.

 * Update startAgents in lib/ops/opsservice to start the agents and the update operation in automatic mode.
The agent started on one of the master nodes will be the driver for the operation. The same node will be used to initialize the operation plan (as the operation is started by the cluster controller in this
workflow).
Also, update `gravity agent deploy` command line with explicit options to specify additional command parameters for both `leader` and `regular` agents.

 * Remove `gravity plan init` and `gravity plan sync` as these were always specific to the update operation. Rename `gravity plan init` to `gravity update init-plan` as this command is still used when triggering update from UI.

* Thread operation/operation ID to every function implementing the bits for specific `gravity plan` sub-commands so it's possible to focus it explicitly on a specific operation.

 * Remove checking of DNS endpoints from the update `endpoints` phase as kube-dns/coreDNS changes to 5.3.x/5.4.x have broken the endpoints/service and the simplest workaround in these versions would be to ignore them completely (See https://github.com/gravitational/gravity.e/issues/3866).

 * Start update operation in blocking mode in CLI (unless overridden with the `--manual` or `--no-block` flags) in foreground as opposed to running in background in a `systemd` unit as this is the user expectation and consistent with other cluster operation workflows. I'm keeping the old `unattended` mode though to avoid breaking too much of robotest. But this behavior is not default anymore and will require a flag to reverse (`--no-block`).

'gravity plan' [doc](https://docs.google.com/document/d/1NelviOvS2uSZIv1fT5rPtUqUMss1_u3UXi4EPKO-MwA/edit?usp=sharing)

Updates https://github.com/gravitational/gravity.e/issues/3866.