### PR TITLE
Tele CLI/UX improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
 # Current Kubernetes version: 1.13.0
-K8S_VER := 11300
+K8S_VER := 1.13.0
+# Kubernetes version suffix for the planet package, constructed by concatenating
+# major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
+# 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
+K8S_VER_SUFFIX := $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
 GOLFLAGS ?= -w -s
 
 ETCD_VER := v2.3.7
@@ -38,7 +42,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.0.4
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 5.5.7-$(K8S_VER)
+PLANET_TAG := 5.5.7-$(K8S_VER_SUFFIX)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)
@@ -452,11 +456,13 @@ telekube: GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
 telekube: $(GRAVITY_BUILDDIR)/telekube.tar
 
 $(GRAVITY_BUILDDIR)/telekube.tar: packages
-	$(GRAVITY_BUILDDIR)/tele build $(ASSETSDIR)/telekube/resources/app.yaml -f \
+	GRAVITY_K8S_VERSION=$(K8S_VER) $(GRAVITY_BUILDDIR)/tele build \
+		$(ASSETSDIR)/telekube/resources/app.yaml -f \
 		--version=$(TELEKUBE_APP_TAG) \
 		--state-dir=$(PACKAGES_DIR) \
 		--skip-version-check \
 		-o $(GRAVITY_BUILDDIR)/telekube.tar
+
 
 #
 # builds wormhole installer

--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -3,6 +3,8 @@ kind: Bundle
 metadata:
   name: telekube
   resourceVersion: "0.0.0"
+  description: |
+    Base cluster image with Kubernetes v${GRAVITY_K8S_VERSION}
 logo: file://logo.svg
 endpoints:
   - name: "Gravity Control Panel"

--- a/lib/app/app.go
+++ b/lib/app/app.go
@@ -385,12 +385,6 @@ type Application struct {
 	Manifest schema.Manifest `json:"manifest"`
 }
 
-func (a Application) GetName() string        { return a.Manifest.Metadata.Name }
-func (a Application) GetVersion() string     { return a.Manifest.Metadata.ResourceVersion }
-func (a Application) GetType() string        { return a.Manifest.DescribeKind() }
-func (a Application) GetCreated() time.Time  { return a.PackageEnvelope.Created }
-func (a Application) GetDescription() string { return a.Manifest.Metadata.Description }
-
 // String formats the specified application for output
 func (a Application) String() string {
 	return fmt.Sprintf("%v:%v", a.Name(), a.Package.Version)

--- a/lib/app/app.go
+++ b/lib/app/app.go
@@ -385,6 +385,12 @@ type Application struct {
 	Manifest schema.Manifest `json:"manifest"`
 }
 
+func (a Application) GetName() string        { return a.Manifest.Metadata.Name }
+func (a Application) GetVersion() string     { return a.Manifest.Metadata.ResourceVersion }
+func (a Application) GetType() string        { return a.Manifest.DescribeKind() }
+func (a Application) GetCreated() time.Time  { return a.PackageEnvelope.Created }
+func (a Application) GetDescription() string { return a.Manifest.Metadata.Description }
+
 // String formats the specified application for output
 func (a Application) String() string {
 	return fmt.Sprintf("%v:%v", a.Name(), a.Package.Version)

--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -55,6 +55,9 @@ func Build(ctx context.Context, builder *Builder) error {
 	case schema.KindApplication:
 		builder.Config.Progress = utils.NewProgress(ctx, "Build",
 			appBuildSteps, builder.Config.Silent)
+	default:
+		return trace.BadParameter("unknown manifest kind %q",
+			builder.Manifest.Kind)
 	}
 
 	switch builder.Manifest.Kind {

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -232,8 +232,8 @@ func (b *Builder) SelectRuntime() (*semver.Version, error) {
 	switch runtime.Name {
 	case constants.BaseImageName, defaults.Runtime:
 	default:
-		return nil, trace.BadParameter("unsupported base image %q, only "+
-			"\"gravity\" is supported as a base image at the moment", runtime.Name)
+		return nil, trace.BadParameter("unsupported base image %q, only %q is "+
+			"supported as a base image", runtime.Name, constants.BaseImageName)
 	}
 	if runtime.Version != loc.LatestVersion {
 		b.Infof("Using pinned runtime version: %s.", runtime.Version)

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -229,6 +229,10 @@ func (b *Builder) SelectRuntime() (*semver.Version, error) {
 	if runtime == nil {
 		return nil, trace.NotFound("failed to determine application runtime")
 	}
+	if runtime.Name != constants.BaseImageName {
+		return nil, trace.BadParameter("unsupported base image %q, only "+
+			"\"gravity\" is supported as a base image at the moment", runtime.Name)
+	}
 	if runtime.Version != loc.LatestVersion {
 		b.Infof("Using pinned runtime version: %s.", runtime.Version)
 		b.PrintSubStep("Will use runtime version %s from manifest", runtime.Version)

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -229,7 +229,9 @@ func (b *Builder) SelectRuntime() (*semver.Version, error) {
 	if runtime == nil {
 		return nil, trace.NotFound("failed to determine application runtime")
 	}
-	if runtime.Name != constants.BaseImageName {
+	switch runtime.Name {
+	case constants.BaseImageName, defaults.Runtime:
+	default:
 		return nil, trace.BadParameter("unsupported base image %q, only "+
 			"\"gravity\" is supported as a base image at the moment", runtime.Name)
 	}

--- a/lib/catalog/lister.go
+++ b/lib/catalog/lister.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/hub"
+	"github.com/gravitational/gravity/lib/schema"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/ghodss/yaml"
@@ -77,7 +78,7 @@ func NewListItemFromHubApp(app hub.App) (*listItem, error) {
 		Name:    app.Name,
 		Version: *semver,
 		Created: app.Created,
-		Type:    "Cluster", // We currently publish only cluster images to the hub.
+		Type:    schema.KindCluster,
 	}, nil
 }
 
@@ -123,10 +124,10 @@ func (l ListItems) Latest() (result ListItems, err error) {
 		if item.GetVersion().PreRelease != "" {
 			continue
 		}
-		if _, ok := m[item.GetName()]; !ok {
+		if existing, ok := m[item.GetName()]; !ok {
 			m[item.GetName()] = item
 		} else {
-			if m[item.GetName()].GetVersion().LessThan(item.GetVersion()) {
+			if existing.GetVersion().LessThan(item.GetVersion()) {
 				m[item.GetName()] = item
 			}
 		}
@@ -152,7 +153,7 @@ func (l ListItems) Swap(i, j int) {
 // The items are sorted first by type (cluster images appear before application
 // images), then by name (lexicographically) and finally by semantic version.
 func (l ListItems) Less(i, j int) bool {
-	if l[i].GetType() == "Cluster" && l[j].GetType() != "Cluster" {
+	if l[i].GetType() == schema.KindCluster && l[j].GetType() != schema.KindCluster {
 		return true
 	}
 	if l[i].GetName() < l[j].GetName() {

--- a/lib/catalog/lister.go
+++ b/lib/catalog/lister.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/hub"
+
+	"github.com/gravitational/trace"
+)
+
+// Lister defines common interface for listing application and cluster images.
+type Lister interface {
+	//
+	List(all bool) ([]ListItem, error)
+}
+
+// ListItem defines interface for a single list item.
+type ListItem interface {
+	GetName() string
+	GetVersion() string
+	GetType() string
+	GetCreated() time.Time
+	GetDescription() string
+}
+
+type hubLister struct{}
+
+func NewLister() (*hubLister, error) {
+	return &hubLister{}, nil
+}
+
+func (l *hubLister) List(all bool) (result []ListItem, err error) {
+	hub, err := hub.New(hub.Config{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	items, err := hub.List(all)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, item := range items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func List(lister Lister, all bool, format constants.Format) error {
+	items, err := lister.List(all)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	switch format {
+	case constants.EncodingText:
+		w := new(tabwriter.Writer)
+		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+		fmt.Fprintf(w, "Name:Version\tType\tCreated (UTC)\tDescription\n")
+		fmt.Fprintf(w, "------------\t----\t-------------\t-----------\n")
+		for _, item := range items {
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\n",
+				formatName(item.GetName(), item.GetVersion()),
+				item.GetType(),
+				item.GetCreated().Format(constants.ShortDateFormat),
+				formatDescription(item.GetDescription()))
+		}
+		w.Flush()
+	case constants.EncodingJSON:
+		bytes, err := json.MarshalIndent(items, "", "    ")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(string(bytes))
+	case constants.EncodingYAML:
+		bytes, err := yaml.Marshal(items)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(string(bytes))
+	default:
+		return trace.BadParameter("unknown output format %q, supported are: %v",
+			format, constants.OutputFormats)
+	}
+	return nil
+}
+
+func formatName(name, version string) string {
+	if name == constants.LegacyBaseImageName {
+		name = constants.BaseImageName
+	}
+	return fmt.Sprintf("%v:%v", name, version)
+}
+
+func formatDescription(description string) string {
+	if description == "" {
+		return "-"
+	}
+	return description
+}

--- a/lib/catalog/lister_test.go
+++ b/lib/catalog/lister_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package catalog
+
+import (
+	"sort"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/gravity/lib/compare"
+
+	check "gopkg.in/check.v1"
+)
+
+type listerSuite struct{}
+
+var _ = check.Suite(&listerSuite{})
+
+func (s *listerSuite) TestLatestAndSorting(c *check.C) {
+	items := ListItems{
+		listItem{Name: "alpine", Version: v("1.0.0"), Type: "Application"},
+		listItem{Name: "nginx", Version: v("0.0.1"), Type: "Application"},
+		listItem{Name: "nginx", Version: v("1.2.3"), Type: "Application"},
+		listItem{Name: "alpine", Version: v("1.0.0-rc.3"), Type: "Application"},
+		listItem{Name: "nginx", Version: v("2.0.0-alpha.1"), Type: "Application"},
+		listItem{Name: "kafka", Version: v("1.0.1"), Type: "Application"},
+		listItem{Name: "zookeeper", Version: v("1.0.0-beta.2"), Type: "Application"},
+		listItem{Name: "kubernetes", Version: v("13.0.0"), Type: "Cluster"},
+		listItem{Name: "kubernetes", Version: v("14.0.0-beta.1"), Type: "Cluster"},
+	}
+	latest, err := items.Latest()
+	c.Assert(err, check.IsNil)
+	sort.Sort(latest)
+	c.Assert(latest, compare.DeepEquals, ListItems{
+		listItem{Name: "kubernetes", Version: v("13.0.0"), Type: "Cluster"},
+		listItem{Name: "alpine", Version: v("1.0.0"), Type: "Application"},
+		listItem{Name: "kafka", Version: v("1.0.1"), Type: "Application"},
+		listItem{Name: "nginx", Version: v("1.2.3"), Type: "Application"},
+	})
+}
+
+func v(ver string) semver.Version {
+	return *semver.New(ver)
+}

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -711,7 +711,7 @@ var (
 		"kubernetes.default.svc.cluster.local",
 	}
 
-	// LegacyBaseImageName is the legacy base cluster image name
+	// LegacyBaseImageName is the name of the base cluster image used in earlier versions
 	LegacyBaseImageName = "telekube"
 	// BaseImageName is the current base cluster image name
 	BaseImageName = "gravity"

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -432,7 +432,7 @@ const (
 	HumanDateFormatMilli = "Mon Jan _2 15:04:05.000 UTC"
 
 	// ShortDateFormat is the short version of human readable timestamp format
-	ShortDateFormat = "01/02/06 15:04"
+	ShortDateFormat = "2006-01-02 15:04"
 
 	// LatestVersion is the shortcut for the latest Telekube version
 	LatestVersion = "latest"
@@ -710,6 +710,11 @@ var (
 		"kubernetes.default.svc.cluster",
 		"kubernetes.default.svc.cluster.local",
 	}
+
+	// LegacyBaseImageName is the legacy base cluster image name
+	LegacyBaseImageName = "telekube"
+	// BaseImageName is the current base cluster image name
+	BaseImageName = "gravity"
 )
 
 // Format is the type for supported output formats

--- a/lib/hub/hub.go
+++ b/lib/hub/hub.go
@@ -84,17 +84,7 @@ type App struct {
 	Created time.Time `json:"created"`
 	// SizeBytes is the application size in bytes
 	SizeBytes int64 `json:"sizeBytes"`
-	// Type is the image type, application or cluster
-	Type string `json:"type"`
-	// Description is the image description
-	Description string `json:"description"`
 }
-
-func (a App) GetName() string        { return a.Name }
-func (a App) GetVersion() string     { return a.Version }
-func (a App) GetType() string        { return "Cluster" }
-func (a App) GetCreated() time.Time  { return a.Created }
-func (a App) GetDescription() string { return a.Description }
 
 // s3Hub is the S3-backed hub implementation
 type s3Hub struct {

--- a/lib/hub/hub.go
+++ b/lib/hub/hub.go
@@ -84,7 +84,17 @@ type App struct {
 	Created time.Time `json:"created"`
 	// SizeBytes is the application size in bytes
 	SizeBytes int64 `json:"sizeBytes"`
+	// Type is the image type, application or cluster
+	Type string `json:"type"`
+	// Description is the image description
+	Description string `json:"description"`
 }
+
+func (a App) GetName() string        { return a.Name }
+func (a App) GetVersion() string     { return a.Version }
+func (a App) GetType() string        { return "Cluster" }
+func (a App) GetCreated() time.Time  { return a.Created }
+func (a App) GetDescription() string { return a.Description }
 
 // s3Hub is the S3-backed hub implementation
 type s3Hub struct {

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -155,8 +155,16 @@ func (l *Locator) Set(v string) error {
 	return nil
 }
 
+// String returns the locator's string representation.
 func (l Locator) String() string {
-	return fmt.Sprintf("%v/%v:%v", l.Repository, l.Name, l.Version)
+	str := l.Name
+	if l.Repository != "" {
+		str = fmt.Sprintf("%v/%v", l.Repository, str)
+	}
+	if l.Version != "" {
+		str = fmt.Sprintf("%v:%v", str, l.Version)
+	}
+	return str
 }
 
 // WithVersion returns a copy of this locator with version set to the specified one

--- a/lib/loc/make.go
+++ b/lib/loc/make.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pack
+package loc
 
 import (
 	"strings"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/loc"
 
 	"github.com/gravitational/trace"
 )
@@ -30,24 +29,24 @@ import (
 //  - if it's in the 'repo/name:ver' format, returns it
 //  - if it's in the 'name:ver' format, returns locator with system repo (systemrepo/name:ver)
 //  - if it's in the 'name' format, returns locator with system repo and latest meta-version (systemrepo/name:0.0.0+latest)
-func MakeLocator(app string) (*loc.Locator, error) {
-	locator, err := loc.ParseLocator(app)
+func MakeLocator(app string) (*Locator, error) {
+	locator, err := ParseLocator(app)
 	if err == nil {
 		return locator, nil
 	}
 	parts := strings.Split(app, ":")
 	if len(parts) == 1 {
-		return loc.NewLocator(defaults.SystemAccountOrg, app, loc.LatestVersion)
+		return NewLocator(defaults.SystemAccountOrg, app, LatestVersion)
 	}
 	if len(parts) == 2 {
 		version := parts[1]
 		switch version {
 		case constants.LatestVersion:
-			version = loc.LatestVersion
+			version = LatestVersion
 		case constants.StableVersion:
-			version = loc.StableVersion
+			version = StableVersion
 		}
-		return loc.NewLocator(defaults.SystemAccountOrg, parts[0], version)
+		return NewLocator(defaults.SystemAccountOrg, parts[0], version)
 	}
 	return nil, trace.BadParameter(
 		"invalid app name format: %v, should be: 'repo/name:ver' or 'name:ver' or 'name'", app)

--- a/lib/ops/cluster.go
+++ b/lib/ops/cluster.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/gravity/lib/cloudprovider/aws"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/storage"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -111,7 +111,7 @@ func CreateCluster(operator Operator, clusterI storage.Cluster) (*SiteOperationK
 			Count:        nodeSpec.Count,
 		}
 	}
-	appPackage, err := pack.MakeLocator(cluster.Spec.App)
+	appPackage, err := loc.MakeLocator(cluster.Spec.App)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -433,8 +433,10 @@ func (o *Operator) validateNewSiteRequest(req *ops.NewSiteRequest) error {
 		return trace.Wrap(err)
 	}
 
-	if app.Manifest.Kind != schema.KindBundle {
-		return trace.BadParameter("cannot create site with app of type %q", app.Manifest.Kind)
+	switch app.Manifest.Kind {
+	case schema.KindBundle, schema.KindCluster:
+	default:
+		return trace.BadParameter("cannot create cluster with app of type %q", app.Manifest.Kind)
 	}
 
 	err = validateLabels(req.Labels)

--- a/lib/schema/constants.go
+++ b/lib/schema/constants.go
@@ -124,9 +124,9 @@ const (
 var (
 	// APIVersionV2 specifies the current API version
 	APIVersionV2 = fmt.Sprintf("%v/%v", GroupName, Version)
-	// APIVersionV2Cluster is the apiVersion for cluster images
+	// APIVersionV2Cluster is the API version for cluster images
 	APIVersionV2Cluster = fmt.Sprintf("%v/%v", ClusterGroupName, Version)
-	// APIVersionV2App is the apiVersion for app images
+	// APIVersionV2App is the API version for app images
 	APIVersionV2App = fmt.Sprintf("%v/%v", AppGroupName, Version)
 )
 

--- a/lib/schema/constants.go
+++ b/lib/schema/constants.go
@@ -84,6 +84,10 @@ const (
 
 	// GroupName specifies the name of the group for application manifest package
 	GroupName = "bundle.gravitational.io"
+	// ClusterGroupName is the API group for cluster image manifest
+	ClusterGroupName = "cluster.gravitational.io"
+	// AppGroupName is the API group for app image manifest
+	AppGroupName = "app.gravitational.io"
 	// Version specifies the current package version
 	Version = "v2"
 
@@ -117,8 +121,14 @@ const (
 	ApplicationDefaultNamespace = "default"
 )
 
-// APIVersionV2 specifies the current API version
-var APIVersionV2 = fmt.Sprintf("%v/%v", GroupName, Version)
+var (
+	// APIVersionV2 specifies the current API version
+	APIVersionV2 = fmt.Sprintf("%v/%v", GroupName, Version)
+	// APIVersionV2Cluster is the apiVersion for cluster images
+	APIVersionV2Cluster = fmt.Sprintf("%v/%v", ClusterGroupName, Version)
+	// APIVersionV2App is the apiVersion for app images
+	APIVersionV2App = fmt.Sprintf("%v/%v", AppGroupName, Version)
+)
 
 // SupportedProvider is a list of currently supported providers
 var SupportedProviders = []string{

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -156,8 +156,11 @@ func (m *Manifest) SetBase(locator loc.Locator) {
 	m.SystemOptions.Runtime = &Runtime{
 		Locator: locator,
 	}
-	m.BaseImage = &BaseImage{
-		Locator: locator,
+	// Only update baseImage property if it was originally set to preserve
+	// backward compatibility - otherwise older clusters will reject the
+	// manifest due to additional property restriction.
+	if m.BaseImage != nil {
+		m.BaseImage.Locator = locator
 	}
 }
 

--- a/lib/schema/parse.go
+++ b/lib/schema/parse.go
@@ -328,7 +328,7 @@ func (m *Manifest) UnmarshalJSON(data []byte) error {
 	}
 
 	switch header.APIVersion {
-	case APIVersionV2:
+	case APIVersionV2, APIVersionV2Cluster, APIVersionV2App:
 		if err := schema.Validate(bytes.NewReader(data)); err != nil {
 			log.Warnf("Failed to validate manifest against schema: %v.",
 				trace.DebugReport(err))

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -69,7 +69,8 @@ const manifestSchema = `
             "labels": {"type": "object"}
           }
         },
-	"logo": {"type": "string"},
+        "baseImage": {"type": "string", "default": "gravity:0.0.0+stable"},
+        "logo": {"type": "string"},
         "releaseNotes": {"type": "string"},
         "endpoints": {
           "type": "array",

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -69,7 +69,7 @@ const manifestSchema = `
             "labels": {"type": "object"}
           }
         },
-        "baseImage": {"type": "string", "default": "gravity:0.0.0+stable"},
+        "baseImage": {"type": "string"},
         "logo": {"type": "string"},
         "releaseNotes": {"type": "string"},
         "endpoints": {

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
-	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/process"
 	"github.com/gravitational/gravity/lib/rpc/proto"
 	rpcserver "github.com/gravitational/gravity/lib/rpc/server"
@@ -230,7 +229,7 @@ func (i *InstallConfig) GetAdvertiseAddr() (string, error) {
 // GetAppPackage returns the application package for this installer
 func (i *InstallConfig) GetAppPackage() (*loc.Locator, error) {
 	if i.AppPackage != "" {
-		return pack.MakeLocator(i.AppPackage)
+		return loc.MakeLocator(i.AppPackage)
 	}
 	env, err := localenv.New(i.ReadStateDir)
 	if err != nil {

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -207,7 +207,7 @@ func checkForUpdate(env *localenv.LocalEnvironment, operator ops.Operator, site 
 		updatePackage = site.App.Package.Name
 	}
 
-	updateLoc, err := pack.MakeLocator(updatePackage)
+	updateLoc, err := loc.MakeLocator(updatePackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -33,8 +33,6 @@ type Application struct {
 	Insecure *bool
 	// StateDir is the local state directory
 	StateDir *string
-	// Quiet allows to suppress console output
-	Quiet *bool
 	// VersionCmd outputs the binary version
 	VersionCmd VersionCmd
 	// BuildCmd builds app installer tarball
@@ -79,6 +77,8 @@ type BuildCmd struct {
 	SkipVersionCheck *bool
 	// Parallel defines the number of tasks to execute concurrently
 	Parallel *int
+	// Quiet allows to suppress console output
+	Quiet *bool
 }
 
 type ListCmd struct {
@@ -87,8 +87,6 @@ type ListCmd struct {
 	Runtimes *bool
 	// Format is the output format
 	Format *constants.Format
-	// WithPrereleases shows pre-releases too
-	WithPrereleases *bool
 	// All displays all available versions
 	All *bool
 }
@@ -102,4 +100,6 @@ type PullCmd struct {
 	OutFile *string
 	// Force overwrites existing tarball
 	Force *bool
+	// Quiet allows to suppress console output
+	Quiet *bool
 }

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -89,6 +89,8 @@ type ListCmd struct {
 	Format *constants.Format
 	// WithPrereleases shows pre-releases too
 	WithPrereleases *bool
+	// All displays all available versions
+	All *bool
 }
 
 // PullCmd downloads app installer from Ops Center

--- a/tool/tele/cli/pull.go
+++ b/tool/tele/cli/pull.go
@@ -24,14 +24,13 @@ import (
 	"github.com/gravitational/gravity/lib/hub"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
-	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 )
 
 func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool) error {
-	locator, err := pack.MakeLocator(app)
+	locator, err := loc.MakeLocator(app)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -56,9 +56,10 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.Parallel = tele.BuildCmd.Flag("parallel", "Specifies the number of concurrent tasks. If < 0, the number of tasks is not restricted, if unspecified, then tasks are capped at the number of logical CPU cores").Int()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "Display a list of user applications published in remote Ops Center")
-	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes").Short('r').Bool()
+	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes").Short('r').Hidden().Bool()
 	tele.ListCmd.Format = common.Format(tele.ListCmd.Flag("format", fmt.Sprintf("Output format, one of: %v", constants.OutputFormats)).Default(string(constants.EncodingText)))
-	tele.ListCmd.WithPrereleases = tele.ListCmd.Flag("with-prereleases", "Include pre-releases (alpha, beta, rc) in the output too").Bool()
+	tele.ListCmd.WithPrereleases = tele.ListCmd.Flag("with-prereleases", "Include pre-releases (alpha, beta, rc) in the output too").Hidden().Bool()
+	tele.ListCmd.All = tele.ListCmd.Flag("all", "Display all available versions").Bool()
 
 	tele.PullCmd.CmdClause = app.Command("pull", "Pull an application from remote Ops Center")
 	tele.PullCmd.App = tele.PullCmd.Arg("app", "Name of application to download: <name>:<version> or just <name> to download the latest").Required().String()

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -36,7 +36,6 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.Debug = app.Flag("debug", "Enable debug mode").Bool()
 	tele.Insecure = app.Flag("insecure", "Skip TLS verification when making HTTP requests").Default("false").Bool()
 	tele.StateDir = app.Flag("state-dir", "Directory for temporary local state").Hidden().String()
-	tele.Quiet = app.Flag("quiet", "Suppress any extra output to stdout").Short('q').Bool()
 
 	tele.VersionCmd.CmdClause = app.Command("version", "Print version and exit")
 	tele.VersionCmd.Output = common.Format(tele.VersionCmd.Flag("output", "Output format, text or json").Short('o').Default(string(constants.EncodingText)))
@@ -54,17 +53,18 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.SetDeps = loc.LocatorSlice(tele.BuildCmd.Flag("set-dep", "Rewrite dependencies section in the application manifest file during vendoring, e.g. 'gravitational.io/site-app:0.0.39' will overwrite dependency to 'gravitational.io/site-app:0.0.39'").Hidden())
 	tele.BuildCmd.SkipVersionCheck = tele.BuildCmd.Flag("skip-version-check", "Skip version compatibility check").Hidden().Bool()
 	tele.BuildCmd.Parallel = tele.BuildCmd.Flag("parallel", "Specifies the number of concurrent tasks. If < 0, the number of tasks is not restricted, if unspecified, then tasks are capped at the number of logical CPU cores").Int()
+	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any extra output to stdout").Short('q').Bool()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "Display a list of user applications published in remote Ops Center")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes").Short('r').Hidden().Bool()
 	tele.ListCmd.Format = common.Format(tele.ListCmd.Flag("format", fmt.Sprintf("Output format, one of: %v", constants.OutputFormats)).Default(string(constants.EncodingText)))
-	tele.ListCmd.WithPrereleases = tele.ListCmd.Flag("with-prereleases", "Include pre-releases (alpha, beta, rc) in the output too").Hidden().Bool()
 	tele.ListCmd.All = tele.ListCmd.Flag("all", "Display all available versions").Bool()
 
 	tele.PullCmd.CmdClause = app.Command("pull", "Pull an application from remote Ops Center")
 	tele.PullCmd.App = tele.PullCmd.Arg("app", "Name of application to download: <name>:<version> or just <name> to download the latest").Required().String()
 	tele.PullCmd.OutFile = tele.PullCmd.Flag("output", "Name of downloaded tarball, defaults to <name>-<version>.tar").Short('o').String()
 	tele.PullCmd.Force = tele.PullCmd.Flag("force", "Overwrite existing tarball").Short('f').Bool()
+	tele.PullCmd.Quiet = tele.PullCmd.Flag("quiet", "Suppress any extra output to stdout").Short('q').Bool()
 
 	return tele
 }

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -100,9 +100,8 @@ func Run(tele Application) error {
 			*tele.Quiet)
 	case tele.ListCmd.FullCommand():
 		return list(*env,
-			*tele.ListCmd.Runtimes,
-			*tele.ListCmd.Format,
-			*tele.ListCmd.WithPrereleases)
+			*tele.ListCmd.All,
+			*tele.ListCmd.Format)
 	}
 
 	return trace.NotFound("unknown command %v", cmd)

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -57,7 +57,7 @@ func Run(tele Application) error {
 			Overwrite:        *tele.BuildCmd.Overwrite,
 			Repository:       *tele.BuildCmd.Repository,
 			SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
-			Silent:           *tele.Quiet,
+			Silent:           *tele.BuildCmd.Quiet,
 			Insecure:         *tele.Insecure,
 		}, service.VendorRequest{
 			PackageName:            *tele.BuildCmd.Name,
@@ -97,7 +97,7 @@ func Run(tele Application) error {
 			*tele.PullCmd.App,
 			*tele.PullCmd.OutFile,
 			*tele.PullCmd.Force,
-			*tele.Quiet)
+			*tele.PullCmd.Quiet)
 	case tele.ListCmd.FullCommand():
 		return list(*env,
 			*tele.ListCmd.All,


### PR DESCRIPTION
This PR implements most of UX improvements for tele from https://github.com/gravitational/gravity.e/issues/3911. The next big chunk of work that will have to be done before that ticket could be closed will be migrating OSS hub to become a chart repository and teaching tele to work with it, but I wanted to merge these smaller fixes/improvements now. Here's the gist:

* When building telekube-app, add description that includes Kubernetes version (propagated from makefile).
* Add support for `baseImage` manifest field. This is basically the same as `systemOptions.runtime` but the future docs will be referring to base image instead.
* Multiple `tele ls` behavior and UX tweaks:
  - Move common parts of code to an interface shared by OSS/enterprise so we don't have to reimplement stuff anymore.
  - Replace "telekube" with "gravity". This is a purely cosmetic change, again b/c future docs will be using "gravity" as base image.
  - Show only latest stable versions by default.
  - Add `--all` flag to show all.
  - Sort output by image type / name / version.
* Move `--quiet` flag from being shared by all command only to those commands that actually use it.
