### PR TITLE
Default to tele version when selecting runtime.

### DIFF
--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -62,7 +62,7 @@ func Build(ctx context.Context, builder *Builder) error {
 
 	switch builder.Manifest.Kind {
 	case schema.KindBundle, schema.KindCluster:
-		builder.NextStep("Selecting application runtime")
+		builder.NextStep("Selecting base image version")
 		runtimeVersion, err := builder.SelectRuntime()
 		if err != nil {
 			return trace.Wrap(err)
@@ -73,6 +73,9 @@ func Build(ctx context.Context, builder *Builder) error {
 		}
 		err = builder.SyncPackageCache(runtimeVersion)
 		if err != nil {
+			if trace.IsNotFound(err) {
+				return trace.NotFound("base image version %v not found", runtimeVersion)
+			}
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/builder/builder_test.go
+++ b/lib/builder/builder_test.go
@@ -93,7 +93,8 @@ func (s *BuilderSuite) TestSelectRuntimeVersion(c *check.C) {
 
 	b.Manifest = schema.MustParseManifestYAML([]byte(manifestInvalidBase))
 	ver, err = b.SelectRuntime()
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, trace.BadParameter(""))
+	c.Assert(err, check.ErrorMatches, "unsupported base image .*")
 }
 
 const (

--- a/lib/builder/builder_test.go
+++ b/lib/builder/builder_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/gravitational/version"
+	"github.com/sirupsen/logrus"
+	check "gopkg.in/check.v1"
+)
+
+func TestBuilder(t *testing.T) { check.TestingT(t) }
+
+type BuilderSuite struct{}
+
+var _ = check.Suite(&BuilderSuite{})
+
+func (s *BuilderSuite) TestVersionsCompatibility(c *check.C) {
+	testCases := []struct {
+		teleVer    semver.Version
+		runtimeVer semver.Version
+		compatible bool
+		comment    string
+	}{
+		{
+			teleVer:    *semver.New("5.5.0"),
+			runtimeVer: *semver.New("5.5.0"),
+			compatible: true,
+			comment:    "tele and runtime versions are the same",
+		},
+		{
+			teleVer:    *semver.New("5.5.1"),
+			runtimeVer: *semver.New("5.5.0"),
+			compatible: true,
+			comment:    "tele version is newer than runtime version",
+		},
+		{
+			teleVer:    *semver.New("5.5.0"),
+			runtimeVer: *semver.New("5.5.1"),
+			compatible: false,
+			comment:    "runtime version is newer than tele version",
+		},
+		{
+			teleVer:    *semver.New("5.5.0"),
+			runtimeVer: *semver.New("5.4.0"),
+			compatible: false,
+			comment:    "tele and runtime versions are different releases",
+		},
+	}
+	for _, t := range testCases {
+		c.Assert(versionsCompatible(t.teleVer, t.runtimeVer), check.Equals,
+			t.compatible, check.Commentf(t.comment))
+	}
+}
+
+func (s *BuilderSuite) TestSelectRuntimeVersion(c *check.C) {
+	b := &Builder{
+		Config: Config{
+			FieldLogger: logrus.WithField(trace.Component, "test"),
+			Progress:    utils.NewNopProgress(),
+		},
+	}
+
+	b.Manifest = schema.MustParseManifestYAML([]byte(manifestWithBase))
+	ver, err := b.SelectRuntime()
+	c.Assert(err, check.IsNil)
+	c.Assert(ver, check.DeepEquals, semver.New("5.5.0"))
+
+	b.Manifest = schema.MustParseManifestYAML([]byte(manifestWithoutBase))
+	version.Init("5.4.2")
+	ver, err = b.SelectRuntime()
+	c.Assert(err, check.IsNil)
+	c.Assert(ver, check.DeepEquals, semver.New("5.4.2"))
+
+	b.Manifest = schema.MustParseManifestYAML([]byte(manifestInvalidBase))
+	ver, err = b.SelectRuntime()
+	c.Assert(err, check.NotNil)
+}
+
+const (
+	manifestWithBase = `apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+baseImage: gravity:5.5.0
+metadata:
+  name: test
+  resourceVersion: 1.0.0`
+
+	manifestWithoutBase = `apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+metadata:
+  name: test
+  resourceVersion: 1.0.0`
+
+	manifestInvalidBase = `apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+baseImage: example:1.2.3
+metadata:
+  name: test
+  resourceVersion: 1.0.0`
+)

--- a/lib/catalog/lister.go
+++ b/lib/catalog/lister.go
@@ -155,8 +155,8 @@ func (l ListItems) Swap(i, j int) {
 // The items are sorted first by type (cluster images appear before application
 // images), then by name (lexicographically) and finally by semantic version.
 func (l ListItems) Less(i, j int) bool {
-	if l[i].GetType() == schema.KindCluster && l[j].GetType() != schema.KindCluster {
-		return true
+	if l[i].GetType() != l[j].GetType() {
+		return l[i].GetType() == schema.KindCluster
 	}
 	if l[i].GetName() < l[j].GetName() {
 		return true


### PR DESCRIPTION
This PR changes the way tele picks runtime (base image) version when it's not explicitly pinned in the manifest.

* When runtime is not pinned, tele defaults to its own version. It ensures 100% compatibility. See the linked ticket for more reasonings/benefits of this approach.
* When runtime is pinned, it is used as before, but compatibility check has become a bit more strict - in addition to having equal maj/min semver components, tele should be >= runtime version.

Closes https://github.com/gravitational/gravity.e/issues/3969.
