### PR TITLE
Improve teleport nodes resiliency.

### DIFF
--- a/docs/5.x/testplan.md
+++ b/docs/5.x/testplan.md
@@ -124,10 +124,12 @@ spec:
 ### Failover & Resiliency
 
 - [ ] Install 3-node cluster.
-  - [ ] Shutdown currently active master node (let's say it's `node-1`).
+  - [ ] Stop the planet systemd service on the active master node (let's say it's `node-1`).
     - [ ] Verify that another node was elected as master and all relevant Kubernetes services are running.
     - [ ] Verify that `kubectl` commands keep working.
     - [ ] Verify that `gravity status` is reporting the cluster as degraded.
+    - [ ] Verify can still SSH onto `node-1` via Teleport using cluster UI.
+  - [ ] Shutdown `node-1` completely.
   - [ ] Remove the shutdown node from the cluster by executing `gravity remove node-1 --force` from one of the remaining healthy nodes.
     - [ ] Verify that `node-1` is successfully removed from the cluster.
     - [ ] Verify that `gravity status` is reporting the cluster as healthy (may take a minute for it to recover).

--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -64,6 +64,14 @@ func (p provisionedServers) Masters() []*ProvisionedServer {
 	return servers
 }
 
+// MasterIPs returns a list of advertise IPs of master nodes.
+func (p provisionedServers) MasterIPs() (ips []string) {
+	for _, master := range p.Masters() {
+		ips = append(ips, master.AdvertiseIP)
+	}
+	return ips
+}
+
 // Nodes returns a sub-list of this server list that contains only nodes
 func (p provisionedServers) Nodes() []*ProvisionedServer {
 	nodes := make([]*ProvisionedServer, 0)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1905,6 +1905,14 @@ func (r Servers) Masters() (masters []Server) {
 	return
 }
 
+// MasterIPs returns a list of advertise IPs of master nodes.
+func (r Servers) MasterIPs() (ips []string) {
+	for _, master := range r.Masters() {
+		ips = append(ips, master.AdvertiseIP)
+	}
+	return ips
+}
+
 type AgentProfile struct {
 	// Instructions defines the set of shell commands to download and start an agent
 	// on a host


### PR DESCRIPTION
Previously teleport nodes were using a single master node as their auth server so if that node went down, all teleport nodes would effectively be rendered useless as they wouldn't be able to register. With this PR:

* Teleport nodes on masters prefer their local auth server and fallback to other masters.
* Teleport nodes on regular nodes use auth servers on masters.
