### PR TITLE
Fix AWS install.

### DIFF
--- a/assets/telekube/resources/clusterDeprovision.yaml
+++ b/assets/telekube/resources/clusterDeprovision.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-deprovision
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/clusterDeprovision.yaml
+++ b/assets/telekube/resources/clusterDeprovision.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-deprovision
-  namespace: default
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/clusterProvision.yaml
+++ b/assets/telekube/resources/clusterProvision.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-provision
-  namespace: default
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/clusterProvision.yaml
+++ b/assets/telekube/resources/clusterProvision.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-provision
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesDeprovision.yaml
+++ b/assets/telekube/resources/nodesDeprovision.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-deprovision
-  namespace: default
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesDeprovision.yaml
+++ b/assets/telekube/resources/nodesDeprovision.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-deprovision
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesProvision.yaml
+++ b/assets/telekube/resources/nodesProvision.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-provision
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesProvision.yaml
+++ b/assets/telekube/resources/nodesProvision.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-provision
-  namespace: default
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 
 	"github.com/coreos/go-semver/semver"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -787,9 +787,9 @@ const (
 	// AWSRegion is the default AWS region
 	AWSRegion = "us-east-1"
 	// AWSVPCCIDR is the default AWS VPC CIDR
-	AWSVPCCIDR = "10.100.0.0/16"
+	AWSVPCCIDR = "10.1.0.0/16"
 	// AWSSubnetCIDR is the default AWS subnet CIDR
-	AWSSubnetCIDR = "10.100.0.0/24"
+	AWSSubnetCIDR = "10.1.0.0/24"
 
 	// ApplicationLabel defines the label used to annotate kubernetes resources
 	// to group them together

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -228,7 +228,7 @@ func (s *site) selectSubnets(operation ops.SiteOperation) (*storage.Subnets, err
 	}
 
 	// machines on AWS will receive IPs from this subnet
-	subnet := operation.GetVars().AWS.SubnetCIDR
+	subnet := operation.GetVars().AWS.VPCCIDR
 	if subnet == "" {
 		return nil, trace.BadParameter("no subnet CIDR in operation vars: %v", operation)
 	}


### PR DESCRIPTION
This PR implements a few fixes for the use-case of installing a cluster on AWS using automatic provisioner via Ops Center:

* Launch provisioning hooks in `kube-system` namespace because gravity-site doesn't have access to `default` anymore.
* Update default VPC CIDR range to match provisioner: https://github.com/gravitational/provisioner/blob/master/provider/awsutil/vpc.go#L13. It used to be 10.100/16, but apparently got changed so gravity was picking conflicting subnets.