### PR TITLE
[5.4.x] Backport multiple fixes.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -636,12 +636,12 @@
   version = "5.4.0"
 
 [[projects]]
-  digest = "1:fc7f5af08c8908dab9b24f2f45f3fe1b55269991ca3e8ede485f432dd08f6915"
+  digest = "1:e025b0f4997273273c5dc46a17caddb27ab7dc8b8aa9ffb50d326e7aeb4059c7"
   name = "github.com/gravitational/roundtrip"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ad87871f2c4d31b9bef3f3c6224c3f5e50d0bac1"
-  version = "0.0.2"
+  revision = "e1e0cd6b05a6bb1791b262e63160038828fd7b3a"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:f01b1009f6ab14bbd9257884dc63897eaf59cd7e7cdd59b1dae4bebad7cea154"
@@ -672,7 +672,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:a10fd3a73305c096aaedea3f09e4fe37ee06221a2c4936a9d343677427b30cdf"
+  digest = "1:c97a2f86cec26c48b28cebc7f60ed8da0331bf886a05ab18dd35e0eb75f5fb6f"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -715,8 +715,8 @@
     "lib/web/ui",
   ]
   pruneopts = "UT"
-  revision = "874bbe7ab1ca7d11cd741a5cde0c35a4040c27b7"
-  version = "v2.4.10"
+  revision = "f15ac376ac8624c039a5142d78342b4f9ea62f8d"
+  version = "v2.4.12"
 
 [[projects]]
   digest = "1:22c8951489f0e27ec3b2d50d9f74086ff3f08554ce5965d418d6a10296b9ea04"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -176,11 +176,11 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/roundtrip"
-  version = "0.0.2"
+  version = "=v1.0.0"
 
 [[constraint]]
   name = "github.com/gravitational/teleport"
-  version = "=v2.4.10"
+  version = "=v2.4.12"
 
 [[constraint]]
   version = "0.0.1"

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CURRENT_COMMIT := $(shell git rev-parse HEAD)
 VERSION_FLAGS := -X github.com/gravitational/gravity/vendor/github.com/gravitational/version.gitCommit=$(CURRENT_COMMIT) -X github.com/gravitational/gravity/vendor/github.com/gravitational/version.version=$(GRAVITY_VERSION)
 GRAVITY_LINKFLAGS = "$(VERSION_FLAGS) $(GOLFLAGS)"
 
-TELEPORT_TAG = 2.4.7
+TELEPORT_TAG = 2.4.12
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
 PLANET_TAG := 5.4.7-$(K8S_VER)

--- a/assets/telekube/resources/clusterDeprovision.yaml
+++ b/assets/telekube/resources/clusterDeprovision.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-deprovision
-  namespace: default
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/clusterProvision.yaml
+++ b/assets/telekube/resources/clusterProvision.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: cluster-provision
-  namespace: default
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesDeprovision.yaml
+++ b/assets/telekube/resources/nodesDeprovision.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-deprovision
-  namespace: default
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/assets/telekube/resources/nodesProvision.yaml
+++ b/assets/telekube/resources/nodesProvision.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: nodes-provision
-  namespace: default
+  namespace: kube-system
 spec:
   activeDeadlineSeconds: 240
   template:

--- a/lib/app/client/client.go
+++ b/lib/app/client/client.go
@@ -425,17 +425,17 @@ func (c *Client) createApp(locator loc.Locator, manifest []byte, reader io.Reade
 
 // PostJSON posts data as JSON to the server
 func (c *Client) PostJSON(endpoint string, data interface{}) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.PostJSON(endpoint, data))
+	return telehttplib.ConvertResponse(c.Client.PostJSON(context.TODO(), endpoint, data))
 }
 
 // Get issues HTTP GET request to the server
 func (c *Client) Get(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Get(endpoint, params))
+	return telehttplib.ConvertResponse(c.Client.Get(context.TODO(), endpoint, params))
 }
 
 // Delete issues HTTP DELETE request to the server
 func (c *Client) Delete(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.DeleteWithParams(endpoint, params))
+	return telehttplib.ConvertResponse(c.Client.DeleteWithParams(context.TODO(), endpoint, params))
 }
 
 // PostForm is a generic method that issues http POST request to the server
@@ -445,12 +445,12 @@ func (c *Client) PostForm(
 	files ...roundtrip.File) (*roundtrip.Response, error) {
 
 	return telehttplib.ConvertResponse(
-		c.Client.PostForm(endpoint, values, files...))
+		c.Client.PostForm(context.TODO(), endpoint, values, files...))
 }
 
 // getFile streams binary data from the specified endpoint
 func (c *Client) getFile(endpoint string, params url.Values) (io.ReadCloser, error) {
-	file, err := c.GetFile(endpoint, params)
+	file, err := c.GetFile(context.TODO(), endpoint, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/blob/client/blobclient.go
+++ b/lib/blob/client/blobclient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -183,7 +184,7 @@ func (c *Client) OpenBLOB(hash string) (blob.ReadSeekCloser, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return c.OpenFile(endpoint, url.Values{})
+	return c.OpenFile(context.TODO(), endpoint, url.Values{})
 }
 
 // PostForm is a generic method that issues http POST request to the server
@@ -193,15 +194,15 @@ func (c *Client) PostForm(
 	files ...roundtrip.File) (*roundtrip.Response, error) {
 
 	return telehttplib.ConvertResponse(
-		c.Client.PostForm(endpoint, vals, files...))
+		c.Client.PostForm(context.TODO(), endpoint, vals, files...))
 }
 
 // Get issues http GET request to the server
 func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Get(u, params))
+	return telehttplib.ConvertResponse(c.Client.Get(context.TODO(), u, params))
 }
 
 // Delete issues http DELETE Request to the server
 func (c *Client) Delete(u string) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Delete(u))
+	return telehttplib.ConvertResponse(c.Client.Delete(context.TODO(), u))
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 
 	"github.com/coreos/go-semver/semver"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -780,9 +780,9 @@ const (
 	// AWSRegion is the default AWS region
 	AWSRegion = "us-east-1"
 	// AWSVPCCIDR is the default AWS VPC CIDR
-	AWSVPCCIDR = "10.100.0.0/16"
+	AWSVPCCIDR = "10.1.0.0/16"
 	// AWSSubnetCIDR is the default AWS subnet CIDR
-	AWSSubnetCIDR = "10.100.0.0/24"
+	AWSSubnetCIDR = "10.1.0.0/24"
 
 	// ApplicationLabel defines the label used to annotate kubernetes resources
 	// to group them together

--- a/lib/ops/monitoring/influxdb.go
+++ b/lib/ops/monitoring/influxdb.go
@@ -17,6 +17,7 @@ limitations under the License.
 package monitoring
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -107,12 +108,12 @@ func (i *influxDB) UpdateRetentionPolicy(policy RetentionPolicy) error {
 
 // Get is like roundtrip.Client.Get but converts returned HTTP errors into trace errors
 func (i *influxDB) Get(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(i.Client.Get(endpoint, params))
+	return httplib.ConvertResponse(i.Client.Get(context.TODO(), endpoint, params))
 }
 
 // PostForm is like roundtrip.Client.PostForm but converts returned HTTP errors into trace errors
 func (i *influxDB) PostForm(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(i.Client.PostForm(endpoint, params))
+	return httplib.ConvertResponse(i.Client.PostForm(context.TODO(), endpoint, params))
 }
 
 // influxDBResponse represents a response from InfluxDB API

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -669,7 +669,7 @@ func (c *Client) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
 }
 
 func (c *Client) UpsertRepository(repository string) error {
-	_, err := c.PostForm(c.Endpoint("repositories"), url.Values{
+	_, err := c.PostForm(context.TODO(), c.Endpoint("repositories"), url.Values{
 		"name": []string{repository},
 	})
 	if err != nil {
@@ -727,7 +727,7 @@ func (c *Client) CreatePackage(loc loc.Locator, data io.Reader) (*pack.PackageEn
 		Filename: loc.String(),
 		Reader:   data,
 	}
-	out, err := c.PostForm(c.Endpoint("repositories", loc.Repository, "packages"), url.Values{}, file)
+	out, err := c.PostForm(context.TODO(), c.Endpoint("repositories", loc.Repository, "packages"), url.Values{}, file)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -753,7 +753,7 @@ func (c *Client) ReadPackage(loc loc.Locator) (*pack.PackageEnvelope, io.ReadClo
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	re, err := c.Client.GetFile(c.Endpoint("repositories", loc.Repository,
+	re, err := c.Client.GetFile(context.TODO(), c.Endpoint("repositories", loc.Repository,
 		"packages", loc.Name, loc.Version, "file"), url.Values{})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -1420,22 +1420,22 @@ func (c *Client) DeleteGithubConnector(key ops.SiteKey, name string) error {
 
 // PostJSON issues HTTP POST request to the server with the provided JSON data
 func (c *Client) PostJSON(endpoint string, data interface{}) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.PostJSON(endpoint, data))
+	return telehttplib.ConvertResponse(c.Client.PostJSON(context.TODO(), endpoint, data))
 }
 
 // PutJSON issues HTTP PUT request to the server with the provided JSON data
 func (c *Client) PutJSON(endpoint string, data interface{}) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.PutJSON(endpoint, data))
+	return telehttplib.ConvertResponse(c.Client.PutJSON(context.TODO(), endpoint, data))
 }
 
 // Get issues HTTP GET request to the server
 func (c *Client) Get(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Get(endpoint, params))
+	return telehttplib.ConvertResponse(c.Client.Get(context.TODO(), endpoint, params))
 }
 
 // GetFile issues HTTP GET request to the server to download a file
 func (c *Client) GetFile(endpoint string, params url.Values) (*roundtrip.FileResponse, error) {
-	re, err := c.Client.GetFile(endpoint, params)
+	re, err := c.Client.GetFile(context.TODO(), endpoint, params)
 	if err != nil {
 		if uerr, ok := err.(*url.Error); ok && uerr != nil && uerr.Err != nil {
 			return nil, trace.Wrap(uerr.Err)
@@ -1454,13 +1454,13 @@ func (c *Client) GetFile(endpoint string, params url.Values) (*roundtrip.FileRes
 
 // Delete issues HTTP DELETE request to the server
 func (c *Client) Delete(endpoint string) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Delete(endpoint))
+	return telehttplib.ConvertResponse(c.Client.Delete(context.TODO(), endpoint))
 }
 
 // DeleteWithParams issues HTTP DELETE request to the server
 func (c *Client) DeleteWithParams(endpoint string, params url.Values) (*roundtrip.Response, error) {
 	return telehttplib.ConvertResponse(c.Client.DeleteWithParams(
-		endpoint, params))
+		context.TODO(), endpoint, params))
 }
 
 // PostStream makes a POST request to the server using data from

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -228,7 +228,7 @@ func (s *site) selectSubnets(operation ops.SiteOperation) (*storage.Subnets, err
 	}
 
 	// machines on AWS will receive IPs from this subnet
-	subnet := operation.GetVars().AWS.SubnetCIDR
+	subnet := operation.GetVars().AWS.VPCCIDR
 	if subnet == "" {
 		return nil, trace.BadParameter("no subnet CIDR in operation vars: %v", operation)
 	}

--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -64,6 +64,14 @@ func (p provisionedServers) Masters() []*ProvisionedServer {
 	return servers
 }
 
+// MasterIPs returns a list of advertise IPs of master nodes.
+func (p provisionedServers) MasterIPs() (ips []string) {
+	for _, master := range p.Masters() {
+		ips = append(ips, master.AdvertiseIP)
+	}
+	return ips
+}
+
 // Nodes returns a sub-list of this server list that contains only nodes
 func (p provisionedServers) Nodes() []*ProvisionedServer {
 	nodes := make([]*ProvisionedServer, 0)

--- a/lib/pack/webpack/webclient.go
+++ b/lib/pack/webpack/webclient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webpack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -180,7 +181,7 @@ func (c *Client) createOrUpsertPackage(loc loc.Locator, data io.Reader, upsert b
 
 // UpdatePackageLabels updates package's labels
 func (c *Client) UpdatePackageLabels(loc loc.Locator, addLabels map[string]string, removeLabels []string) error {
-	_, err := c.PostJSON(c.Endpoint("repositories", loc.Repository, "packages", loc.Name, loc.Version),
+	_, err := c.PostJSON(context.TODO(), c.Endpoint("repositories", loc.Repository, "packages", loc.Name, loc.Version),
 		labels{
 			AddLabels:    addLabels,
 			RemoveLabels: removeLabels,
@@ -216,7 +217,7 @@ func (c *Client) ReadPackage(loc loc.Locator) (*pack.PackageEnvelope, io.ReadClo
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "failed to read package %s", loc.String())
 	}
-	re, err := c.Client.GetFile(endpoint, url.Values{})
+	re, err := c.Client.GetFile(context.TODO(), endpoint, url.Values{})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -245,15 +246,15 @@ func (c *Client) PostForm(
 	files ...roundtrip.File) (*roundtrip.Response, error) {
 
 	return telehttplib.ConvertResponse(
-		c.Client.PostForm(endpoint, vals, files...))
+		c.Client.PostForm(context.TODO(), endpoint, vals, files...))
 }
 
 // Get issues http GET request to the server
 func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Get(u, params))
+	return telehttplib.ConvertResponse(c.Client.Get(context.TODO(), u, params))
 }
 
 // Delete issues http Delete Request to the server
 func (c *Client) Delete(u string) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Delete(u))
+	return telehttplib.ConvertResponse(c.Client.Delete(context.TODO(), u))
 }

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -300,7 +300,7 @@ func planetAgentStatus(ctx context.Context) (*pb.SystemStatus, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := client.Get(addr, url.Values{})
+	resp, err := client.Get(context.TODO(), addr, url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/storage/keyval/users.go
+++ b/lib/storage/keyval/users.go
@@ -98,7 +98,7 @@ func (b *backend) CreateUser(u storage.User) (storage.User, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = b.createValBytes(b.key(usersP, u.GetName(), valP), data, b.ttl(u.GetExpiry()))
+	err = b.createValBytes(b.key(usersP, u.GetName(), valP), data, b.ttl(u.Expiry()))
 	if err != nil {
 		if trace.IsAlreadyExists(err) {
 			return nil, trace.AlreadyExists("user %q already exists", u)
@@ -113,7 +113,7 @@ func (b *backend) UpsertUser(u storage.User) (storage.User, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = b.upsertValBytes(b.key(usersP, u.GetName(), valP), data, b.ttl(u.GetExpiry()))
+	err = b.upsertValBytes(b.key(usersP, u.GetName(), valP), data, b.ttl(u.Expiry()))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1930,6 +1930,14 @@ func (r Servers) Masters() (masters []Server) {
 	return
 }
 
+// MasterIPs returns a list of advertise IPs of master nodes.
+func (r Servers) MasterIPs() (ips []string) {
+	for _, master := range r.Masters() {
+		ips = append(ips, master.AdvertiseIP)
+	}
+	return ips
+}
+
 // String formats this list of servers as text
 func (r Servers) String() string {
 	var formats []string

--- a/lib/storage/user.go
+++ b/lib/storage/user.go
@@ -721,12 +721,14 @@ func (*userMarshaler) UnmarshalUser(bytes []byte) (teleservices.User, error) {
 
 // GenerateUser generates new user
 func (*userMarshaler) GenerateUser(in teleservices.User) (teleservices.User, error) {
+	expires := in.Expiry()
 	return &UserV2{
 		Kind:    teleservices.KindUser,
 		Version: teleservices.V2,
 		Metadata: teleservices.Metadata{
 			Name:      in.GetName(),
 			Namespace: teledefaults.Namespace,
+			Expires:   &expires,
 		},
 		Spec: UserSpecV2{
 			// always generate password, even though it won't be used
@@ -739,6 +741,7 @@ func (*userMarshaler) GenerateUser(in teleservices.User) (teleservices.User, err
 			SAMLIdentities:   in.GetSAMLIdentities(),
 			GithubIdentities: in.GetGithubIdentities(),
 			Roles:            in.GetRoles(),
+			Expires:          expires,
 		},
 	}, nil
 }

--- a/vendor/github.com/gravitational/roundtrip/client.go
+++ b/vendor/github.com/gravitational/roundtrip/client.go
@@ -37,6 +37,7 @@ package roundtrip
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -93,6 +94,15 @@ func CookieJar(jar http.CookieJar) ClientParam {
 	}
 }
 
+// SanitizerEnabled will enable the input sanitizer which passes the URL
+// path through a strict whitelist.
+func SanitizerEnabled(sanitizerEnabled bool) ClientParam {
+	return func(c *Client) error {
+		c.sanitizerEnabled = sanitizerEnabled
+		return nil
+	}
+}
+
 // Client is a wrapper holding HTTP client. It hold target server address and a version prefix,
 // and provides common features for building HTTP client wrappers.
 type Client struct {
@@ -108,6 +118,9 @@ type Client struct {
 	jar http.CookieJar
 	// newTracer creates new request tracer
 	newTracer NewTracer
+	// sanitizerEnabled will enable the input sanitizer which passes the URL
+	// path through a strict whitelist.
+	sanitizerEnabled bool
 }
 
 // NewClient returns a new instance of roundtrip.Client, or nil and error
@@ -157,13 +170,22 @@ func (c *Client) Endpoint(params ...string) string {
 //
 // c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
-func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Response, error) {
+func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return c.RoundTrip(func() (*http.Response, error) {
 		if len(files) == 0 {
 			req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(vals.Encode()))
 			if err != nil {
 				return nil, err
 			}
+			req = req.WithContext(ctx)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			c.addAuth(req)
 			return c.client.Do(req)
@@ -194,9 +216,10 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 		if err != nil {
 			return nil, err
 		}
-		c.addAuth(req)
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type",
 			fmt.Sprintf(`multipart/form-data;boundary="%v"`, writer.Boundary()))
+		c.addAuth(req)
 		return c.client.Do(req)
 	})
 }
@@ -205,7 +228,15 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 //
 // c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -213,6 +244,7 @@ func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) 
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -224,7 +256,15 @@ func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) 
 //
 // c.PutJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -232,6 +272,7 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -243,7 +284,15 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 //
 // c.PatchJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PatchJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -251,6 +300,7 @@ func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -262,13 +312,22 @@ func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error)
 //
 // re, err := c.Delete(c.Endpoint("users", "id1"))
 //
-func (c *Client) Delete(endpoint string) (*Response, error) {
+func (c *Client) Delete(ctx context.Context, endpoint string) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -279,21 +338,29 @@ func (c *Client) Delete(endpoint string) (*Response, error) {
 //
 // re, err := c.DeleteWithParams(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
 //
-func (c *Client) DeleteWithParams(endpoint string, params url.Values) (*Response, error) {
+func (c *Client) DeleteWithParams(ctx context.Context, endpoint string, params url.Values) (*Response, error) {
 	baseURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
 	baseURL.RawQuery = params.Encode()
-	return c.Delete(baseURL.String())
+	return c.Delete(ctx, baseURL.String())
 }
 
 // Get executes GET request to the server endpoint with optional query arguments passed in params
 //
 // re, err := c.Get(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
-func (c *Client) Get(u string, params url.Values) (*Response, error) {
-	baseUrl, err := url.Parse(u)
+func (c *Client) Get(ctx context.Context, endpoint string, params url.Values) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	baseUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -304,6 +371,7 @@ func (c *Client) Get(u string, params url.Values) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -314,8 +382,16 @@ func (c *Client) Get(u string, params url.Values) (*Response, error) {
 //
 // f, err := c.GetFile("files", "report.txt") // returns "/v1/files/report.txt"
 //
-func (c *Client) GetFile(u string, params url.Values) (*FileResponse, error) {
-	baseUrl, err := url.Parse(u)
+func (c *Client) GetFile(ctx context.Context, endpoint string, params url.Values) (*FileResponse, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	baseUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -324,6 +400,7 @@ func (c *Client) GetFile(u string, params url.Values) (*FileResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	c.addAuth(req)
 	tracer := c.newTracer()
 	tracer.Start(req)
@@ -349,13 +426,22 @@ type ReadSeekCloser interface {
 // OpenFile opens file using HTTP protocol and uses `Range` headers
 // to seek to various positions in the file, this means that server
 // has to support the flags `Range` and `Content-Range`
-func (c *Client) OpenFile(u string, params url.Values) (ReadSeekCloser, error) {
-	endpoint, err := url.Parse(u)
+func (c *Client) OpenFile(ctx context.Context, endpoint string, params url.Values) (ReadSeekCloser, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
-	endpoint.RawQuery = params.Encode()
-	return newSeeker(c, endpoint.String())
+	u.RawQuery = params.Encode()
+
+	return newSeeker(c, ctx, u.String())
 }
 
 // RoundTripFn inidicates any function that can be passed to RoundTrip

--- a/vendor/github.com/gravitational/roundtrip/sanitize.go
+++ b/vendor/github.com/gravitational/roundtrip/sanitize.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// errorMessage is the error message to return when invalid input is provided by the caller.
+const errorMessage = "invalid path, path can only be composed of characters, hyphens, slashes, and dots"
+
+// whitelistPattern is the pattern of allowed characters for the path.
+var whitelistPattern = regexp.MustCompile(`^[0-9A-Za-z@/_:.-]*$`)
+
+// isPathSafe checks if the passed in path conforms to a whitelist.
+func isPathSafe(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+
+	e, err := url.PathUnescape(u.Path)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(e, "..") {
+		return fmt.Errorf(errorMessage)
+	}
+
+	if !whitelistPattern.MatchString(e) {
+		return fmt.Errorf(errorMessage)
+	}
+
+	return nil
+}

--- a/vendor/github.com/gravitational/roundtrip/seeker.go
+++ b/vendor/github.com/gravitational/roundtrip/seeker.go
@@ -1,6 +1,7 @@
 package roundtrip
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -62,12 +63,13 @@ func (s *seeker) canSeek() error {
 	return s.lastError
 }
 
-func newSeeker(c *Client, endpoint string) (ReadSeekCloser, error) {
+func newSeeker(c *Client, ctx context.Context, endpoint string) (ReadSeekCloser, error) {
 	response, err := c.RoundTrip(func() (*http.Response, error) {
 		req, err := http.NewRequest("HEAD", endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		return c.client.Do(req)
 	})

--- a/vendor/github.com/gravitational/teleport/Gopkg.lock
+++ b/vendor/github.com/gravitational/teleport/Gopkg.lock
@@ -4,13 +4,19 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "19f72df4d05d31cbe1c56bfc8045c96babff6c7e"
 
 [[projects]]
   branch = "master"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse"
+  ]
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
@@ -21,7 +27,35 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/dynamodb","service/dynamodb/dynamodbattribute","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/dynamodb",
+    "service/dynamodb/dynamodbattribute",
+    "service/sts"
+  ]
   revision = "a201bf33b18ad4ab54344e4bc26b87eb6ad37b8e"
   version = "v1.12.25"
 
@@ -43,7 +77,11 @@
 
 [[projects]]
   name = "github.com/boombuler/barcode"
-  packages = [".","qr","utils"]
+  packages = [
+    ".",
+    "qr",
+    "utils"
+  ]
   revision = "fe0f26ff6d26693948ee8189aa064ee8c54141fa"
 
 [[projects]]
@@ -59,14 +97,28 @@
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = ["client","pkg/pathutil","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","version"]
+  packages = [
+    "client",
+    "pkg/pathutil",
+    "pkg/srv",
+    "pkg/tlsutil",
+    "pkg/transport",
+    "pkg/types",
+    "version"
+  ]
   revision = "9d43462d174c664f5edf313dec0de31e1ef4ed47"
   version = "v3.2.6"
 
 [[projects]]
   branch = "master"
   name = "github.com/coreos/go-oidc"
-  packages = ["http","jose","key","oauth2","oidc"]
+  packages = [
+    "http",
+    "jose",
+    "key",
+    "oauth2",
+    "oidc"
+  ]
   revision = "e51edf2e47e65e5708600d4da6fca1388ee437b4"
   source = "github.com/gravitational/go-oidc"
 
@@ -78,7 +130,11 @@
 
 [[projects]]
   name = "github.com/coreos/pkg"
-  packages = ["health","httputil","timeutil"]
+  packages = [
+    "health",
+    "httputil",
+    "timeutil"
+  ]
   revision = "1914e367e85eaf0c25d495b48e060dfe6190f8d0"
 
 [[projects]]
@@ -117,18 +173,30 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["jsonpb","proto","protoc-gen-go/descriptor","ptypes/any","ptypes/empty"]
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes/any",
+    "ptypes/empty"
+  ]
   revision = "8ee79997227bf9b34611aee7946ae64735e6fd93"
 
 [[projects]]
   name = "github.com/google/gops"
-  packages = ["agent","internal","signal"]
+  packages = [
+    "agent",
+    "internal",
+    "signal"
+  ]
   revision = "fa6968806ca68b7db113256f300d82b5206a2c3c"
   version = "v0.3.1"
 
 [[projects]]
   name = "github.com/gravitational/configure"
-  packages = ["cstrings","jsonschema"]
+  packages = [
+    "cstrings",
+    "jsonschema"
+  ]
   revision = "1db4b84fe9dbbbaf40827aa714dcca17b368de2c"
 
 [[projects]]
@@ -144,22 +212,10 @@
   revision = "52bc17adf63c0807b5e5b5d91350703630f621c7"
 
 [[projects]]
-  name = "github.com/gravitational/license"
-  packages = [".","constants"]
-  revision = "102213511ace56c97ccf1eef645835e16f84d130"
-  version = "0.0.4"
-
-[[projects]]
-  name = "github.com/gravitational/reporting"
-  packages = [".","client","types"]
-  revision = "3c4a4e96fb5896e14fe29da7fcce14b8d93f3965"
-  version = "0.0.4"
-
-[[projects]]
-  branch = "master"
   name = "github.com/gravitational/roundtrip"
   packages = ["."]
-  revision = "4162b978cd8cbec3f35dea84aae8d5fc696363c7"
+  revision = "e1e0cd6b05a6bb1791b262e63160038828fd7b3a"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/gravitational/trace"
@@ -175,7 +231,7 @@
 
 [[projects]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  packages = ["runtime","runtime/internal","third_party/googleapis/google/api","utilities"]
+  packages = ["third_party/googleapis/google/api"]
   revision = "a8f25bd1ab549f8b87afd48aa9181221e9d439bb"
   version = "v1.1.0"
 
@@ -214,7 +270,10 @@
 
 [[projects]]
   name = "github.com/mailgun/lemma"
-  packages = ["random","secret"]
+  packages = [
+    "random",
+    "secret"
+  ]
   revision = "e8b0cd607f5855f9a4a33f8ae5d033178f559964"
   version = "0.0.2"
 
@@ -231,7 +290,10 @@
 [[projects]]
   branch = "alexander/copy"
   name = "github.com/mailgun/oxy"
-  packages = ["forward","utils"]
+  packages = [
+    "forward",
+    "utils"
+  ]
   revision = "0c3e45a1f7b20e1f818612ad4f42abfc0923f3d5"
 
 [[projects]]
@@ -252,7 +314,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mdp/rsc"
-  packages = ["gf256","qr","qr/coding"]
+  packages = [
+    "gf256",
+    "qr",
+    "qr/coding"
+  ]
   revision = "90f07065088deccf50b28eb37c93dad3078c0f3c"
 
 [[projects]]
@@ -269,7 +335,11 @@
 
 [[projects]]
   name = "github.com/pquerna/otp"
-  packages = [".","hotp","totp"]
+  packages = [
+    ".",
+    "hotp",
+    "totp"
+  ]
   revision = "54653902c20e47f3417541d35435cb6d6162e28a"
 
 [[projects]]
@@ -286,7 +356,11 @@
 
 [[projects]]
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "50022896a67062a54a54f268fb6fe4bf90b34859"
 
 [[projects]]
@@ -296,13 +370,20 @@
 
 [[projects]]
   name = "github.com/russellhaering/gosaml2"
-  packages = [".","types"]
+  packages = [
+    ".",
+    "types"
+  ]
   revision = "8908227c114abe0b63b1f0606abae72d11bf632a"
 
 [[projects]]
   branch = "master"
   name = "github.com/russellhaering/goxmldsig"
-  packages = [".","etreeutils","types"]
+  packages = [
+    ".",
+    "etreeutils",
+    "types"
+  ]
   revision = "605161228693b2efadce55323c9c661a40c5fbaa"
 
 [[projects]]
@@ -312,7 +393,10 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [".","hooks/syslog"]
+  packages = [
+    ".",
+    "hooks/syslog"
+  ]
   revision = "8ab1e1b91d5f1a6124287906f8b0402844d3a2b3"
   source = "github.com/gravitational/logrus"
   version = "1.0.0"
@@ -330,7 +414,11 @@
 
 [[projects]]
   name = "github.com/vulcand/oxy"
-  packages = ["connlimit","ratelimit","utils"]
+  packages = [
+    "connlimit",
+    "ratelimit",
+    "utils"
+  ]
   revision = "5725fecc9a4f3aa6fdc3ffd29cef771241809add"
 
 [[projects]]
@@ -357,12 +445,33 @@
 
 [[projects]]
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish","curve25519","ed25519","ed25519/internal/edwards25519","nacl/secretbox","poly1305","salsa20/salsa","ssh","ssh/agent","ssh/terminal"]
+  packages = [
+    "bcrypt",
+    "blowfish",
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "nacl/secretbox",
+    "poly1305",
+    "salsa20/salsa",
+    "ssh",
+    "ssh/agent",
+    "ssh/terminal"
+  ]
   revision = "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace","websocket"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace",
+    "websocket"
+  ]
   revision = "48359f4f600b3a2d5cf657458e3f940021631a56"
 
 [[projects]]
@@ -372,7 +481,23 @@
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["encoding","encoding/internal","encoding/internal/identifier","encoding/unicode","internal/gen","internal/triegen","internal/ucd","internal/utf8internal","runes","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "encoding",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "internal/utf8internal",
+    "runes",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "19e51611da83d6be54ddafce4a4af510cb3e9ea4"
 
 [[projects]]
@@ -383,7 +508,23 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","codes","connectivity","credentials","grpclb/grpc_lb_v1","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "codes",
+    "connectivity",
+    "credentials",
+    "grpclb/grpc_lb_v1",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "b3ddf786825de56a4178401b7e174ee332173b66"
   version = "v1.5.2"
 
@@ -405,6 +546,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "97a726bb183a88f10d511f1853d157e006b3a6a3a8d2887dddc0aa8f92506175"
+  inputs-digest = "b639d257ab5f42460f8ba390133a689b548867e6ac2e67f1dd339e6d4f87ea80"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/gravitational/teleport/Gopkg.toml
+++ b/vendor/github.com/gravitational/teleport/Gopkg.toml
@@ -79,8 +79,8 @@ ignored = ["github.com/Sirupsen/logrus"]
   branch = "master"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/gravitational/roundtrip"
+  version = "=v1.0.0"
 
 [[constraint]]
   version = "0.0.1"

--- a/vendor/github.com/gravitational/teleport/Makefile
+++ b/vendor/github.com/gravitational/teleport/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=2.4.10
+VERSION=2.4.12
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build

--- a/vendor/github.com/gravitational/teleport/lib/auth/clt.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/clt.go
@@ -109,13 +109,13 @@ func (c *Client) GetTransport() *http.Transport {
 // PostJSON is a generic method that issues http POST request to the server
 func (c *Client) PostJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PostJSON(endpoint, val))
+	return httplib.ConvertResponse(c.Client.PostJSON(context.TODO(), endpoint, val))
 }
 
 // PutJSON is a generic method that issues http PUT request to the server
 func (c *Client) PutJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PutJSON(endpoint, val))
+	return httplib.ConvertResponse(c.Client.PutJSON(context.TODO(), endpoint, val))
 }
 
 // PostForm is a generic method that issues http POST request to the server
@@ -124,17 +124,17 @@ func (c *Client) PostForm(
 	vals url.Values,
 	files ...roundtrip.File) (*roundtrip.Response, error) {
 
-	return httplib.ConvertResponse(c.Client.PostForm(endpoint, vals, files...))
+	return httplib.ConvertResponse(c.Client.PostForm(context.TODO(), endpoint, vals, files...))
 }
 
 // Get issues http GET request to the server
 func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Get(u, params))
+	return httplib.ConvertResponse(c.Client.Get(context.TODO(), u, params))
 }
 
 // Delete issues http Delete Request to the server
 func (c *Client) Delete(u string) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Delete(u))
+	return httplib.ConvertResponse(c.Client.Delete(context.TODO(), u))
 }
 
 // GetSessions returns a list of active sessions in the cluster

--- a/vendor/github.com/gravitational/teleport/lib/auth/github.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/github.go
@@ -125,7 +125,8 @@ func (s *AuthServer) ValidateGithubAuthCallback(q url.Values) (*GithubAuthRespon
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = s.createGithubUser(connector, *claims)
+	expires := s.clock.Now().UTC().Add(defaults.OAuth2TTL)
+	err = s.createGithubUser(connector, *claims, expires)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -194,7 +195,7 @@ func (s *AuthServer) ValidateGithubAuthCallback(q url.Values) (*GithubAuthRespon
 	return response, nil
 }
 
-func (s *AuthServer) createGithubUser(connector services.GithubConnector, claims services.GithubClaims) error {
+func (s *AuthServer) createGithubUser(connector services.GithubConnector, claims services.GithubClaims, expires time.Time) error {
 	logins := connector.MapClaims(claims)
 	if len(logins) == 0 {
 		return trace.BadParameter(
@@ -210,11 +211,11 @@ func (s *AuthServer) createGithubUser(connector services.GithubConnector, claims
 		Metadata: services.Metadata{
 			Name:      claims.Username,
 			Namespace: defaults.Namespace,
+			Expires:   &expires,
 		},
 		Spec: services.UserSpecV2{
-			Roles:   modules.GetModules().RolesFromLogins(logins),
-			Traits:  modules.GetModules().TraitsFromLogins(logins),
-			Expires: s.clock.Now().UTC().Add(defaults.OAuth2TTL),
+			Roles:  modules.GetModules().RolesFromLogins(logins),
+			Traits: modules.GetModules().TraitsFromLogins(logins),
 			GithubIdentities: []services.ExternalIdentity{{
 				ConnectorID: connector.GetName(),
 				Username:    claims.Username,
@@ -230,6 +231,9 @@ func (s *AuthServer) createGithubUser(connector services.GithubConnector, claims
 			},
 		},
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	existingUser, err := s.GetUser(claims.Username)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)

--- a/vendor/github.com/gravitational/teleport/lib/auth/new_web_user.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/new_web_user.go
@@ -208,7 +208,7 @@ func (s *AuthServer) CreateSignupU2FRegisterRequest(token string) (u2fRegisterRe
 
 	_, err = s.GetPasswordHash(tokenData.User.Name)
 	if err == nil {
-		return nil, trace.AlreadyExists("can't add user %q, user already exists", tokenData.User)
+		return nil, trace.AlreadyExists("can't add user %q, user already exists", tokenData.User.Name)
 	}
 
 	c, err := u2f.NewChallenge(universalSecondFactor.AppID, universalSecondFactor.Facets)

--- a/vendor/github.com/gravitational/teleport/lib/auth/oidc.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/oidc.go
@@ -324,11 +324,11 @@ func (a *AuthServer) createOIDCUser(connector services.OIDCConnector, ident *oid
 		Metadata: services.Metadata{
 			Name:      ident.Email,
 			Namespace: defaults.Namespace,
+			Expires:   &ident.ExpiresAt,
 		},
 		Spec: services.UserSpecV2{
-			Roles:   roles,
-			Traits:  traits,
-			Expires: ident.ExpiresAt,
+			Roles:  roles,
+			Traits: traits,
 			OIDCIdentities: []services.ExternalIdentity{
 				{
 					ConnectorID: connector.GetName(),

--- a/vendor/github.com/gravitational/teleport/lib/auth/saml.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/saml.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (
@@ -121,11 +137,11 @@ func (a *AuthServer) createSAMLUser(connector services.SAMLConnector, assertionI
 		Metadata: services.Metadata{
 			Name:      assertionInfo.NameID,
 			Namespace: defaults.Namespace,
+			Expires:   &expiresAt,
 		},
 		Spec: services.UserSpecV2{
 			Roles:          roles,
 			Traits:         traits,
-			Expires:        expiresAt,
 			SAMLIdentities: []services.ExternalIdentity{{ConnectorID: connector.GetName(), Username: assertionInfo.NameID}},
 			CreatedBy: services.CreatedBy{
 				User: services.UserRef{Name: "system"},

--- a/vendor/github.com/gravitational/teleport/lib/auth/trustedcluster.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/trustedcluster.go
@@ -18,6 +18,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"net/http"
@@ -335,7 +336,7 @@ func (s *AuthServer) sendValidateRequestToProxy(host string, validateRequest *Va
 		return nil, trace.Wrap(err)
 	}
 
-	out, err := httplib.ConvertResponse(clt.PostJSON(clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw))
+	out, err := httplib.ConvertResponse(clt.PostJSON(context.TODO(), clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/vendor/github.com/gravitational/teleport/lib/auth/tun.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/tun.go
@@ -1113,9 +1113,7 @@ type tunConn struct {
 }
 
 func (c *tunConn) Close() error {
-	err := c.Conn.Close()
-	err = c.client.Close()
-	return trace.Wrap(err)
+	return trace.NewAggregate(c.Conn.Close(), c.client.Close())
 }
 
 const (

--- a/vendor/github.com/gravitational/teleport/lib/backend/codec.go
+++ b/vendor/github.com/gravitational/teleport/lib/backend/codec.go
@@ -41,11 +41,11 @@ func (c *JSONCodec) UpsertJSONVal(path []string, key string, val interface{}, tt
 }
 
 func (c *JSONCodec) GetJSONVal(path []string, key string, val interface{}) error {
-	bytes, err := json.Marshal(val)
+	_, err := json.Marshal(val)
 	if err != nil {
 		return err
 	}
-	bytes, err = c.GetVal(path, key)
+	bytes, err := c.GetVal(path, key)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gravitational/teleport/lib/backend/dynamo/dynamodbbk.go
+++ b/vendor/github.com/gravitational/teleport/lib/backend/dynamo/dynamodbbk.go
@@ -131,7 +131,7 @@ func New(params backend.Params) (backend.Backend, error) {
 	err := utils.ObjectToStruct(params, &cfg)
 	if err != nil {
 		log.Error(err)
-		return nil, trace.BadParameter("DynamoDB configuration is invalid", err)
+		return nil, trace.BadParameter("DynamoDB configuration is invalid: %v", err)
 	}
 
 	defer log.Debug("AWS session created")

--- a/vendor/github.com/gravitational/teleport/lib/backend/etcdbk/etcd.go
+++ b/vendor/github.com/gravitational/teleport/lib/backend/etcdbk/etcd.go
@@ -72,7 +72,7 @@ func New(params backend.Params) (backend.Backend, error) {
 	// convert generic backend parameters structure to etcd config:
 	var cfg *Config
 	if err = utils.ObjectToStruct(params, &cfg); err != nil {
-		return nil, trace.BadParameter("invalid etcd configuration", err)
+		return nil, trace.BadParameter("invalid etcd configuration: %v", err)
 	}
 	if err = cfg.Validate(); err != nil {
 		return nil, trace.Wrap(err)

--- a/vendor/github.com/gravitational/teleport/lib/client/https_client.go
+++ b/vendor/github.com/gravitational/teleport/lib/client/https_client.go
@@ -18,6 +18,7 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -62,18 +63,18 @@ type WebClient struct {
 
 func (w *WebClient) PostJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.PostJSON(endpoint, val))
+	return httplib.ConvertResponse(w.Client.PostJSON(context.TODO(), endpoint, val))
 }
 
 func (w *WebClient) PutJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.PutJSON(endpoint, val))
+	return httplib.ConvertResponse(w.Client.PutJSON(context.TODO(), endpoint, val))
 }
 
 func (w *WebClient) Get(endpoint string, val url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.Get(endpoint, val))
+	return httplib.ConvertResponse(w.Client.Get(context.TODO(), endpoint, val))
 }
 
 func (w *WebClient) Delete(endpoint string) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.Delete(endpoint))
+	return httplib.ConvertResponse(w.Client.Delete(context.TODO(), endpoint))
 }

--- a/vendor/github.com/gravitational/teleport/lib/events/auditlog.go
+++ b/vendor/github.com/gravitational/teleport/lib/events/auditlog.go
@@ -345,12 +345,12 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]Event
 	l.Debugf("SearchEvents(%v, %v, query=%v)", fromUTC, toUTC, query)
 	queryVals, err := url.ParseQuery(query)
 	if err != nil {
-		return nil, trace.BadParameter("missing parameter query", query)
+		return nil, trace.BadParameter("missing parameter query: %q", query)
 	}
 	// how many days of logs to search?
 	days := int(toUTC.Sub(fromUTC).Hours() / 24)
 	if days < 0 {
-		return nil, trace.BadParameter("query", query)
+		return nil, trace.BadParameter("invalid time interval: from(%q) > to(%q)", fromUTC, toUTC)
 	}
 
 	// scan the log directory:

--- a/vendor/github.com/gravitational/teleport/lib/reversetunnel/peer.go
+++ b/vendor/github.com/gravitational/teleport/lib/reversetunnel/peer.go
@@ -53,7 +53,7 @@ func (p *clusterPeers) pickPeer() (*clusterPeer, error) {
 		}
 	}
 	if currentPeer == nil {
-		return nil, trace.NotFound("no active peers found for %v")
+		return nil, trace.NotFound("no active peers found for %v", p.clusterName)
 	}
 	return currentPeer, nil
 }
@@ -151,7 +151,7 @@ type clusterPeer struct {
 }
 
 func (s *clusterPeer) CachingAccessPoint() (auth.AccessPoint, error) {
-	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later")
+	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later", s)
 }
 
 func (s *clusterPeer) GetClient() (auth.ClientI, error) {

--- a/vendor/github.com/gravitational/teleport/lib/reversetunnel/srv.go
+++ b/vendor/github.com/gravitational/teleport/lib/reversetunnel/srv.go
@@ -511,7 +511,7 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 		// pose as another. so we have to check that authority
 		// matches by some other way (in absence of x509 chains)
 		if err := s.checkTrustedKey(services.HostCA, authDomain, cert.SignatureKey); err != nil {
-			logger.Warningf("this claims to be signed as authDomain %v, but no matching signing keys found")
+			logger.Warningf("this claims to be signed as authDomain %v, but no matching signing keys found", authDomain)
 			return nil, trace.Wrap(err)
 		}
 		return &ssh.Permissions{

--- a/vendor/github.com/gravitational/teleport/lib/services/resource.go
+++ b/vendor/github.com/gravitational/teleport/lib/services/resource.go
@@ -250,7 +250,7 @@ const MetadataSchema = `{
     "labels": {
       "type": "object",
       "patternProperties": {
-         "^[a-zA-Z/.0-9_]$":  { "type": "string" }
+         "^[a-zA-Z/.0-9_*-]+$":  { "type": "string" }
       }
     }
   }

--- a/vendor/github.com/gravitational/teleport/lib/services/role.go
+++ b/vendor/github.com/gravitational/teleport/lib/services/role.go
@@ -1716,7 +1716,7 @@ const RoleSpecV3SchemaDefinitions = `
       "node_labels": {
         "type": "object",
         "patternProperties": {
-          "^[a-zA-Z/.0-9_]$": { "type": "string" }
+          "^[a-zA-Z/.0-9_*-]+$": { "type": "string"}
         }
       },
       "logins": {
@@ -1760,7 +1760,7 @@ const RoleSpecV2SchemaTemplate = `{
     "node_labels": {
       "type": "object",
       "patternProperties": {
-         "^[a-zA-Z/.0-9_]$":  { "type": "string" }
+         "^[a-zA-Z/.0-9_-]$":  { "type": "string" }
       }
     },
     "namespaces": {

--- a/vendor/github.com/gravitational/teleport/lib/services/user.go
+++ b/vendor/github.com/gravitational/teleport/lib/services/user.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package services
 
 import (
@@ -386,12 +402,10 @@ func (u *UserV2) Equals(other User) bool {
 	return true
 }
 
-// Expiry returns expiry time for temporary users
+// Expiry returns expiry time for temporary users. Prefer expires from
+// metadata, if it does not exist, fall back to expires in spec.
 func (u *UserV2) Expiry() time.Time {
-	if u.Metadata.Expires == nil {
-		return time.Time{}
-	}
-	if !u.Metadata.Expires.IsZero() {
+	if u.Metadata.Expires != nil && !u.Metadata.Expires.IsZero() {
 		return *u.Metadata.Expires
 	}
 	return u.Spec.Expires

--- a/vendor/github.com/gravitational/teleport/lib/srv/regular/sshserver.go
+++ b/vendor/github.com/gravitational/teleport/lib/srv/regular/sshserver.go
@@ -534,7 +534,7 @@ func (s *Server) serveAgent(ctx *srv.ServerContext) error {
 	socketPath := filepath.Join(socketDir, fmt.Sprintf("teleport-%v.socket", pid))
 	if err := os.Chown(socketDir, uid, gid); err != nil {
 		if err := dirCloser.Close(); err != nil {
-			log.Warn("failed to remove directory: %v", err)
+			log.WithError(err).Warn("failed to remove directory")
 		}
 		return trace.ConvertSystemError(err)
 	}

--- a/vendor/github.com/gravitational/teleport/lib/utils/certs.go
+++ b/vendor/github.com/gravitational/teleport/lib/utils/certs.go
@@ -41,7 +41,7 @@ func ParseSigningKeyStorePEM(keyPEM, certPEM string) (*SigningKeyStore, error) {
 	}
 	rsaKey, ok := key.(*rsa.PrivateKey)
 	if !ok {
-		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported for signatures")
+		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported for signatures", key)
 	}
 	certASN, _ := pem.Decode([]byte(certPEM))
 	if certASN == nil {

--- a/vendor/github.com/gravitational/teleport/lib/utils/websocketwriter.go
+++ b/vendor/github.com/gravitational/teleport/lib/utils/websocketwriter.go
@@ -81,7 +81,9 @@ func (w *WebSockWrapper) Write(data []byte) (n int, err error) {
 	} else {
 		var utf8 string
 		utf8, err = w.encoder.String(string(data))
-		err = websocket.Message.Send(w.ws, utf8)
+		if err == nil {
+			err = websocket.Message.Send(w.ws, utf8)
+		}
 	}
 	if err != nil {
 		n = 0

--- a/vendor/github.com/gravitational/teleport/lib/web/saml.go
+++ b/vendor/github.com/gravitational/teleport/lib/web/saml.go
@@ -115,7 +115,7 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		log.Debugf("redirecting to web browser")
 		err = csrf.VerifyToken(response.Req.CSRFToken, r)
 		if err != nil {
-			l.Warningf("unable to verify CSRF token", err)
+			l.WithError(err).Warn("unable to verify CSRF token")
 			return nil, trace.AccessDenied("access denied")
 		}
 

--- a/vendor/github.com/gravitational/teleport/lib/web/terminal.go
+++ b/vendor/github.com/gravitational/teleport/lib/web/terminal.go
@@ -292,7 +292,7 @@ func resolveHostPort(value string, existingServers []services.Server) (string, i
 			hostName = host
 			hostPort, err = strconv.Atoi(port)
 			if err != nil {
-				return "", 0, trace.BadParameter("server: invalid port", err)
+				return "", 0, trace.BadParameter("server: invalid port: %v", err)
 			}
 		}
 	}

--- a/vendor/github.com/gravitational/teleport/version.go
+++ b/vendor/github.com/gravitational/teleport/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.4.10"
+	Version = "2.4.12"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
This PR backports a few fixes for the issues I discovered while going over the test plan for 5.5.0, namely:

* The issue with teleport nodes connecting to a single auth server.
* The issue with AWS installation.
* Apply cluster role teleport label explicitly (not sure it's required in 5.4 but I thought it's a better approach anyway).
* Also, upgrade to teleport 2.4.12 and fix an issue with non-expiring SSO users.

Requires https://github.com/gravitational/gravity.e/pull/3977.