### PR TITLE
[5.2] backport package collection fix

### DIFF
--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -122,6 +123,8 @@ type OperationPhaseData struct {
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`
 	// Data is arbitrary text data to provide to a phase executor
 	Data string `json:"data,omitempty" yaml:"data,omitempty"`
+	// GarbageCollect specifies configuration specific to garbage collect operation
+	GarbageCollect *GarbageCollectOperationData `json:"garbage_collect,omitempty" yaml:"garbage_collect,omitempty"`
 }
 
 // ElectionChange describes changes to make to cluster elections
@@ -130,6 +133,20 @@ type ElectionChange struct {
 	EnableServers []Server `json:"enable_server,omitempty" yaml:"enable_server,omitempty"`
 	// DisableServers is a list of servers that we should disable elections on
 	DisableServers []Server `json:"disable_servers,omitempty" yaml:"disable_servers,omitempty"`
+}
+
+// GarbageCollectOperationData describes configuration for the garbage collect operation
+type GarbageCollectOperationData struct {
+	// RemoteApps lists remote applications known to cluster
+	RemoteApps []Application `json:"remote_apps,omitempty" yaml:"remote_apps,omitempty"`
+}
+
+// Application describes an application for the package cleaner
+type Application struct {
+	// Locator references the application package
+	loc.Locator
+	// Manifest is the application's manifest
+	schema.Manifest
 }
 
 // PlanChange represents a single operation plan state change

--- a/lib/vacuum/internal/fsm/builder_test.go
+++ b/lib/vacuum/internal/fsm/builder_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
@@ -43,8 +44,13 @@ func (S) TestSingleNodePlan(c *C) {
 	servers := []storage.Server{
 		{Hostname: "node-1", ClusterRole: string(schema.ServiceRoleMaster)},
 	}
+	remoteApps := []storage.Application{
+		{
+			Locator: loc.MustParseLocator("remote/app:0.0.1"),
+		},
+	}
 
-	plan, err := NewOperationPlan(operation, servers)
+	plan, err := NewOperationPlan(operation, servers, remoteApps)
 	c.Assert(err, IsNil)
 	c.Assert(plan, compare.DeepEquals, &storage.OperationPlan{
 		OperationID:   operation.ID,
@@ -73,6 +79,11 @@ func (S) TestSingleNodePlan(c *C) {
 					{
 						ID:          "/packages/cluster",
 						Description: `Prune unused cluster packages`,
+						Data: &storage.OperationPhaseData{
+							GarbageCollect: &storage.GarbageCollectOperationData{
+								RemoteApps: remoteApps,
+							},
+						},
 					},
 					{
 						ID:          "/packages/node-1",
@@ -112,8 +123,13 @@ func (S) TestMultiNodePlan(c *C) {
 		{Hostname: "node-2", ClusterRole: string(schema.ServiceRoleNode)},
 		{Hostname: "node-3", ClusterRole: string(schema.ServiceRoleMaster)},
 	}
+	remoteApps := []storage.Application{
+		{
+			Locator: loc.MustParseLocator("remote/app:0.0.1"),
+		},
+	}
 
-	plan, err := NewOperationPlan(operation, servers)
+	plan, err := NewOperationPlan(operation, servers, remoteApps)
 	c.Assert(err, IsNil)
 	c.Assert(plan, compare.DeepEquals, &storage.OperationPlan{
 		OperationID:   operation.ID,
@@ -150,6 +166,11 @@ func (S) TestMultiNodePlan(c *C) {
 					{
 						ID:          "/packages/cluster",
 						Description: `Prune unused cluster packages`,
+						Data: &storage.OperationPhaseData{
+							GarbageCollect: &storage.GarbageCollectOperationData{
+								RemoteApps: remoteApps,
+							},
+						},
 					},
 					{
 						ID:          "/packages/node-1",

--- a/lib/vacuum/internal/phases/registry.go
+++ b/lib/vacuum/internal/phases/registry.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/state"
-	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/vacuum/prune"
 	"github.com/gravitational/gravity/lib/vacuum/prune/registry"
 
@@ -41,22 +41,12 @@ func NewRegistry(
 	clusterApp loc.Locator,
 	clusterApps app.Applications,
 	clusterPackages pack.PackageService,
-	emitter utils.Emitter,
+	silent localenv.Silent,
+	logger log.FieldLogger,
 ) (*registryExecutor, error) {
-	return &registryExecutor{
-		Emitter:     emitter,
-		FieldLogger: log.WithField("phase", params.Phase),
-		app:         clusterApp,
-		apps:        clusterApps,
-		packages:    clusterPackages,
-	}, nil
-}
-
-// Execute prunes unused docker images on this node
-func (r *registryExecutor) Execute(ctx context.Context) error {
 	stateDir, err := state.GetStateDir()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
@@ -67,24 +57,31 @@ func (r *registryExecutor) Execute(ctx context.Context) error {
 		ClientKeyPath:   state.Secret(stateDir, "kubelet.key"),
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
 	pruner, err := registry.New(registry.Config{
-		App:          &r.app,
-		Apps:         r.apps,
-		Packages:     r.packages,
+		App:          &clusterApp,
+		Apps:         clusterApps,
+		Packages:     clusterPackages,
 		ImageService: imageService,
 		Config: prune.Config{
-			Emitter:     r.Emitter,
-			FieldLogger: r.FieldLogger.WithField(trace.Component, "gc:registry"),
+			Silent:      silent,
+			FieldLogger: logger,
 		},
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
+	return &registryExecutor{
+		FieldLogger: logger,
+		Pruner:      pruner,
+		silent:      silent,
+	}, nil
+}
 
-	err = pruner.Prune(ctx)
+// Execute prunes unused docker images on this node
+func (r *registryExecutor) Execute(ctx context.Context) error {
+	err := r.Prune(ctx)
 	return trace.Wrap(err)
 }
 
@@ -106,9 +103,7 @@ func (r *registryExecutor) Rollback(context.Context) error {
 type registryExecutor struct {
 	// FieldLogger is the logger the executor uses
 	log.FieldLogger
-	// Emitter outputs progress messages to stdout
-	utils.Emitter
-	app      loc.Locator
-	apps     app.Applications
-	packages pack.PackageService
+	// Pruner is the actual clean up implementation
+	prune.Pruner
+	silent localenv.Silent
 }

--- a/lib/vacuum/plan.go
+++ b/lib/vacuum/plan.go
@@ -30,7 +30,7 @@ func (r *Collector) getOrCreateOperationPlan() (plan *storage.OperationPlan, err
 	}
 
 	if trace.IsNotFound(err) {
-		plan, err = fsm.NewOperationPlan(*r.Operation, r.Servers)
+		plan, err = fsm.NewOperationPlan(*r.Operation, r.Servers, r.RemoteApps)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/vacuum/prune/journal/journal.go
+++ b/lib/vacuum/prune/journal/journal.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/vacuum/prune"
 
 	"github.com/gravitational/trace"
@@ -70,9 +69,6 @@ func (r *Config) checkAndSetDefaults() error {
 	}
 	if r.FieldLogger == nil {
 		r.FieldLogger = log.WithField(trace.Component, "gc:journal")
-	}
-	if r.Emitter == nil {
-		r.Emitter = utils.NopEmitter()
 	}
 	return nil
 }

--- a/lib/vacuum/prune/pack/pack.go
+++ b/lib/vacuum/prune/pack/pack.go
@@ -24,8 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/pack"
-	"github.com/gravitational/gravity/lib/schema"
-	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/vacuum/prune"
 
 	"github.com/coreos/go-semver/semver"
@@ -64,9 +63,6 @@ func (r *Config) checkAndSetDefaults() error {
 	if r.FieldLogger == nil {
 		r.FieldLogger = log.WithField(trace.Component, "gc:package")
 	}
-	if r.Emitter == nil {
-		r.Emitter = utils.NopEmitter()
-	}
 	return nil
 }
 
@@ -75,22 +71,14 @@ type Config struct {
 	// Config specifies the common pruner configuration
 	prune.Config
 	// App specifies the cluster application
-	App *Application
+	App *storage.Application
 	// Apps lists other cluster applications.
 	// There might be several applications meaningful for the cluster
 	// if it's an Ops Center and has been connected with multiple remote
 	// clusters.
-	Apps []Application
+	Apps []storage.Application
 	// Packages specifies the package service to prune
 	Packages packageService
-}
-
-// Application describes an application for the package cleaner
-type Application struct {
-	// Locator references the application package
-	loc.Locator
-	// Manifest is the application's manifest
-	schema.Manifest
 }
 
 // packageService defines the subset of package APIs as required for pruning

--- a/lib/vacuum/prune/pack/pack_test.go
+++ b/lib/vacuum/prune/pack/pack_test.go
@@ -362,7 +362,7 @@ func (*S) TestDoesnotPrunePackagesFromRemoteClusters(c *C) {
 	)
 	allPackages = append(allPackages, remoteDependencies...)
 
-	apps := []Application{*remote}
+	apps := []storage.Application{*remote}
 
 	// exercise
 	p, err := New(Config{
@@ -431,7 +431,7 @@ func (*S) TestDoesnotPruneUnrelatedPackages(c *C) {
 	c.Assert(byLocator(allPackages), compare.SortedSliceEquals, byLocator(expected))
 }
 
-func newApp(app, runtimeApp, runtimePackage packageEnvelope, dependencies ...packageEnvelope) (*Application, []packageEnvelope) {
+func newApp(app, runtimeApp, runtimePackage packageEnvelope, dependencies ...packageEnvelope) (*storage.Application, []packageEnvelope) {
 	m := schema.Manifest{
 		Header: schema.Header{
 			TypeMeta: metav1.TypeMeta{
@@ -461,7 +461,7 @@ func newApp(app, runtimeApp, runtimePackage packageEnvelope, dependencies ...pac
 			m.Dependencies.Apps = append(m.Dependencies.Apps, schema.Dependency{Locator: dep.Locator})
 		}
 	}
-	return &Application{
+	return &storage.Application{
 		Locator:  app.Locator,
 		Manifest: m,
 	}, append(dependencies, app, runtimeApp, runtimePackage)

--- a/lib/vacuum/prune/pruner.go
+++ b/lib/vacuum/prune/pruner.go
@@ -18,8 +18,11 @@ package prune
 
 import (
 	"context"
+	"fmt"
+	"time"
 
-	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/localenv"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -35,7 +38,9 @@ func (r Config) PrintStep(format string, args ...interface{}) {
 	if r.DryRun {
 		format = "[dry-run] " + format
 	}
-	_, _ = r.Emitter.PrintStep(format, args...)
+	message := fmt.Sprintf(format, args...)
+	_, _ = r.Silent.Printf("%v\t%v\n", time.Now().UTC().Format(constants.HumanDateFormatSeconds),
+		message)
 }
 
 // Config is the common pruner configuration
@@ -44,6 +49,6 @@ type Config struct {
 	DryRun bool
 	// FieldLogger specifies the logger
 	log.FieldLogger
-	// Emitter specifies the progress output stream
-	Emitter utils.Emitter
+	// Silent specifies the progress output stream
+	Silent localenv.Silent
 }

--- a/lib/vacuum/prune/registry/registry.go
+++ b/lib/vacuum/prune/registry/registry.go
@@ -62,9 +62,6 @@ func (r *Config) checkAndSetDefaults() error {
 	if r.FieldLogger == nil {
 		r.FieldLogger = log.WithField(trace.Component, "gc:registry")
 	}
-	if r.Emitter == nil {
-		r.Emitter = utils.NopEmitter()
-	}
 	return nil
 }
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -674,7 +674,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			phase = fsm.RootPhase
 		}
 		if phase != "" {
-			return garbageCollectPhase(localEnv, phase, *g.GarbageCollectCmd.PhaseTimeout,
+			return executeGarbageCollectPhase(localEnv, phase, *g.GarbageCollectCmd.PhaseTimeout,
 				*g.GarbageCollectCmd.Force)
 		}
 		return garbageCollect(localEnv, *g.GarbageCollectCmd.Manual, *g.GarbageCollectCmd.Confirmed)


### PR DESCRIPTION
Backport [fix](https://github.com/gravitational/gravity/pull/171)  to `gravity gc` to enable package collection on regular nodes.

Fixes https://github.com/gravitational/gravity.e/issues/3878.