### PR TITLE
App list command tweaks.

### DIFF
--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -706,6 +706,8 @@ type AppInstallCmd struct {
 // AppListCmd shows all application releases.
 type AppListCmd struct {
 	*kingpin.CmdClause
+	// All displays releases with all possible statuses.
+	All *bool
 }
 
 // AppUpgradeCmd upgrades a release.

--- a/tool/gravity/cli/helm.go
+++ b/tool/gravity/cli/helm.go
@@ -184,7 +184,7 @@ func releaseInstall(env *localenv.LocalEnvironment, conf releaseInstallConfig) e
 	return nil
 }
 
-func releaseList(env *localenv.LocalEnvironment) error {
+func releaseList(env *localenv.LocalEnvironment, all bool) error {
 	helmClient, err := helm.NewClient(helm.ClientConfig{
 		DNSAddress: env.DNS.Addr(),
 	})
@@ -192,7 +192,9 @@ func releaseList(env *localenv.LocalEnvironment) error {
 		return trace.Wrap(err)
 	}
 	defer helmClient.Close()
-	releases, err := helmClient.List(helm.ListParameters{})
+	releases, err := helmClient.List(helm.ListParameters{
+		All: all,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -242,7 +242,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppInstallCmd.RegistryKey = g.AppInstallCmd.Flag("registry-key", "Docker registry client private key path.").String()
 
 	g.AppListCmd.CmdClause = g.AppCmd.Command("ls", "Show all application releases.").Alias("list")
-	g.AppListCmd.All = g.AppListCmd.Flag("all", "Display releases with all statuses.").Short('a').Bool()
+	g.AppListCmd.All = g.AppListCmd.Flag("all", "Do not filter releases by status.").Short('a').Bool()
 
 	g.AppUpgradeCmd.CmdClause = g.AppCmd.Command("upgrade", "Upgrade a release using the specified application image.")
 	g.AppUpgradeCmd.Release = g.AppUpgradeCmd.Arg("release", "Release name to upgrade.").Required().String()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -241,7 +241,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppInstallCmd.RegistryCert = g.AppInstallCmd.Flag("registry-cert", "Docker registry client certificate path.").String()
 	g.AppInstallCmd.RegistryKey = g.AppInstallCmd.Flag("registry-key", "Docker registry client private key path.").String()
 
-	g.AppListCmd.CmdClause = g.AppCmd.Command("ls", "Show all application releases.")
+	g.AppListCmd.CmdClause = g.AppCmd.Command("ls", "Show all application releases.").Alias("list")
+	g.AppListCmd.All = g.AppListCmd.Flag("all", "Display releases with all statuses.").Short('a').Bool()
 
 	g.AppUpgradeCmd.CmdClause = g.AppCmd.Command("upgrade", "Upgrade a release using the specified application image.")
 	g.AppUpgradeCmd.Release = g.AppUpgradeCmd.Arg("release", "Release name to upgrade.").Required().String()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -449,7 +449,8 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			},
 		})
 	case g.AppListCmd.FullCommand():
-		return releaseList(localEnv)
+		return releaseList(localEnv,
+			*g.AppListCmd.All)
 	case g.AppUpgradeCmd.FullCommand():
 		return releaseUpgrade(localEnv, releaseUpgradeConfig{
 			Release: *g.AppUpgradeCmd.Release,


### PR DESCRIPTION
Made a couple of adjustments to the `gravity app ls` command while playing with the application catalog:

* Add `list` alias for the command.
* Include additional release statuses in default output (to be able to see releases that are being installed/uninstalled/upgraded/etc. - will be needed for the dashboard too).
* Add `--all` flag to the command to display releases with all possible statuses (including "deleted", "superseded", etc. which you normally don't need to see).