### PR TITLE
Fixes for shrink and process.

### DIFF
--- a/lib/install/phases/connect.go
+++ b/lib/install/phases/connect.go
@@ -99,7 +99,7 @@ func (p *connectExecutor) Execute(ctx context.Context) error {
 	}
 	p.Progress.NextStep("Connecting to installer")
 
-	clusterClient, err := clients.TeleportAuth(ctx, p.ClusterOperator, "localhost", p.Plan.ClusterName)
+	clusterClient, err := p.getAuthClient(ctx, p.ClusterOperator, "localhost", p.Plan.ClusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -110,7 +110,7 @@ func (p *connectExecutor) Execute(ctx context.Context) error {
 
 	installerHost, _ := utils.SplitHostPort(trustedCluster.GetProxyAddress(), "")
 	installerProxyAddr := fmt.Sprintf("%v:%v,%v", installerHost, defaults.WizardPackServerPort, defaults.WizardProxyServerPort)
-	installerClient, err := clients.TeleportAuth(ctx, p.InstallerOperator, installerProxyAddr, trustedCluster.GetName())
+	installerClient, err := p.getAuthClient(ctx, p.InstallerOperator, installerProxyAddr, trustedCluster.GetName())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -144,6 +144,19 @@ func (p *connectExecutor) Execute(ctx context.Context) error {
 
 	p.Info("Connected to installer.")
 	return nil
+}
+
+func (p *connectExecutor) getAuthClient(ctx context.Context, operator ops.Operator, proxyHost, clusterName string) (client auth.ClientI, err error) {
+	// Retry a few times to account for possible network errors.
+	err = utils.RetryOnNetworkError(defaults.RetryInterval, defaults.RetryLessAttempts, func() error {
+		client, err = clients.TeleportAuth(ctx, operator, proxyHost, clusterName)
+		if err != nil {
+			logrus.Warnf("Error getting teleport client %v/%v: %v.", proxyHost, clusterName, trace.DebugReport(err))
+			return trace.Wrap(err)
+		}
+		return nil
+	})
+	return client, trace.Wrap(err)
 }
 
 // getAuthorities returns user/host authorities for the specified cluster

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -423,8 +423,8 @@ func (s *site) pickShrinkMasterRunner(ctx *operationContext, removedServer stora
 			}, nil
 		}
 	}
-	return nil, trace.NotFound("could not find appropriate master server among %v",
-		masters)
+	return nil, trace.NotFound("%v is being removed and no more master nodes are available to execute the operation",
+		removedServer)
 }
 
 func (s *site) waitForServerToDisappear(hostname string) error {

--- a/lib/ops/opsservice/teleport.go
+++ b/lib/ops/opsservice/teleport.go
@@ -124,7 +124,7 @@ func (s *site) getTeleportServerNoRetry(labelName, labelValue string) (server *t
 	return newTeleportServer(servers[0])
 }
 
-// getAllTeleportServer queries all teleport servers in a retry loop
+// getAllTeleportServers queries all teleport servers in a retry loop
 func (s *site) getAllTeleportServers() (teleservers, error) {
 	anyServers := func(string, []teleservices.Server) error {
 		return nil


### PR DESCRIPTION
This PR improves the way the "master" server runner is chosen during shrink operation. It makes sure that if the node that's being removed is master, it can't be chosen as a master runner. Previously, the code would choose any master node which had a decent chance of choosing the node that's being removed which could lead to all sorts of issues. Closes https://github.com/gravitational/gravity.e/issues/3740.

While testing, I have also observed that when installing a 3-node cluster, the two non-leader gravity-site processes would not initialize properly with error `failed to find any peer with hash(964ae66380e9b7cfadb9752193aafe8aea7596819bfad0ae302315a9fac8f763), failed to load RPC credentials` so I added retry to RPC credentials initialization and made sure it fixes the issue.