### PR TITLE
Add 5.2.11 and 5.3.9 release notes.

### DIFF
--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -9,7 +9,8 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 5.5.0-rc.1    | No  | March 4th, 2019      | -                    | 1.13.4             | 3.0.4            |
 | 5.4.7         | No  | March 1st, 2019      | -                    | 1.13.4             | 2.4.10           |
-| 5.2.10        | Yes | March 1st, 2019      | October, 15th, 2019  | 1.11.8             | 2.4.10           |
+| 5.3.9         | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7
+| 5.2.11        | Yes | March 7th, 2019      | October, 15th, 2019  | 1.11.8             | 2.4.10           |
 | 5.0.29        | Yes | February, 12th 2019  | April, 13th 2019     | 1.9.12-gravitational | 2.4.10         |
 | 4.68.0        | Yes | January, 17th 2019   | November, 16th 2018  | 1.7.18-gravitational | 2.3.5          |
 | 3.64.0        | Yes | December, 21st 2017  | June, 2nd 2018       | 1.5.7              | 2.0.6            |
@@ -23,6 +24,23 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     article in our Help Center.
 
 ## 5.x Releases
+
+### 5.2.11 LTS
+
+#### Bugfixes
+
+* Fix an issue with manually completing rolled back upgrade plan.
+
+### 5.3.9
+
+#### Improvements
+
+* Use `overlay2` as default storage driver.
+* Enable aggregation layer on the Kubernetes API server.
+
+#### Bugfixes
+
+* Fix an issue with manually completing rolled back upgrade plan.
 
 ### 5.5.0-rc.1
 
@@ -51,7 +69,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     This release fixes a security vulnerability in kubernetes. Please see
     [Kubernetes Announcement](https://discuss.kubernetes.io/t/kubernetes-security-announcement-v1-11-8-1-12-6-1-13-4-released-to-address-medium-severity-cve-2019-1002100/5147) for more information.
 
-### 5.2.10
+### 5.2.10 LTS
 
 #### Bugfixes
 


### PR DESCRIPTION
Weirdly, 5.3.x was gone from the releases table for some reason, I added it back.