### PR TITLE
(docs) rename Telekube -> Gravity + introduce opscenter earlier

### DIFF
--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -1155,7 +1155,7 @@ version: v2
 metadata:
   name: auth0
 spec:
-  redirect_url: "https://telekube-url/portalapi/v1/oidc/callback"
+  redirect_url: "https://gravity-url/portalapi/v1/oidc/callback"
   client_id: <client id>
   client_secret: <client secret>
   issuer_url: "https://example.com/"
@@ -2331,7 +2331,7 @@ workload distribution. Use `taints` property of the node profiles:
 ```yaml
 nodeProfiles:
   - name: node
-    description: "Telekube Node"
+    description: "Gravity Node"
     taints:
     - key: custom-taint
       value: custom-value
@@ -2345,7 +2345,7 @@ To install Kubernetes nodes running only system components, Gravity supports `no
 ```yaml
 nodeProfiles:
   - name: master
-    description: "Telekube Master"
+    description: "Gravity Master"
     taints:
     - key: node-role.kubernetes.io/master
       effect: NoSchedule
@@ -2362,7 +2362,7 @@ as a Kubernetes master node running Etcd as a part of the cluster:
 ```yaml
 nodeProfiles:
   - name: node
-    description: "Telekube Master Node"
+    description: "Gravity Master Node"
     labels:
       node-role.kubernetes.io/master: "true"
 ```
@@ -2373,7 +2373,7 @@ i.e. will run Etcd configured in proxy mode:
 ```yaml
 nodeProfiles:
   - name: node
-    description: "Telekube Node"
+    description: "Gravity Node"
     labels:
       node-role.kubernetes.io/node: "true"
 ```

--- a/docs/5.x/overview.md
+++ b/docs/5.x/overview.md
@@ -48,7 +48,7 @@ public or private infrastructure.
 Gravity consists of these major components:
 
 
-* [gravity](./cluster/#gravity-tool): the CLI tool used to manage the cluster.
+* [gravity](/cluster/#gravity-tool): the CLI tool used to manage the cluster.
 Gravity is only available inside the cluster so you have to either `tsh ssh` into the cluster or use web UI to execute `gravity` commands.
 * **`tele`**: the CLI tool which is used for packaging and publishing applications.
 * **`tsh`**: the SSH client for establishing secure SSH connections between the
@@ -64,10 +64,6 @@ Gravity is only available inside the cluster so you have to either `tsh ssh` int
 Application Bundles may contain "empty", pre-packaged Kubernetes for
 centralized management of Kubernetes resources within an organization or may
 also contain other applications running on Kubernetes. 
-
-
-
-## Workflow
 
 The typical cluster lifecycle consists of the following:
 

--- a/docs/5.x/overview.md
+++ b/docs/5.x/overview.md
@@ -43,11 +43,31 @@ In other words, a Gravity Application Bundle is a _self-contained, downloadable
 Kubernetes appliance_ which enables true application portability across any
 public or private infrastructure.
 
+## Components
+
+Gravity consists of these major components:
+
+
+* [gravity](./cluster/#gravity-tool): the CLI tool used to manage the cluster.
+Gravity is only available inside the cluster so you have to either `tsh ssh` into the cluster or use web UI to execute `gravity` commands.
+* **`tele`**: the CLI tool which is used for packaging and publishing applications.
+* **`tsh`**: the SSH client for establishing secure SSH connections between the
+  Ops Center and the application instances running behind firewalls on private clouds.
+  `tsh` is a part of [Gravitational Teleport](http://gravitational.com/teleport/),
+  a free open source SSH server developed, maintained and supported by Gravitational.
+  It can be used independently from Gravity.
+* [Ops Center](/opscenter): the Web UI for managing published applications and remotely
+  accessing private cloud deployments.
+
 ## Cluster Lifecycle
 
 Application Bundles may contain "empty", pre-packaged Kubernetes for
 centralized management of Kubernetes resources within an organization or may
 also contain other applications running on Kubernetes. 
+
+
+
+## Workflow
 
 The typical cluster lifecycle consists of the following:
 


### PR DESCRIPTION
An update of https://github.com/gravitational/gravity/pull/93