### PR TITLE
[5.4.x] Shrink (incl. ASG) fixes & improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -648,7 +648,7 @@ sloccount:
 
 .PHONY: test-package
 test-package: remove-temp-files
-	TEST_ETCD=$(TEST_ETCD) TEST_ETCD_CONFIG=$(TEST_ETCD_CONFIG) TEST_K8S=$(TEST_K8S) go test -v -test.parallel=0 ./$(p)
+	TEST_ETCD=$(TEST_ETCD) TEST_ETCD_CONFIG=$(TEST_ETCD_CONFIG) TEST_K8S=$(TEST_K8S) go test -v ./$(p)
 
 .PHONY: test-grep-package
 test-grep-package: remove-temp-files

--- a/lib/autoscale/aws/autoscaler.go
+++ b/lib/autoscale/aws/autoscaler.go
@@ -154,7 +154,7 @@ func (a *Autoscaler) DescribeInstance(ctx context.Context, instanceID string) (*
 		return nil, trace.NotFound("instance %v not found", instanceID)
 	}
 	if len(resp.Reservations) != 1 || len(resp.Reservations[0].Instances) != 1 {
-		return nil, trace.BadParameter("expected 1 instance with ID %v, got: %s", resp)
+		return nil, trace.BadParameter("expected 1 instance with ID %v, got: %s", instanceID, resp)
 	}
 	return resp.Reservations[0].Instances[0], nil
 }

--- a/lib/autoscale/aws/autoscaler.go
+++ b/lib/autoscale/aws/autoscaler.go
@@ -141,7 +141,7 @@ func (a *Autoscaler) TurnOffSourceDestinationCheck(ctx context.Context, instance
 }
 
 func (a *Autoscaler) WaitUntilInstanceTerminated(ctx context.Context, instanceID string) error {
-	a.Debugf("WaitUntilInstanceTerminated(%v)", instanceID)
+	a.Infof("WaitUntilInstanceTerminated(%v)", instanceID)
 	localCtx, cancel := context.WithTimeout(ctx, defaults.InstanceTerminationTimeout)
 	defer cancel()
 	err := a.Cloud.WaitUntilInstanceTerminatedWithContext(localCtx, &ec2.DescribeInstancesInput{

--- a/lib/autoscale/aws/autoscaler.go
+++ b/lib/autoscale/aws/autoscaler.go
@@ -150,7 +150,7 @@ func (a *Autoscaler) DescribeInstance(ctx context.Context, instanceID string) (*
 	if err != nil {
 		return nil, utils.ConvertEC2Error(err)
 	}
-	if len(resp.Reservations) != 1 && len(resp.Reservations[0].Instances) != 1 {
+	if len(resp.Reservations) != 1 || len(resp.Reservations[0].Instances) != 1 {
 		return nil, trace.BadParameter("expected 1 instance with ID %v, got: %s", resp)
 	}
 	return resp.Reservations[0].Instances[0], nil

--- a/lib/autoscale/aws/autoscaler.go
+++ b/lib/autoscale/aws/autoscaler.go
@@ -150,6 +150,9 @@ func (a *Autoscaler) DescribeInstance(ctx context.Context, instanceID string) (*
 	if err != nil {
 		return nil, utils.ConvertEC2Error(err)
 	}
+	if len(resp.Reservations) == 0 || len(resp.Reservations[0].Instances) == 0 {
+		return nil, trace.NotFound("instance %v not found", instanceID)
+	}
 	if len(resp.Reservations) != 1 || len(resp.Reservations[0].Instances) != 1 {
 		return nil, trace.BadParameter("expected 1 instance with ID %v, got: %s", resp)
 	}
@@ -253,4 +256,14 @@ func ConvertError(err error, args ...interface{}) error {
 		}
 	}
 	return err
+}
+
+func instanceState(instance ec2.Instance) string {
+	// All fields on the ec2.Instance object are pointers so while
+	// mandatory fields like state likely can't be nil, be on the
+	// safe side and make sure.
+	if instance.State != nil {
+		return aws.StringValue(instance.State.Name)
+	}
+	return ""
 }

--- a/lib/autoscale/aws/autoscaler_test.go
+++ b/lib/autoscale/aws/autoscaler_test.go
@@ -46,6 +46,9 @@ func (s *AutoscalerSuite) TestInstanceTerminate(c *check.C) {
 	instance := &gaws.Instance{
 		ID: "instance-1",
 	}
+	ec := newMockEC2(&ec2.Instance{
+		InstanceId: aws.String("instance-1"),
+	})
 	queue := newMockQueue("queue-1")
 	a, err := New(Config{
 		ClusterName: clusterName,
@@ -53,6 +56,7 @@ func (s *AutoscalerSuite) TestInstanceTerminate(c *check.C) {
 			return instance, nil
 		},
 		Queue: queue,
+		Cloud: ec,
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(a, check.NotNil)
@@ -110,7 +114,9 @@ func (s *AutoscalerSuite) TestInstanceLaunching(c *check.C) {
 		ID: "instance-1",
 	}
 	queue := newMockQueue("queue-1")
-	ec := newMockEC2()
+	ec := newMockEC2(&ec2.Instance{
+		InstanceId: aws.String("instance-1"),
+	})
 	a, err := New(Config{
 		ClusterName: clusterName,
 		NewLocalInstance: func() (*gaws.Instance, error) {
@@ -173,12 +179,14 @@ func newMockQueue(url string) *mockQueue {
 }
 
 type mockEC2 struct {
-	modifyC chan *ec2.ModifyInstanceAttributeInput
+	modifyC  chan *ec2.ModifyInstanceAttributeInput
+	instance *ec2.Instance
 }
 
-func newMockEC2() *mockEC2 {
+func newMockEC2(instance *ec2.Instance) *mockEC2 {
 	return &mockEC2{
-		modifyC: make(chan *ec2.ModifyInstanceAttributeInput, 10),
+		modifyC:  make(chan *ec2.ModifyInstanceAttributeInput, 10),
+		instance: instance,
 	}
 }
 
@@ -191,6 +199,20 @@ func (m *mockEC2) ModifyInstanceAttributeWithContext(ctx aws.Context, input *ec2
 	default:
 		return nil, trace.BadParameter("blocked on channel send")
 	}
+}
+
+func (m *mockEC2) DescribeInstancesWithContext(ctx aws.Context, input *ec2.DescribeInstancesInput, opts ...request.Option) (*ec2.DescribeInstancesOutput, error) {
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{m.instance},
+			},
+		},
+	}, nil
+}
+
+func (m *mockEC2) WaitUntilInstanceTerminatedWithContext(ctx aws.Context, input *ec2.DescribeInstancesInput, opts ...request.WaiterOption) error {
+	return nil
 }
 
 type message struct {

--- a/lib/autoscale/aws/discovery.go
+++ b/lib/autoscale/aws/discovery.go
@@ -26,11 +26,12 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 
 	"github.com/gravitational/trace"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PublishDiscovery periodically updates discovery information
 func (a *Autoscaler) PublishDiscovery(ctx context.Context, operator ops.Operator) {
+	a.Info("Start publishing discovery info.")
 	err := a.syncDiscovery(ctx, operator)
 	if err != nil {
 		a.Errorf("Failed to publish discovery: %v.", trace.DebugReport(err))
@@ -39,6 +40,7 @@ func (a *Autoscaler) PublishDiscovery(ctx context.Context, operator ops.Operator
 	for {
 		select {
 		case <-ctx.Done():
+			a.Info("Stop publishing discovery info.")
 			return
 		case <-ticker.C:
 			err = a.syncDiscovery(ctx, operator)

--- a/lib/autoscale/aws/events.go
+++ b/lib/autoscale/aws/events.go
@@ -105,6 +105,9 @@ func (a *Autoscaler) processEvent(ctx context.Context, operator Operator, event 
 			return trace.Wrap(err)
 		}
 	case InstanceTerminating:
+		if err := a.WaitUntilInstanceTerminated(ctx, event.InstanceID); err != nil {
+			return trace.Wrap(err, "failed to wait for instance to terminate: %v", event)
+		}
 		if err := a.removeInstance(ctx, operator, event); err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}

--- a/lib/autoscale/aws/services.go
+++ b/lib/autoscale/aws/services.go
@@ -43,6 +43,7 @@ type SQS interface {
 // EC2 is an interface representing AWS Elastic Compute cloud
 type EC2 interface {
 	ModifyInstanceAttributeWithContext(aws.Context, *ec2.ModifyInstanceAttributeInput, ...request.Option) (*ec2.ModifyInstanceAttributeOutput, error)
+	DescribeInstancesWithContext(aws.Context, *ec2.DescribeInstancesInput, ...request.Option) (*ec2.DescribeInstancesOutput, error)
 	WaitUntilInstanceTerminatedWithContext(aws.Context, *ec2.DescribeInstancesInput, ...request.WaiterOption) error
 }
 

--- a/lib/autoscale/aws/services.go
+++ b/lib/autoscale/aws/services.go
@@ -43,6 +43,7 @@ type SQS interface {
 // EC2 is an interface representing AWS Elastic Compute cloud
 type EC2 interface {
 	ModifyInstanceAttributeWithContext(aws.Context, *ec2.ModifyInstanceAttributeInput, ...request.Option) (*ec2.ModifyInstanceAttributeOutput, error)
+	WaitUntilInstanceTerminatedWithContext(aws.Context, *ec2.DescribeInstancesInput, ...request.WaiterOption) error
 }
 
 // Operator is a simplified operator interface to mock in tests

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -963,6 +963,10 @@ const (
 	// AgentDeployTimeout specifies the maximum amount of time to wait to deploy agents
 	// for an operation that spans multiple nodes
 	AgentDeployTimeout = 5 * time.Minute
+
+	// InstanceTerminationTimeout is the maximum amount of time to wait
+	// for AWS EC2 to terminate
+	InstanceTerminationTimeout = 20 * time.Minute
 )
 
 var (

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -965,7 +965,7 @@ const (
 	AgentDeployTimeout = 5 * time.Minute
 
 	// InstanceTerminationTimeout is the maximum amount of time to wait
-	// for AWS EC2 to terminate
+	// for AWS EC2 instance to terminate
 	InstanceTerminationTimeout = 20 * time.Minute
 )
 

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -121,7 +121,7 @@ func (s *site) validateShrinkRequest(req ops.CreateSiteShrinkOperationRequest, c
 	serverName := req.Servers[0]
 	if len(cluster.ClusterState.Servers) == 1 {
 		return nil, trace.BadParameter(
-			"cannot shrink 1-node cluster, please uninstall it via Ops Center")
+			"cannot shrink 1-node cluster, use --force flag to uninstall")
 	}
 
 	server, err := cluster.ClusterState.FindServer(serverName)
@@ -130,7 +130,7 @@ func (s *site) validateShrinkRequest(req ops.CreateSiteShrinkOperationRequest, c
 	}
 
 	// check to make sure the server exists and can be found
-	servers, err := s.getTeleportServers()
+	servers, err := s.getAllTeleportServers()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to query teleport servers")
 	}
@@ -205,17 +205,19 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 	//    uninstall on it (if the node is online)
 	var masterRunner, agentRunner *serverRunner
 
-	masterRunner, err = s.getMasterRunner(ctx)
+	masterRunner, err = s.pickShrinkMasterRunner(ctx, *server)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	ctx.Infof("Selected %v (%v) as master runner.",
+		masterRunner.server.HostName(),
+		masterRunner.server.Address())
 
 	// determine whether the node being removed is online and, if so, launch
 	// a shrink agent on it
 	online := false
-	var teleserver *teleportServer
 	if !state.NodeRemoved {
-		teleserver, err = s.getTeleportServerNoRetry(ops.Hostname, serverName)
+		_, err := s.getTeleportServerNoRetry(ops.Hostname, serverName)
 		if err != nil {
 			ctx.Warningf("node %q is offline: %v", serverName, trace.DebugReport(err))
 		} else {
@@ -285,10 +287,10 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		Message:    "removing the node from the cluster",
 	})
 
-	// delete node from the cluster
-	if teleserver != nil {
-		runner := s.newTeleportServerRunner(ctx, teleserver)
-		err = s.serfNodeLeave(runner)
+	// if the node is online, it needs to leave the serf cluster to
+	// prevent joining back
+	if online {
+		err = s.serfNodeLeave(agentRunner)
 		if err != nil {
 			if !force {
 				return trace.Wrap(err, "failed to remove the node from the serf cluster")
@@ -296,6 +298,8 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 			ctx.Warnf("Failed to remove node %q from serf cluster: %v.", serverName, trace.DebugReport(err))
 		}
 	}
+
+	// delete the Kubernetes node and force-leave its serf member
 	if err = s.removeNodeFromCluster(*server, masterRunner); err != nil {
 		if !force {
 			return trace.Wrap(err, "failed to remove the node from the cluster")
@@ -404,6 +408,23 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 	})
 
 	return nil
+}
+
+func (s *site) pickShrinkMasterRunner(ctx *operationContext, removedServer storage.Server) (*serverRunner, error) {
+	masters, err := s.getTeleportServers(schema.ServiceLabelRole, string(schema.ServiceRoleMaster))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Pick any master server except the one that's being removed.
+	for _, master := range masters {
+		if master.IP != removedServer.AdvertiseIP {
+			return &serverRunner{
+				&master, &teleportRunner{ctx, s.domainName, s.teleport()},
+			}, nil
+		}
+	}
+	return nil, trace.NotFound("%v is being removed and no more master nodes are available to execute the operation",
+		removedServer)
 }
 
 func (s *site) waitForServerToDisappear(hostname string) error {
@@ -605,7 +626,7 @@ func (s *site) removeNodeFromCluster(server storage.Server, runner *serverRunner
 func (s *site) serfNodeLeave(runner *serverRunner) error {
 	// Issue `serf leave` from the node to remove the node from the serf cluster
 	command := s.planetEnterCommand(defaults.SerfBin, "leave")
-	err := utils.Retry(defaults.RetryInterval, defaults.RetryAttempts, func() error {
+	err := utils.Retry(defaults.RetryInterval, defaults.RetryLessAttempts, func() error {
 		out, err := runner.Run(command...)
 		if err != nil {
 			return trace.Wrap(err, "command %q failed: %s", command, out)

--- a/lib/ops/opsservice/teleport.go
+++ b/lib/ops/opsservice/teleport.go
@@ -124,8 +124,8 @@ func (s *site) getTeleportServerNoRetry(labelName, labelValue string) (server *t
 	return newTeleportServer(servers[0])
 }
 
-// getTeleportServer queries all teleport servers in a retry loop
-func (s *site) getTeleportServers() (teleservers, error) {
+// getAllTeleportServers queries all teleport servers in a retry loop
+func (s *site) getAllTeleportServers() (teleservers, error) {
 	anyServers := func(string, []teleservices.Server) error {
 		return nil
 	}
@@ -133,11 +133,10 @@ func (s *site) getTeleportServers() (teleservers, error) {
 		defaults.RetryInterval, defaults.RetryLessAttempts, anyServers)
 }
 
-// getTeleportServer queries the teleport server with the specified label in a retry loop
-func (s *site) getTeleportServer(labelName, labelValue string) (server *teleportServer, err error) {
-	labels := map[string]string{labelName: labelValue}
+// getTeleportServers returns all servers matching provided label
+func (s *site) getTeleportServers(labelName, labelValue string) (result []teleportServer, err error) {
 	servers, err := s.getTeleportServersWithTimeout(
-		labels,
+		map[string]string{labelName: labelValue},
 		defaults.TeleportServerQueryTimeout,
 		defaults.RetryInterval,
 		defaults.RetryLessAttempts,
@@ -145,7 +144,27 @@ func (s *site) getTeleportServer(labelName, labelValue string) (server *teleport
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return newTeleportServer(servers[0])
+	for _, server := range servers {
+		teleportServer, err := newTeleportServer(server)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		result = append(result, *teleportServer)
+	}
+	return result, nil
+}
+
+// getTeleportServer queries the teleport server with the specified label in a retry loop
+func (s *site) getTeleportServer(labelName, labelValue string) (server *teleportServer, err error) {
+	servers, err := s.getTeleportServers(labelName, labelValue)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(servers) == 0 {
+		return nil, trace.NotFound("no teleport servers matching %v=%v",
+			labelName, labelValue)
+	}
+	return &servers[0], nil
 }
 
 // getTeleportServerWithTimeout queries the teleport server with the specified label in a retry loop.

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -1152,10 +1152,6 @@ func (p *Process) initService() (err error) {
 		}
 
 		p.Info("Running inside Kubernetes: starting leader election.")
-		// gravity site leader election
-		if err := p.startElection(); err != nil {
-			return trace.Wrap(err)
-		}
 
 		if err := p.initClusterCertificate(client); err != nil {
 			return trace.Wrap(err)
@@ -1173,6 +1169,9 @@ func (p *Process) initService() (err error) {
 			return trace.Wrap(err)
 		}
 
+		if err := p.startElection(); err != nil {
+			return trace.Wrap(err)
+		}
 	} else {
 		p.Debug("Not running inside Kubernetes.")
 	}

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -235,6 +235,7 @@ type message struct {
 	Message string `json:"message"`
 }
 
+// ConvertEC2Error converts error from AWS EC2 API to appropriate trace error.
 func ConvertEC2Error(err error) error {
 	if err == nil {
 		return nil
@@ -243,7 +244,13 @@ func ConvertEC2Error(err error) error {
 	if !ok {
 		return err
 	}
+	// For some reason, AWS Go SDK does not define constants for EC2 error
+	// codes so we're using strings here.
 	switch awsErr.Code() {
+	case "InvalidInstanceID.NotFound":
+		return trace.NotFound(awsErr.Message())
+	case "InvalidInstanceID.Malformed":
+		return trace.BadParameter(awsErr.Message())
 	}
 	return err
 }

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -235,6 +235,19 @@ type message struct {
 	Message string `json:"message"`
 }
 
+func ConvertEC2Error(err error) error {
+	if err == nil {
+		return nil
+	}
+	awsErr, ok := err.(awserr.Error)
+	if !ok {
+		return err
+	}
+	switch awsErr.Code() {
+	}
+	return err
+}
+
 // ConvertS3Error converts an error from AWS S3 API to an appropriate trace error
 func ConvertS3Error(err error) error {
 	if err == nil {


### PR DESCRIPTION
This PR implements a number of improvements for shrink operation:

* In ASG use-case, wait for the instance to terminate before launching shrink. Closes https://github.com/gravitational/gravity.e/issues/3992.
* Make sure that only gravity-site leader monitors ASG events. Previously all of them monitored it which caused multiple shrink operation to start.
* Backport https://github.com/gravitational/gravity/pull/301 to prevent shrink from running commands on the leaving node.