### PR TITLE
Add 5.5.1 changelog.

### DIFF
--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -7,7 +7,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 5.5.0         | Yes | March 8th, 2019      | March 7th, 2020      | 1.13.4             | 3.0.4            |
+| 5.5.1         | Yes | March 19th, 2019     | March 7th, 2020      | 1.13.4             | 3.0.4            |
 | 5.4.9         | No  | March 12th, 2019     | -                    | 1.13.4             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7
 | 5.2.11        | Yes | March 7th, 2019      | October, 15th, 2019  | 1.11.8             | 2.4.10           |
@@ -28,6 +28,16 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     do not receive updates and bugfixes.
 
 ## 5.x Releases
+
+### 5.1.1 LTS
+
+#### Improvements
+
+* Improve shrink operation behavior when using Auto-Scaling Groups on AWS.
+
+#### Bugfixes
+
+* Fix an issue with `gravity report` sometimes producing unreadable tarball.
 
 ### 5.4.9
 


### PR DESCRIPTION
@a-palchikov I wasn't sure if https://github.com/gravitational/gravity.e/issues/3986 was worth mentioning in the changelog, or the best way to describe it in customer-friendly terms. Lmk if you think it should be included.