### PR TITLE
bump kubernetes on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ GRAVITY_PKG_PATH ?= github.com/gravitational/gravity
 ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
-# Current Kubernetes version: 1.13.4
-K8S_VER := 1.13.4
+# Current Kubernetes version: 1.13.5
+K8S_VER := 1.13.5
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
@@ -42,7 +42,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.1.8
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 5.5.13-$(K8S_VER_SUFFIX)
+PLANET_TAG := 5.6.0-$(K8S_VER_SUFFIX)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)


### PR DESCRIPTION
This is mainly to prevent regressions by ensuring the master branch is up to date. For now I've called the planet release 5.6.0 for tracking master.