### PR TITLE
Update vendored teleport.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -886,7 +886,7 @@
 
 [[projects]]
   branch = "branch/3.1-g"
-  digest = "1:396ba9a929b4815908eebac658a1b664c9b5df51bd125457463da92392fcaa49"
+  digest = "1:91032510f5e373a7b231cfb2836f14bb33e57447f215c007d79375b087acc41d"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -942,7 +942,7 @@
     "lib/web/ui",
   ]
   pruneopts = "UT"
-  revision = "90cc9daaee0584f9a4480a0474e302b0e2e52cb5"
+  revision = "d5d895c26d6c9d2520d2a35bcc83f248f00a279b"
 
 [[projects]]
   digest = "1:22c8951489f0e27ec3b2d50d9f74086ff3f08554ce5965d418d6a10296b9ea04"

--- a/vendor/github.com/gravitational/teleport/lib/auth/init.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/init.go
@@ -421,6 +421,10 @@ func migrateLegacyResources(cfg InitConfig, asrv *AuthServer) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	err = migrateRoleRules(asrv)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -503,6 +507,60 @@ func migrateAdminRole(asrv *AuthServer) error {
 	log.Infof("Migrating default admin role, adding default kubernetes groups.")
 	role.SetKubeGroups(services.Allow, defaultRole.GetKubeGroups(services.Allow))
 	return asrv.UpsertRole(role, backend.Forever)
+}
+
+// migrateRoleRules adds missing permissions to roles.
+//
+// Currently it adds read-only permissions for audit events to all roles that
+// have read-only session permissions to make sure audit log tab will work.
+func migrateRoleRules(asrv *AuthServer) error {
+	roles, err := asrv.GetRoles()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, role := range roles {
+		allowRules := role.GetRules(services.Allow)
+		denyRules := role.GetRules(services.Deny)
+		// First make sure access to events hasn't been explicitly denied.
+		if checkRules(denyRules, services.KindEvent, services.RO()) {
+			log.Debugf("Role %q explicitly denies events access.", role.GetName())
+			continue
+		}
+		// Next see if the role already has access to events.
+		if checkRules(allowRules, services.KindEvent, services.RO()) {
+			log.Debugf("Role %q already has events access.", role.GetName())
+			continue
+		}
+		// See if the role has access to sessions.
+		if !checkRules(allowRules, services.KindSession, services.RO()) {
+			log.Debugf("Role %q does not have sessions access.", role.GetName())
+			continue
+		}
+		// If we got here, the role does not yet have events access and
+		// has session access so add a rule for events as well.
+		log.Infof("Adding events access to role %q.", role.GetName())
+		allowRules = append(allowRules, services.NewRule(services.KindEvent, services.RO()))
+		role.SetRules(services.Allow, allowRules)
+		err := asrv.UpsertRole(role, backend.Forever)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// checkRules returns true if any of the provided rules contain specified resource/verbs.
+func checkRules(rules []services.Rule, kind string, verbs []string) bool {
+	for _, rule := range rules {
+		if rule.HasResource(kind) || rule.HasResource(services.Wildcard) {
+			for _, verb := range verbs {
+				if rule.HasVerb(verb) || rule.HasVerb(services.Wildcard) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // isFirstStart returns 'true' if the auth server is starting for the 1st time

--- a/vendor/github.com/gravitational/teleport/lib/services/role.go
+++ b/vendor/github.com/gravitational/teleport/lib/services/role.go
@@ -44,6 +44,7 @@ var AdminUserRules = []Rule{
 	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
+	NewRule(KindEvent, RO()),
 }
 
 // DefaultImplicitRules provides access to the default set of implicit rules
@@ -859,6 +860,16 @@ func (r *Rule) ProcessActions(parser predicate.Parser) error {
 		fn()
 	}
 	return nil
+}
+
+// HasResource returns true if the rule has the specified resource.
+func (r *Rule) HasResource(resource string) bool {
+	for _, r := range r.Resources {
+		if r == resource {
+			return true
+		}
+	}
+	return false
 }
 
 // HasVerb returns true if the rule has verb,

--- a/vendor/github.com/gravitational/teleport/lib/web/apiserver.go
+++ b/vendor/github.com/gravitational/teleport/lib/web/apiserver.go
@@ -184,7 +184,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid", h.WithClusterAuth(h.siteSessionGet))  // get active session metadata
 
 	// recorded sessions handlers
-	h.GET("/webapi/sites/:site/events", h.WithClusterAuth(h.siteEventsGet))                                            // get recorded list of sessions (from events)
+	h.GET("/webapi/sites/:site/events", h.WithClusterAuth(h.clusterSearchSessionEvents))                               // get recorded list of sessions (from events)
+	h.GET("/webapi/sites/:site/events/search", h.WithClusterAuth(h.clusterSearchEvents))                               // search site events
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid/events", h.WithClusterAuth(h.siteSessionEventsGet)) // get recorded session's timing information (from events)
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid/stream", h.siteSessionStreamGet)                    // get recorded session's bytes (from events)
 
@@ -1506,7 +1507,7 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 
 const maxStreamBytes = 5 * 1024 * 1024
 
-// siteEventsGet allows to search for events on site
+// clusterSearchSessionEvents allows to search for session events on a cluster
 //
 // GET /v1/webapi/sites/:site/events
 //
@@ -1517,7 +1518,7 @@ const maxStreamBytes = 5 * 1024 * 1024
 //             the default backend performs exact search: ?key=value means "event
 //             with a field 'key' with value 'value'
 //
-func (h *Handler) siteEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	query := r.URL.Query()
 
 	clt, err := ctx.GetUserClient(site)
@@ -1551,6 +1552,78 @@ func (h *Handler) siteEventsGet(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.Wrap(err)
 	}
 	return eventsListGetResponse{Events: el}, nil
+}
+
+// clusterSearchEvents returns all audit log events matching the provided criteria
+//
+// GET /v1/webapi/sites/:site/events/search
+//
+// Query parameters:
+//   "from"   : date range from, encoded as RFC3339
+//   "to"     : date range to, encoded as RFC3339
+//   "include": optional semicolon-separated list of event names to return e.g.
+//              include=session.start;session.end, all are returned if empty
+//   "limit"  : optional maximum number of events to return
+//
+func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	values := r.URL.Query()
+	from, err := queryTime(values, "from", time.Now().UTC().AddDate(0, -1, 0))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	to, err := queryTime(values, "to", time.Now().UTC())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	limit, err := queryLimit(values, "limit", defaults.EventsIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	query := url.Values{}
+	if include := values.Get("include"); include != "" {
+		query[events.EventType] = strings.Split(include, ";")
+	}
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	events, err := clt.SearchEvents(from, to, query.Encode(), limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return eventsListGetResponse{Events: events}, nil
+}
+
+// queryTime parses the query string parameter with the specified name as a
+// RFC3339 time and returns it.
+//
+// If there's no such parameter, specified default value is returned.
+func queryTime(query url.Values, name string, def time.Time) (time.Time, error) {
+	str := query.Get(name)
+	if str == "" {
+		return def, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return time.Time{}, trace.BadParameter("failed to parse %v as RFC3339 time: %v", name, str)
+	}
+	return parsed, nil
+}
+
+// queryLimit returns the limit parameter with the specified name from the
+// query string.
+//
+// If there's no such parameter, specified default limit is returned.
+func queryLimit(query url.Values, name string, def int) (int, error) {
+	str := query.Get(name)
+	if str == "" {
+		return def, nil
+	}
+	limit, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, trace.BadParameter("failed to parse %v as limit: %v", name, str)
+	}
+	return limit, nil
 }
 
 type siteSessionStreamGetResponse struct {


### PR DESCRIPTION
This is to include a new Teleport's new web API method for searching audit events implemented in https://github.com/gravitational/teleport/pull/2632. Closes https://github.com/gravitational/gravity.e/issues/4019.