### PR TITLE
Update webapi for new dashboard.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -225,8 +225,10 @@ const (
 	// SystemLogDir is the directory where gravity logs go
 	SystemLogDir = "/var/log"
 
-	// TelekubePackage is the Telekube application package name
+	// TelekubePackage is the Telekube cluster image name.
 	TelekubePackage = "telekube"
+	// OpsCenterPackage is the Ops Center cluster image name.
+	OpsCenterPackage = "opscenter"
 
 	// EnvironmentPath is the path to the environment file
 	EnvironmentPath = "/etc/environment"

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -202,6 +202,14 @@ func (o *OperatorACL) CreateUser(req NewUserRequest) error {
 	return o.operator.CreateUser(req)
 }
 
+// UpdateUser updates the specified user information.
+func (o *OperatorACL) UpdateUser(ctx context.Context, req UpdateUserRequest) error {
+	if err := o.Action(teleservices.KindUser, teleservices.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	return o.operator.UpdateUser(ctx, req)
+}
+
 func (o *OperatorACL) DeleteLocalUser(name string) error {
 	if err := o.Action(teleservices.KindUser, teleservices.VerbDelete); err != nil {
 		return trace.Wrap(err)
@@ -1062,4 +1070,36 @@ func (o *OperatorACL) EmitAuditEvent(ctx context.Context, req AuditEventRequest)
 		return trace.Wrap(err)
 	}
 	return o.operator.EmitAuditEvent(ctx, req)
+}
+
+// CreateUserInvite creates a new invite token for a user.
+func (o *OperatorACL) CreateUserInvite(ctx context.Context, req CreateUserInviteRequest) (*storage.UserToken, error) {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return o.operator.CreateUserInvite(ctx, req)
+}
+
+// GetUserInvites returns all active user invites.
+func (o *OperatorACL) GetUserInvites(ctx context.Context, key SiteKey) ([]storage.UserInvite, error) {
+	if err := o.ClusterAction(key.SiteDomain, storage.KindInvite, teleservices.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return o.operator.GetUserInvites(ctx, key)
+}
+
+// DeleteUserInvite deletes the specified user invite.
+func (o *OperatorACL) DeleteUserInvite(ctx context.Context, req DeleteUserInviteRequest) error {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbDelete); err != nil {
+		return trace.Wrap(err)
+	}
+	return o.operator.DeleteUserInvite(ctx, req)
+}
+
+// CreateUserReset creates a new reset token for a user.
+func (o *OperatorACL) CreateUserReset(ctx context.Context, req CreateUserResetRequest) (*storage.UserToken, error) {
+	if err := o.Action(teleservices.KindUser, teleservices.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return o.operator.CreateUserReset(ctx, req)
 }

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/roundtrip"
 	telehttplib "github.com/gravitational/teleport/lib/httplib"
 	teleservices "github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
@@ -65,8 +64,6 @@ type WebHandlerConfig struct {
 	Authenticator httplib.Authenticator
 	// Devmode is whether the process is started in dev mode
 	Devmode bool
-	// PublicAdvertiseAddr is the process public advertise address
-	PublicAdvertiseAddr utils.NetAddr
 }
 
 type WebHandler struct {
@@ -103,6 +100,7 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 
 	// Applications API
 	h.GET("/portal/v1/apps", h.needsAuth(h.getApps))
+	h.GET("/portal/v1/gravity", h.needsAuth(h.getGravity))
 
 	// Accounts API
 	h.POST("/portal/v1/accounts", h.needsAuth(h.createAccount))
@@ -114,15 +112,20 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 	h.GET("/portal/v1/currentuserinfo", h.needsAuth(h.getCurrentUserInfo))
 	h.POST("/portal/v1/users", h.needsAuth(h.createUser))
 	h.DELETE("/portal/v1/users/:user_email", h.needsAuth(h.deleteLocalUser))
+	h.PUT("/portal/v1/accounts/:account_id/sites/:site_domain/users/:user_email", h.needsAuth(h.updateUser))
 
 	// API keys API
 	h.POST("/portal/v1/apikeys/user/:user_email", h.needsAuth(h.createAPIKey))
 	h.GET("/portal/v1/apikeys/user/:user_email", h.needsAuth(h.getAPIKeys))
 	h.DELETE("/portal/v1/apikeys/user/:user_email/:api_key", h.needsAuth(h.deleteAPIKey))
 
-	// Tokens
+	// Invites API
+	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/userinvites", h.needsAuth(h.createUserInvite))
+	h.GET("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/userinvites", h.needsAuth(h.getUserInvites))
+	h.DELETE("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/userinvites/:name", h.needsAuth(h.deleteUserInvite))
+
+	// Tokens API
 	h.POST("/portal/v1/tokens/install", h.needsAuth(h.createInstallToken))
-	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/userinvites", h.needsAuth(h.inviteUser))
 	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/userresets", h.needsAuth(h.resetUser))
 	h.POST("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/provision", h.needsAuth(h.createProvisioningToken))
 	h.GET("/portal/v1/accounts/:account_id/sites/:site_domain/tokens/expand", h.needsAuth(h.getExpandToken))
@@ -367,6 +370,30 @@ func (h *WebHandler) getApps(w http.ResponseWriter, r *http.Request, p httproute
 	return nil
 }
 
+/* getGravity exports the cluster's gravity binary.
+
+   GET /portal/v1/gravity
+*/
+func (h *WebHandler) getGravity(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
+	cluster, err := ctx.Operator.GetLocalSite()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	gravityPackage, err := cluster.App.Manifest.Dependencies.ByName(constants.GravityPackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, reader, err := h.cfg.Packages.ReadPackage(*gravityPackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer reader.Close()
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", "attachment; filename=gravity")
+	_, err = io.Copy(w, reader)
+	return trace.Wrap(err)
+}
+
 /*  inviteUser resets user credentials and returns a user token
 
     POST /portal/v1/accounts/:account_id/sites/:site_domain/usertokens/resets
@@ -376,58 +403,65 @@ func (h *WebHandler) resetUser(w http.ResponseWriter, r *http.Request, p httprou
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	var req ops.UserResetRequest
+	var req ops.CreateUserResetRequest
 	if err := json.Unmarshal(data, &req); err != nil {
 		return trace.BadParameter(err.Error())
 	}
-
-	userToken, err := ctx.Identity.CreateResetToken(
-		fmt.Sprintf("https://%v", h.cfg.PublicAdvertiseAddr.String()),
-		req.Name,
-		req.TTL)
+	resetToken, err := ctx.Operator.CreateUserReset(r.Context(), req)
 	if err != nil {
-		log.Debugf("User reset error: %v.", err)
 		return trace.Wrap(err)
 	}
-
-	roundtrip.ReplyJSON(w, http.StatusOK, userToken)
+	roundtrip.ReplyJSON(w, http.StatusOK, resetToken)
 	return nil
 }
 
-/*  inviteUser creates a user invite and returns user token
+/*  createUserInvite creates a new invite token for a user.
 
     POST /portal/v1/accounts/:account_id/sites/:site_domain/usertokens/invites
 */
-func (h *WebHandler) inviteUser(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
+func (h *WebHandler) createUserInvite(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	var req ops.UserInviteRequest
+	var req ops.CreateUserInviteRequest
 	if err := json.Unmarshal(data, &req); err != nil {
 		return trace.BadParameter(err.Error())
 	}
-
-	invite := storage.UserInvite{
-		CreatedBy: ctx.User.GetName(),
-		Name:      req.Name,
-		Roles:     req.Roles,
-		ExpiresIn: req.TTL,
-	}
-
-	advertiseURL := fmt.Sprintf("https://%v", h.cfg.PublicAdvertiseAddr.String())
-	userToken, err := ctx.Identity.CreateInviteToken(advertiseURL, invite)
+	inviteToken, err := ctx.Operator.CreateUserInvite(r.Context(), req)
 	if err != nil {
-		log.Debugf("User invite error: %v.", err)
 		return trace.Wrap(err)
 	}
+	roundtrip.ReplyJSON(w, http.StatusOK, inviteToken)
+	return nil
+}
 
-	events.Emit(r.Context(), ctx.Operator, events.InviteCreated, events.Fields{
-		events.FieldName:  req.Name,
-		events.FieldRoles: req.Roles,
+/*  getUserInvites returns all active user invites.
+
+    GET /portal/v1/accounts/:account_id/sites/:site_domain/usertokens/invites
+*/
+func (h *WebHandler) getUserInvites(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
+	invites, err := ctx.Operator.GetUserInvites(r.Context(), siteKey(p))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, invites)
+	return nil
+}
+
+/*  deleteUserInvite deletes the specified user invite.
+
+    DELETE /portal/v1/accounts/:account_id/sites/:site_domain/usertokens/invites/:name
+*/
+func (h *WebHandler) deleteUserInvite(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
+	err := ctx.Operator.DeleteUserInvite(r.Context(), ops.DeleteUserInviteRequest{
+		SiteKey: siteKey(p),
+		Name:    p.ByName("name"),
 	})
-
-	roundtrip.ReplyJSON(w, http.StatusOK, userToken)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, statusOK("invite deleted"))
 	return nil
 }
 
@@ -568,6 +602,22 @@ func (h *WebHandler) createUser(w http.ResponseWriter, r *http.Request, p httpro
 		return trace.Wrap(err)
 	}
 	roundtrip.ReplyJSON(w, http.StatusOK, statusOK("user created"))
+	return nil
+}
+
+/* updateUser updates the specified user information.
+
+   PUT /portal/v1/accounts/:account_id/sites/:site_domain/users/:user_email
+*/
+func (h *WebHandler) updateUser(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
+	var req ops.UpdateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return trace.BadParameter(err.Error())
+	}
+	if err := context.Operator.UpdateUser(r.Context(), req); err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, statusOK("user updated"))
 	return nil
 }
 

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -100,7 +100,7 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 
 	// Applications API
 	h.GET("/portal/v1/apps", h.needsAuth(h.getApps))
-	h.GET("/portal/v1/gravity", h.needsAuth(h.getGravity))
+	h.GET("/portal/v1/gravity", h.needsAuth(h.getGravityBinary))
 
 	// Accounts API
 	h.POST("/portal/v1/accounts", h.needsAuth(h.createAccount))
@@ -370,11 +370,11 @@ func (h *WebHandler) getApps(w http.ResponseWriter, r *http.Request, p httproute
 	return nil
 }
 
-/* getGravity exports the cluster's gravity binary.
+/* getGravityBinary exports the cluster's gravity binary.
 
    GET /portal/v1/gravity
 */
-func (h *WebHandler) getGravity(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
+func (h *WebHandler) getGravityBinary(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
 	cluster, err := ctx.Operator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -145,6 +145,15 @@ func (r *Router) CreateUser(req ops.NewUserRequest) error {
 	return r.Local.CreateUser(req)
 }
 
+// UpdateUser updates the specified user information.
+func (r *Router) UpdateUser(ctx context.Context, req ops.UpdateUserRequest) error {
+	client, err := r.PickClient(req.SiteDomain)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return client.UpdateUser(ctx, req)
+}
+
 func (r *Router) DeleteLocalUser(name string) error {
 	return r.Local.DeleteLocalUser(name)
 }
@@ -894,4 +903,40 @@ func (r *Router) ListReleases(key ops.SiteKey) ([]storage.Release, error) {
 // EmitAuditEvent saves the provided event in the audit log.
 func (r *Router) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) error {
 	return r.Local.EmitAuditEvent(ctx, req)
+}
+
+// CreateUserInvite creates a new invite token for a user.
+func (r *Router) CreateUserInvite(ctx context.Context, req ops.CreateUserInviteRequest) (*storage.UserToken, error) {
+	client, err := r.PickClient(req.SiteDomain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return client.CreateUserInvite(ctx, req)
+}
+
+// GetUserInvites returns all active user invites.
+func (r *Router) GetUserInvites(ctx context.Context, key ops.SiteKey) ([]storage.UserInvite, error) {
+	client, err := r.PickClient(key.SiteDomain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return client.GetUserInvites(ctx, key)
+}
+
+// DeleteUserInvite deletes the specified user invite.
+func (r *Router) DeleteUserInvite(ctx context.Context, req ops.DeleteUserInviteRequest) error {
+	client, err := r.PickClient(req.SiteDomain)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return client.DeleteUserInvite(ctx, req)
+}
+
+// CreateUserInvite creates a new reset token for a user.
+func (r *Router) CreateUserReset(ctx context.Context, req ops.CreateUserResetRequest) (*storage.UserToken, error) {
+	client, err := r.PickClient(req.SiteDomain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return client.CreateUserReset(ctx, req)
 }

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	teleservices "github.com/gravitational/teleport/lib/services"
+	teleutils "github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	"github.com/mailgun/timetools"
 	log "github.com/sirupsen/logrus"
@@ -115,6 +116,9 @@ type Config struct {
 
 	// ProcessID uniquely identifies gravity process
 	ProcessID string
+
+	// PublicAddr is the operator service public advertise address
+	PublicAddr teleutils.NetAddr
 
 	// InstallLogFiles is a list of additional install log files
 	// to add to install and expand operations for local troubleshooting
@@ -284,6 +288,10 @@ func (o *Operator) users() users.Identity {
 
 func (o *Operator) clock() timetools.TimeProvider {
 	return o.cfg.Clock
+}
+
+func (o *Operator) publicURL() string {
+	return fmt.Sprintf("https://" + o.cfg.PublicAddr.String())
 }
 
 func (o *Operator) GetAccount(accountID string) (*ops.Account, error) {

--- a/lib/ops/opsservice/users.go
+++ b/lib/ops/opsservice/users.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/events"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/trace"
+)
+
+// UpdateUser updates the specified user information.
+func (o *Operator) UpdateUser(ctx context.Context, req ops.UpdateUserRequest) error {
+	err := req.Check()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = o.users().UpdateUser(req.Name, storage.UpdateUserReq{
+		FullName: &req.FullName,
+		Roles:    &req.Roles,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// CreateUserInvite creates a new invite token for a user.
+func (o *Operator) CreateUserInvite(ctx context.Context, req ops.CreateUserInviteRequest) (*storage.UserToken, error) {
+	err := req.Check()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	invite, err := o.users().CreateInviteToken(o.publicURL(), storage.UserInvite{
+		Name:      req.Name,
+		CreatedBy: storage.UserFromContext(ctx),
+		Roles:     req.Roles,
+		ExpiresIn: req.TTL,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	events.Emit(ctx, o, events.InviteCreated, events.Fields{
+		events.FieldName:  req.Name,
+		events.FieldRoles: req.Roles,
+	})
+	return invite, nil
+}
+
+// CreateUserReset creates a new reset token for a user.
+func (o *Operator) CreateUserReset(ctx context.Context, req ops.CreateUserResetRequest) (*storage.UserToken, error) {
+	err := req.Check()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	reset, err := o.users().CreateResetToken(o.publicURL(), req.Name, req.TTL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return reset, nil
+}
+
+// GetUserInvites returns all active user invites.
+func (o *Operator) GetUserInvites(ctx context.Context, key ops.SiteKey) ([]storage.UserInvite, error) {
+	invites, err := o.users().GetUserInvites(key.AccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return invites, nil
+}
+
+// DeleteUserInvite deletes the specified user invite.
+func (o *Operator) DeleteUserInvite(ctx context.Context, req ops.DeleteUserInviteRequest) error {
+	err := req.Check()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = o.users().DeleteUserInvite(req.AccountID, req.Name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -1208,6 +1208,7 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		SNIHost:         seedConfig.SNIHost,
 		SeedConfig:      *seedConfig,
 		ProcessID:       p.id,
+		PublicAddr:      p.cfg.Pack.GetPublicAddr(),
 		InstallLogFiles: p.cfg.InstallLogFiles,
 		LogForwarders:   logs,
 		AuditLog:        authClient,
@@ -1238,13 +1239,12 @@ func (p *Process) initService(ctx context.Context) (err error) {
 	}
 
 	p.handlers.Operator, err = opshandler.NewWebHandler(opshandler.WebHandlerConfig{
-		Users:               p.identity,
-		Operator:            p.operator,
-		Applications:        applications,
-		Packages:            p.packages,
-		Authenticator:       p.handlers.WebProxy.GetHandler().AuthenticateRequest,
-		Backend:             p.backend,
-		PublicAdvertiseAddr: p.cfg.Pack.GetPublicAddr(),
+		Users:         p.identity,
+		Operator:      p.operator,
+		Applications:  applications,
+		Packages:      p.packages,
+		Authenticator: p.handlers.WebProxy.GetHandler().AuthenticateRequest,
+		Backend:       p.backend,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -123,7 +123,8 @@ func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
 		return nil, trace.Wrap(err)
 	}
 	// Initially the local cluster name is set as a principal.
-	authGateway.SetPublicAddrs([]string{cluster.Domain})
+	authGateway.SetSSHPublicAddrs([]string{cluster.Domain})
+	authGateway.SetKubernetesPublicAddrs([]string{cluster.Domain})
 	err = opsservice.UpsertAuthGateway(client, p.identity, authGateway)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -71,6 +71,8 @@ const (
 	KindClusterConfiguration = "clusterconfiguration"
 	// KindRelease defines the application release resource type
 	KindRelease = "release"
+	// KindInvite defines the user invite token.
+	KindInvite = "invite"
 )
 
 // CanonicalKind translates the specified kind to canonical form.

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -101,6 +101,16 @@ func SplitHostPort(in, defaultPort string) (host string, port string) {
 	return parts[0], defaultPort
 }
 
+// EnsurePort makes sure that the provided address includes a port and adds
+// the specified default one if it does not.
+func EnsurePort(address, defaultPort string) string {
+	if _, _, err := net.SplitHostPort(address); err == nil {
+		return address
+	} else {
+		return net.JoinHostPort(address, defaultPort)
+	}
+}
+
 // Hosts returns a list of hosts from the provided host:port addresses
 func Hosts(addrs []string) (hosts []string) {
 	for _, addr := range addrs {

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -106,9 +106,8 @@ func SplitHostPort(in, defaultPort string) (host string, port string) {
 func EnsurePort(address, defaultPort string) string {
 	if _, _, err := net.SplitHostPort(address); err == nil {
 		return address
-	} else {
-		return net.JoinHostPort(address, defaultPort)
 	}
+	return net.JoinHostPort(address, defaultPort)
 }
 
 // Hosts returns a list of hosts from the provided host:port addresses

--- a/lib/webapi/clusterinfo.go
+++ b/lib/webapi/clusterinfo.go
@@ -39,7 +39,7 @@ type webClusterInfo struct {
 	PublicURLs []string `json:"publicURL"`
 	// InternalURLs is a list of internal cluster management URLs.
 	InternalURLs []string `json:"internalURLs"`
-	// Commans contains various commands that can be run on the cluster.
+	// Commands contains various commands that can be run on the cluster.
 	Commands webClusterCommands `json:"commands"`
 }
 

--- a/lib/webapi/clusterinfo.go
+++ b/lib/webapi/clusterinfo.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webapi
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// webClusterInfo encapsulates basic information about cluster such as
+// management endpoints and status used by the control panel.
+type webClusterInfo struct {
+	// ClusterState is the current cluster state.
+	ClusterState string `json:"clusterState"`
+	// PublicURLs is the advertised public cluster URLs set via auth gateway resource.
+	PublicURLs []string `json:"publicURL"`
+	// InternalURLs is a list of internal cluster management URLs.
+	InternalURLs []string `json:"internalURLs"`
+	// Commans contains various commands that can be run on the cluster.
+	Commands webClusterCommands `json:"commands"`
+}
+
+// webClusterCommands contains commands displayed to a user for cluster
+// expansion, remote access and so on.
+type webClusterCommands struct {
+	// TshLogin contains tsh login command.
+	TshLogin string `json:"tshLogin"`
+	// GravityDownload contains command to download gravity binary.
+	GravityDownload string `json:"gravityDownload"`
+	// GravityJoin contains gravity join commands for each node profile.
+	GravityJoin map[string]string `json:"gravityJoin"`
+}
+
+// getClusterInfo collects information for the specified cluster.
+func getClusterInfo(operator ops.Operator, cluster ops.Site) (*webClusterInfo, error) {
+	authGateway, err := operator.GetAuthGateway(cluster.Key())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	masterNode, err := cluster.FirstMaster()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var internalAddrs []string
+	for _, node := range cluster.Masters() {
+		internalAddrs = append(internalAddrs, fmt.Sprintf("%v:%v",
+			node.AdvertiseIP, defaults.GravitySiteNodePort))
+	}
+	var publicAddrs []string
+	for _, webAddr := range authGateway.GetWebPublicAddrs() {
+		publicAddrs = append(publicAddrs, utils.EnsurePort(
+			webAddr, defaults.HTTPSPort))
+	}
+	var proxyAddr string
+	if len(publicAddrs) != 0 {
+		proxyAddr = publicAddrs[0]
+	} else {
+		proxyAddr = internalAddrs[0]
+	}
+	tshLoginCommand, err := renderCommand(tshLoginTpl, map[string]string{
+		"proxyAddr": proxyAddr,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	joinToken, err := operator.GetExpandToken(cluster.Key())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	gravityDownloadCommand, err := renderCommand(gravityDownloadTpl, map[string]string{
+		"node":  masterNode.AdvertiseIP,
+		"port":  strconv.Itoa(defaults.GravitySiteNodePort),
+		"token": joinToken.Token,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	gravityJoinCommands := make(map[string]string)
+	for _, profile := range cluster.App.Manifest.NodeProfiles {
+		gravityJoinCommands[profile.Name], err = renderCommand(gravityJoinTpl, map[string]string{
+			"node":  masterNode.AdvertiseIP,
+			"token": joinToken.Token,
+			"role":  profile.Name,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return &webClusterInfo{
+		ClusterState: cluster.State,
+		PublicURLs:   makeURLs(publicAddrs),
+		InternalURLs: makeURLs(internalAddrs),
+		Commands: webClusterCommands{
+			TshLogin:        tshLoginCommand,
+			GravityDownload: gravityDownloadCommand,
+			GravityJoin:     gravityJoinCommands,
+		},
+	}, nil
+}
+
+// renderCommand returns the rendered command based on provided template and parameters.
+func renderCommand(tpl *template.Template, params map[string]string) (string, error) {
+	var b bytes.Buffer
+	if err := tpl.Execute(&b, params); err != nil {
+		return "", trace.Wrap(err)
+	}
+	return b.String(), nil
+}
+
+// makeURLs converts provided addresses into URLs.
+func makeURLs(addrs []string) (urls []string) {
+	for _, addr := range addrs {
+		if !strings.HasPrefix(addr, "https://") {
+			urls = append(urls, fmt.Sprintf("https://%v", addr))
+		} else {
+			urls = append(urls, addr)
+		}
+	}
+	return urls
+}
+
+var (
+	// gravityJoinTpl is the gravity join command template.
+	gravityJoinTpl = template.Must(template.New("join").Parse(
+		"gravity join {{.node}} --token={{.token}} --role={{.role}}"))
+	// gravityDownloadTpl is the gravity download command template.
+	gravityDownloadTpl = template.Must(template.New("gravity").Parse(
+		`curl -k -H "Authorization: Bearer {{.token}}" https://{{.node}}:{{.port}}/portal/v1/gravity -o gravity`))
+	// tshLoginTpl is the tsh login command template.
+	tshLoginTpl = template.Must(template.New("tsh").Parse(
+		"tsh login --proxy={{.proxyAddr}}"))
+)

--- a/tool/gravity/cli/user.go
+++ b/tool/gravity/cli/user.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -126,18 +127,17 @@ func resetUser(env *localenv.LocalEnvironment, email string, ttl time.Duration) 
 		return trace.Wrap(err)
 	}
 
-	req := ops.UserResetRequest{
-		Name: email,
-		TTL:  ttl,
-	}
-
-	userToken, err := operator.ResetUser(cluster.Key(), req)
+	resetToken, err := operator.CreateUserReset(context.TODO(), ops.CreateUserResetRequest{
+		SiteKey: cluster.Key(),
+		Name:    email,
+		TTL:     ttl,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	fmt.Printf("Password reset token has been created and is valid for %v. Share this URL with the user:\n%v\n\nNOTE: make sure this URL is accessible!\n",
-		ttl.String(), userToken.URL)
+		ttl.String(), resetToken.URL)
 
 	return nil
 }
@@ -153,20 +153,18 @@ func inviteUser(env *localenv.LocalEnvironment, username string, roles []string,
 		return trace.Wrap(err)
 	}
 
-	roles = utils.FlattenStringSlice(roles)
-	req := ops.UserInviteRequest{
-		Name:  username,
-		Roles: roles,
-		TTL:   ttl,
-	}
-
-	userToken, err := operator.InviteUser(cluster.Key(), req)
+	inviteToken, err := operator.CreateUserInvite(context.TODO(), ops.CreateUserInviteRequest{
+		SiteKey: cluster.Key(),
+		Name:    username,
+		Roles:   utils.FlattenStringSlice(roles),
+		TTL:     ttl,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	fmt.Printf("Signup token has been created and is valid for %v hours. Share this URL with the user:\n%v\n\nNOTE: make sure this URL is accessible!\n",
-		ttl.String(), userToken.URL)
+		ttl.String(), inviteToken.URL)
 
 	return nil
 }


### PR DESCRIPTION
This PR implements a few changes in web API needed to power the new dashboard:

* Add a new "cluster info" web API method that returns basic cluster information such as public/internal endpoints.
* The bulk of the changes is making handlers that previously always used local cluster services (such as update user, create invite, etc.) to be routed to remote clusters when necessary. This required adding those methods to the operator service so router can be used. Note: I kept old web handlers for compatibility so current UI continues to work, will remove them once we're fully migrated to the new UI.
* Other minor things, such as including user's "bundle" in a list of application releases so it is displayed in the table with other apps too.

Closes https://github.com/gravitational/gravity.e/issues/4039, closes https://github.com/gravitational/gravity.e/issues/4040.