### PR TITLE
Web API updates.

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -1048,7 +1048,7 @@ func (o *OperatorACL) GetAuthGateway(key SiteKey) (storage.AuthGateway, error) {
 }
 
 // ListReleases returns all currently installed application releases in a cluster.
-func (o *OperatorACL) ListReleases(key SiteKey) ([]storage.Release, error) {
+func (o *OperatorACL) ListReleases(req ListReleasesRequest) ([]storage.Release, error) {
 	// TODO: Ideally this method would filter out releases a user does not
 	// have access to, however Teleport's resources support only a single
 	// namespace (default) for now so it is impossible to, for example,
@@ -1058,10 +1058,10 @@ func (o *OperatorACL) ListReleases(key SiteKey) ([]storage.Release, error) {
 	// Hence, we're returning all releases based on the broader "cluster"
 	// permission here but in the future, when Teleport starts respecting
 	// namespaces, it might be worth implementing a more granular ACL.
-	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.ListReleases(key)
+	return o.operator.ListReleases(req)
 }
 
 // EmitAuditEvent saves the provided event in the audit log.

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1021,7 +1021,15 @@ type Applications interface {
 	// a binary data stream
 	GetAppInstaller(AppInstallerRequest) (io.ReadCloser, error)
 	// ListReleases returns all currently installed application releases in a cluster.
-	ListReleases(SiteKey) ([]storage.Release, error)
+	ListReleases(ListReleasesRequest) ([]storage.Release, error)
+}
+
+// ListReleasesRequest is a request to list installed application releases.
+type ListReleasesRequest struct {
+	// SiteKey is the cluster routing key.
+	SiteKey
+	// IncludeIcons is whether to retrieve application icons as well.
+	IncludeIcons bool `json:"include_icons"`
 }
 
 // AppInstallerRequest is a request to generate installer tarball.

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -1533,9 +1533,9 @@ func (c *Client) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
 }
 
 // ListReleases returns all currently installed application releases in a cluster.
-func (c *Client) ListReleases(key ops.SiteKey) ([]storage.Release, error) {
-	response, err := c.Get(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "releases"),
-		url.Values{})
+func (c *Client) ListReleases(req ops.ListReleasesRequest) ([]storage.Release, error) {
+	response, err := c.Get(c.Endpoint("accounts", req.AccountID, "sites", req.SiteDomain, "releases"),
+		url.Values{"include_icons": []string{strconv.FormatBool(req.IncludeIcons)}})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/resources.go
+++ b/lib/ops/opshandler/resources.go
@@ -20,12 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsclient"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/roundtrip"
 	telehttplib "github.com/gravitational/teleport/lib/httplib"
@@ -149,11 +149,9 @@ func (h *WebHandler) getReleases(w http.ResponseWriter, r *http.Request, p httpr
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	var includeIcons bool
-	if i := r.Form.Get("include_icons"); i != "" {
-		if includeIcons, err = strconv.ParseBool(i); err != nil {
-			return trace.Wrap(err)
-		}
+	includeIcons, err := utils.ParseBoolFlag(r, "include_icons", false)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	releases, err := ctx.Operator.ListReleases(ops.ListReleasesRequest{
 		SiteKey:      siteKey(p),

--- a/lib/ops/opshandler/resources.go
+++ b/lib/ops/opshandler/resources.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsclient"
 	"github.com/gravitational/gravity/lib/storage"
 
@@ -143,7 +145,20 @@ func (h *WebHandler) getAuthGateway(w http.ResponseWriter, r *http.Request, p ht
      []storage.Release
 */
 func (h *WebHandler) getReleases(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
-	releases, err := ctx.Operator.ListReleases(siteKey(p))
+	err := r.ParseForm()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var includeIcons bool
+	if i := r.Form.Get("include_icons"); i != "" {
+		if includeIcons, err = strconv.ParseBool(i); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	releases, err := ctx.Operator.ListReleases(ops.ListReleasesRequest{
+		SiteKey:      siteKey(p),
+		IncludeIcons: includeIcons,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -892,12 +892,12 @@ func (r *Router) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
 }
 
 // ListReleases returns all currently installed application releases in a cluster.
-func (r *Router) ListReleases(key ops.SiteKey) ([]storage.Release, error) {
-	client, err := r.PickClient(key.SiteDomain)
+func (r *Router) ListReleases(req ops.ListReleasesRequest) ([]storage.Release, error) {
+	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.ListReleases(key)
+	return client.ListReleases(req)
 }
 
 // EmitAuditEvent saves the provided event in the audit log.

--- a/lib/ops/opsservice/releases_test.go
+++ b/lib/ops/opsservice/releases_test.go
@@ -65,9 +65,11 @@ func (s *ReleasesSuite) TestListReleases(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Make sure they're returned.
-	releases, err := s.services.Operator.ListReleases(ops.SiteKey{
-		AccountID:  s.localCluster.AccountID,
-		SiteDomain: s.localCluster.Domain,
+	releases, err := s.services.Operator.ListReleases(ops.ListReleasesRequest{
+		SiteKey: ops.SiteKey{
+			AccountID:  s.localCluster.AccountID,
+			SiteDomain: s.localCluster.Domain,
+		},
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(releases, compare.DeepEquals, []storage.Release{release1, release2})

--- a/lib/storage/release.go
+++ b/lib/storage/release.go
@@ -39,6 +39,10 @@ type Release interface {
 	GetChartName() string
 	// GetChartVersion returns the deployed chart version.
 	GetChartVersion() string
+	// GetChartIcon returns the chart application icon.
+	GetChartIcon() string
+	// SetChartIcon sets the chart application icon.
+	SetChartIcon(string)
 	// GetChart returns the full chart name that includes version.
 	GetChart() string
 	// GetAppVersion returns the application version (may be empty).
@@ -99,6 +103,8 @@ type ReleaseSpecV1 struct {
 	ChartName string `json:"chart_name"`
 	// ChartVersion is the deployed chart version.
 	ChartVersion string `json:"chart_version"`
+	// ChartIcon is the chart application icon.
+	ChartIcon string `json:"chart_icon,omitempty"`
 	// AppVersion is the application version (may be empty).
 	AppVersion string `json:"app_version"`
 	// Namespace is the namespace where release is deployed.
@@ -127,6 +133,16 @@ func (r *ReleaseV1) GetChartName() string {
 // GetChartVersion returns the deployed chart version.
 func (r *ReleaseV1) GetChartVersion() string {
 	return r.Spec.ChartVersion
+}
+
+// GetChartIcon returns the chart application icon.
+func (r *ReleaseV1) GetChartIcon() string {
+	return r.Spec.ChartIcon
+}
+
+// SetChartIcon returns the chart application icon.
+func (r *ReleaseV1) SetChartIcon(val string) {
+	r.Spec.ChartIcon = val
 }
 
 // GetChart returns the full chart name that includes version.
@@ -240,6 +256,7 @@ var ReleaseV1Schema = fmt.Sprintf(`{
   "properties": {
     "chart_name": {"type": "string"},
     "chart_version": {"type": "string"},
+    "chart_icon": {"type": "string"},
     "app_version": {"type": "string"},
     "namespace": {"type": "string"}
   }

--- a/lib/storage/release.go
+++ b/lib/storage/release.go
@@ -140,7 +140,7 @@ func (r *ReleaseV1) GetChartIcon() string {
 	return r.Spec.ChartIcon
 }
 
-// SetChartIcon returns the chart application icon.
+// SetChartIcon sets the chart application icon.
 func (r *ReleaseV1) SetChartIcon(val string) {
 	r.Spec.ChartIcon = val
 }

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -468,4 +469,18 @@ func ParseProxyAddr(proxyAddr, defaultWebPort, defaultSSHPort string) (host stri
 	}
 
 	return "", "", "", trace.BadParameter("unable to parse port: %v", port)
+}
+
+// PasseBoolFlag extracts boolean parameter of the specified name from the
+// provided request's query string, or returns default.
+func ParseBoolFlag(r *http.Request, name string, def bool) (bool, error) {
+	sValue := r.URL.Query().Get(name)
+	if sValue == "" {
+		return def, nil
+	}
+	bValue, err := strconv.ParseBool(sValue)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return bValue, nil
 }

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -278,9 +278,6 @@ func NewAPI(cfg Config) (*Handler, error) {
 	h.GET("/apps/:repository/:package/:version", h.needsAuth(h.getAppPackage))
 	h.GET("/apps/:repository/:package/:version/installer", h.needsAuth(h.getAppInstaller))
 
-	// Releases
-	h.GET("/sites/:domain/releases", h.needsAuth(h.getReleases))
-
 	// User
 	h.GET("/user/context", h.needsAuth(h.getWebContext))
 	h.GET("/user/status", h.needsAuth(h.getUserStatus))
@@ -2125,29 +2122,6 @@ func (m *Handler) updateRetentionPolicy(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 	return httplib.OK(), nil
-}
-
-/* getReleases returns all application releases currently deployed in a cluster.
-
-     GET /portalapi/v1/sites/:domain/releases
-
-   Success response:
-
-     []webRelease
-*/
-func (m *Handler) getReleases(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	cluster, err := context.Operator.GetSite(ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	releases, err := getReleases(context.Operator, *cluster)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return releases, nil
 }
 
 func getReleases(operator ops.Operator, cluster ops.Site) ([]webRelease, error) {

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -248,9 +248,9 @@ func NewAPI(cfg Config) (*Handler, error) {
 	h.POST("/sites", h.needsAuth(h.createSite))
 	h.POST("/sites/:domain/expand", h.needsAuth(h.expandSite))
 	h.POST("/sites/:domain/shrink", h.needsAuth(h.shrinkSite))
-	h.GET("/sites/:domain", h.needsAuth(h.getSite))
 	h.GET("/sites/:domain/info", h.needsAuth(h.getClusterInfo))
-	h.GET("/sites", h.needsAuth(h.getSites))
+	h.GET("/sites", h.needsAuth(h.getClusters))
+	h.GET("/sites/:domain", h.needsAuth(h.getCluster))
 	h.GET("/sites/:domain/servers", h.needsAuth(h.getServers))
 	h.GET("/sites/:domain/report", h.needsAuth(h.getSiteReport))
 	h.PUT("/sites/:domain", h.needsAuth(h.updateSiteApp))
@@ -1298,33 +1298,36 @@ func (m *Handler) shrinkSite(w http.ResponseWriter, r *http.Request, p httproute
 	return siteShrinkOutput{Operation: *operation}, nil
 }
 
-// getSite retrieves details on the specified site
+// getCluster returns the specified cluster object.
 //
-// GET /portalapi/v1/sites/:domain
-//
-// Input: site_id
+//   GET /portalapi/v1/sites/:domain?shallow=(true|false)
 //
 // Output:
-// {
-//   "id": "344238abcd7"
-//   "created": "2016-05-14 13:00:05"
-//   "domain_name": "example.com"
-//   "account_id": "1ab238a8cd5"
-//   "state": "active"
-//   "provisioner": "aws_terraform"
-//   "app": {"package": "gravitational.io/test:1.0.0", "manifest": <...application manifest...>}
-// }
-func (m *Handler) getSite(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	siteDomain := p[0].Value
-	site, err := context.Operator.GetSite(ops.SiteKey{
-		SiteDomain: siteDomain,
-		AccountID:  context.User.GetAccountID(),
-	})
+//
+//   webCluster
+//
+// If 'shallow' flag is true, returns stripped down cluster objects that do
+// not include raw manifest data, icons and other verbose fields.
+func (m *Handler) getCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
+	shallow, err := getBoolFlag(r, "shallow", false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return site, nil
+	key, err := clusterKey(context, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cluster, err := context.Operator.GetSite(*key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	releases, err := getReleases(context.Operator, *cluster)
+	if err != nil {
+		m.Errorf("Failed to retrieve releases information for cluster %v: %v.",
+			cluster, trace.DebugReport(err))
+	}
+	webCluster := newWebCluster(*cluster, releases, shallow)
+	return &webCluster, nil
 }
 
 // getApps retrieves the list of site app's packages of all available versions
@@ -1520,29 +1523,80 @@ func readFile(r *http.Request, name string) ([]byte, error) {
 	return data, nil
 }
 
-// getSites retrieves details of all sites for the specified account
+// webCluster represents a UI cluster object.
+type webCluster struct {
+	// Site is the backend cluster object.
+	ops.Site
+	// Releases is a list of applications installed on the cluster.
+	Releases []webRelease `json:"releases"`
+}
+
+// newWebCluster makes a new web representation of a cluster.
+func newWebCluster(cluster ops.Site, releases []webRelease, shallow bool) webCluster {
+	webCluster := webCluster{Site: cluster, Releases: releases}
+	// If 'shallow' is true, return a stripped down copy of the cluster
+	// object with some of the fields set to empty values such as icons
+	// and manifest data.
+	//
+	// This significantly reduces amount of traffic b/w frontend and server and
+	// improves the web application performance.
+	if shallow {
+		webCluster.App = ops.Application{}
+		for i := range webCluster.Releases {
+			webCluster.Releases[i].ChartIcon = ""
+		}
+	}
+	return webCluster
+}
+
+// getBoolFlag extracts boolean parameter of the specified name from the
+// provided request's query string, or returns default.
+func getBoolFlag(r *http.Request, name string, def bool) (bool, error) {
+	sValue := r.URL.Query().Get(name)
+	if sValue == "" {
+		return def, nil
+	}
+	bValue, err := strconv.ParseBool(sValue)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return bValue, nil
+}
+
+// getClusters returns all registered clusters.
 //
-// GET /portalapi/v1/sites
+// TODO: This method should eventually go away as both Gravity and Teleport
+//       dashboards will be using the same Teleport's "get clusters" API that
+//       will be just returning extended objects for Gravity.
 //
-// Input: site_id
+//   GET /portalapi/v1/sites?shallow=(true|false)
 //
 // Output:
-// [{
-//   "id": "344238abcd7"
-//   "created": "2016-05-14 13:00:05"
-//   "domain_name": "example.com"
-//   "account_id": "1ab238a8cd5"
-//   "state": "active"
-//   "provisioner": "aws_terraform"
-//   "app": {"package": "gravitational.io/test:1.0.0", "manifest": <...application manifest...>}
-// }]
-func (m *Handler) getSites(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	sites, err := context.Operator.GetSites(context.User.GetAccountID())
+//
+//   []webCluster
+//
+// If 'shallow' flag is true, returns stripped down cluster objects that do
+// not include raw manifest data, icons and other verbose fields.
+func (m *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
+	shallow, err := getBoolFlag(r, "shallow", false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return sites, nil
+	clusters, err := context.Operator.GetSites(context.User.GetAccountID())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var webClusters []webCluster
+	for _, cluster := range clusters {
+		releases, err := getReleases(context.Operator, cluster)
+		if err != nil {
+			m.Errorf("Failed to retrieve releases information for cluster %v: %v.",
+				cluster, trace.DebugReport(err))
+		}
+		webClusters = append(webClusters, newWebCluster(
+			cluster, releases, shallow))
+	}
+	return webClusters, nil
 }
 
 type siteUpdateInput struct {
@@ -2089,31 +2143,38 @@ func (m *Handler) getReleases(w http.ResponseWriter, r *http.Request, p httprout
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	releases, err := context.Operator.ListReleases(cluster.Key())
+	releases, err := getReleases(context.Operator, *cluster)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return releases, nil
+}
+
+func getReleases(operator ops.Operator, cluster ops.Site) ([]webRelease, error) {
+	releases, err := operator.ListReleases(ops.ListReleasesRequest{
+		SiteKey:      cluster.Key(),
+		IncludeIcons: true,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	result := make([]webRelease, 0, len(releases))
 	for _, release := range releases {
-		app, err := context.Applications.GetApp(release.GetLocator())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		result = append(result, webRelease{
 			Name:         release.GetName(),
 			Namespace:    release.GetNamespace(),
 			Description:  release.GetMetadata().Description,
 			ChartName:    release.GetChartName(),
 			ChartVersion: release.GetChartVersion(),
+			ChartIcon:    release.GetChartIcon(),
 			AppVersion:   release.GetAppVersion(),
 			Status:       release.GetStatus(),
 			Updated:      release.GetUpdated(),
-			Icon:         app.Manifest.Logo,
 		})
 	}
 	// Prepend the user's bundle to the list of installed apps.
 	if !cluster.IsGravity() && !cluster.IsOpsCenter() {
-		endpoints, err := context.Operator.GetApplicationEndpoints(cluster.Key())
+		endpoints, err := operator.GetApplicationEndpoints(cluster.Key())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2121,9 +2182,9 @@ func (m *Handler) getReleases(w http.ResponseWriter, r *http.Request, p httprout
 			Description:  cluster.App.Manifest.Metadata.Description,
 			ChartName:    cluster.App.Manifest.Metadata.Name,
 			ChartVersion: cluster.App.Manifest.Metadata.ResourceVersion,
+			ChartIcon:    cluster.App.Manifest.Logo,
 			Status:       cluster.ReleaseStatus(),
 			Updated:      cluster.App.PackageEnvelope.Created,
-			Icon:         cluster.App.Manifest.Logo,
 			Endpoints:    endpoints,
 		}}, result...)
 	}
@@ -2142,14 +2203,14 @@ type webRelease struct {
 	ChartName string `json:"chartName"`
 	// ChartVersion is the version of the release chart.
 	ChartVersion string `json:"chartVersion"`
+	// ChartIcon is base64-encoded chart application icon.
+	ChartIcon string `json:"icon,omitempty"`
 	// AppVersion is the optional application version.
 	AppVersion string `json:"appVersion"`
 	// Status is the release status.
 	Status string `json:"status"`
 	// Updated is when the release was last updated.
 	Updated time.Time `json:"updated"`
-	// Icon is base64-encoded application icon.
-	Icon string `json:"icon,omitempty"`
 	// Endpoints contains the application endpoints.
 	Endpoints []ops.Endpoint `json:"endpoints,omitempty"`
 }

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1306,7 +1306,7 @@ func (m *Handler) shrinkSite(w http.ResponseWriter, r *http.Request, p httproute
 // If 'shallow' flag is true, returns stripped down cluster objects that do
 // not include raw manifest data, icons and other verbose fields.
 func (m *Handler) getCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	shallow, err := getBoolFlag(r, "shallow", false)
+	shallow, err := utils.ParseBoolFlag(r, "shallow", false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1546,20 +1546,6 @@ func newWebCluster(cluster ops.Site, releases []webRelease, shallow bool) webClu
 	return webCluster
 }
 
-// getBoolFlag extracts boolean parameter of the specified name from the
-// provided request's query string, or returns default.
-func getBoolFlag(r *http.Request, name string, def bool) (bool, error) {
-	sValue := r.URL.Query().Get(name)
-	if sValue == "" {
-		return def, nil
-	}
-	bValue, err := strconv.ParseBool(sValue)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	return bValue, nil
-}
-
 // getClusters returns all registered clusters.
 //
 // TODO: This method should eventually go away as both Gravity and Teleport
@@ -1575,7 +1561,7 @@ func getBoolFlag(r *http.Request, name string, def bool) (bool, error) {
 // If 'shallow' flag is true, returns stripped down cluster objects that do
 // not include raw manifest data, icons and other verbose fields.
 func (m *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	shallow, err := getBoolFlag(r, "shallow", false)
+	shallow, err := utils.ParseBoolFlag(r, "shallow", false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
A few updates to web API for the new dashboard:

* Return information about installed app releases in `/sites` and `/sites/<clustername>` handlers.
* Add `shallow` flag to the aforementioned methods which, if set to true, makes them return stripped down cluster objects which UI does not always need (saving traffic / increasing performance during polling).
* Remove standalone `/releases` web API method cause they are available as a part of web cluster object now.