### PR TITLE
Make resource controller cluster-aware.

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -942,16 +942,20 @@ func (o *OperatorACL) UpsertUser(ctx context.Context, key SiteKey, user teleserv
 
 // GetUser returns a user by name
 func (o *OperatorACL) GetUser(key SiteKey, name string) (teleservices.User, error) {
-	if err := o.currentUserActions(name, teleservices.VerbList, teleservices.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		if err := o.currentUserActions(name, teleservices.VerbList, teleservices.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.GetUser(key, name)
 }
 
 // GetUsers returns all users
 func (o *OperatorACL) GetUsers(key SiteKey) ([]teleservices.User, error) {
-	if err := o.userActions(teleservices.VerbList, teleservices.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		if err := o.userActions(teleservices.VerbList, teleservices.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.GetUsers(key)
 }
@@ -982,8 +986,10 @@ func (o *OperatorACL) GetClusterAuthPreference(key SiteKey) (teleservices.AuthPr
 
 // UpsertGithubConnector creates or updates a Github connector
 func (o *OperatorACL) UpsertGithubConnector(ctx context.Context, key SiteKey, connector teleservices.GithubConnector) error {
-	if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbCreate, teleservices.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbCreate, teleservices.VerbUpdate); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return o.operator.UpsertGithubConnector(ctx, key, connector)
 }
@@ -992,8 +998,10 @@ func (o *OperatorACL) UpsertGithubConnector(ctx context.Context, key SiteKey, co
 //
 // Returned connector exclude client secret unless withSecrets is true.
 func (o *OperatorACL) GetGithubConnector(key SiteKey, name string, withSecrets bool) (teleservices.GithubConnector, error) {
-	if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.GetGithubConnector(key, name, withSecrets)
 }
@@ -1002,16 +1010,20 @@ func (o *OperatorACL) GetGithubConnector(key SiteKey, name string, withSecrets b
 //
 // Returned connectors exclude client secret unless withSecrets is true.
 func (o *OperatorACL) GetGithubConnectors(key SiteKey, withSecrets bool) ([]teleservices.GithubConnector, error) {
-	if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbList, teleservices.VerbRead); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbList, teleservices.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.GetGithubConnectors(key, withSecrets)
 }
 
 // DeleteGithubConnector deletes a Github connector by name
 func (o *OperatorACL) DeleteGithubConnector(ctx context.Context, key SiteKey, name string) error {
-	if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbDelete); err != nil {
-		return trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		if err := o.AuthConnectorActions(teleservices.KindGithubConnector, teleservices.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return o.operator.DeleteGithubConnector(ctx, key, name)
 }
@@ -1059,32 +1071,40 @@ func (o *OperatorACL) EmitAuditEvent(ctx context.Context, req AuditEventRequest)
 
 // CreateUserInvite creates a new invite token for a user.
 func (o *OperatorACL) CreateUserInvite(ctx context.Context, req CreateUserInviteRequest) (*storage.UserToken, error) {
-	if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbCreate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbCreate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.CreateUserInvite(ctx, req)
 }
 
 // GetUserInvites returns all active user invites.
 func (o *OperatorACL) GetUserInvites(ctx context.Context, key SiteKey) ([]storage.UserInvite, error) {
-	if err := o.ClusterAction(key.SiteDomain, storage.KindInvite, teleservices.VerbList); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+		if err := o.ClusterAction(key.SiteDomain, storage.KindInvite, teleservices.VerbList); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.GetUserInvites(ctx, key)
 }
 
 // DeleteUserInvite deletes the specified user invite.
 func (o *OperatorACL) DeleteUserInvite(ctx context.Context, req DeleteUserInviteRequest) error {
-	if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbDelete); err != nil {
-		return trace.Wrap(err)
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		if err := o.ClusterAction(req.SiteDomain, storage.KindInvite, teleservices.VerbDelete); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return o.operator.DeleteUserInvite(ctx, req)
 }
 
 // CreateUserReset creates a new reset token for a user.
 func (o *OperatorACL) CreateUserReset(ctx context.Context, req CreateUserResetRequest) (*storage.UserToken, error) {
-	if err := o.Action(teleservices.KindUser, teleservices.VerbUpdate); err != nil {
-		return nil, trace.Wrap(err)
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+		if err := o.Action(teleservices.KindUser, teleservices.VerbUpdate); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return o.operator.CreateUserReset(ctx, req)
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1558,6 +1558,12 @@ func (k SiteKey) String() string {
 		"site(account_id=%v, site_domain=%v)", k.AccountID, k.SiteDomain)
 }
 
+// IsEqualTo returns true if the two cluster keys are equal.
+func (k SiteKey) IsEqualTo(other SiteKey) bool {
+	return k.AccountID == other.AccountID &&
+		k.SiteDomain == other.SiteDomain
+}
+
 // AgentCreds represent install agent username and password used
 // to identify install agents for the site
 type AgentCreds struct {

--- a/lib/ops/opshandler/resources.go
+++ b/lib/ops/opshandler/resources.go
@@ -181,7 +181,7 @@ func (h *WebHandler) getReleases(w http.ResponseWriter, r *http.Request, p httpr
      teleservices.Role
 */
 func (h *WebHandler) getUser(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
-	user, err := ctx.Identity.GetUser(p.ByName("name"))
+	user, err := ctx.Operator.GetUser(siteKey(p), p.ByName("name"))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -198,7 +198,7 @@ func (h *WebHandler) getUser(w http.ResponseWriter, r *http.Request, p httproute
      []teleservices.User
 */
 func (h *WebHandler) getUsers(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *HandlerContext) error {
-	users, err := ctx.Identity.GetUsers()
+	users, err := ctx.Operator.GetUsers(siteKey(p))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -266,7 +266,7 @@ func (h *WebHandler) getGithubConnector(w http.ResponseWriter, r *http.Request, 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	connector, err := ctx.Identity.GetGithubConnector(p.ByName("id"), withSecrets)
+	connector, err := ctx.Operator.GetGithubConnector(siteKey(p), p.ByName("id"), withSecrets)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -283,7 +283,7 @@ func (h *WebHandler) getGithubConnectors(w http.ResponseWriter, r *http.Request,
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	connectors, err := ctx.Identity.GetGithubConnectors(withSecrets)
+	connectors, err := ctx.Operator.GetGithubConnectors(siteKey(p), withSecrets)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -29,14 +29,15 @@ import (
 	"github.com/fatih/color"
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // Resources is a controller that manages cluster local resources
 type Resources struct {
 	// Config is the controller configuration
 	Config
-	// cluster is the local cluster
-	cluster *ops.Site
+	// Log is used for logging.
+	Log logrus.FieldLogger
 }
 
 // Config is gravity resource controller configuration
@@ -66,13 +67,9 @@ func New(config Config) (*Resources, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	localCluster, err := config.Operator.GetLocalSite()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	return &Resources{
-		Config:  config,
-		cluster: localCluster,
+		Config: config,
+		Log:    logrus.WithField(trace.Component, "resources"),
 	}, nil
 }
 
@@ -81,13 +78,14 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 	if err := req.Check(); err != nil {
 		return trace.Wrap(err)
 	}
+	r.Log.Infof("%s.", req)
 	switch req.Resource.Kind {
 	case teleservices.KindGithubConnector:
 		conn, err := teleservices.GetGithubConnectorMarshaler().Unmarshal(req.Resource.Raw)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := r.Operator.UpsertGithubConnector(ctx, r.cluster.Key(), conn); err != nil {
+		if err := r.Operator.UpsertGithubConnector(ctx, req.SiteKey, conn); err != nil {
 			return trace.Wrap(err)
 		}
 		r.Printf("Created Github connector %q\n", conn.GetName())
@@ -96,7 +94,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := r.Operator.UpsertUser(ctx, r.cluster.Key(), user); err != nil {
+		if err := r.Operator.UpsertUser(ctx, req.SiteKey, user); err != nil {
 			return trace.Wrap(err)
 		}
 		r.Printf("Created user %q\n", user.GetName())
@@ -136,7 +134,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = r.Operator.CreateLogForwarder(ctx, r.cluster.Key(), forwarder)
+		err = r.Operator.CreateLogForwarder(ctx, req.SiteKey, forwarder)
 		if err != nil && !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err)
 		}
@@ -144,7 +142,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 			if !req.Upsert {
 				return trace.Wrap(err)
 			}
-			err := r.Operator.UpdateLogForwarder(ctx, r.cluster.Key(), forwarder)
+			err := r.Operator.UpdateLogForwarder(ctx, req.SiteKey, forwarder)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -159,8 +157,8 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 			return trace.Wrap(err)
 		}
 		_, err = r.Operator.UpdateClusterCertificate(ctx, ops.UpdateCertificateRequest{
-			AccountID:   r.cluster.AccountID,
-			SiteDomain:  r.cluster.Domain,
+			AccountID:   req.AccountID,
+			SiteDomain:  req.SiteDomain,
 			Certificate: []byte(keyPair.GetCert()),
 			PrivateKey:  []byte(keyPair.GetPrivateKey()),
 		})
@@ -176,7 +174,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := r.Operator.UpsertClusterAuthPreference(ctx, r.cluster.Key(), cap); err != nil {
+		if err := r.Operator.UpsertClusterAuthPreference(ctx, req.SiteKey, cap); err != nil {
 			return trace.Wrap(err)
 		}
 		r.Println("Updated cluster authentication preference")
@@ -188,7 +186,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err := config.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
-		err = r.Operator.UpdateSMTPConfig(ctx, r.cluster.Key(), config)
+		err = r.Operator.UpdateSMTPConfig(ctx, req.SiteKey, config)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -201,7 +199,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err := alert.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
-		err = r.Operator.UpdateAlert(ctx, r.cluster.Key(), alert)
+		err = r.Operator.UpdateAlert(ctx, req.SiteKey, alert)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -210,7 +208,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		// Alert recipient can be created only if SMTP settings
 		// are present, otherwise it will result into invalid
 		// Alertmanager configuration.
-		if _, err := r.Operator.GetSMTPConfig(r.cluster.Key()); err != nil {
+		if _, err := r.Operator.GetSMTPConfig(req.SiteKey); err != nil {
 			if trace.IsNotFound(err) {
 				return trace.BadParameter("alert target can only " +
 					"be created when cluster SMTP settings " +
@@ -226,7 +224,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err := target.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
-		err = r.Operator.UpdateAlertTarget(ctx, r.cluster.Key(), target)
+		err = r.Operator.UpdateAlertTarget(ctx, req.SiteKey, target)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -236,7 +234,7 @@ func (r *Resources) Create(ctx context.Context, req resources.CreateRequest) err
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = r.Operator.UpsertAuthGateway(ctx, r.cluster.Key(), gw)
+		err = r.Operator.UpsertAuthGateway(ctx, req.SiteKey, gw)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -258,29 +256,30 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 	if err := req.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	r.Log.Debugf("%s.", req)
 	switch req.Kind {
 	case teleservices.KindGithubConnector, teleservices.KindAuthConnector:
 		if req.Name != "" {
-			connector, err := r.Operator.GetGithubConnector(r.cluster.Key(), req.Name, req.WithSecrets)
+			connector, err := r.Operator.GetGithubConnector(req.SiteKey, req.Name, req.WithSecrets)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &githubCollection{connectors: []teleservices.GithubConnector{connector}}, nil
 		}
-		connectors, err := r.Operator.GetGithubConnectors(r.cluster.Key(), req.WithSecrets)
+		connectors, err := r.Operator.GetGithubConnectors(req.SiteKey, req.WithSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &githubCollection{connectors: connectors}, nil
 	case teleservices.KindUser:
 		if req.Name != "" {
-			user, err := r.Operator.GetUser(r.cluster.Key(), req.Name)
+			user, err := r.Operator.GetUser(req.SiteKey, req.Name)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &userCollection{users: []teleservices.User{user}}, nil
 		}
-		users, err := r.Operator.GetUsers(r.cluster.Key())
+		users, err := r.Operator.GetUsers(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -307,7 +306,7 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		}
 		return &tokenCollection{tokens: tokens}, nil
 	case storage.KindLogForwarder:
-		forwarders, err := r.Operator.GetLogForwarders(r.cluster.Key())
+		forwarders, err := r.Operator.GetLogForwarders(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -328,7 +327,7 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		return &logForwardersCollection{logForwarders: filtered}, nil
 	case storage.KindTLSKeyPair:
 		// always ignore name parameter for tls key pairs, because there is only one
-		cert, err := r.Operator.GetClusterCertificate(r.cluster.Key(), req.WithSecrets)
+		cert, err := r.Operator.GetClusterCertificate(req.SiteKey, req.WithSecrets)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -338,13 +337,13 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		r.Println(color.YellowString("Cluster auth preference resource is " +
 			"obsolete and will be removed in a future release. Please use " +
 			"auth gateway resource instead: https://gravitational.com/gravity/docs/cluster/#configuring-cluster-authentication-gateway."))
-		authPreference, err := r.Operator.GetClusterAuthPreference(r.cluster.Key())
+		authPreference, err := r.Operator.GetClusterAuthPreference(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return clusterAuthPreferenceCollection{authPreference}, nil
 	case storage.KindAuthGateway:
-		gw, err := r.Operator.GetAuthGateway(r.cluster.Key())
+		gw, err := r.Operator.GetAuthGateway(req.SiteKey)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				return nil, trace.NotFound("auth gateway resource not found")
@@ -353,13 +352,13 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		}
 		return &authGatewayCollection{gw}, nil
 	case storage.KindSMTPConfig:
-		config, err := r.Operator.GetSMTPConfig(r.cluster.Key())
+		config, err := r.Operator.GetSMTPConfig(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return smtpConfigCollection{config}, nil
 	case storage.KindAlert:
-		alerts, err := r.Operator.GetAlerts(r.cluster.Key())
+		alerts, err := r.Operator.GetAlerts(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -379,19 +378,19 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		}
 		return alertCollection(filtered), nil
 	case storage.KindAlertTarget:
-		alertTargets, err := r.Operator.GetAlertTargets(r.cluster.Key())
+		alertTargets, err := r.Operator.GetAlertTargets(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return alertTargetCollection(alertTargets), nil
 	case storage.KindRuntimeEnvironment:
-		env, err := r.Operator.GetClusterEnvironmentVariables(r.cluster.Key())
+		env, err := r.Operator.GetClusterEnvironmentVariables(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return envCollection{env: env}, nil
 	case storage.KindClusterConfiguration:
-		config, err := r.Operator.GetClusterConfiguration(r.cluster.Key())
+		config, err := r.Operator.GetClusterConfiguration(req.SiteKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -408,9 +407,10 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 	if err := req.Check(); err != nil {
 		return trace.Wrap(err)
 	}
+	r.Log.Infof("%s.", req)
 	switch req.Kind {
 	case teleservices.KindGithubConnector:
-		if err := r.Operator.DeleteGithubConnector(ctx, r.cluster.Key(), req.Name); err != nil {
+		if err := r.Operator.DeleteGithubConnector(ctx, req.SiteKey, req.Name); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -418,7 +418,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		}
 		r.Printf("Github connector %q has been deleted\n", req.Name)
 	case teleservices.KindUser:
-		if err := r.Operator.DeleteUser(ctx, r.cluster.Key(), req.Name); err != nil {
+		if err := r.Operator.DeleteUser(ctx, req.SiteKey, req.Name); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -440,7 +440,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		}
 		r.Printf("Token %q has been deleted for user %q\n", req.Name, user)
 	case storage.KindLogForwarder:
-		if err := r.Operator.DeleteLogForwarder(ctx, r.cluster.Key(), req.Name); err != nil {
+		if err := r.Operator.DeleteLogForwarder(ctx, req.SiteKey, req.Name); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -448,7 +448,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		}
 		r.Printf("Log forwarder %q has been deleted\n", req.Name)
 	case storage.KindTLSKeyPair:
-		if err := r.Operator.DeleteClusterCertificate(ctx, r.cluster.Key()); err != nil {
+		if err := r.Operator.DeleteClusterCertificate(ctx, req.SiteKey); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -459,7 +459,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		// SMTP configuration can be deleted only if there is no
 		// alert recipient configured, otherwise it will result
 		// into invalid Alertmanager configuration.
-		alertTargets, err := r.Operator.GetAlertTargets(r.cluster.Key())
+		alertTargets, err := r.Operator.GetAlertTargets(req.SiteKey)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
@@ -469,7 +469,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 				"please remove alert target using 'gravity " +
 				"resource rm alerttarget' first")
 		}
-		if err := r.Operator.DeleteSMTPConfig(ctx, r.cluster.Key()); err != nil {
+		if err := r.Operator.DeleteSMTPConfig(ctx, req.SiteKey); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -477,7 +477,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		}
 		r.Println("SMTP configuration has been deleted")
 	case storage.KindAlert:
-		if err := r.Operator.DeleteAlert(ctx, r.cluster.Key(), req.Name); err != nil {
+		if err := r.Operator.DeleteAlert(ctx, req.SiteKey, req.Name); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}
@@ -485,7 +485,7 @@ func (r *Resources) Remove(ctx context.Context, req resources.RemoveRequest) err
 		}
 		r.Printf("Alert %q has been deleted\n", req.Name)
 	case storage.KindAlertTarget:
-		if err := r.Operator.DeleteAlertTarget(ctx, r.cluster.Key()); err != nil {
+		if err := r.Operator.DeleteAlertTarget(ctx, req.SiteKey); err != nil {
 			if trace.IsNotFound(err) && req.Force {
 				return nil
 			}

--- a/lib/ops/resources/gravity/gravity_test.go
+++ b/lib/ops/resources/gravity/gravity_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsclient"
 	"github.com/gravitational/gravity/lib/ops/resources"
 	"github.com/gravitational/gravity/lib/storage"
@@ -37,9 +38,10 @@ import (
 func TestGravityResources(t *testing.T) { check.TestingT(t) }
 
 type GravityResourcesSuite struct {
-	s      *Suite
-	r      *Resources
-	server *httptest.Server
+	s       *Suite
+	r       *Resources
+	cluster *ops.Site
+	server  *httptest.Server
 }
 
 var _ = check.Suite(&GravityResourcesSuite{
@@ -59,6 +61,8 @@ func (s *GravityResourcesSuite) SetUpSuite(c *check.C) {
 		Silent:   localenv.Silent(false),
 	})
 	c.Assert(err, check.IsNil)
+	s.cluster, err = client.GetLocalSite()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *GravityResourcesSuite) TearDownSuite(c *check.C) {
@@ -69,26 +73,26 @@ func (s *GravityResourcesSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *GravityResourcesSuite) TestGithubConnectorResource(c *check.C) {
-	err := s.r.Create(context.TODO(), resources.CreateRequest{Resource: toUnknown(c, githubConnector)})
+	err := s.r.Create(context.TODO(), resources.CreateRequest{SiteKey: s.cluster.Key(), Resource: toUnknown(c, githubConnector)})
 	c.Assert(err, check.IsNil)
 
-	collection, err := s.r.GetCollection(resources.ListRequest{Kind: teleservices.KindGithubConnector, WithSecrets: true})
+	collection, err := s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: teleservices.KindGithubConnector, WithSecrets: true})
 	c.Assert(err, check.IsNil)
 	compare.DeepCompare(c, collection, &githubCollection{[]teleservices.GithubConnector{githubConnector}})
 
-	err = s.r.Remove(context.TODO(), resources.RemoveRequest{Kind: teleservices.KindGithubConnector, Name: "github"})
+	err = s.r.Remove(context.TODO(), resources.RemoveRequest{SiteKey: s.cluster.Key(), Kind: teleservices.KindGithubConnector, Name: "github"})
 	c.Assert(err, check.IsNil)
 
-	collection, err = s.r.GetCollection(resources.ListRequest{Kind: teleservices.KindGithubConnector})
+	collection, err = s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: teleservices.KindGithubConnector})
 	c.Assert(err, check.IsNil)
 	compare.DeepCompare(c, collection, &githubCollection{[]teleservices.GithubConnector{}})
 }
 
 func (s *GravityResourcesSuite) TestUser(c *check.C) {
-	err := s.r.Create(context.TODO(), resources.CreateRequest{Resource: toUnknown(c, user)})
+	err := s.r.Create(context.TODO(), resources.CreateRequest{SiteKey: s.cluster.Key(), Resource: toUnknown(c, user)})
 	c.Assert(err, check.IsNil)
 
-	collectionI, err := s.r.GetCollection(resources.ListRequest{Kind: "user", Name: "test"})
+	collectionI, err := s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "user", Name: "test"})
 	c.Assert(err, check.IsNil)
 	collection, ok := collectionI.(*userCollection)
 	c.Assert(ok, check.Equals, true)
@@ -97,27 +101,27 @@ func (s *GravityResourcesSuite) TestUser(c *check.C) {
 	user.SetRawObject(collection.users[0].GetRawObject())
 	compare.DeepCompare(c, collection, &userCollection{[]teleservices.User{user}})
 
-	err = s.r.Remove(context.TODO(), resources.RemoveRequest{Kind: "user", Name: "test"})
+	err = s.r.Remove(context.TODO(), resources.RemoveRequest{SiteKey: s.cluster.Key(), Kind: "user", Name: "test"})
 	c.Assert(err, check.IsNil)
 
-	collectionI, err = s.r.GetCollection(resources.ListRequest{Kind: "user", Name: "test"})
+	collectionI, err = s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "user", Name: "test"})
 	c.Assert(err, check.FitsTypeOf, trace.NotFound(""))
 }
 
 func (s *GravityResourcesSuite) TestToken(c *check.C) {
 	token := storage.NewToken("test", s.s.Creds.Email)
 
-	err := s.r.Create(context.TODO(), resources.CreateRequest{Resource: toUnknown(c, token)})
+	err := s.r.Create(context.TODO(), resources.CreateRequest{SiteKey: s.cluster.Key(), Resource: toUnknown(c, token)})
 	c.Assert(err, check.IsNil)
 
-	collection, err := s.r.GetCollection(resources.ListRequest{Kind: "token", Name: "test", User: s.s.Creds.Email})
+	collection, err := s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "token", Name: "test", User: s.s.Creds.Email})
 	c.Assert(err, check.IsNil)
 	compare.DeepCompare(c, collection, &tokenCollection{[]storage.Token{token}})
 
-	err = s.r.Remove(context.TODO(), resources.RemoveRequest{Kind: "token", Name: "test", Owner: s.s.Creds.Email})
+	err = s.r.Remove(context.TODO(), resources.RemoveRequest{SiteKey: s.cluster.Key(), Kind: "token", Name: "test", Owner: s.s.Creds.Email})
 	c.Assert(err, check.IsNil)
 
-	collection, err = s.r.GetCollection(resources.ListRequest{Kind: "token", Name: "test", User: s.s.Creds.Email})
+	collection, err = s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "token", Name: "test", User: s.s.Creds.Email})
 	c.Assert(err, check.FitsTypeOf, trace.NotFound(""))
 }
 

--- a/lib/ops/resources/resources_test.go
+++ b/lib/ops/resources/resources_test.go
@@ -46,7 +46,7 @@ func (s *ResourceControlSuite) TestResourceControl(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	w := &bytes.Buffer{}
-	err = control.Get(w, "", "", false, "text", "")
+	err = control.Get(w, ListRequest{}, "text")
 	c.Assert(err, check.IsNil)
 	c.Assert(w.String(), check.Equals, `kind1/resource1
 kind2/resource2
@@ -61,7 +61,7 @@ kind1/resource3
 	c.Assert(err, check.IsNil)
 
 	w.Reset()
-	err = control.Get(w, "", "", false, "text", "")
+	err = control.Get(w, ListRequest{}, "text")
 	c.Assert(err, check.IsNil)
 	c.Assert(w.String(), check.Equals, `kind1/resource1
 kind1/resource3

--- a/lib/webapi/resources.go
+++ b/lib/webapi/resources.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/resources"
 	"github.com/gravitational/gravity/lib/ops/resources/gravity"
 	"github.com/gravitational/gravity/lib/utils"
@@ -42,8 +43,12 @@ func (m *Handler) Resources(ctx *AuthContext) (resources.Resources, error) {
 
 // getResourceHandler is GET handler that returns ConfigItems for requested resource kind
 func (m *Handler) getResourceHandler(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
+	key, err := clusterKey(ctx, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	kind := p.ByName("kind")
-	data, err := m.getResources(kind, ctx)
+	data, err := m.getResources(*key, kind, ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -67,8 +72,13 @@ func (m *Handler) upsertResourceHandler(w http.ResponseWriter, r *http.Request, 
 		return nil, trace.Wrap(err)
 	}
 
+	key, err := clusterKey(ctx, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	isNew := r.Method == http.MethodPost
-	items, err := m.upsertResource(r.Context(), isNew, *rawRes, ctx)
+	items, err := m.upsertResource(r.Context(), *key, isNew, *rawRes, ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -78,9 +88,13 @@ func (m *Handler) upsertResourceHandler(w http.ResponseWriter, r *http.Request, 
 
 // deleteResourceHandler is DELETE handler that removes a resource by its kind and name values
 func (m *Handler) deleteResourceHandler(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
+	key, err := clusterKey(ctx, p)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	resourceKind := p.ByName("kind")
 	resourceName := p.ByName("name")
-	if err := m.deleteResource(r.Context(), resourceKind, resourceName, ctx); err != nil {
+	if err := m.deleteResource(r.Context(), *key, resourceKind, resourceName, ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -88,19 +102,20 @@ func (m *Handler) deleteResourceHandler(w http.ResponseWriter, r *http.Request, 
 }
 
 // deleteResource deletes a resource
-func (m *Handler) deleteResource(ctx context.Context, resourceKind string, resourceName string, authCtx *AuthContext) error {
+func (m *Handler) deleteResource(ctx context.Context, key ops.SiteKey, resourceKind string, resourceName string, authCtx *AuthContext) error {
 	controller, err := m.plugin.Resources(authCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	return controller.Remove(ctx, resources.RemoveRequest{
-		Kind: resourceKind,
-		Name: resourceName,
+		SiteKey: key,
+		Kind:    resourceKind,
+		Name:    resourceName,
 	})
 }
 
 // getResources returns a collection of ConfigItem wrappers that contains resources of requested kind
-func (m *Handler) getResources(kind string, ctx *AuthContext) ([]ui.ConfigItem, error) {
+func (m *Handler) getResources(key ops.SiteKey, kind string, ctx *AuthContext) ([]ui.ConfigItem, error) {
 	if kind == "" {
 		return nil, trace.BadParameter("missing resource kind")
 	}
@@ -113,6 +128,7 @@ func (m *Handler) getResources(kind string, ctx *AuthContext) ([]ui.ConfigItem, 
 		return nil, trace.Wrap(err)
 	}
 	collection, err := controller.GetCollection(resources.ListRequest{
+		SiteKey:     key,
 		Kind:        kind,
 		WithSecrets: webCtx.UserACL.AuthConnectors.Read,
 	})
@@ -131,8 +147,8 @@ func (m *Handler) getResources(kind string, ctx *AuthContext) ([]ui.ConfigItem, 
 }
 
 // upsertResource updates a resource and returns ConfigItem wrapper with the updated resource
-func (m *Handler) upsertResource(ctx context.Context, isNew bool, rawRes teleservices.UnknownResource, authCtx *AuthContext) (interface{}, error) {
-	exists, err := m.checkIfResourceExists(rawRes, authCtx)
+func (m *Handler) upsertResource(ctx context.Context, key ops.SiteKey, isNew bool, rawRes teleservices.UnknownResource, authCtx *AuthContext) (interface{}, error) {
+	exists, err := m.checkIfResourceExists(key, rawRes, authCtx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -149,6 +165,7 @@ func (m *Handler) upsertResource(ctx context.Context, isNew bool, rawRes teleser
 		return nil, trace.Wrap(err)
 	}
 	err = controller.Create(ctx, resources.CreateRequest{
+		SiteKey:  key,
 		Resource: rawRes,
 		Upsert:   true,
 	})
@@ -176,14 +193,15 @@ func extractYAMLInfo(yaml string) (*teleservices.UnknownResource, error) {
 }
 
 // checkIfResourceExists returns true if the specified resource already exists
-func (m *Handler) checkIfResourceExists(rawRes teleservices.UnknownResource, ctx *AuthContext) (bool, error) {
+func (m *Handler) checkIfResourceExists(key ops.SiteKey, rawRes teleservices.UnknownResource, ctx *AuthContext) (bool, error) {
 	resourceController, err := m.plugin.Resources(ctx)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
 	_, err = resourceController.GetCollection(resources.ListRequest{
-		Kind: rawRes.Kind,
-		Name: rawRes.Metadata.Name,
+		SiteKey: key,
+		Kind:    rawRes.Kind,
+		Name:    rawRes.Metadata.Name,
 	})
 	if err != nil && !trace.IsNotFound(err) {
 		return false, trace.Wrap(err)


### PR DESCRIPTION
This PR enhances resource controller to support routing requests for creating/listing/deleting resources to remote clusters. Previously, resource controller only worked with the local cluster, which does not work for us anymore because the new dashboard needs to be able to manage certain resources on remote clusters (in the Ops Center use-case). Thus, `(Create|List|Delete)Resource` requests now have a `SiteKey` so requests get routed to appropriate cluster using existing opsrouters machinery, instead of always being routed to the local cluster.

Also, tweak acl rules a bit so the remote agent can manage users/roles/authconnectors for remote clusters.

Refs https://github.com/gravitational/gravity.e/issues/4071.