### PR TITLE
Kubernetes proxy fixes.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -894,7 +894,7 @@
 
 [[projects]]
   branch = "branch/3.2-g"
-  digest = "1:dc70d53cfb938ba2490891306441c151e2256eb957d06a5e6dab3d4f3c7e4874"
+  digest = "1:2d9aec3c832481bd817f951e43ab87e03417519a086279a48767629d94f0284b"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -949,7 +949,7 @@
     "lib/web/ui",
   ]
   pruneopts = "UT"
-  revision = "495a59bc1737cf62aa9850f5eed7e6fc3117c0c2"
+  revision = "d88eaecef78779b0211cbe458230fd3ce0989bde"
 
 [[projects]]
   digest = "1:22c8951489f0e27ec3b2d50d9f74086ff3f08554ce5965d418d6a10296b9ea04"

--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -66,21 +66,15 @@ rules:
   - list
   - watch
 # The following permissions are required for Teleport's Kubernetes proxy
-# functionality which uses Kubernetes CSR API for signing client certs.
+# functionality which uses Kubernetes Impersonation API.
 - apiGroups:
-  - certificates.k8s.io
+  - ""
   resources:
-  - certificatesigningrequests
+  - users
+  - groups
+  - serviceaccounts
   verbs:
-  - create
-  - watch
-  - delete
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  verbs:
-  - update
+  - impersonate
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/lib/ops/endpoints.go
+++ b/lib/ops/endpoints.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// ClusterEndpoints contains system cluster endpoints such as Teleport
+// proxy address or cluster control panel URL.
+type ClusterEndpoints struct {
+	// Internal contains internal cluster endpoints.
+	Internal clusterEndpoints
+	// Public contains public cluster endpoints.
+	Public clusterEndpoints
+}
+
+// AuthGateways returns all auth gateway endpoints.
+func (e ClusterEndpoints) AuthGateways() []string {
+	if len(e.Public.AuthGateways) > 0 {
+		return e.Public.AuthGateways
+	}
+	return e.Internal.AuthGateways
+}
+
+// AuthGateway returns a single auth gateway endpoint.
+func (e ClusterEndpoints) AuthGateway() string {
+	gateways := e.AuthGateways()
+	if len(gateways) > 0 {
+		return gateways[0]
+	}
+	return ""
+}
+
+// ManagementURLs returns all cluster management URLs.
+func (e ClusterEndpoints) ManagementURLs() []string {
+	if len(e.Public.ManagementURLs) > 0 {
+		return e.Public.ManagementURLs
+	}
+	return e.Internal.ManagementURLs
+}
+
+// clusterEndpoints combines various types of cluster endpoints.
+type clusterEndpoints struct {
+	// AuthGateways is a list of Teleport proxy addresses.
+	AuthGateways []string
+	// ManagementURLs is a list of URLs pointing to cluster dashboard.
+	ManagementURLs []string
+}
+
+// GetClusterEndpoints returns system endpoints for the specified cluster.
+func GetClusterEndpoints(operator Operator, key SiteKey) (*ClusterEndpoints, error) {
+	cluster, err := operator.GetSite(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	authGateway, err := operator.GetAuthGateway(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Internal endpoints point directly to master nodes.
+	var internal clusterEndpoints
+	for _, master := range cluster.Masters() {
+		internal.AuthGateways = append(internal.AuthGateways,
+			fmt.Sprintf("%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
+		internal.ManagementURLs = append(internal.ManagementURLs,
+			fmt.Sprintf("https://%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
+	}
+	// Public endpoints are configured via auth gateway resource.
+	var public clusterEndpoints
+	for _, address := range authGateway.GetWebPublicAddrs() {
+		public.AuthGateways = append(public.AuthGateways,
+			utils.EnsurePort(address, defaults.HTTPSPort))
+		public.ManagementURLs = append(public.ManagementURLs,
+			fmt.Sprintf("https://%v", utils.EnsurePort(address, defaults.HTTPSPort)))
+	}
+	return &ClusterEndpoints{
+		Internal: internal,
+		Public:   public,
+	}, nil
+}

--- a/lib/ops/endpoints.go
+++ b/lib/ops/endpoints.go
@@ -17,7 +17,7 @@ limitations under the License.
 package ops
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/storage"
@@ -43,8 +43,8 @@ func (e ClusterEndpoints) AuthGateways() []string {
 	return e.Internal.AuthGateways
 }
 
-// AuthGateway returns a single auth gateway endpoint.
-func (e ClusterEndpoints) AuthGateway() string {
+// FirstAuthGateway returns the first auth gateway endpoint.
+func (e ClusterEndpoints) FirstAuthGateway() string {
 	gateways := e.AuthGateways()
 	if len(gateways) > 0 {
 		return gateways[0]
@@ -86,9 +86,9 @@ func getClusterEndpoints(cluster *Site, gateway storage.AuthGateway) (*ClusterEn
 	var internal clusterEndpoints
 	for _, master := range cluster.Masters() {
 		internal.AuthGateways = append(internal.AuthGateways,
-			fmt.Sprintf("%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
+			utils.EnsurePort(master.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)))
 		internal.ManagementURLs = append(internal.ManagementURLs,
-			fmt.Sprintf("https://%v:%v", master.AdvertiseIP, defaults.GravitySiteNodePort))
+			utils.EnsurePortURL(master.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)))
 	}
 	// Public endpoints are configured via auth gateway resource.
 	var public clusterEndpoints
@@ -96,7 +96,7 @@ func getClusterEndpoints(cluster *Site, gateway storage.AuthGateway) (*ClusterEn
 		public.AuthGateways = append(public.AuthGateways,
 			utils.EnsurePort(address, defaults.HTTPSPort))
 		public.ManagementURLs = append(public.ManagementURLs,
-			fmt.Sprintf("https://%v", utils.EnsurePort(address, defaults.HTTPSPort)))
+			utils.EnsurePortURL(address, defaults.HTTPSPort))
 	}
 	return &ClusterEndpoints{
 		Internal: internal,

--- a/lib/ops/endpoints_test.go
+++ b/lib/ops/endpoints_test.go
@@ -18,10 +18,12 @@ package ops
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
 
 	"gopkg.in/check.v1"
 )
@@ -57,34 +59,25 @@ func (s *EndpointsSuite) TestClusterEndpoints(c *check.C) {
 	c.Assert(endpoints, check.DeepEquals, &ClusterEndpoints{
 		Internal: clusterEndpoints{
 			AuthGateways: []string{
-				fmt.Sprintf("%v:%v", master1.AdvertiseIP,
-					defaults.GravitySiteNodePort),
-				fmt.Sprintf("%v:%v", master2.AdvertiseIP,
-					defaults.GravitySiteNodePort),
+				utils.EnsurePort(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+				utils.EnsurePort(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 			},
 			ManagementURLs: []string{
-				fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
-					defaults.GravitySiteNodePort),
-				fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
-					defaults.GravitySiteNodePort),
+				utils.EnsurePortURL(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+				utils.EnsurePortURL(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 			},
 		},
 		Public: clusterEndpoints{},
 	})
 	c.Assert(endpoints.AuthGateways(), check.DeepEquals, []string{
-		fmt.Sprintf("%v:%v", master1.AdvertiseIP,
-			defaults.GravitySiteNodePort),
-		fmt.Sprintf("%v:%v", master2.AdvertiseIP,
-			defaults.GravitySiteNodePort),
+		utils.EnsurePort(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+		utils.EnsurePort(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 	})
-	c.Assert(endpoints.AuthGateway(), check.Equals,
-		fmt.Sprintf("%v:%v", master1.AdvertiseIP,
-			defaults.GravitySiteNodePort))
+	c.Assert(endpoints.FirstAuthGateway(), check.Equals,
+		utils.EnsurePort(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)))
 	c.Assert(endpoints.ManagementURLs(), check.DeepEquals, []string{
-		fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
-			defaults.GravitySiteNodePort),
-		fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
-			defaults.GravitySiteNodePort),
+		utils.EnsurePortURL(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+		utils.EnsurePortURL(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 	})
 
 	publicAddr := "cluster.example.com:444"
@@ -95,16 +88,12 @@ func (s *EndpointsSuite) TestClusterEndpoints(c *check.C) {
 	c.Assert(endpoints, check.DeepEquals, &ClusterEndpoints{
 		Internal: clusterEndpoints{
 			AuthGateways: []string{
-				fmt.Sprintf("%v:%v", master1.AdvertiseIP,
-					defaults.GravitySiteNodePort),
-				fmt.Sprintf("%v:%v", master2.AdvertiseIP,
-					defaults.GravitySiteNodePort),
+				utils.EnsurePort(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+				utils.EnsurePort(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 			},
 			ManagementURLs: []string{
-				fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
-					defaults.GravitySiteNodePort),
-				fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
-					defaults.GravitySiteNodePort),
+				utils.EnsurePortURL(master1.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
+				utils.EnsurePortURL(master2.AdvertiseIP, strconv.Itoa(defaults.GravitySiteNodePort)),
 			},
 		},
 		Public: clusterEndpoints{
@@ -119,7 +108,7 @@ func (s *EndpointsSuite) TestClusterEndpoints(c *check.C) {
 	c.Assert(endpoints.AuthGateways(), check.DeepEquals, []string{
 		publicAddr,
 	})
-	c.Assert(endpoints.AuthGateway(), check.Equals, publicAddr)
+	c.Assert(endpoints.FirstAuthGateway(), check.Equals, publicAddr)
 	c.Assert(endpoints.ManagementURLs(), check.DeepEquals, []string{
 		fmt.Sprintf("https://%v", publicAddr),
 	})

--- a/lib/ops/endpoints_test.go
+++ b/lib/ops/endpoints_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"gopkg.in/check.v1"
+)
+
+type EndpointsSuite struct{}
+
+var _ = check.Suite(&EndpointsSuite{})
+
+func (s *EndpointsSuite) TestClusterEndpoints(c *check.C) {
+	master1 := storage.Server{
+		AdvertiseIP: "192.168.1.1",
+		ClusterRole: string(schema.ServiceRoleMaster),
+	}
+	node := storage.Server{
+		AdvertiseIP: "192.168.1.2",
+		ClusterRole: string(schema.ServiceRoleNode),
+	}
+	master2 := storage.Server{
+		AdvertiseIP: "192.168.1.3",
+		ClusterRole: string(schema.ServiceRoleMaster),
+	}
+	cluster := &Site{
+		ClusterState: storage.ClusterState{
+			Servers: []storage.Server{
+				master1, node, master2,
+			},
+		},
+	}
+	gateway := storage.DefaultAuthGateway()
+
+	endpoints, err := getClusterEndpoints(cluster, gateway)
+	c.Assert(err, check.IsNil)
+	c.Assert(endpoints, check.DeepEquals, &ClusterEndpoints{
+		Internal: clusterEndpoints{
+			AuthGateways: []string{
+				fmt.Sprintf("%v:%v", master1.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+				fmt.Sprintf("%v:%v", master2.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+			},
+			ManagementURLs: []string{
+				fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+				fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+			},
+		},
+		Public: clusterEndpoints{},
+	})
+	c.Assert(endpoints.AuthGateways(), check.DeepEquals, []string{
+		fmt.Sprintf("%v:%v", master1.AdvertiseIP,
+			defaults.GravitySiteNodePort),
+		fmt.Sprintf("%v:%v", master2.AdvertiseIP,
+			defaults.GravitySiteNodePort),
+	})
+	c.Assert(endpoints.AuthGateway(), check.Equals,
+		fmt.Sprintf("%v:%v", master1.AdvertiseIP,
+			defaults.GravitySiteNodePort))
+	c.Assert(endpoints.ManagementURLs(), check.DeepEquals, []string{
+		fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
+			defaults.GravitySiteNodePort),
+		fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
+			defaults.GravitySiteNodePort),
+	})
+
+	publicAddr := "cluster.example.com:444"
+	gateway.SetPublicAddrs([]string{publicAddr})
+
+	endpoints, err = getClusterEndpoints(cluster, gateway)
+	c.Assert(err, check.IsNil)
+	c.Assert(endpoints, check.DeepEquals, &ClusterEndpoints{
+		Internal: clusterEndpoints{
+			AuthGateways: []string{
+				fmt.Sprintf("%v:%v", master1.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+				fmt.Sprintf("%v:%v", master2.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+			},
+			ManagementURLs: []string{
+				fmt.Sprintf("https://%v:%v", master1.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+				fmt.Sprintf("https://%v:%v", master2.AdvertiseIP,
+					defaults.GravitySiteNodePort),
+			},
+		},
+		Public: clusterEndpoints{
+			AuthGateways: []string{
+				publicAddr,
+			},
+			ManagementURLs: []string{
+				fmt.Sprintf("https://%v", publicAddr),
+			},
+		},
+	})
+	c.Assert(endpoints.AuthGateways(), check.DeepEquals, []string{
+		publicAddr,
+	})
+	c.Assert(endpoints.AuthGateway(), check.Equals, publicAddr)
+	c.Assert(endpoints.ManagementURLs(), check.DeepEquals, []string{
+		fmt.Sprintf("https://%v", publicAddr),
+	})
+}

--- a/lib/ops/opsservice/endpoints.go
+++ b/lib/ops/opsservice/endpoints.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -996,13 +996,14 @@ func (p *Process) initService(ctx context.Context) (err error) {
 	}
 
 	p.handlers.WebProxy, err = teleweb.NewHandler(teleweb.Config{
-		Proxy:        reverseTunnel,
-		AuthServers:  p.teleportConfig.AuthServers[0],
-		DomainName:   p.teleportConfig.Hostname,
-		ProxyClient:  proxyConn.Client,
-		DisableUI:    true,
-		ProxySSHAddr: p.teleportConfig.Proxy.SSHAddr,
-		ProxyWebAddr: p.teleportConfig.Proxy.WebAddr,
+		Proxy:         reverseTunnel,
+		AuthServers:   p.teleportConfig.AuthServers[0],
+		DomainName:    p.teleportConfig.Hostname,
+		ProxyClient:   proxyConn.Client,
+		DisableUI:     true,
+		ProxySSHAddr:  p.teleportConfig.Proxy.SSHAddr,
+		ProxyWebAddr:  p.teleportConfig.Proxy.WebAddr,
+		ProxySettings: p.proxySettings(),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -22,7 +22,9 @@ import (
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
+	teledefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
 
 	"github.com/gravitational/trace"
@@ -74,6 +76,9 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	serviceConfig.Access = p.identity
 	serviceConfig.Console = logrus.StandardLogger().Writer()
 	serviceConfig.ClusterConfiguration = p.identity
+	// Use high-res polling period so principal changes are detected
+	// faster when auth gateway settings are updated.
+	serviceConfig.PollingPeriod = teledefaults.HighResPollingPeriod
 	return serviceConfig, nil
 }
 
@@ -138,4 +143,20 @@ func (p *Process) getAuthGatewayConfig() (storage.AuthGateway, error) {
 		return nil, trace.Wrap(err)
 	}
 	return opsservice.GetAuthGateway(client, p.identity)
+}
+
+// proxySettings returns Teleport proxy settings based on the Teleport config.
+func (p *Process) proxySettings() client.ProxySettings {
+	settings := client.ProxySettings{
+		Kube: client.KubeProxySettings{
+			Enabled: p.teleportConfig.Proxy.Kube.Enabled,
+		},
+		SSH: client.SSHProxySettings{
+			ListenAddr: p.teleportConfig.Proxy.SSHAddr.String(),
+		},
+	}
+	if len(p.teleportConfig.Proxy.Kube.PublicAddrs) > 0 {
+		settings.Kube.PublicAddr = p.teleportConfig.Proxy.Kube.PublicAddrs[0].String()
+	}
+	return settings
 }

--- a/lib/storage/authgateway.go
+++ b/lib/storage/authgateway.go
@@ -295,14 +295,17 @@ func (gw *AuthGatewayV1) ApplyToTeleportConfig(config *teleconfig.FileConfig) {
 			U2F:           u2f,
 		}
 	}
-	config.Auth.PublicAddr = append(config.Auth.PublicAddr,
-		gw.GetSSHPublicAddrs()...)
-	config.Proxy.SSHPublicAddr = append(config.Proxy.SSHPublicAddr,
-		gw.GetSSHPublicAddrs()...)
-	config.Proxy.PublicAddr = append(config.Proxy.PublicAddr,
-		gw.GetWebPublicAddrs()...)
-	config.Proxy.Kube.PublicAddr = append(config.Proxy.Kube.PublicAddr,
-		gw.GetKubernetesPublicAddrs()...)
+	// Make sure user-set values take precedence as Teleport may just
+	// grab first value from the list, for example when advertising
+	// Kubernetes proxy public address.
+	config.Auth.PublicAddr = append(gw.GetSSHPublicAddrs(),
+		config.Auth.PublicAddr...)
+	config.Proxy.SSHPublicAddr = append(gw.GetSSHPublicAddrs(),
+		config.Proxy.SSHPublicAddr...)
+	config.Proxy.PublicAddr = append(gw.GetWebPublicAddrs(),
+		config.Proxy.PublicAddr...)
+	config.Proxy.Kube.PublicAddr = append(gw.GetKubernetesPublicAddrs(),
+		config.Proxy.Kube.PublicAddr...)
 }
 
 // GetMaxConnections returns max connections setting.

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -111,6 +111,11 @@ func EnsurePort(address, defaultPort string) string {
 	return net.JoinHostPort(address, defaultPort)
 }
 
+// EnsurePortURL is like EnsurePort but for URLs.
+func EnsurePortURL(url, defaultPort string) string {
+	return ParseOpsCenterAddress(url, defaultPort)
+}
+
 // Hosts returns a list of hosts from the provided host:port addresses
 func Hosts(addrs []string) (hosts []string) {
 	for _, addr := range addrs {

--- a/lib/webapi/clusterinfo.go
+++ b/lib/webapi/clusterinfo.go
@@ -18,14 +18,11 @@ package webapi
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
-	"strings"
 	"text/template"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/ops"
-	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 )
@@ -56,32 +53,16 @@ type webClusterCommands struct {
 
 // getClusterInfo collects information for the specified cluster.
 func getClusterInfo(operator ops.Operator, cluster ops.Site) (*webClusterInfo, error) {
-	authGateway, err := operator.GetAuthGateway(cluster.Key())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	masterNode, err := cluster.FirstMaster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var internalAddrs []string
-	for _, node := range cluster.Masters() {
-		internalAddrs = append(internalAddrs, fmt.Sprintf("%v:%v",
-			node.AdvertiseIP, defaults.GravitySiteNodePort))
-	}
-	var publicAddrs []string
-	for _, webAddr := range authGateway.GetWebPublicAddrs() {
-		publicAddrs = append(publicAddrs, utils.EnsurePort(
-			webAddr, defaults.HTTPSPort))
-	}
-	var proxyAddr string
-	if len(publicAddrs) != 0 {
-		proxyAddr = publicAddrs[0]
-	} else {
-		proxyAddr = internalAddrs[0]
+	endpoints, err := ops.GetClusterEndpoints(operator, cluster.Key())
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	tshLoginCommand, err := renderCommand(tshLoginTpl, map[string]string{
-		"proxyAddr": proxyAddr,
+		"proxyAddr": endpoints.AuthGateway(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -111,8 +92,8 @@ func getClusterInfo(operator ops.Operator, cluster ops.Site) (*webClusterInfo, e
 	}
 	return &webClusterInfo{
 		ClusterState: cluster.State,
-		PublicURLs:   makeURLs(publicAddrs),
-		InternalURLs: makeURLs(internalAddrs),
+		PublicURLs:   endpoints.Public.ManagementURLs,
+		InternalURLs: endpoints.Internal.ManagementURLs,
 		Commands: webClusterCommands{
 			TshLogin:        tshLoginCommand,
 			GravityDownload: gravityDownloadCommand,
@@ -128,18 +109,6 @@ func renderCommand(tpl *template.Template, params map[string]string) (string, er
 		return "", trace.Wrap(err)
 	}
 	return b.String(), nil
-}
-
-// makeURLs converts provided addresses into URLs.
-func makeURLs(addrs []string) (urls []string) {
-	for _, addr := range addrs {
-		if !strings.HasPrefix(addr, "https://") {
-			urls = append(urls, fmt.Sprintf("https://%v", addr))
-		} else {
-			urls = append(urls, addr)
-		}
-	}
-	return urls
 }
 
 var (

--- a/lib/webapi/clusterinfo.go
+++ b/lib/webapi/clusterinfo.go
@@ -62,7 +62,7 @@ func getClusterInfo(operator ops.Operator, cluster ops.Site) (*webClusterInfo, e
 		return nil, trace.Wrap(err)
 	}
 	tshLoginCommand, err := renderCommand(tshLoginTpl, map[string]string{
-		"proxyAddr": endpoints.AuthGateway(),
+		"proxyAddr": endpoints.FirstAuthGateway(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -362,9 +362,9 @@ func printAgentStatus(status statusapi.Agent, w io.Writer) {
 func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 	description := node.AdvertiseIP
 	if node.Profile != "" {
-		description = fmt.Sprintf("%v, %v", description, node.Profile)
+		description = fmt.Sprintf("%v / %v", description, node.Profile)
 	}
-	fmt.Fprintf(w, "        * %v (%v)\n", unknownFallback(node.Hostname), description)
+	fmt.Fprintf(w, "        * %v / %v\n", unknownFallback(node.Hostname), description)
 	switch node.Status {
 	case statusapi.NodeOffline:
 		fmt.Fprintf(w, "            Status:\t%v\n", color.YellowString("offline"))


### PR DESCRIPTION
This PR addresses a few issues with Kubernetes proxy that appeared after upgrading to Teleport 3.2. Teleport starting from 3.2 uses Kubernetes Impersonation API instead of CSR API.

* Revendor latest Teleport to address a bug related to sending empty auth information to API server.
* Update gravity-site RBAC to allow impersonation requests.
* Fix a couple of issues with `tsh login` - e.g. it now expects Teleport proxy to returns "proxy settings" which gravity-site wasn't returning before.

Plus a couple of general fixes:

* Factor out the logic for assembling "cluster endpoints" (auth gateway address and UI) to a common method which is now used by both gravity status and new UI so they display consistent info.
* A couple of tweaks to gravity status output.