### PR TITLE
Couple UX tweaks.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -230,6 +230,11 @@ const (
 	// OpsCenterPackage is the Ops Center cluster image name.
 	OpsCenterPackage = "opscenter"
 
+	// GravityDisplayName is the display-friendly name of the base image.
+	GravityDisplayName = "Gravity"
+	// GravityHubDisplayName is the display-friendly name of the Hub image.
+	GravityHubDisplayName = "Gravity Hub"
+
 	// EnvironmentPath is the path to the environment file
 	EnvironmentPath = "/etc/environment"
 

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -2053,9 +2053,9 @@ func (m *Handler) getAppInstaller(w http.ResponseWriter, r *http.Request, p http
 	}
 	defer reader.Close()
 
-	w.Header().Set("Content-Type", "application/x-gzip")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(
-		`attachment; filename="%v-installer.tar.gz"`, locator.String()))
+	w.Header().Set("Content-Type", "application/tar")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%v-%v.tar"`,
+		locator.Name, locator.Version))
 	_, err = io.Copy(w, reader)
 	return nil, trace.Wrap(err)
 }

--- a/lib/webapi/webhandler.go
+++ b/lib/webapi/webhandler.go
@@ -176,7 +176,17 @@ func (h *WebHandler) configHandler(w http.ResponseWriter, r *http.Request, p htt
 		}
 		manifest := cluster.App.Manifest
 		config.User.Logo = manifest.Logo
-		config.User.Login.HeaderText = manifest.Metadata.Name
+		// TODO(r0mant): Ideally our manifest would have something like
+		// display name but for now provide custom headers for our
+		// system images.
+		switch manifest.Metadata.Name {
+		case defaults.TelekubePackage:
+			config.User.Login.HeaderText = defaults.GravityDisplayName
+		case defaults.OpsCenterPackage:
+			config.User.Login.HeaderText = defaults.GravityHubDisplayName
+		default:
+			config.User.Login.HeaderText = manifest.Metadata.Name
+		}
 	}
 
 	if h.cfg.Mode == constants.ComponentSite || h.cfg.Wizard {


### PR DESCRIPTION
* Update name of the file for installer tarball generated by web API. It was obsolete (still used ".tar.gz" extension) and not user-friendly (included repo name for example). Now it's `name-version.tar`. Needed by the new dashboard.

* Also tweak web display name for our internal apps (gravity/opscenter) a bit.