### PR TITLE
Rename opscenter to hub in tele output.

### DIFF
--- a/lib/catalog/lister.go
+++ b/lib/catalog/lister.go
@@ -249,8 +249,11 @@ func List(lister Lister, all bool, format constants.Format) error {
 }
 
 func convertName(name string) string {
-	if name == constants.LegacyBaseImageName {
-		name = constants.BaseImageName
+	switch name {
+	case constants.LegacyBaseImageName:
+		return constants.BaseImageName
+	case constants.LegacyHubImageName:
+		return constants.HubImageName
 	}
 	return name
 }

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -763,6 +763,11 @@ var (
 	LegacyBaseImageName = "telekube"
 	// BaseImageName is the current base cluster image name
 	BaseImageName = "gravity"
+
+	// LegacyHubImageName is the legacy name of the Hub cluster image.
+	LegacyHubImageName = "opscenter"
+	// HubImageName is the name of the Hub cluster image.
+	HubImageName = "hub"
 )
 
 // Format is the type for supported output formats

--- a/lib/hub/hub.go
+++ b/lib/hub/hub.go
@@ -73,7 +73,7 @@ type Hub interface {
 	// List returns a list of applications in the hub
 	List(withPrereleases bool) ([]App, error)
 	// Downloads downloads the specified application installer into provided file
-	Download(*os.File, loc.Locator, utils.Progress) error
+	Download(*os.File, loc.Locator) error
 	// Get returns application installer tarball of the specified version
 	Get(loc.Locator) (io.ReadCloser, error)
 	// GetLatestVersion returns latest version of the specified application
@@ -178,7 +178,7 @@ func (h *s3Hub) List(withPrereleases bool) (items []App, err error) {
 }
 
 // Downloads downloads the specified application installer into provided file
-func (h *s3Hub) Download(f *os.File, locator loc.Locator, progress utils.Progress) (err error) {
+func (h *s3Hub) Download(f *os.File, locator loc.Locator) (err error) {
 	version := locator.Version
 	// in case the provided version is a special 'latest' or 'stable' label,
 	// we need to look into respective bucket to find out the actual version
@@ -191,7 +191,6 @@ func (h *s3Hub) Download(f *os.File, locator loc.Locator, progress utils.Progres
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	progress.NextStep(fmt.Sprintf("Downloading %v:%v", locator.Name, locator.Version))
 	h.Infof("Downloading: %v.", h.appPath(locator.Name, locator.Version))
 	n, err := h.downloader.Download(f, &s3.GetObjectInput{
 		Bucket: aws.String(h.Bucket),
@@ -226,7 +225,7 @@ func (h *s3Hub) Get(locator loc.Locator) (io.ReadCloser, error) {
 			}
 		},
 	}
-	err = h.Download(tarFile, locator, utils.DiscardProgress)
+	err = h.Download(tarFile, locator)
 	if err != nil {
 		readCloser.Close()
 		return nil, trace.Wrap(err)

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -878,7 +878,11 @@ func (r *Router) UpsertAuthGateway(ctx context.Context, key ops.SiteKey, gw stor
 
 // GetAuthGateway returns auth gateway configuration.
 func (r *Router) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
-	return r.Local.GetAuthGateway(key)
+	client, err := r.PickClient(key.SiteDomain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return client.GetAuthGateway(key)
 }
 
 // ListReleases returns all currently installed application releases in a cluster.

--- a/tool/tele/cli/pull.go
+++ b/tool/tele/cli/pull.go
@@ -35,6 +35,7 @@ func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	name := locator.Name
 
 	// tele ls displays base images as "gravity" while the actual image
 	// name is "telekube" (for legacy reasons).
@@ -55,7 +56,7 @@ func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool)
 	}
 
 	if outFile == "" {
-		outFile = fmt.Sprintf("%v-%v.tar", locator.Name, locator.Version)
+		outFile = fmt.Sprintf("%v-%v.tar", name, locator.Version)
 	}
 
 	fi, err := utils.StatFile(outFile)
@@ -76,7 +77,9 @@ func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool)
 	progress := utils.NewProgress(context.TODO(), "Download", 1, quiet)
 	defer progress.Stop()
 
-	err = hub.Download(f, *locator, progress)
+	progress.NextStep(fmt.Sprintf("Downloading %v:%v", name, locator.Version))
+
+	err = hub.Download(f, *locator)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This is similar to what we did to `telekube`/`gravity` - make tele show `hub` instead of `opscenter`.

Also, use remote operator client when retrieving auth gateway. This fixes install via UI wizard (otherwise it shows internal error after completing install and trying to show the cluster).

@a-palchikov @knisbet We can cut `6.0.0-rc.1` after this (and its enterprise counterpart) is merged.