### PR TITLE
Remove obsolete webapi handlers.

### DIFF
--- a/lib/webapi/resources.go
+++ b/lib/webapi/resources.go
@@ -43,12 +43,8 @@ func (m *Handler) Resources(ctx *AuthContext) (resources.Resources, error) {
 
 // getResourceHandler is GET handler that returns ConfigItems for requested resource kind
 func (m *Handler) getResourceHandler(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	key, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	kind := p.ByName("kind")
-	data, err := m.getResources(*key, kind, ctx)
+	data, err := m.getResources(clusterKey(ctx, p), kind, ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -72,13 +68,8 @@ func (m *Handler) upsertResourceHandler(w http.ResponseWriter, r *http.Request, 
 		return nil, trace.Wrap(err)
 	}
 
-	key, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	isNew := r.Method == http.MethodPost
-	items, err := m.upsertResource(r.Context(), *key, isNew, *rawRes, ctx)
+	items, err := m.upsertResource(r.Context(), clusterKey(ctx, p), isNew, *rawRes, ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -88,13 +79,9 @@ func (m *Handler) upsertResourceHandler(w http.ResponseWriter, r *http.Request, 
 
 // deleteResourceHandler is DELETE handler that removes a resource by its kind and name values
 func (m *Handler) deleteResourceHandler(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	key, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	resourceKind := p.ByName("kind")
 	resourceName := p.ByName("name")
-	if err := m.deleteResource(r.Context(), *key, resourceKind, resourceName, ctx); err != nil {
+	if err := m.deleteResource(r.Context(), clusterKey(ctx, p), resourceKind, resourceName, ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -202,15 +202,6 @@ func NewAPI(cfg Config) (*Handler, error) {
 	// OAuth2 callbacks
 	h.GET("/github/callback", telehttplib.MakeHandler(h.githubCallback))
 
-	// TODO(r0mant): Delete legacy handlers when 6.0 user interface is merged.
-	h.GET("/accounts/existing/invites", h.needsAuth(h.getUserInvites))
-	h.DELETE("/accounts/existing/invites/:username", h.needsAuth(h.deleteUserInvite))
-	h.PUT("/accounts/existing/users", h.needsAuth(h.updateUser))
-	h.GET("/accounts/existing/users", h.needsAuth(h.getUsers))
-	h.DELETE("/accounts/existing/users/:username", h.needsAuth(h.deleteUser))
-	h.POST("/accounts/existing/users/password", h.needsAuth(h.updateUserPassword))
-	h.GET("/sites/:domain/endpoints", h.needsAuth(h.getSiteEndpoints))
-
 	// Users
 	h.GET("/sites/:domain/users", h.needsAuth(h.getUsers))
 	h.PUT("/sites/:domain/users", h.needsAuth(h.updateUser))
@@ -400,24 +391,11 @@ func (m *Handler) getUserToken(w http.ResponseWriter, r *http.Request, p httprou
 }
 
 // clusterKey returns cluster key based on the provided parameters.
-func clusterKey(ctx *AuthContext, p httprouter.Params) (*ops.SiteKey, error) {
-	if p.ByName("domain") != "" {
-		return &ops.SiteKey{
-			AccountID:  ctx.User.GetAccountID(),
-			SiteDomain: p.ByName("domain"),
-		}, nil
+func clusterKey(ctx *AuthContext, p httprouter.Params) ops.SiteKey {
+	return ops.SiteKey{
+		AccountID:  ctx.User.GetAccountID(),
+		SiteDomain: p.ByName("domain"),
 	}
-	// This is only needed to support legacy handlers which didn't include
-	// cluster name in their paths - for those, the local cluster is
-	// returned.
-	//
-	// TODO(r0mant): Delete this when 6.0 user interface is merged.
-	localCluster, err := ctx.Operator.GetLocalSite()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	key := localCluster.Key()
-	return &key, nil
 }
 
 type inviteUserReq struct {
@@ -434,13 +412,9 @@ func (m *Handler) createUserInvite(w http.ResponseWriter, r *http.Request, p htt
 	if err := telehttplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	inviteToken, err := ctx.Operator.CreateUserInvite(r.Context(),
 		ops.CreateUserInviteRequest{
-			SiteKey: *clusterKey,
+			SiteKey: clusterKey(ctx, p),
 			Name:    req.Name,
 			Roles:   req.Roles,
 		})
@@ -455,11 +429,7 @@ func (m *Handler) createUserInvite(w http.ResponseWriter, r *http.Request, p htt
 // GET /portalapi/v1/sites/:domain/invites
 //
 func (m *Handler) getUserInvites(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	invites, err := ctx.Operator.GetUserInvites(r.Context(), *clusterKey)
+	invites, err := ctx.Operator.GetUserInvites(r.Context(), clusterKey(ctx, p))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -471,12 +441,8 @@ func (m *Handler) getUserInvites(w http.ResponseWriter, r *http.Request, p httpr
 // DELETE /portalapi/v1/sites/:domain/invites/:name
 //
 func (m *Handler) deleteUserInvite(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	err = ctx.Operator.DeleteUserInvite(r.Context(), ops.DeleteUserInviteRequest{
-		SiteKey: *clusterKey,
+	err := ctx.Operator.DeleteUserInvite(r.Context(), ops.DeleteUserInviteRequest{
+		SiteKey: clusterKey(ctx, p),
 		Name:    p.ByName("username"),
 	})
 	if err != nil {
@@ -490,13 +456,9 @@ func (m *Handler) deleteUserInvite(w http.ResponseWriter, r *http.Request, p htt
 // GET /portalapi/v1/sites/:domain/users/:username/reset
 //
 func (m *Handler) createUserReset(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	resetToken, err := ctx.Operator.CreateUserReset(r.Context(),
 		ops.CreateUserResetRequest{
-			SiteKey: *clusterKey,
+			SiteKey: clusterKey(ctx, p),
 			Name:    p.ByName("username"),
 			TTL:     defaults.UserResetTokenTTL,
 		})
@@ -524,17 +486,12 @@ func (m *Handler) getWebContext(w http.ResponseWriter, r *http.Request, p httpro
 // GET /portalapi/v1/sites/:domain/users
 //
 func (m *Handler) getUsers(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	clusterKey, err := clusterKey(ctx, p)
+	users, err := ctx.Operator.GetUsers(clusterKey(ctx, p))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	users, err := ctx.Operator.GetUsers(*clusterKey)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	invites, err := ctx.Operator.GetUserInvites(r.Context(), *clusterKey)
+	invites, err := ctx.Operator.GetUserInvites(r.Context(), clusterKey(ctx, p))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -567,12 +524,8 @@ func (m *Handler) updateUser(w http.ResponseWriter, r *http.Request, p httproute
 	if err := telehttplib.ReadJSON(r, &uiUser); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	err = ctx.Operator.UpdateUser(r.Context(), ops.UpdateUserRequest{
-		SiteKey:  *clusterKey,
+	err := ctx.Operator.UpdateUser(r.Context(), ops.UpdateUserRequest{
+		SiteKey:  clusterKey(ctx, p),
 		Name:     uiUser.Email,
 		FullName: uiUser.Name,
 		Roles:    uiUser.Roles,
@@ -590,11 +543,7 @@ func (m *Handler) updateUser(w http.ResponseWriter, r *http.Request, p httproute
 // It deletes user invite and all associated tokens
 //
 func (m *Handler) deleteUser(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *AuthContext) (interface{}, error) {
-	clusterKey, err := clusterKey(ctx, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	err = ctx.Operator.DeleteUser(r.Context(), *clusterKey, p.ByName("username"))
+	err := ctx.Operator.DeleteUser(r.Context(), clusterKey(ctx, p), p.ByName("username"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1313,11 +1262,7 @@ func (m *Handler) getCluster(w http.ResponseWriter, r *http.Request, p httproute
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key, err := clusterKey(context, p)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	cluster, err := context.Operator.GetSite(*key)
+	cluster, err := context.Operator.GetSite(clusterKey(context, p))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1744,25 +1689,6 @@ func (m *Handler) getClusterInfo(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 	return clusterInfo, nil
-}
-
-// getEndpoints returns a list of endpoints of the application installed on site
-//
-//   GET /portalapi/v1/sites/:domain/endpoints
-//
-// Input:
-//
-//   none
-//
-// Output:
-//
-//   []ops.Endpoint
-func (m *Handler) getSiteEndpoints(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	endpoints, err := context.Operator.GetApplicationEndpoints(ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
-	})
-	return endpoints, trace.Wrap(err)
 }
 
 // getSiteReport returns a tarball with collected information about the site


### PR DESCRIPTION
I kept them for compatibility with the old UI but now that the new UI has been merged, we can get rid of them.