### PR TITLE
Add rhel 8 to supported distros.

### DIFF
--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -76,7 +76,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16"]
         - name: ubuntu-core
@@ -112,7 +112,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16"]
         - name: ubuntu-core
@@ -153,7 +153,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16"]
         - name: ubuntu-core


### PR DESCRIPTION
I've spun up a RHEL 8 instance on EC2, installed a cluster successfully and clicked through the UI tabs, seems to be working. Ideally, we'll need to add it to robotest too.

Note, CentOS 8 is not out yet.

Closes https://github.com/gravitational/gravity.e/issues/4081.