### PR TITLE
[5.5] fix restart regression

### DIFF
--- a/lib/install/process.go
+++ b/lib/install/process.go
@@ -35,7 +35,6 @@ func InitProcess(ctx context.Context, installerConfig Config, gravityConfig proc
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	setLoggingOptions()
 	err = p.InitRPCCredentials()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/process/wizard.go
+++ b/lib/process/wizard.go
@@ -83,10 +83,6 @@ func WizardTeleportConfig(clusterName, stateDir string) *telecfg.FileConfig {
 	return &telecfg.FileConfig{
 		Global: telecfg.Global{
 			DataDir: stateDir,
-			Logger: telecfg.Log{
-				Output:   "stderr",
-				Severity: "warn",
-			},
 			Storage: backend.Config{
 				// TODO Eventually we should change this to "dir" backend
 				// because bolt backend is being deprecated in teleport

--- a/lib/update/clusterconfig/plan_test.go
+++ b/lib/update/clusterconfig/plan_test.go
@@ -119,7 +119,8 @@ func (S) TestSingleNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-1"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[0],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -292,7 +293,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-1"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[0],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -378,7 +380,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-3"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[2],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -556,7 +559,8 @@ address: "0.0.0.0"`),
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-1"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[0],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -637,7 +641,8 @@ address: "0.0.0.0"`),
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-2"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[1],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{

--- a/lib/update/environ/plan_test.go
+++ b/lib/update/environ/plan_test.go
@@ -118,7 +118,8 @@ func (S) TestSingleNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-1"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[0],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -311,7 +312,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-1"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[0],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -398,7 +400,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-3"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[2],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -492,7 +495,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-2"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[1],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{
@@ -570,7 +574,8 @@ func (S) TestMultiNodePlan(c *C) {
 								Executor:    libphase.RestartContainer,
 								Description: `Restart container on node "node-4"`,
 								Data: &storage.OperationPhaseData{
-									Package: &app.Package,
+									ExecServer: &servers[3],
+									Package:    &app.Package,
 									Update: &storage.UpdateOperationData{
 										Servers: []storage.UpdateServer{
 											{

--- a/lib/update/internal/rollingupdate/builder.go
+++ b/lib/update/internal/rollingupdate/builder.go
@@ -132,7 +132,8 @@ func (r Builder) restart(server storage.UpdateServer) update.Phase {
 	node := r.node("restart", "Restart container on node %q", server.Hostname)
 	node.Executor = libphase.RestartContainer
 	node.Data = &storage.OperationPhaseData{
-		Package: &r.App,
+		ExecServer: &server.Server,
+		Package:    &r.App,
 		Update: &storage.UpdateOperationData{
 			Servers: []storage.UpdateServer{server},
 		},

--- a/lib/utils/logginghook.go
+++ b/lib/utils/logginghook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package install
+package utils
 
 import (
 	"io/ioutil"
@@ -27,7 +27,7 @@ import (
 	syslogrus "github.com/sirupsen/logrus/hooks/syslog"
 )
 
-// InitLogging initalizes logging for local installer
+// InitLogging initalizes logging to log both to syslog and to a file
 func InitLogging(logFile string) {
 	log.StandardLogger().Hooks.Add(&Hook{
 		path: logFile,

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/httplib"
-	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/process"
 	"github.com/gravitational/gravity/lib/schema"
@@ -122,15 +121,17 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.RPCAgentRunCmd.FullCommand(),
 		g.LeaveCmd.FullCommand(),
 		g.RemoveCmd.FullCommand(),
+		g.ResourceCreateCmd.FullCommand(),
+		g.ResourceRemoveCmd.FullCommand(),
 		g.OpsAgentCmd.FullCommand():
-		install.InitLogging(*g.SystemLogFile)
+		utils.InitLogging(*g.SystemLogFile)
 		// install and join command also duplicate their logs to the file in
 		// the current directory for convenience, unless the user set their
 		// own location
 		switch cmd {
 		case g.InstallCmd.FullCommand(), g.JoinCmd.FullCommand():
 			if *g.SystemLogFile == defaults.GravitySystemLog {
-				install.InitLogging(defaults.GravitySystemLogFile)
+				utils.InitLogging(defaults.GravitySystemLogFile)
 			}
 		}
 	}


### PR DESCRIPTION
 * Fix a regression with rolling update with restart not configured to happen on the target node.
 * Configure resource create/remove operations to log similar to install operation - both to `syslog` and a log file.