### PR TITLE
[5.5.x] backport a few bugfixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -943,11 +943,12 @@
   revision = "8d626fcff656a0fca570e9b0dd919b8e4e4709eb"
 
 [[projects]]
-  digest = "1:22c8951489f0e27ec3b2d50d9f74086ff3f08554ce5965d418d6a10296b9ea04"
+  digest = "1:afb36747f009e72637bdf1b3f5d27f3c1d5e1fc5478fc4aba2a33e40e8829dee"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4a5e142f3251b3a98e8fd71c2a32eb225af06b6d"
+  revision = "a5c40b57db7203332a073f20771214d0eeb2a168"
+  version = "1.1.7"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,8 +32,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  #version = "1.1.6"
-  revision = "4a5e142f3251b3a98e8fd71c2a32eb225af06b6d"
+  version = "=1.1.7"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,9 +204,6 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
-	// BlockingOperationEnvVar specifies whether to wait for operation to complete
-	BlockingOperationEnvVar = "GRAVITY_BLOCKING_OPERATION"
-
 	// DockerRegistry is a default name for private docker registry
 	DockerRegistry = "leader.telekube.local:5000"
 

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -756,7 +756,7 @@ After all phases have completed successfully, complete the operation using "grav
 		return trace.Wrap(err)
 	}
 	go func() {
-		fsmErr := fsm.ExecutePlan(p.Context, utils.NewNopProgress(), false)
+		fsmErr := fsm.ExecutePlan(p.Context, utils.NewNopProgress())
 		if err != nil {
 			p.Errorf("Failed to execute plan: %v.",
 				trace.DebugReport(err))

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -73,6 +73,12 @@ type Params struct {
 	PhaseID string
 	// Force is whether to force execution/rollback
 	Force bool
+	// Resume determines whether a failed/in-progress phase is rerun.
+	//
+	// It is different from Force which forces a phase in any state
+	// to be rerun - this is unexpected when the operation is resumed
+	// and only the unfinished/failed steps are re-executed
+	Resume bool
 	// Progress is optional progress reporter
 	Progress utils.Progress
 }
@@ -140,7 +146,7 @@ func New(config Config) (*FSM, error) {
 }
 
 // ExecutePlan iterates over all phases of the plan and executes them in order
-func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress, force bool) error {
+func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 	plan, err := f.GetPlan()
 	if err != nil {
 		return trace.Wrap(err)
@@ -150,7 +156,7 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress, force bo
 		err := f.ExecutePhase(ctx, Params{
 			PhaseID:  phase.ID,
 			Progress: progress,
-			Force:    force,
+			Resume:   true,
 		})
 		if err != nil {
 			return trace.Wrap(err, "failed to execute phase %q", phase.ID)
@@ -176,7 +182,7 @@ func (f *FSM) ExecutePhase(ctx context.Context, p Params) error {
 	if phase.IsCompleted() && !p.Force {
 		return nil
 	}
-	if phase.IsInProgress() && !(p.Force || phase.HasSubphases()) {
+	if phase.IsInProgress() && !(p.Force || p.Resume || phase.HasSubphases()) {
 		return trace.BadParameter(
 			"phase %q is in progress, use --force flag to force execution", phase.ID)
 	}

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -331,8 +331,7 @@ func (i *Installer) GetFSM() (*fsm.FSM, error) {
 
 // startFSM executes operation plan using the provided FSM
 func (i *Installer) startFSM(fsm *fsm.FSM) {
-	force := false
-	err := fsm.ExecutePlan(i.Context, utils.NewNopProgress(), force)
+	err := fsm.ExecutePlan(i.Context, utils.NewNopProgress())
 	if err != nil {
 		i.Errorf("Failed to execute plan: %v.", trace.DebugReport(err))
 	}

--- a/lib/update/cluster/automatic.go
+++ b/lib/update/cluster/automatic.go
@@ -70,8 +70,7 @@ func AutomaticUpgrade(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 	}
 	defer fsm.Close()
 
-	force := false
-	fsmErr := fsm.Run(ctx, force)
+	fsmErr := fsm.Run(ctx)
 	if fsmErr != nil {
 		log.Warnf("Failed to execute plan: %v.", fsmErr)
 		// fallthrough

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -486,7 +486,8 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 			Data: &storage.OperationPhaseData{
 				Server:     &server.Server,
 				ExecServer: &leadMaster.Server,
-			}},
+			},
+		},
 		{
 			ID:          "system-upgrade",
 			Executor:    updateSystem,
@@ -496,7 +497,8 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 				Update: &storage.UpdateOperationData{
 					Servers: []storage.UpdateServer{server},
 				},
-			}},
+			},
+		},
 	}
 	if supportsTaints {
 		phases = append(phases, update.Phase{
@@ -515,7 +517,8 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 		Data: &storage.OperationPhaseData{
 			Server:     &server.Server,
 			ExecServer: &leadMaster.Server,
-		}})
+		},
+	})
 	if waitsForEndpoints {
 		phases = append(phases, update.Phase{
 			ID:          "endpoints",
@@ -524,7 +527,8 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 			Data: &storage.OperationPhaseData{
 				Server:     &server.Server,
 				ExecServer: &leadMaster.Server,
-			}})
+			},
+		})
 	}
 	if supportsTaints {
 		phases = append(phases, update.Phase{
@@ -534,7 +538,8 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 			Data: &storage.OperationPhaseData{
 				Server:     &server.Server,
 				ExecServer: &leadMaster.Server,
-			}})
+			},
+		})
 	}
 	return phases
 }
@@ -545,11 +550,11 @@ func (r phaseBuilder) cleanup() *update.Phase {
 		Description: "Run cleanup tasks",
 	})
 
-	for _, server := range r.servers {
-		node := r.node(server.Server, &root, "Clean up node %q")
+	for i := range r.servers {
+		node := r.node(r.servers[i].Server, &root, "Clean up node %q")
 		node.Executor = cleanupNode
 		node.Data = &storage.OperationPhaseData{
-			Server: &server.Server,
+			Server: &r.servers[i].Server,
 		}
 		root.AddParallel(node)
 	}
@@ -675,19 +680,20 @@ func setLeaderElection(enable, disable []storage.Server, server storage.UpdateSe
 			ElectionChange: &storage.ElectionChange{
 				EnableServers:  enable,
 				DisableServers: disable,
-			}},
+			},
+		},
 	}
 }
 
-func servers(updates ...storage.UpdateServer) (result []storage.Server) {
+func serversToStorage(updates ...storage.UpdateServer) (result []storage.Server) {
 	for _, update := range updates {
 		result = append(result, update.Server)
 	}
 	return result
 }
 
-var disable = servers
-var enable = servers
+var disable = serversToStorage
+var enable = serversToStorage
 
 type waitsForEndpoints bool
 

--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/gravitational/gravity/lib/app"
 	apptest "github.com/gravitational/gravity/lib/app/service/test"
 	"github.com/gravitational/gravity/lib/archive"
-	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
@@ -45,7 +47,7 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 	runtimeLoc2 := loc.MustParseLocator("gravitational.io/runtime:2.0.0")
 	appLoc2 := loc.MustParseLocator("gravitational.io/app:2.0.0")
 
-	params := newTestPlan(c, params{
+	params := params{
 		installedRuntime:         runtimeLoc1,
 		installedApp:             appLoc1,
 		updateRuntime:            runtimeLoc2,
@@ -64,60 +66,42 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 				Enabled:    true,
 			},
 		},
-	})
-	plan := params.plan
-
-	leadMaster := params.servers[0]
-	builder := phaseBuilder{planConfig: params}
-	init := *builder.init(leadMaster.Server)
-	checks := *builder.checks().Require(init)
-	preUpdate := *builder.preUpdate().Require(init)
-	bootstrap := *builder.bootstrap().Require(init)
-	coreDNS := *builder.corednsPhase(leadMaster.Server)
-	masters := *builder.masters(leadMaster, params.servers[1:2], false).Require(checks, bootstrap, preUpdate, coreDNS)
-	nodes := *builder.nodes(leadMaster, params.servers[2:], false).Require(masters)
-	etcd := *builder.etcdPlan(leadMaster.Server, plan.Servers[1:2], plan.Servers[2:], "1.0.0", "2.0.0")
-	migration := builder.migration(leadMaster.Server).Require(etcd)
-	c.Assert(migration, check.NotNil)
-	config := *builder.config(servers(params.servers[:2]...)).Require(masters)
-
-	runtimeLocs := []loc.Locator{
-		loc.MustParseLocator("gravitational.io/runtime-dep-2:2.0.0"),
-		loc.MustParseLocator("gravitational.io/rbac-app:2.0.0"),
-		runtimeLoc2,
+		dnsConfig:  storage.DefaultDNSConfig,
+		// Use an alternative (other than first) master node as leader
+		leadMaster: updates[1],
 	}
-	runtime := *builder.runtime(runtimeLocs).Require(masters)
-
-	appLocs := []loc.Locator{loc.MustParseLocator("gravitational.io/app-dep-2:2.0.0"), appLoc2}
-	app := *builder.app(appLocs).Require(runtime)
-	cleanup := *builder.cleanup().Require(app)
-
-	plan.Phases = update.Phases{
-		init,
-		checks,
-		preUpdate,
-		coreDNS,
-		bootstrap,
-		masters,
-		nodes,
-		etcd,
-		*migration,
-		config,
-		runtime,
-		app,
-		cleanup,
-	}.AsPhases()
-	update.ResolvePlan(&plan)
+	config := newTestPlan(c, params)
 
 	// exercise
-	obtainedPlan, err := newOperationPlan(params)
+	obtainedPlan, err := newOperationPlan(config)
 	c.Assert(err, check.IsNil)
-	// Reset the capacity so the plans can be compared
-	obtainedPlan.Phases = resetCap(obtainedPlan.Phases)
 	update.ResolvePlan(obtainedPlan)
 
 	// verify
-	c.Assert(*obtainedPlan, compare.DeepEquals, plan)
+	c.Assert(*obtainedPlan, check.DeepEquals, storage.OperationPlan{
+		OperationID:    config.operation.ID,
+		OperationType:  config.operation.Type,
+		AccountID:      config.operation.AccountID,
+		ClusterName:    config.operation.SiteDomain,
+		Servers:        servers,
+		DNSConfig:      storage.DefaultDNSConfig,
+		GravityPackage: gravityUpdateLoc,
+		Phases: []storage.OperationPhase{
+			params.init(),
+			params.checks(),
+			params.preUpdate(),
+			params.coreDNS(),
+			params.bootstrap(),
+			params.masters(updates[0:1]),
+			params.nodes(),
+			params.etcd(updates[0:1]),
+			params.migration(),
+			params.config(),
+			params.runtime(),
+			params.app("/runtime"),
+			params.cleanup(),
+		},
+	})
 }
 
 func (s *PlanSuite) TestPlanWithoutRuntimeUpdate(c *check.C) {
@@ -126,7 +110,7 @@ func (s *PlanSuite) TestPlanWithoutRuntimeUpdate(c *check.C) {
 	appLoc1 := loc.MustParseLocator("gravitational.io/app:1.0.0")
 	appLoc2 := loc.MustParseLocator("gravitational.io/app:2.0.0")
 
-	params := newTestPlan(c, params{
+	params := params{
 		installedRuntime:         runtimeLoc1,
 		installedApp:             appLoc1,
 		updateRuntime:            runtimeLoc1, // same runtime on purpose
@@ -135,30 +119,33 @@ func (s *PlanSuite) TestPlanWithoutRuntimeUpdate(c *check.C) {
 		installedAppManifest:     installedAppManifest,
 		updateRuntimeManifest:    installedRuntimeManifest, // same manifest on purpose
 		updateAppManifest:        updateAppManifest,
-	})
-	plan := params.plan
-
-	leadMaster := params.servers[0]
-	builder := phaseBuilder{planConfig: params}
-	init := *builder.init(leadMaster.Server)
-	checks := *builder.checks().Require(init)
-	preUpdate := *builder.preUpdate().Require(init)
-	appLocs := []loc.Locator{loc.MustParseLocator("gravitational.io/app-dep-2:2.0.0"), appLoc2}
-	app := *builder.app(appLocs).Require(preUpdate)
-	cleanup := *builder.cleanup().Require(app)
-
-	plan.Phases = update.Phases{init, checks, preUpdate, app, cleanup}.AsPhases()
-	update.ResolvePlan(&plan)
+		dnsConfig:                storage.DefaultDNSConfig,
+		leadMaster:               updates[0],
+	}
+	config := newTestPlan(c, params)
 
 	// exercise
-	obtainedPlan, err := newOperationPlan(params)
+	obtainedPlan, err := newOperationPlan(config)
 	c.Assert(err, check.IsNil)
-	// Reset the capacity so the plans can be compared
-	obtainedPlan.Phases = resetCap(obtainedPlan.Phases)
 	update.ResolvePlan(obtainedPlan)
 
 	// verify
-	c.Assert(*obtainedPlan, compare.DeepEquals, plan)
+	c.Assert(*obtainedPlan, check.DeepEquals, storage.OperationPlan{
+		OperationID:    config.operation.ID,
+		OperationType:  config.operation.Type,
+		AccountID:      config.operation.AccountID,
+		ClusterName:    config.operation.SiteDomain,
+		Servers:        servers,
+		DNSConfig:      storage.DefaultDNSConfig,
+		GravityPackage: gravityInstalledLoc,
+		Phases: []storage.OperationPhase{
+			params.init(),
+			params.checks(),
+			params.preUpdate(),
+			params.app("/pre-update"),
+			params.cleanup(),
+		},
+	})
 }
 
 func (s *PlanSuite) TestUpdatesEtcdFromManifestWithoutLabels(c *check.C) {
@@ -269,102 +256,691 @@ func (s *PlanSuite) TestCorrectlyDeterminesWhetherToUpdateEtcd(c *check.C) {
 	c.Assert(updateVersion, check.Equals, "3.3.3")
 }
 
-func newTestPlan(c *check.C, p params) planConfig {
-	runtimeLoc := loc.MustParseLocator("gravitational.io/planet:2.0.0")
-	servers := []storage.Server{
-		{
-			AdvertiseIP: "192.168.0.1",
-			Hostname:    "node-1",
-			Role:        "node",
-			ClusterRole: string(schema.ServiceRoleMaster),
-		},
-		{
-			AdvertiseIP: "192.168.0.2",
-			Hostname:    "node-2",
-			Role:        "node",
-			ClusterRole: string(schema.ServiceRoleMaster),
-		},
-		{
-			AdvertiseIP: "192.168.0.3",
-			Hostname:    "node-3",
-			Role:        "node",
-			ClusterRole: string(schema.ServiceRoleNode),
-		},
-	}
-	updates := []storage.UpdateServer{
-		{
-			Server: servers[0],
-			Runtime: storage.RuntimePackage{
-				Update: &storage.RuntimeUpdate{Package: runtimeLoc},
-			},
-		},
-		{
-			Server: servers[1],
-			Runtime: storage.RuntimePackage{
-				Update: &storage.RuntimeUpdate{Package: runtimeLoc},
-			},
-		},
-		{
-			Server: servers[2],
-			Runtime: storage.RuntimePackage{
-				Update: &storage.RuntimeUpdate{Package: runtimeLoc},
-			},
-		},
-	}
-	operation := storage.SiteOperation{
-		AccountID:  "000",
-		SiteDomain: "test",
-		ID:         "123",
-		Type:       ops.OperationUpdate,
-	}
-	params := planConfig{
+func newTestPlan(c *check.C, params params) planConfig {
+	config := planConfig{
 		operator:  testOperator,
 		operation: operation,
 		servers:   updates,
 		installedRuntime: app.Application{
-			Package:  p.installedRuntime,
-			Manifest: schema.MustParseManifestYAML([]byte(p.installedRuntimeManifest)),
+			Package:  params.installedRuntime,
+			Manifest: schema.MustParseManifestYAML([]byte(params.installedRuntimeManifest)),
 			PackageEnvelope: pack.PackageEnvelope{
-				Manifest: []byte(p.installedRuntimeManifest),
+				Manifest: []byte(params.installedRuntimeManifest),
 			},
 		},
 		installedApp: app.Application{
-			Package:  p.installedApp,
-			Manifest: schema.MustParseManifestYAML([]byte(p.installedAppManifest)),
+			Package:  params.installedApp,
+			Manifest: schema.MustParseManifestYAML([]byte(params.installedAppManifest)),
 			PackageEnvelope: pack.PackageEnvelope{
-				Manifest: []byte(p.installedAppManifest),
+				Manifest: []byte(params.installedAppManifest),
 			},
 		},
 		updateRuntime: app.Application{
-			Package:  p.updateRuntime,
-			Manifest: schema.MustParseManifestYAML([]byte(p.updateRuntimeManifest)),
+			Package:  params.updateRuntime,
+			Manifest: schema.MustParseManifestYAML([]byte(params.updateRuntimeManifest)),
 			PackageEnvelope: pack.PackageEnvelope{
-				Manifest: []byte(p.updateRuntimeManifest),
+				Manifest: []byte(params.updateRuntimeManifest),
 			},
 		},
 		updateApp: app.Application{
-			Package:  p.updateApp,
-			Manifest: schema.MustParseManifestYAML([]byte(p.updateAppManifest)),
+			Package:  params.updateApp,
+			Manifest: schema.MustParseManifestYAML([]byte(params.updateAppManifest)),
 			PackageEnvelope: pack.PackageEnvelope{
-				Manifest: []byte(p.updateAppManifest),
+				Manifest: []byte(params.updateAppManifest),
 			},
 		},
-		links:            p.links,
-		trustedClusters:  p.trustedClusters,
+		links:            params.links,
+		trustedClusters:  params.trustedClusters,
 		shouldUpdateEtcd: shouldUpdateEtcdTest,
-		updateCoreDNS:    p.updateCoreDNS,
+		updateCoreDNS:    params.updateCoreDNS,
+		leadMaster:       params.leadMaster,
 	}
-	gravityPackage, err := params.updateRuntime.Manifest.Dependencies.ByName(
+	gravityPackage, err := config.updateRuntime.Manifest.Dependencies.ByName(
 		constants.GravityPackage)
 	c.Assert(err, check.IsNil)
-	params.plan = storage.OperationPlan{
+	config.plan = storage.OperationPlan{
 		OperationID:    operation.ID,
 		OperationType:  operation.Type,
+		AccountID:      operation.AccountID,
 		ClusterName:    operation.SiteDomain,
 		Servers:        servers,
 		GravityPackage: *gravityPackage,
+		DNSConfig:      params.dnsConfig,
 	}
-	return params
+	return config
+}
+
+func (r *params) init() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/init",
+		Executor:    updateInit,
+		Description: "Initialize update operation",
+		Data: &storage.OperationPhaseData{
+			Package:          &r.updateApp,
+			ExecServer:       &r.leadMaster.Server,
+			InstalledPackage: &r.installedApp,
+			Update: &storage.UpdateOperationData{
+				Servers: updates,
+			},
+		},
+	}
+}
+
+func (r *params) checks() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/checks",
+		Executor:    updateChecks,
+		Description: "Run preflight checks",
+		Requires:    []string{"/init"},
+		Data: &storage.OperationPhaseData{
+			Package:          &r.updateApp,
+			InstalledPackage: &r.installedApp,
+		},
+	}
+}
+
+func (r *params) preUpdate() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/pre-update",
+		Executor:    preUpdate,
+		Description: "Run pre-update application hook",
+		Requires:    []string{"/init"},
+		Data: &storage.OperationPhaseData{
+			Package: &r.updateApp,
+		},
+	}
+}
+
+func (r *params) coreDNS() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/coredns",
+		Description: "Provision CoreDNS resources",
+		Executor:    coredns,
+		Data: &storage.OperationPhaseData{
+			Server: &r.leadMaster.Server,
+		},
+	}
+}
+
+func (r *params) bootstrap() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/bootstrap",
+		Description: "Bootstrap update operation on nodes",
+		Requires:    []string{"/init"},
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/bootstrap/node-1",
+				Executor:    updateBootstrap,
+				Description: `Bootstrap node "node-1"`,
+				Data: &storage.OperationPhaseData{
+					ExecServer:       &servers[0],
+					Package:          &r.updateApp,
+					InstalledPackage: &r.installedApp,
+					Update: &storage.UpdateOperationData{
+						Servers: updates[0:1],
+					},
+				},
+			},
+			{
+				ID:          "/bootstrap/node-2",
+				Executor:    updateBootstrap,
+				Description: `Bootstrap node "node-2"`,
+				Data: &storage.OperationPhaseData{
+					ExecServer:       &servers[1],
+					Package:          &r.updateApp,
+					InstalledPackage: &r.installedApp,
+					Update: &storage.UpdateOperationData{
+						Servers: updates[1:2],
+					},
+				},
+			},
+			{
+				ID:          "/bootstrap/node-3",
+				Executor:    updateBootstrap,
+				Description: `Bootstrap node "node-3"`,
+				Data: &storage.OperationPhaseData{
+					ExecServer:       &servers[2],
+					Package:          &r.updateApp,
+					InstalledPackage: &r.installedApp,
+					Update: &storage.UpdateOperationData{
+						Servers: updates[2:3],
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *params) masters(otherMasters []storage.UpdateServer) storage.OperationPhase {
+	t := func(format string, node storage.UpdateServer) string {
+		return fmt.Sprintf(format, node.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          "/masters",
+		Description: "Update master nodes",
+		Requires:    []string{"/checks", "/bootstrap", "/pre-update", "/coredns"},
+		Phases: []storage.OperationPhase{
+			r.leaderMasterPhase(),
+			{
+				ID:          t("/masters/elect-%v", r.leadMaster),
+				Executor:    electionStatus,
+				Description: t("Make node %q Kubernetes leader", r.leadMaster),
+				Data: &storage.OperationPhaseData{
+					Server: &r.leadMaster.Server,
+					ElectionChange: &storage.ElectionChange{
+						EnableServers:  []storage.Server{r.leadMaster.Server},
+						DisableServers: serversToStorage(otherMasters...),
+					},
+				},
+				Requires: []string{t("/masters/%v", r.leadMaster)},
+			},
+			r.otherMasterPhase(otherMasters[0]),
+		},
+	}
+}
+
+func (r *params) leaderMasterPhase() storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, r.leadMaster.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/masters/%v"),
+		Description: t("Update system software on master node %q"),
+		Phases: []storage.OperationPhase{
+			{
+				ID:          t("/masters/%v/kubelet-permissions"),
+				Description: t("Add permissions to kubelet on %q"),
+				Executor:    kubeletPermissions,
+				Data: &storage.OperationPhaseData{
+					Server: &r.leadMaster.Server,
+				},
+			},
+			{
+				ID:          t("/masters/%[1]v/stepdown-%[1]v"),
+				Executor:    electionStatus,
+				Description: t("Step down %q as Kubernetes leader"),
+				Data: &storage.OperationPhaseData{
+					Server: &r.leadMaster.Server,
+					ElectionChange: &storage.ElectionChange{
+						DisableServers: []storage.Server{r.leadMaster.Server},
+					},
+				},
+				Requires: []string{t("/masters/%v/kubelet-permissions")},
+			},
+			{
+				ID:          t("/masters/%v/drain"),
+				Executor:    drainNode,
+				Description: t("Drain node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &r.leadMaster.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/masters/%[1]v/stepdown-%[1]v")},
+			},
+			{
+				ID:          t("/masters/%v/system-upgrade"),
+				Executor:    updateSystem,
+				Description: t("Update system software on node %q"),
+				Data: &storage.OperationPhaseData{
+					ExecServer: &r.leadMaster.Server,
+					Update: &storage.UpdateOperationData{
+						Servers: []storage.UpdateServer{r.leadMaster},
+					},
+				},
+				Requires: []string{t("/masters/%v/drain")},
+			},
+			{
+				ID:          t("/masters/%v/uncordon"),
+				Executor:    uncordonNode,
+				Description: t("Uncordon node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &r.leadMaster.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/masters/%v/system-upgrade")},
+			},
+		},
+	}
+}
+
+func (r *params) otherMasterPhase(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/masters/%v"),
+		Description: t("Update system software on master node %q"),
+		Requires:    []string{fmt.Sprintf("/masters/elect-%v", r.leadMaster.Hostname)},
+		Phases: []storage.OperationPhase{
+			{
+				ID:          t("/masters/%v/drain"),
+				Executor:    drainNode,
+				Description: t("Drain node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+			},
+			{
+				ID:          t("/masters/%v/system-upgrade"),
+				Executor:    updateSystem,
+				Description: t("Update system software on node %q"),
+				Data: &storage.OperationPhaseData{
+					ExecServer: &server.Server,
+					Update: &storage.UpdateOperationData{
+						Servers: []storage.UpdateServer{server},
+					},
+				},
+				Requires: []string{t("/masters/%v/drain")},
+			},
+			{
+				ID:          t("/masters/%v/uncordon"),
+				Executor:    uncordonNode,
+				Description: t("Uncordon node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/masters/%v/system-upgrade")},
+			},
+			{
+				ID:          t("/masters/%v/endpoints"),
+				Executor:    endpoints,
+				Description: t("Wait for DNS/cluster endpoints on %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/masters/%v/uncordon")},
+			},
+			{
+				ID:          t("/masters/%[1]v/enable-%[1]v"),
+				Executor:    electionStatus,
+				Description: t("Enable leader election on node %q"),
+				Data: &storage.OperationPhaseData{
+					Server: &server.Server,
+					ElectionChange: &storage.ElectionChange{
+						EnableServers: []storage.Server{server.Server},
+					},
+				},
+				Requires: []string{t("/masters/%v/endpoints")},
+			},
+		},
+	}
+}
+
+func (r *params) nodes() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/nodes",
+		Description: "Update regular nodes",
+		Requires:    []string{"/masters"},
+		Phases: []storage.OperationPhase{
+			r.nodePhase(updates[2]),
+		},
+	}
+}
+
+func (r *params) nodePhase(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/nodes/%v"),
+		Description: t("Update system software on node %q"),
+		Phases: []storage.OperationPhase{
+			{
+				ID:          t("/nodes/%v/drain"),
+				Executor:    drainNode,
+				Description: t("Drain node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+			},
+			{
+				ID:          t("/nodes/%v/system-upgrade"),
+				Executor:    updateSystem,
+				Description: t("Update system software on node %q"),
+				Data: &storage.OperationPhaseData{
+					ExecServer: &server.Server,
+					Update: &storage.UpdateOperationData{
+						Servers: []storage.UpdateServer{server},
+					},
+				},
+				Requires: []string{t("/nodes/%v/drain")},
+			},
+			{
+				ID:          t("/nodes/%v/uncordon"),
+				Executor:    uncordonNode,
+				Description: t("Uncordon node %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/nodes/%v/system-upgrade")},
+			},
+			{
+				ID:          t("/nodes/%v/endpoints"),
+				Executor:    endpoints,
+				Description: t("Wait for DNS/cluster endpoints on %q"),
+				Data: &storage.OperationPhaseData{
+					Server:     &server.Server,
+					ExecServer: &r.leadMaster.Server,
+				},
+				Requires: []string{t("/nodes/%v/uncordon")},
+			},
+		},
+	}
+}
+
+func (r params) etcd(otherMasters []storage.UpdateServer) storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/etcd",
+		Description: "Upgrade etcd 1.0.0 to 2.0.0",
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/etcd/backup",
+				Description: "Backup etcd data",
+				Phases: []storage.OperationPhase{
+					r.etcdBackupNode(r.leadMaster),
+					// FIXME: assumes len(otherMasters) == 1
+					r.etcdBackupNode(otherMasters[0]),
+				},
+			},
+			{
+				ID:          "/etcd/shutdown",
+				Description: "Shutdown etcd cluster",
+				Phases: []storage.OperationPhase{
+					r.etcdShutdownNode(r.leadMaster, true),
+					// FIXME: assumes len(otherMasters) == 1
+					r.etcdShutdownNode(otherMasters[0], false),
+					r.etcdShutdownWorkerNode(updates[2]),
+				},
+			},
+			{
+				ID:          "/etcd/upgrade",
+				Description: "Upgrade etcd servers",
+				Phases: []storage.OperationPhase{
+					r.etcdUpgradeNode(r.leadMaster),
+					// FIXME: assumes len(otherMasters) == 1
+					r.etcdUpgradeNode(otherMasters[0]),
+					// upgrade regular nodes
+					r.etcdUpgradeNode(updates[2]),
+				},
+			},
+			{
+				ID:          "/etcd/restore",
+				Description: "Restore etcd data from backup",
+				Executor:    updateEtcdRestore,
+				Data: &storage.OperationPhaseData{
+					Server: &r.leadMaster.Server,
+				},
+				Requires: []string{"/etcd/upgrade"},
+			},
+			{
+				ID:          "/etcd/restart",
+				Description: "Restart etcd servers",
+				Phases: []storage.OperationPhase{
+					r.etcdRestartLeaderNode(),
+					// FIXME: assumes len(otherMasters) == 1
+					r.etcdRestartNode(otherMasters[0]),
+					// upgrade regular nodes
+					r.etcdRestartNode(updates[2]),
+					r.etcdRestartGravity(),
+				},
+			},
+		},
+	}
+}
+
+func (r params) etcdBackupNode(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/backup/%v"),
+		Description: t("Backup etcd on node %q"),
+		Executor:    updateEtcdBackup,
+		Data: &storage.OperationPhaseData{
+			Server: &server.Server,
+		},
+	}
+}
+
+func (r params) etcdShutdownNode(server storage.UpdateServer, isLeader bool) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/shutdown/%v"),
+		Description: t("Shutdown etcd on node %q"),
+		Executor:    updateEtcdShutdown,
+		Requires:    []string{t("/etcd/backup/%v")},
+		Data: &storage.OperationPhaseData{
+			Server: &server.Server,
+			Data:   strconv.FormatBool(isLeader),
+		},
+	}
+}
+
+func (r params) etcdShutdownWorkerNode(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/shutdown/%v"),
+		Description: t("Shutdown etcd on node %q"),
+		Executor:    updateEtcdShutdown,
+		Data: &storage.OperationPhaseData{
+			Server: &server.Server,
+			Data:   "false",
+		},
+	}
+}
+
+func (r params) etcdUpgradeNode(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/upgrade/%v"),
+		Description: t("Upgrade etcd on node %q"),
+		Executor:    updateEtcdMaster,
+		Requires:    []string{t("/etcd/shutdown/%v")},
+		Data: &storage.OperationPhaseData{
+			Server: &server.Server,
+		},
+	}
+}
+
+func (r params) etcdRestartLeaderNode() storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, r.leadMaster.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/restart/%v"),
+		Description: t("Restart etcd on node %q"),
+		Executor:    updateEtcdRestart,
+		Requires:    []string{"/etcd/restore"},
+		Data: &storage.OperationPhaseData{
+			Server: &r.leadMaster.Server,
+		},
+	}
+}
+
+func (r params) etcdRestartNode(server storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		return fmt.Sprintf(format, server.Hostname)
+	}
+	return storage.OperationPhase{
+		ID:          t("/etcd/restart/%v"),
+		Description: t("Restart etcd on node %q"),
+		Executor:    updateEtcdRestart,
+		Requires:    []string{t("/etcd/upgrade/%v")},
+		Data: &storage.OperationPhaseData{
+			Server: &server.Server,
+		},
+	}
+}
+
+func (r params) etcdRestartGravity() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          fmt.Sprint("/etcd/restart/", constants.GravityServiceName),
+		Description: fmt.Sprint("Restart ", constants.GravityServiceName, " service"),
+		Executor:    updateEtcdRestartGravity,
+		Data: &storage.OperationPhaseData{
+			Server: &r.leadMaster.Server,
+		},
+	}
+}
+
+func (r *params) migration() storage.OperationPhase {
+	phase := storage.OperationPhase{
+		ID:          "/migration",
+		Description: "Perform system database migration",
+		Requires:    []string{"/etcd"},
+	}
+	if len(r.links) != 0 && len(r.trustedClusters) == 0 {
+		phase.Phases = append(phase.Phases, storage.OperationPhase{
+			ID:          "/migration/links",
+			Description: "Migrate remote Ops Center links to trusted clusters",
+			Executor:    migrateLinks,
+		})
+	}
+	phase.Phases = append(phase.Phases, storage.OperationPhase{
+		ID:          "/migration/labels",
+		Description: "Update node labels",
+		Executor:    updateLabels,
+	})
+	// FIXME: add roles migration step
+	return phase
+}
+
+func (r params) config() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/config",
+		Description: "Update system configuration on nodes",
+		Requires:    []string{"/masters"},
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/config/node-1",
+				Executor:    config,
+				Description: `Update system configuration on node "node-1"`,
+				Data: &storage.OperationPhaseData{
+					Server: &servers[0],
+				},
+			},
+			{
+				ID:          "/config/node-2",
+				Executor:    config,
+				Description: `Update system configuration on node "node-2"`,
+				Data: &storage.OperationPhaseData{
+					Server: &servers[1],
+				},
+			},
+		},
+	}
+}
+
+func (r params) runtime() storage.OperationPhase {
+	rbacLoc := loc.MustParseLocator("gravitational.io/rbac-app:2.0.0")
+	runtimeDepLoc := loc.MustParseLocator("gravitational.io/runtime-dep-2:2.0.0")
+	runtimeLoc := loc.MustParseLocator("gravitational.io/runtime:2.0.0")
+	return storage.OperationPhase{
+		ID:          "/runtime",
+		Description: "Update application runtime",
+		Requires:    []string{"/masters"},
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/runtime/rbac-app",
+				Executor:    updateApp,
+				Description: `Update system application "rbac-app" to 2.0.0`,
+				Data: &storage.OperationPhaseData{
+					Package: &rbacLoc,
+				},
+			},
+			{
+				ID:          "/runtime/runtime-dep-2",
+				Executor:    updateApp,
+				Description: `Update system application "runtime-dep-2" to 2.0.0`,
+				Data: &storage.OperationPhaseData{
+					Package: &runtimeDepLoc,
+				},
+				Requires: []string{"/runtime/rbac-app"},
+			},
+			{
+				ID:          "/runtime/runtime",
+				Executor:    updateApp,
+				Description: `Update system application "runtime" to 2.0.0`,
+				Data: &storage.OperationPhaseData{
+					Package: &runtimeLoc,
+				},
+				Requires: []string{"/runtime/runtime-dep-2"},
+			},
+		},
+	}
+}
+
+func (r params) app(requires ...string) storage.OperationPhase {
+	appLoc := loc.MustParseLocator("gravitational.io/app:2.0.0")
+	appDepLoc := loc.MustParseLocator("gravitational.io/app-dep-2:2.0.0")
+	return storage.OperationPhase{
+		ID:          "/app",
+		Description: "Update installed application",
+		Requires:    requires,
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/app/app-dep-2",
+				Executor:    updateApp,
+				Description: `Update application "app-dep-2" to 2.0.0`,
+				Data: &storage.OperationPhaseData{
+					Package: &appDepLoc,
+				},
+			},
+			{
+				ID:          "/app/app",
+				Executor:    updateApp,
+				Description: `Update application "app" to 2.0.0`,
+				Data: &storage.OperationPhaseData{
+					Package: &appLoc,
+				},
+			},
+		},
+	}
+}
+
+func (r params) cleanup() storage.OperationPhase {
+	return storage.OperationPhase{
+		ID:          "/gc",
+		Description: "Run cleanup tasks",
+		Requires:    []string{"/app"},
+		Phases: []storage.OperationPhase{
+			{
+				ID:          "/gc/node-1",
+				Executor:    cleanupNode,
+				Description: `Clean up node "node-1"`,
+				Data: &storage.OperationPhaseData{
+					Server: &updates[0].Server,
+				},
+			},
+			{
+				ID:          "/gc/node-2",
+				Executor:    cleanupNode,
+				Description: `Clean up node "node-2"`,
+				Data: &storage.OperationPhaseData{
+					Server: &updates[1].Server,
+				},
+			},
+			{
+				ID:          "/gc/node-3",
+				Executor:    cleanupNode,
+				Description: `Clean up node "node-3"`,
+				Data: &storage.OperationPhaseData{
+					Server: &updates[2].Server,
+				},
+			},
+		},
+	}
 }
 
 type params struct {
@@ -379,10 +955,8 @@ type params struct {
 	updateCoreDNS            bool
 	links                    []storage.OpsCenterLink
 	trustedClusters          []teleservices.TrustedCluster
-}
-
-func resetCap(phases []storage.OperationPhase) []storage.OperationPhase {
-	return phases[:len(phases):len(phases)]
+	leadMaster               storage.UpdateServer
+	dnsConfig                storage.DNSConfig
 }
 
 func shouldUpdateEtcdTest(planConfig) (bool, string, string, error) {
@@ -415,6 +989,56 @@ type testRotator struct {
 	runtimeConfigPackage  loc.Locator
 	teleportMasterPackage loc.Locator
 	teleportNodePackage   loc.Locator
+}
+
+var runtimePackage = storage.RuntimePackage{
+	Update: &storage.RuntimeUpdate{
+		Package: loc.MustParseLocator("gravitational.io/planet:2.0.0"),
+	},
+}
+var gravityInstalledLoc = loc.MustParseLocator("gravitational.io/gravity:1.0.0")
+var gravityUpdateLoc = loc.MustParseLocator("gravitational.io/gravity:2.0.0")
+var servers = []storage.Server{
+	{
+		AdvertiseIP: "192.168.0.1",
+		Hostname:    "node-1",
+		Role:        "node",
+		ClusterRole: string(schema.ServiceRoleMaster),
+	},
+	{
+		AdvertiseIP: "192.168.0.2",
+		Hostname:    "node-2",
+		Role:        "node",
+		ClusterRole: string(schema.ServiceRoleMaster),
+	},
+	{
+		AdvertiseIP: "192.168.0.3",
+		Hostname:    "node-3",
+		Role:        "node",
+		ClusterRole: string(schema.ServiceRoleNode),
+	},
+}
+
+var updates = []storage.UpdateServer{
+	{
+		Server:  servers[0],
+		Runtime: runtimePackage,
+	},
+	{
+		Server:  servers[1],
+		Runtime: runtimePackage,
+	},
+	{
+		Server:  servers[2],
+		Runtime: runtimePackage,
+	},
+}
+
+var operation = storage.SiteOperation{
+	AccountID:  "000",
+	SiteDomain: "test",
+	ID:         "123",
+	Type:       ops.OperationUpdate,
 }
 
 const installedRuntimeManifest = `apiVersion: bundle.gravitational.io/v2

--- a/lib/vacuum/vacuum.go
+++ b/lib/vacuum/vacuum.go
@@ -48,7 +48,7 @@ func New(config Config) (*Collector, error) {
 }
 
 // Run runs the garbage collection.
-func (r *Collector) Run(ctx context.Context, force bool) error {
+func (r *Collector) Run(ctx context.Context) error {
 	machine, err := r.init()
 	if err != nil {
 		return trace.Wrap(err)
@@ -56,7 +56,7 @@ func (r *Collector) Run(ctx context.Context, force bool) error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- r.executePlan(ctx, machine, force)
+		errCh <- r.executePlan(ctx, machine)
 	}()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
@@ -82,7 +82,7 @@ L:
 // RunPhase runs the specified garbage collection phase.
 func (r *Collector) RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error {
 	if phase == libfsm.RootPhase {
-		return trace.Wrap(r.Run(ctx, force))
+		return trace.Wrap(r.Run(ctx))
 	}
 
 	machine, err := r.init()
@@ -138,8 +138,8 @@ func (r *Collector) init() (*libfsm.FSM, error) {
 	return machine, nil
 }
 
-func (r *Collector) executePlan(ctx context.Context, machine *libfsm.FSM, force bool) error {
-	planErr := machine.ExecutePlan(ctx, nil, force)
+func (r *Collector) executePlan(ctx context.Context, machine *libfsm.FSM) error {
+	planErr := machine.ExecutePlan(ctx, nil)
 	if planErr != nil {
 		r.Warnf("Failed to execute plan: %v.", trace.DebugReport(planErr))
 	}

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -63,7 +63,7 @@ func updateConfig(ctx context.Context, localEnv, updateEnv *localenv.LocalEnviro
 	}
 	defer updater.Close()
 	if !manual {
-		err = updater.Run(ctx, false)
+		err = updater.Run(ctx)
 		return trace.Wrap(err)
 	}
 	localEnv.Println(updateConfigManualOperationBanner)
@@ -177,6 +177,7 @@ func (r configInitializer) newOperationPlan(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
+	leader *storage.Server,
 ) (*storage.OperationPlan, error) {
 	plan, err := clusterconfig.NewOperationPlan(operator, clusterEnv.Apps, operation, r.config, cluster.ClusterState.Servers)
 	if err != nil {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -58,21 +58,16 @@ func updateTrigger(
 	localEnv *localenv.LocalEnvironment,
 	updateEnv *localenv.LocalEnvironment,
 	updatePackage string,
-	manual, block, noValidateVersion bool,
+	manual, noValidateVersion bool,
 ) error {
 	ctx := context.TODO()
-	updater, err := newClusterUpdater(ctx, localEnv, updateEnv, updatePackage, manual, block, noValidateVersion)
+	updater, err := newClusterUpdater(ctx, localEnv, updateEnv, updatePackage, manual, noValidateVersion)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	unattended := !manual && !block
-	if unattended {
-		return nil
-	}
 	if !manual {
-		err = updater.Run(ctx, false)
-		return trace.Wrap(err)
+		return trace.Wrap(updater.Run(ctx))
 	}
 	localEnv.Println(updateClusterManualOperationBanner)
 	return nil
@@ -82,12 +77,11 @@ func newClusterUpdater(
 	ctx context.Context,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	updatePackage string,
-	manual, block, noValidateVersion bool,
+	manual, noValidateVersion bool,
 ) (updater, error) {
-	unattended := !manual && !block
 	init := &clusterInitializer{
 		updatePackage: updatePackage,
-		unattended:    unattended,
+		unattended:    !manual,
 	}
 	updater, err := newUpdater(ctx, localEnv, updateEnv, init)
 	if err != nil {
@@ -201,9 +195,10 @@ func (r clusterInitializer) newOperationPlan(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
+	leader *storage.Server,
 ) (*storage.OperationPlan, error) {
 	plan, err := clusterupdate.InitOperationPlan(
-		ctx, localEnv, updateEnv, clusterEnv, operation.Key(),
+		ctx, localEnv, updateEnv, clusterEnv, operation.Key(), leader,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -67,7 +67,8 @@ func updateTrigger(
 	}
 	defer updater.Close()
 	if !manual {
-		return trace.Wrap(updater.Run(ctx))
+		// The cluster is updating in background
+		return nil
 	}
 	localEnv.Println(updateClusterManualOperationBanner)
 	return nil

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -507,9 +507,7 @@ type PlanRollbackCmd struct {
 // PlanResumeCmd resumes active operation
 type PlanResumeCmd struct {
 	*kingpin.CmdClause
-	// Force forces rollback of the phase given in Phase
-	Force *bool
-	// PhaseTimeout is the rollback timeout
+	// PhaseTimeout is the phase timeout
 	PhaseTimeout *time.Duration
 }
 
@@ -561,9 +559,6 @@ type UpdateTriggerCmd struct {
 	App *string
 	// Manual starts operation in manual mode
 	Manual *bool
-	// Block controls whether to wait for the operation to finish.
-	// If false, this enables to run the operation unattended
-	Block *bool
 	// SkipVersionCheck suppresses version mismatch errors
 	SkipVersionCheck *bool
 }
@@ -607,9 +602,6 @@ type UpgradeCmd struct {
 	App *string
 	// Manual starts upgrade in manual mode
 	Manual *bool
-	// Block controls whether to wait for the operation to finish.
-	// If false, this enables to run the operation unattended
-	Block *bool
 	// Phase is upgrade operation phase to execute
 	Phase *string
 	// Timeout is phase execution timeout

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -58,7 +58,7 @@ func updateEnviron(
 	}
 	defer updater.Close()
 	if !manual {
-		err = updater.Run(ctx, false)
+		err = updater.Run(ctx)
 		return trace.Wrap(err)
 	}
 	localEnv.Println(updateEnvironManualOperationBanner)
@@ -167,6 +167,7 @@ func (environInitializer) newOperationPlan(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
+	leader *storage.Server,
 ) (*storage.OperationPlan, error) {
 	plan, err := environ.NewOperationPlan(operator, clusterEnv.Apps, operation, cluster.ClusterState.Servers)
 	if err != nil {

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -58,7 +58,7 @@ func garbageCollect(env *localenv.LocalEnvironment, manual, confirmed bool) erro
 
 	ctx := context.TODO()
 	if !manual {
-		err = collector.Run(ctx, false)
+		err = collector.Run(ctx)
 		return trace.Wrap(err)
 	}
 

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -498,7 +498,7 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, ope
 	defer progress.Stop()
 
 	if p.PhaseID == fsm.RootPhase {
-		return trace.Wrap(ResumeInstall(ctx, installFSM, progress, p.Force))
+		return trace.Wrap(ResumeInstall(ctx, installFSM, progress))
 	}
 
 	err = installFSM.ExecutePhase(ctx, fsm.Params{
@@ -553,7 +553,7 @@ func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParam
 	progress := utils.NewProgress(ctx, fmt.Sprintf("Executing join phase %q", p.PhaseID), -1, false)
 	defer progress.Stop()
 	if p.PhaseID == fsm.RootPhase {
-		return trace.Wrap(ResumeInstall(ctx, joinFSM, progress, p.Force))
+		return trace.Wrap(ResumeInstall(ctx, joinFSM, progress))
 	}
 	return joinFSM.ExecutePhase(ctx, fsm.Params{
 		PhaseID:  p.PhaseID,
@@ -609,8 +609,8 @@ func rollbackJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhasePara
 	})
 }
 
-func ResumeInstall(ctx context.Context, machine *fsm.FSM, progress utils.Progress, force bool) error {
-	fsmErr := machine.ExecutePlan(ctx, progress, force)
+func ResumeInstall(ctx context.Context, machine *fsm.FSM, progress utils.Progress) error {
+	fsmErr := machine.ExecutePlan(ctx, progress)
 	if fsmErr != nil {
 		return trace.Wrap(fsmErr)
 	}

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -53,7 +53,11 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = clusterupdate.InitOperationPlan(ctx, localEnv, updateEnv, clusterEnv, operation.Key())
+	leader, err := findLocalServer(*cluster)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = clusterupdate.InitOperationPlan(ctx, localEnv, updateEnv, clusterEnv, operation.Key(), leader)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -151,7 +151,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanRollbackCmd.PhaseTimeout = g.PlanRollbackCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 
 	g.PlanResumeCmd.CmdClause = g.PlanCmd.Command("resume", "Resume last aborted operation")
-	g.PlanResumeCmd.Force = g.PlanResumeCmd.Flag("force", "Force execution of specified phase").Bool()
 	g.PlanResumeCmd.PhaseTimeout = g.PlanResumeCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark operation as completed")
@@ -164,10 +163,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpdateTriggerCmd.CmdClause = g.UpdateCmd.Command("trigger", "Trigger an update operation for given application").Hidden()
 	g.UpdateTriggerCmd.App = g.UpdateTriggerCmd.Arg("app", "Application version to update to, in the 'name:version' or 'name' (for latest version) format. If unspecified, currently installed application is updated").String()
 	g.UpdateTriggerCmd.Manual = g.UpdateTriggerCmd.Flag("manual", "Manual operation. Do not trigger automatic update").Short('m').Bool()
-	g.UpdateTriggerCmd.Block = g.UpdateTriggerCmd.Flag("block", "Wait for operation to finish (default). Use --no-block to run the operation unattended instead").
-		OverrideDefaultFromEnvar(constants.BlockingOperationEnvVar).
-		Default("true").
-		Bool()
 	g.UpdateTriggerCmd.SkipVersionCheck = g.UpdateTriggerCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 
 	g.UpdatePlanInitCmd.CmdClause = g.UpdateCmd.Command("init-plan", "Initialize operation plan").Hidden()
@@ -176,10 +171,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpgradeCmd.CmdClause = g.Command("upgrade", "Trigger an update operation for given application").Hidden()
 	g.UpgradeCmd.App = g.UpgradeCmd.Arg("app", "Application version to update to, in the 'name:version' or 'name' (for latest version) format. If unspecified, currently installed application is updated").String()
 	g.UpgradeCmd.Manual = g.UpgradeCmd.Flag("manual", "Manual upgrade mode").Short('m').Bool()
-	g.UpgradeCmd.Block = g.UpgradeCmd.Flag("block", "Wait for operation to finish (default). Use --no-block to run the operation unattended instead").
-		OverrideDefaultFromEnvar(constants.BlockingOperationEnvVar).
-		Default("true").
-		Bool()
 	g.UpgradeCmd.Phase = g.UpgradeCmd.Flag("phase", "Operation phase to execute").String()
 	g.UpgradeCmd.Timeout = g.UpgradeCmd.Flag("timeout", "Phase execution timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 	g.UpgradeCmd.Force = g.UpgradeCmd.Flag("force", "Force phase execution even if pre-conditions are not satisfied").Bool()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -306,6 +306,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.InstallCmd.FullCommand():
 		if *g.InstallCmd.Resume {
 			*g.InstallCmd.Phase = fsm.RootPhase
+			*g.InstallCmd.Force = false
 		}
 		if *g.InstallCmd.Phase != "" {
 			return executeInstallPhase(localEnv, PhaseParams{
@@ -318,6 +319,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.JoinCmd.FullCommand():
 		if *g.JoinCmd.Resume {
 			*g.JoinCmd.Phase = fsm.RootPhase
+			*g.JoinCmd.Force = false
 		}
 		if *g.JoinCmd.Phase != "" {
 			return executeJoinPhase(localEnv, joinEnv, PhaseParams{
@@ -345,7 +347,6 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			updateEnv,
 			*g.UpdateTriggerCmd.App,
 			*g.UpdateTriggerCmd.Manual,
-			*g.UpdateTriggerCmd.Block,
 			*g.UpdateTriggerCmd.SkipVersionCheck,
 		)
 	case g.UpdatePlanInitCmd.FullCommand():
@@ -353,6 +354,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.UpgradeCmd.FullCommand():
 		if *g.UpgradeCmd.Resume {
 			*g.UpgradeCmd.Phase = fsm.RootPhase
+			*g.UpgradeCmd.Force = false
 		}
 		if *g.UpgradeCmd.Phase != "" {
 			return executePhase(localEnv, updateEnv, joinEnv,
@@ -367,7 +369,6 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			updateEnv,
 			*g.UpgradeCmd.App,
 			*g.UpgradeCmd.Manual,
-			*g.UpgradeCmd.Block,
 			*g.UpgradeCmd.SkipVersionCheck,
 		)
 	case g.PlanExecuteCmd.FullCommand():
@@ -383,7 +384,6 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return executePhase(localEnv, updateEnv, joinEnv,
 			PhaseParams{
 				PhaseID:          fsm.RootPhase,
-				Force:            *g.PlanResumeCmd.Force,
 				Timeout:          *g.PlanResumeCmd.PhaseTimeout,
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
 				OperationID:      *g.PlanCmd.OperationID,

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -89,8 +89,13 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	leader, err := findLocalServer(*cluster)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to find local node in cluster state.\n"+
+			"Make sure you start the operation from one of the cluster master nodes.")
+	}
 	// Create the operation plan so it can be replicated on remote nodes
-	plan, err := init.newOperationPlan(ctx, operator, *cluster, *operation, localEnv, updateEnv, clusterEnv)
+	plan, err := init.newOperationPlan(ctx, operator, *cluster, *operation, localEnv, updateEnv, clusterEnv, leader)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -135,7 +140,9 @@ type updateInitializer interface {
 		cluster ops.Site,
 		operation ops.SiteOperation,
 		localEnv, updateEnv *localenv.LocalEnvironment,
-		clusterEnv *localenv.ClusterEnvironment) (*storage.OperationPlan, error)
+		clusterEnv *localenv.ClusterEnvironment,
+		leader *storage.Server,
+	) (*storage.OperationPlan, error)
 	newUpdater(ctx context.Context,
 		operator ops.Operator,
 		operation ops.SiteOperation,
@@ -148,7 +155,7 @@ type updateInitializer interface {
 
 type updater interface {
 	io.Closer
-	Run(ctx context.Context, force bool) error
+	Run(ctx context.Context) error
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	Complete(error) error

--- a/vendor/github.com/gravitational/trace/log.go
+++ b/vendor/github.com/gravitational/trace/log.go
@@ -20,7 +20,11 @@ package trace
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"reflect"
 	"regexp"
+	"runtime"
 	rundebug "runtime/debug"
 	"sort"
 	"strconv"
@@ -28,8 +32,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"runtime"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -50,6 +53,16 @@ const (
 	DefaultLevelPadding = 4
 )
 
+// IsTerminal checks whether writer is a terminal
+func IsTerminal(w io.Writer) bool {
+	switch v := w.(type) {
+	case *os.File:
+		return terminal.IsTerminal(int(v.Fd()))
+	default:
+		return false
+	}
+}
+
 // TextFormatter is logrus-compatible formatter and adds
 // file and line details to every logged entry.
 type TextFormatter struct {
@@ -59,6 +72,8 @@ type TextFormatter struct {
 	// ComponentPadding is a padding to pick when displaying
 	// and formatting component field, defaults to DefaultComponentPadding
 	ComponentPadding int
+	// EnableColors enables colored output
+	EnableColors bool
 }
 
 // Format implements logrus.Formatter interface and adds file and line
@@ -69,9 +84,10 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 			return
 		}
 	}()
+
 	var file string
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		file = t.Loc()
 	}
 
@@ -79,21 +95,26 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// time
 	if !tf.DisableTimestamp {
-		w.writeField(e.Time.Format(time.RFC3339))
+		w.writeField(e.Time.Format(time.RFC3339), noColor)
 	}
 
 	// level
-	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)))
+	color := noColor
+	if tf.EnableColors {
+		switch e.Level {
+		case log.DebugLevel:
+			color = gray
+		case log.WarnLevel:
+			color = yellow
+		case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+			color = red
+		default:
+			color = blue
+		}
+	}
+	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)), color)
 
-	// component, always output
-	componentI, ok := e.Data[Component]
-	if !ok {
-		componentI = ""
-	}
-	component, ok := componentI.(string)
-	if !ok {
-		component = fmt.Sprintf("%v", componentI)
-	}
+	// always output the component field if available
 	padding := DefaultComponentPadding
 	if tf.ComponentPadding != 0 {
 		padding = tf.ComponentPadding
@@ -101,8 +122,10 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 	if w.Len() > 0 {
 		w.WriteByte(' ')
 	}
-	if component != "" {
-		component = fmt.Sprintf("[%v]", component)
+	value := e.Data[Component]
+	var component string
+	if reflect.ValueOf(value).IsValid() {
+		component = fmt.Sprintf("[%v]", value)
 	}
 	component = strings.ToUpper(padMax(component, padding))
 	if component[len(component)-1] != ' ' {
@@ -112,7 +135,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// message
 	if e.Message != "" {
-		w.writeField(e.Message)
+		w.writeField(e.Message, noColor)
 	}
 
 	// rest of the fields
@@ -122,7 +145,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 
 	// file, if present, always last
 	if file != "" {
-		w.writeField(file)
+		w.writeField(file, noColor)
 	}
 
 	w.WriteByte('\n')
@@ -138,8 +161,8 @@ type JSONFormatter struct {
 
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		new := e.WithFields(log.Fields{
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
@@ -149,44 +172,79 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 		new.Message = e.Message
 		e = new
 	}
-	return (&j.JSONFormatter).Format(e)
+	return j.JSONFormatter.Format(e)
 }
 
-var r = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
 
-func findFrame() int {
-	for i := 3; i < 10; i++ {
-		_, file, _, ok := runtime.Caller(i)
-		if !ok {
-			return -1
-		}
-		if !r.MatchString(file) {
-			return i
+// findFrames positions the stack pointer to the first
+// function that does not match the frameIngorePattern
+// and returns the rest of the stack frames
+func findFrame() *frameCursor {
+	var buf [32]uintptr
+	// Skip enough frames to start at user code.
+	// This number is a mere hint to the following loop
+	// to start as close to user code as possible and getting it right is not mandatory.
+	// The skip count might need to get updated if the call to findFrame is
+	// moved up/down the call stack
+	n := runtime.Callers(4, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	for i := 0; i < n; i++ {
+		frame, _ := frames.Next()
+		if !frameIgnorePattern.MatchString(frame.File) {
+			return &frameCursor{
+				current: &frame,
+				rest:    frames,
+				n:       n,
+			}
 		}
 	}
-	return -1
+	return nil
 }
+
+const (
+	noColor = -1
+	red     = 31
+	yellow  = 33
+	blue    = 36
+	gray    = 37
+)
 
 type writer struct {
 	bytes.Buffer
 }
 
-func (w *writer) writeField(value interface{}) {
+func (w *writer) writeField(value interface{}, color int) {
 	if w.Len() > 0 {
 		w.WriteByte(' ')
 	}
-	w.writeValue(value)
+	w.writeValue(value, color)
 }
 
-func (w *writer) writeValue(value interface{}) {
-	stringVal, ok := value.(string)
-	if !ok {
-		stringVal = fmt.Sprint(value)
+func (w *writer) writeValue(value interface{}, color int) {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+		if needsQuoting(s) {
+			s = fmt.Sprintf("%q", v)
+		}
+	default:
+		s = fmt.Sprintf("%v", v)
 	}
-	if !needsQuoting(stringVal) {
-		w.WriteString(stringVal)
-	} else {
-		w.WriteString(fmt.Sprintf("%q", stringVal))
+	if color != noColor {
+		s = fmt.Sprintf("\x1b[%dm%s\x1b[0m", color, s)
+	}
+	w.WriteString(s)
+}
+
+func (w *writer) writeError(value interface{}) {
+	switch err := value.(type) {
+	case Error:
+		w.WriteString(fmt.Sprintf("[%v]", err.DebugReport()))
+	default:
+		w.WriteString(fmt.Sprintf("[%v]", value))
 	}
 }
 
@@ -196,7 +254,11 @@ func (w *writer) writeKeyValue(key string, value interface{}) {
 	}
 	w.WriteString(key)
 	w.WriteByte(':')
-	w.writeValue(value)
+	if key == log.ErrorKey {
+		w.writeError(value)
+		return
+	}
+	w.writeValue(value, noColor)
 }
 
 func (w *writer) writeMap(m map[string]interface{}) {
@@ -212,11 +274,11 @@ func (w *writer) writeMap(m map[string]interface{}) {
 		if key == Component {
 			continue
 		}
-		switch val := m[key].(type) {
+		switch value := m[key].(type) {
 		case log.Fields:
-			w.writeMap(val)
+			w.writeMap(value)
 		default:
-			w.writeKeyValue(key, val)
+			w.writeKeyValue(key, value)
 		}
 	}
 }

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -19,8 +19,10 @@ limitations under the License.
 package trace
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -40,7 +42,7 @@ func SetDebug(enabled bool) {
 	}
 }
 
-// IsDebug returns true if debug mode is on, false otherwize
+// IsDebug returns true if debug mode is on, false otherwise
 func IsDebug() bool {
 	return atomic.LoadInt32(&debug) == 1
 }
@@ -75,6 +77,25 @@ func UserMessage(err error) string {
 	return err.Error()
 }
 
+// UserMessageWithFields returns user-friendly error with key-pairs as part of the message
+func UserMessageWithFields(err error) string {
+	if err == nil {
+		return ""
+	}
+	if wrap, ok := err.(Error); ok {
+		if len(wrap.GetFields()) == 0 {
+			return wrap.UserMessage()
+		}
+
+		var kvps []string
+		for k, v := range wrap.GetFields() {
+			kvps = append(kvps, fmt.Sprintf("%v=%q", k, v))
+		}
+		return fmt.Sprintf("%v %v", strings.Join(kvps, " "), wrap.UserMessage())
+	}
+	return err.Error()
+}
+
 // DebugReport returns debug report with all known information
 // about the error including stack trace if it was captured
 func DebugReport(err error) string {
@@ -85,6 +106,17 @@ func DebugReport(err error) string {
 		return wrap.DebugReport()
 	}
 	return err.Error()
+}
+
+// GetFields returns any fields that have been added to the error message
+func GetFields(err error) map[string]interface{} {
+	if err == nil {
+		return map[string]interface{}{}
+	}
+	if wrap, ok := err.(Error); ok {
+		return wrap.GetFields()
+	}
+	return map[string]interface{}{}
 }
 
 // WrapWithMessage wraps the original error into Error and adds user message if any
@@ -124,31 +156,58 @@ func Errorf(format string, args ...interface{}) (err error) {
 // true Fatalf calls panic
 func Fatalf(format string, args ...interface{}) error {
 	if IsDebug() {
-		panic(fmt.Sprintf(format, args))
+		panic(fmt.Sprintf(format, args...))
 	} else {
-		return Errorf(format, args)
+		return Errorf(format, args...)
 	}
 }
 
 func newTrace(depth int, err error) *TraceErr {
-	var pc [32]uintptr
-	count := runtime.Callers(depth+1, pc[:])
+	var buf [32]uintptr
+	n := runtime.Callers(depth+1, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	cursor := frameCursor{
+		rest: frames,
+		n:    n,
+	}
+	return newTraceFromFrames(cursor, err)
+}
 
-	traces := make(Traces, count)
-	for i := 0; i < count; i++ {
-		fn := runtime.FuncForPC(pc[i])
-		filePath, line := fn.FileLine(pc[i])
-		traces[i] = Trace{
-			Func: fn.Name(),
-			Path: filePath,
-			Line: line,
+func newTraceFromFrames(cursor frameCursor, err error) *TraceErr {
+	traces := make(Traces, 0, cursor.n)
+	if cursor.current != nil {
+		traces = append(traces, frameToTrace(*cursor.current))
+	}
+	for {
+		frame, more := cursor.rest.Next()
+		traces = append(traces, frameToTrace(frame))
+		if !more {
+			break
 		}
 	}
 	return &TraceErr{
-		err,
-		traces,
-		"",
+		Err:    err,
+		Traces: traces,
 	}
+}
+
+func frameToTrace(frame runtime.Frame) Trace {
+	return Trace{
+		Func: frame.Function,
+		Path: frame.File,
+		Line: frame.Line,
+	}
+}
+
+type frameCursor struct {
+	// current specifies the current stack frame.
+	// if omitted, rest contains the complete stack
+	current *runtime.Frame
+	// rest specifies the rest of stack frames to explore
+	rest *runtime.Frames
+	// n specifies the total number of stack frames
+	n int
 }
 
 // Traces is a list of trace entries
@@ -223,9 +282,14 @@ func (t *Trace) String() string {
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
-	Err     error `json:"error"`
-	Traces  `json:"traces"`
-	Message string `json:"message,omitemtpy"`
+	// Err is the underlying error that TraceErr wraps
+	Err error `json:"error"`
+	// Traces is a slice of stack trace entries for the error
+	Traces `json:"traces"`
+	// Message is an optional message that can be wrapped with the original error
+	Message string `json:"message,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty`
 }
 
 type RawTrace struct {
@@ -244,6 +308,28 @@ func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) {
 	}
 }
 
+// AddFields adds the given map of fields to the error being reported
+func (e *TraceErr) AddFields(fields map[string]interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, len(fields))
+	}
+	for k, v := range fields {
+		e.Fields[k] = v
+	}
+	return e
+}
+
+// AddField adds a single field to the error wrapper as context for the error
+func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, 1)
+	}
+
+	e.Fields[k] = v
+
+	return e
+}
+
 // UserMessage returns user-friendly error message
 func (e *TraceErr) UserMessage() string {
 	if e.Message != "" {
@@ -252,14 +338,46 @@ func (e *TraceErr) UserMessage() string {
 	return UserMessage(e.Err)
 }
 
-// DebugReport returns develeoper-friendly error report
+// DebugReport returns developer-friendly error report
 func (e *TraceErr) DebugReport() string {
-	return fmt.Sprintf("\nERROR REPORT:\nOriginal Error: %T %v\nStack Trace:\n%v\nUser Message: %v\n", e.Err, e.Err.Error(), e.Traces.String(), e.Message)
+	var buffer bytes.Buffer
+	err := reportTemplate.Execute(&buffer, struct {
+		OrigErrType    string
+		OrigErrMessage string
+		Fields         map[string]interface{}
+		StackTrace     string
+		UserMessage    string
+	}{
+		OrigErrType:    fmt.Sprintf("%T", e.Err),
+		OrigErrMessage: e.Err.Error(),
+		Fields:         e.Fields,
+		StackTrace:     e.Traces.String(),
+		UserMessage:    e.UserMessage(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buffer.String()
 }
+
+var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
+var reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields: 
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+User Message: {{.UserMessage}}
+`
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
 	return e.UserMessage()
+}
+
+func (e *TraceErr) GetFields() map[string]interface{} {
+	return e.Fields
 }
 
 // OrigError returns original wrapped error
@@ -303,11 +421,20 @@ type Error interface {
 	// arguments as structured args
 	AddUserMessage(formatArg interface{}, rest ...interface{})
 
+	// AddField adds additional field information to the error
+	AddField(key string, value interface{}) *TraceErr
+
+	// AddFields adds a map of additional fields to the error
+	AddFields(fields map[string]interface{}) *TraceErr
+
 	// UserMessage returns user-friendly error message
 	UserMessage() string
 
-	// DebugReport returns develeoper-friendly error report
+	// DebugReport returns developer-friendly error report
 	DebugReport() string
+
+	// GetFields returns any fields that have been added to the error
+	GetFields() map[string]interface{}
 }
 
 // NewAggregate creates a new aggregate instance from the specified

--- a/vendor/github.com/gravitational/trace/udphook.go
+++ b/vendor/github.com/gravitational/trace/udphook.go
@@ -67,8 +67,8 @@ type Frame struct {
 func (elk *UDPHook) Fire(e *log.Entry) error {
 	// Make a copy to safely modify
 	entry := e.WithFields(nil)
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo-1, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		entry.Data[FileField] = t.String()
 		entry.Data[FunctionField] = t.Func()
 	}


### PR DESCRIPTION
  * resuming operation should not use --force - otherwise even completed phases are re-executed. Instead, introduce a special implicit resume flag for this purpose.
  * update operation plan might be broken if leader node is not first in the list of master nodes (https://github.com/gravitational/gravity.e/issues/4138).
  * run the update operation controller on the same node where the operation was started.
  * revert the blocking by default mode for update (introduced 

Also updates trace to 1.1.7 as `e/version/5.5.x` would have otherwise been incompatible.
Requires https://github.com/gravitational/gravity.e/pull/4145.