### PR TITLE
Do not log binary output of remote report collect call

### DIFF
--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1384,9 +1384,14 @@ type AgentService interface {
 	// GetServerInfos returns a list of server information objects
 	GetServerInfos(ctx context.Context, key SiteOperationKey) (checks.ServerInfos, error)
 
-	// Exec executes command on a remote server
-	// that is identified by meeting point and agent's address addr
+	// Exec executes the command specified with args on a remote server given with addr.
+	// It streams the process's output to the given writer out.
 	Exec(ctx context.Context, opKey SiteOperationKey, addr string, args []string, out io.Writer) error
+
+	// ExecNoLog executes the command specified with args on a remote server given with addr.
+	// It streams the process's output to the given writer out.
+	// Underlying remote call output is not logged
+	ExecNoLog(ctx context.Context, opKey SiteOperationKey, addr string, args []string, out io.Writer) error
 
 	// Validate executes preflight checks on the node specified with addr
 	// against the specified manifest and profile.

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -144,13 +144,24 @@ func (r *AgentService) GetServerInfos(ctx context.Context, key ops.SiteOperation
 // Exec executes command on a remote server
 // that is identified by meeting point and agent's address addr
 func (r *AgentService) Exec(ctx context.Context, key ops.SiteOperationKey, addr string, args []string, out io.Writer) error {
+	return r.exec(ctx, key, addr, args, out, r.FieldLogger)
+}
+
+// ExecNoLog executes the command specified with args on a remote server given with addr.
+// It streams the process's output to the given writer out.
+// Underlying remote call output is not logged
+func (r *AgentService) ExecNoLog(ctx context.Context, key ops.SiteOperationKey, addr string, args []string, out io.Writer) error {
+	return r.exec(ctx, key, addr, args, out, utils.DiscardingLog)
+}
+
+func (r *AgentService) exec(ctx context.Context, key ops.SiteOperationKey, addr string, args []string, out io.Writer, log log.FieldLogger) error {
 	group, err := r.peerStore.getOrCreateGroup(key)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	addr = rpc.AgentAddr(addr)
-	return trace.Wrap(group.exec(ctx, addr, r.FieldLogger, out, args...))
+	return trace.Wrap(group.exec(ctx, addr, log, out, args...))
 }
 
 // Validate executes preflight checks on the node specified with addr

--- a/lib/ops/opsservice/runner.go
+++ b/lib/ops/opsservice/runner.go
@@ -98,7 +98,7 @@ type agentRunner struct {
 
 // RunStream runs the provided command on the specified server and streams output to w
 func (r *agentRunner) RunStream(server remoteServer, w io.Writer, args ...string) error {
-	err := r.AgentService.Exec(context.TODO(), r.ctx.key(), server.Address(), args, w)
+	err := r.AgentService.ExecNoLog(context.TODO(), r.ctx.key(), server.Address(), args, w)
 
 	entry := r.ctx.WithFields(log.Fields{
 		constants.FieldServer:             server.Address(),

--- a/lib/system/environ/validate.go
+++ b/lib/system/environ/validate.go
@@ -46,9 +46,9 @@ func ValidateInstall(env *localenv.LocalEnvironment) func() error {
 			log.WithError(err).Warn("Failed to validate state directory requirements.")
 		}
 		// FIXME: validate enough of directory contents to make an educated decision automatically
-		// if err := validateDirectoryEmpty(stateDir); err != nil {
-		// 	return trace.Wrap(err)
-		// }
+		if err := validateDirectoryEmpty(stateDir); err != nil {
+			return trace.Wrap(err)
+		}
 		if err := validateNoPackageState(env.Packages, env.StateDir); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/utils/progress.go
+++ b/lib/utils/progress.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -357,3 +358,12 @@ func (*nopProgress) PrintInfo(message string, args ...interface{}) {}
 
 // PrintWarn outputs the specified warning message in color and logs the error
 func (*nopProgress) PrintWarn(err error, message string, args ...interface{}) {}
+
+// DiscardingLog is a logger that discards output
+var DiscardingLog = newDiscardingLogger()
+
+func newDiscardingLogger() (logger *logrus.Logger) {
+	logger = logrus.New()
+	logger.Out = ioutil.Discard
+	return logger
+}


### PR DESCRIPTION
Provide a non-logging Exec API in the agent service to use for debug report collection to silence the output of stdout.
Fixes https://github.com/gravitational/gravity.e/issues/4144.