### PR TITLE
Handle server interrupt gracefully - without invoking abort mechanism

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -131,8 +131,8 @@ func (p *Peer) Run(listener net.Listener) error {
 // Stop shuts down this RPC agent
 // Implements signals.Stopper
 func (p *Peer) Stop(ctx context.Context) error {
-	p.Info("Stop.")
-	p.server.Interrupted(ctx)
+	p.Info("Stop service.")
+	p.server.Stopped(ctx, false)
 	return nil
 }
 

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -89,8 +89,8 @@ func (i *Installer) Run(listener net.Listener) error {
 // Stop stops the server and releases resources allocated by the installer.
 // Implements signals.Stopper
 func (i *Installer) Stop(ctx context.Context) error {
-	i.Info("Stop.")
-	i.server.Interrupted(ctx)
+	i.Info("Stop service.")
+	i.server.Stopped(ctx, false)
 	return nil
 }
 

--- a/lib/install/operation.go
+++ b/lib/install/operation.go
@@ -187,7 +187,6 @@ func (i *Installer) newCompletionEvent(status dispatcher.Status) *dispatcher.Eve
 
 func (i *Installer) runStoppers(ctx context.Context, stoppers []signals.Stopper) error {
 	var errors []error
-	i.WithField("stoppers", stoppers).Info("Executing stoppers.")
 	for _, c := range stoppers {
 		if err := c.Stop(ctx); err != nil {
 			errors = append(errors, err)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -67,9 +67,6 @@ func updateTrigger(
 	}
 	defer updater.Close()
 	if !manual {
-		return nil
-	}
-	if !manual {
 		return trace.Wrap(updater.Run(ctx))
 	}
 	localEnv.Println(updateClusterManualOperationBanner)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -67,7 +67,8 @@ func updateTrigger(
 	}
 	defer updater.Close()
 	if !manual {
-		return trace.Wrap(updater.Run(ctx))
+		// The cluster is updating in background
+		return nil
 	}
 	localEnv.Println(updateClusterManualOperationBanner)
 	return nil

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	autoscaleaws "github.com/gravitational/gravity/lib/autoscale/aws"
@@ -765,6 +766,8 @@ func NewServiceListener() (net.Listener, error) {
 // InterruptSignals lists signals installer service considers interrupts
 var InterruptSignals = signals.WithSignals(
 	os.Interrupt,
+	syscall.SIGTERM,
+	syscall.SIGQUIT,
 )
 
 // NewInstallerConnectStrategy returns default installer service connect strategy


### PR DESCRIPTION
Currently, service does not handle at least `SIGTERM` to gracefully shutdown and instead is killed by the system as a result. I was mistakenly believing I could not use interrupt signals to properly shutdown just the service.

This PR handles server interrupts (`SIGTERM`/`SIGQUIT`) gracefully - without invoking abort mechanism of the client.
