### PR TITLE
Remove port range check for 30000-32767 from checks

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -888,7 +888,6 @@ func defaultPortChecker(options *validationpb.ValidateOptions) health.Checker {
 		{Protocol: "tcp", From: 4001, To: 4001, Description: "etcd"},
 		{Protocol: "tcp", From: 7001, To: 7001, Description: "etcd"},
 		{Protocol: "tcp", From: 6443, To: 6443, Description: "kubernetes API server"},
-		{Protocol: "tcp", From: 30000, To: 32767, Description: "kubernetes internal services range"},
 		{Protocol: "tcp", From: 10248, To: 10255, Description: "kubernetes internal services range"},
 		{Protocol: "tcp", From: 5000, To: 5000, Description: "docker registry"},
 		{Protocol: "tcp", From: 3022, To: 3025, Description: "teleport internal SSH control panel"},


### PR DESCRIPTION
Original [PR](https://github.com/gravitational/gravity/pull/451):
```
Kubernetes by default has the range of 30000-32767 for `NodePort` assignment. However, it is not appropriate to ensure (and fail the install) if something is bound within this range, because Kubernetes will actually only choose open ports when assigning a `NodePort`. Additionally, this range can be changed via configuration, so hardcoding verification of it being unused with no way of changing it is problematic.

It would be great to backport this to 5.5.x as well, as currently we have to maintain a fork of Gravity.
```

See also https://community.gravitational.com/t/port-usage-and-verification/163/3