### PR TITLE
Shutdown wizard process first in stop to unblock a possible wait

### DIFF
--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -325,11 +325,12 @@ func (i *Installer) HandleCompleted(ctx context.Context) error {
 
 // stop runs the specified list of stoppers and shuts down the server
 func (i *Installer) stopWithContext(ctx context.Context, stoppers []signals.Stopper) error {
+	// Shut down process first to unblock a possible wait
+	i.config.Process.Shutdown(ctx)
 	i.cancel()
 	i.wg.Wait()
 	i.dispatcher.Close()
 	err := i.runStoppers(ctx, stoppers)
-	i.config.Process.Shutdown(ctx)
 	return trace.Wrap(err)
 }
 

--- a/lib/process/profile.go
+++ b/lib/process/profile.go
@@ -53,6 +53,7 @@ func StartProfiling(ctx context.Context, httpEndpoint, profileDir string) error 
 		trace.Component: "profiling",
 		"pid":           os.Getpid(),
 		"addr":          listener.Addr(),
+		"cmdline":       os.Args,
 		"curl":          fmt.Sprintf("%v/debug/pprof/goroutine?debug=1", listener.Addr()),
 	})
 	if profileDir != "" {


### PR DESCRIPTION
This fixes another regression I only noticed when I retested interactive installer.
The regression crept in after I changed the service behavior w.r.t interruption - it used to be killed by the system previously hence I did not notice the problem originally. But after I made the service handle the `SIGTERM` signal by shutting down properly, it manifested itself.