### PR TITLE
Pass cloud provider to agent so it can query cloud metadata.

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -754,6 +754,7 @@ func (p *Peer) newAgent(opCtx operationContext) (*rpcserver.PeerServer, error) {
 			"addr":          p.AdvertiseAddr,
 		}),
 		AdvertiseAddr: p.AdvertiseAddr,
+		CloudProvider: p.CloudProvider,
 		ServerAddr:    peerAddr,
 		Credentials:   opCtx.Creds,
 		RuntimeConfig: p.RuntimeConfig,

--- a/lib/install/agent.go
+++ b/lib/install/agent.go
@@ -39,6 +39,10 @@ func NewAgent(config AgentConfig) (*rpcserver.PeerServer, error) {
 	if err := FetchCloudMetadata(config.CloudProvider, &config.RuntimeConfig); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	config.WithFields(log.Fields{
+		"provider": config.CloudProvider,
+		"metadata": config.RuntimeConfig.CloudMetadata,
+	}).Info("Fetched cloud metadata.")
 	listener, err := net.Listen("tcp", defaults.GravityRPCAgentAddr(config.AdvertiseAddr))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/install/config.go
+++ b/lib/install/config.go
@@ -315,6 +315,7 @@ func newAgent(ctx context.Context, config Config) (*rpcserver.PeerServer, error)
 	}
 	return NewAgent(AgentConfig{
 		FieldLogger:   config.FieldLogger.WithField(trace.Component, "agent:rpc"),
+		CloudProvider: config.CloudProvider,
 		AdvertiseAddr: config.AdvertiseAddr,
 		ServerAddr:    config.Process.Config().Pack.GetAddr().Addr,
 		Credentials:   *creds,

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -560,6 +560,7 @@ func agent(env *localenv.LocalEnvironment, config agentConfig, serviceName strin
 	agent, err := install.NewAgent(install.AgentConfig{
 		FieldLogger:   log.WithField("addr", config.advertiseAddr),
 		AdvertiseAddr: config.advertiseAddr,
+		CloudProvider: config.cloudProvider,
 		Credentials:   *creds,
 		ServerAddr:    config.serverAddr,
 		RuntimeConfig: runtimeConfig,


### PR DESCRIPTION
Missed it for some reason when working on install refactoring.

Fixes https://github.com/gravitational/gravity.e/issues/4152.