### PR TITLE
[5.5] Reuse devicemapper device for overlay.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -366,9 +366,12 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:d5286d88d5620c43617ecec0ec188ded033bf7a434b0c708cd16cd9a40545d04"
+  digest = "1:32ec7ebceaf0a3bcab3b0d40a3e901cecc9b46d103c81fe206e76fdde5f2f21c"
   name = "github.com/coreos/go-systemd"
-  packages = ["dbus"]
+  packages = [
+    "dbus",
+    "unit",
+  ]
   pruneopts = "UT"
   revision = "40e2722dffead74698ca12a750f64ef313ddce05"
   version = "v16"
@@ -2460,6 +2463,7 @@
     "github.com/coreos/etcd/client",
     "github.com/coreos/etcd/pkg/transport",
     "github.com/coreos/go-semver/semver",
+    "github.com/coreos/go-systemd/unit",
     "github.com/davecgh/go-spew/spew",
     "github.com/docker/distribution",
     "github.com/docker/distribution/configuration",

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -684,11 +684,14 @@ var (
 	EncodingPEM Format = "pem"
 	// EncodingText is for the plaint-text encoding format
 	EncodingText Format = "text"
+	// EncodingShort is for short output format
+	EncodingShort Format = "short"
 	// EncodingYAML is for the YAML encoding format
 	EncodingYAML Format = "yaml"
 	// OutputFormats is a list of recognized output formats for gravity CLI commands
 	OutputFormats = []Format{
 		EncodingText,
+		EncodingShort,
 		EncodingJSON,
 		EncodingYAML,
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -391,6 +391,9 @@ const (
 	// PlanetDir is the name of the planet directory
 	PlanetDir = "planet"
 
+	// DockerDir is the name of the Docker data directory
+	DockerDir = "docker"
+
 	// ShareDir is the name of the share directory
 	ShareDir = "share"
 

--- a/lib/devicemapper/configure.go
+++ b/lib/devicemapper/configure.go
@@ -96,7 +96,7 @@ func Unmount(out io.Writer, entry log.FieldLogger) (err error) {
 	return nil
 }
 
-func queryPhysicalVolume(entry *log.Entry) (disk string, err error) {
+func queryPhysicalVolume(entry log.FieldLogger) (disk string, err error) {
 	entry.Debugf("query physical volume information")
 
 	out := bytes.Buffer{}

--- a/lib/devicemapper/configure.go
+++ b/lib/devicemapper/configure.go
@@ -66,7 +66,7 @@ func Mount(disk string, out io.Writer, entry log.FieldLogger) (err error) {
 }
 
 // Unmount removes docker devicemapper environment
-func Unmount(out io.Writer, entry *log.Entry) (err error) {
+func Unmount(out io.Writer, entry log.FieldLogger) (err error) {
 	disk, err := queryPhysicalVolume(entry)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -89,7 +89,7 @@ func printPhase(w io.Writer, phase storage.OperationPhase, indent int) {
 	}
 }
 
-// FormatOperationPlanShort formats provided operation plan as test with
+// FormatOperationPlanShort formats provided operation plan as text with
 // fewer number of columns.
 func FormatOperationPlanShort(w io.Writer, plan storage.OperationPlan) {
 	var t tabwriter.Writer

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -89,6 +89,8 @@ func printPhase(w io.Writer, phase storage.OperationPhase, indent int) {
 	}
 }
 
+// FormatOperationPlanShort formats provided operation plan as test with
+// fewer number of columns.
 func FormatOperationPlanShort(w io.Writer, plan storage.OperationPlan) {
 	var t tabwriter.Writer
 	t.Init(w, 0, 10, 5, ' ', 0)

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -537,13 +537,30 @@ func (s *site) checkUpdateParameters(update *pack.PackageEnvelope, provisioner s
 }
 
 func (s *site) validateDockerConfig(updateManifest schema.Manifest) error {
-	docker := updateManifest.SystemOptions.DockerConfig()
-	if docker == nil {
-		return nil // No changes.
-	}
 	existingDocker, err := ops.GetDockerConfig(s.service, s.key)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+	docker := updateManifest.SystemOptions.DockerConfig()
+	if docker == nil {
+		// If Docker driver wasn't specified explicitly in manifest and
+		// the cluster is currently using devicemapper, the upgrade
+		// will fail b/c devicemapper is no longer working and the
+		// current behavior is to preserve the driver if it's not
+		// specified in the manifest, so check here and don't let to
+		// proceed.
+		if existingDocker.StorageDriver != constants.DockerStorageDriverDevicemapper {
+			return nil
+		}
+		return trace.BadParameter(
+			`The cluster is currently using devicemapper storage driver which is no longer supported.
+
+Please set the driver to overlay2 explicitly in your manifest and rebuild the installer:
+
+systemOptions:
+  docker:
+    storageDriver: overlay2
+`)
 	}
 	if docker.StorageDriver != existingDocker.StorageDriver &&
 		!utils.StringInSlice(constants.DockerSupportedTargetDrivers, docker.StorageDriver) {

--- a/lib/state/state.go
+++ b/lib/state/state.go
@@ -109,6 +109,15 @@ func LogDir(baseDir string, suffixes ...string) string {
 	return filepath.Join(append(elems, suffixes...)...)
 }
 
+// DockerDir returns Docker data directory.
+func DockerDir() (string, error) {
+	stateDir, err := GetStateDir()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return filepath.Join(stateDir, defaults.PlanetDir, defaults.DockerDir), nil
+}
+
 var (
 	// StateLocatorPaths is a list of locations where gravity state directory pointer is written
 	StateLocatorPaths = []string{

--- a/lib/status/wait.go
+++ b/lib/status/wait.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/trace"
+)
+
+// Wait
+func Wait(ctx context.Context) (err error) {
+	b := utils.NewExponentialBackOff(defaults.NodeStatusTimeout)
+	err = utils.RetryWithInterval(ctx, b, func() error {
+		return trace.Wrap(getLocalNodeStatus(ctx))
+	})
+	return trace.Wrap(err)
+}
+
+func getLocalNodeStatus(ctx context.Context) (err error) {
+	var status *Agent
+	b := utils.NewExponentialBackOff(defaults.NodeStatusTimeout)
+	err = utils.RetryTransient(ctx, b, func() error {
+		status, err = FromLocalPlanetAgent(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if status.GetSystemStatus() != agentpb.SystemStatus_Running {
+		return trace.BadParameter("node is degraded")
+	}
+	return nil
+}

--- a/lib/status/wait.go
+++ b/lib/status/wait.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// Wait
+// Wait blocks until the local agent reports healthy status or until timeout expires.
 func Wait(ctx context.Context) (err error) {
 	b := utils.NewExponentialBackOff(defaults.NodeStatusTimeout)
 	err = utils.RetryWithInterval(ctx, b, func() error {

--- a/lib/status/wait.go
+++ b/lib/status/wait.go
@@ -26,25 +26,17 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// Wait blocks until the local agent reports healthy status or until timeout expires.
-func Wait(ctx context.Context) (err error) {
+// Wait blocks until the local agent reports healthy status or until the
+// provided context expires.
+func Wait(ctx context.Context) error {
 	b := utils.NewExponentialBackOff(defaults.NodeStatusTimeout)
-	err = utils.RetryWithInterval(ctx, b, func() error {
-		return trace.Wrap(getLocalNodeStatus(ctx))
+	return utils.RetryWithInterval(ctx, b, func() error {
+		return getLocalNodeStatus(ctx)
 	})
-	return trace.Wrap(err)
 }
 
-func getLocalNodeStatus(ctx context.Context) (err error) {
-	var status *Agent
-	b := utils.NewExponentialBackOff(defaults.NodeStatusTimeout)
-	err = utils.RetryTransient(ctx, b, func() error {
-		status, err = FromLocalPlanetAgent(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return nil
-	})
+func getLocalNodeStatus(ctx context.Context) error {
+	status, err := FromLocalPlanetAgent(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"time"
 
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/utils"
@@ -158,8 +159,38 @@ type UpdateServer struct {
 	Runtime RuntimePackage `json:"runtime"`
 	// Teleport defines the optional teleport update
 	Teleport TeleportPackage `json:"teleport"`
-	// Docker when true indicates that Docker storage driver is being updated
-	Docker bool `json:"docker"`
+	// Docker describes Docker configuration update on the node
+	Docker DockerUpdate `json:"docker"`
+}
+
+// DockerUpdate describes node's Docker configuration update if there's any.
+type DockerUpdate struct {
+	// Installed is the currently installed configuration.
+	Installed DockerConfig `json:"installed"`
+	// Update is the configuration for the new version.
+	Update *DockerConfig `json:"update,omitempty"`
+}
+
+// ShouldMigrateDockerDevice returns true if the device currently used by
+// Docker devicemapper storage driver should be repurposed for overlay
+// data during this upgrade operation.
+func (s UpdateServer) ShouldMigrateDockerDevice() bool {
+	if s.Docker.Update == nil {
+		return false // No change.
+	}
+	// For safety, only consider explicit change from devicemapper.
+	if s.Docker.Installed.StorageDriver != constants.DockerStorageDriverDevicemapper {
+		return false
+	}
+	// Devicemapper may be using loopback device.
+	if s.GetDockerDevice() == "" {
+		return false
+	}
+	// For safety, only consider explicit change to overlay.
+	return utils.StringInSlice([]string{
+		constants.DockerStorageDriverOverlay,
+		constants.DockerStorageDriverOverlay2,
+	}, s.Docker.Update.StorageDriver)
 }
 
 // RuntimePackage describes the state of the runtime package during update

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -168,16 +168,13 @@ type DockerUpdate struct {
 	// Installed is the currently installed configuration.
 	Installed DockerConfig `json:"installed"`
 	// Update is the configuration for the new version.
-	Update *DockerConfig `json:"update,omitempty"`
+	Update DockerConfig `json:"update"`
 }
 
 // ShouldMigrateDockerDevice returns true if the device currently used by
 // Docker devicemapper storage driver should be repurposed for overlay
 // data during this upgrade operation.
 func (s UpdateServer) ShouldMigrateDockerDevice() bool {
-	if s.Docker.Update == nil {
-		return false // No change.
-	}
 	// For safety, only consider explicit change from devicemapper.
 	if s.Docker.Installed.StorageDriver != constants.DockerStorageDriverDevicemapper {
 		return false

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -158,6 +158,8 @@ type UpdateServer struct {
 	Runtime RuntimePackage `json:"runtime"`
 	// Teleport defines the optional teleport update
 	Teleport TeleportPackage `json:"teleport"`
+	// Docker when true indicates that Docker storage driver is being updated
+	Docker bool `json:"docker"`
 }
 
 // RuntimePackage describes the state of the runtime package during update

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1157,6 +1157,8 @@ type PackageUpdate struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// ConfigPackage specifies optional configuration package dependency
 	ConfigPackage *PackageUpdate `json:"config_package,omitempty"`
+	// NoStart indicates that package service shouldn't be auto-started after upgrade
+	NoStart bool `json:"no_start"`
 }
 
 // String formats this update as human-readable text

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1574,6 +1574,11 @@ func (s *Server) StateDir() string {
 	return defaults.GravityDir
 }
 
+// GetDockerDevice returns device used for Docker devicemapper data.
+func (s *Server) GetDockerDevice() string {
+	return s.Docker.Device.Path()
+}
+
 // KubeNodeID returns the identity of the node within the kubernetes cluster (kubectl get node)
 // when running on a cloud environment such as AWS, kubelet tends to pick up it's hostname from the cloud provider API.
 // So when running on these environments, we should ensure our hostnames match what kubernetes will be doing.

--- a/lib/system/fs.go
+++ b/lib/system/fs.go
@@ -55,7 +55,10 @@ func GetFilesystem(ctx context.Context, path string, runner utils.CommandRunner)
 // RemoveFilesystem erases filesystem from the provided device/partition.
 func RemoveFilesystem(path string, log logrus.FieldLogger) error {
 	var out bytes.Buffer
-	cmd := exec.Command("dd", "if=/dev/zero", fmt.Sprintf("of=%v", path), "bs=10M")
+	// We don't need to fill the entire disk/partition with zeroes,
+	// clearing out the first 1MB should be enough to wipe out the
+	// filesystem header.
+	cmd := exec.Command("dd", "if=/dev/zero", fmt.Sprintf("of=%v", path), "bs=1M", "count=1")
 	if err := utils.ExecL(cmd, &out, log); err != nil {
 		return trace.Wrap(err, "failed to erase %v: %s", path, out.String())
 	}

--- a/lib/system/fs.go
+++ b/lib/system/fs.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -49,6 +50,16 @@ func GetFilesystem(ctx context.Context, path string, runner utils.CommandRunner)
 	}
 
 	return "", trace.NotFound("no filesystem found for %v", path)
+}
+
+// RemoveFilesystem erases filesystem from the provided device/partition.
+func RemoveFilesystem(path string, log logrus.FieldLogger) error {
+	var out bytes.Buffer
+	cmd := exec.Command("dd", "if=/dev/zero", fmt.Sprintf("of=%v", path), "bs=10M")
+	if err := utils.ExecL(cmd, &out, log); err != nil {
+		return trace.Wrap(err, "failed to erase %v: %s", path, out.String())
+	}
+	return nil
 }
 
 // FormatDevice formats block device at the specified path to either xfs or,

--- a/lib/system/fs.go
+++ b/lib/system/fs.go
@@ -96,7 +96,7 @@ func (r *FormatRequest) String() string {
 //
 // If the specified path already has filesystem, it is returned as-is and no
 // formatting is attempted, unless force flag is set, in which case the path
-// is reformatted anyway.
+// is reformatted.
 func FormatDevice(ctx context.Context, req FormatRequest) (filesystem string, err error) {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return "", trace.Wrap(err)
@@ -122,7 +122,7 @@ func FormatDevice(ctx context.Context, req FormatRequest) (filesystem string, er
 			req.Log.Infof("Filesystem on %q is %v.", req.Path, filesystem)
 			return filesystem, nil
 		}
-		req.Log.Infof("Device %q has filesystem %v, will force-reformat due to force flag.",
+		req.Log.Infof("Device %q with existing filesystem %v will be reformatted.",
 			req.Path, filesystem)
 	}
 

--- a/lib/system/mount/service.go
+++ b/lib/system/mount/service.go
@@ -109,6 +109,10 @@ type ServiceConfig struct {
 }
 
 // ServiceName returns name of the mount service.
+//
+// Systemd mount unit must have a name that has all mount point path elements
+// separated by dashes, so the name for "/var/lib/gravity" mount would become
+// "var-lib-gravity.mount".
 func (c ServiceConfig) ServiceName() string {
 	return strings.Replace(c.Where, "/", "-", -1)[1:] + ".mount"
 }

--- a/lib/system/mount/service.go
+++ b/lib/system/mount/service.go
@@ -97,5 +97,5 @@ type ServiceConfig struct {
 
 // ServiceName returns name of the mount service.
 func (c ServiceConfig) ServiceName() string {
-	return strings.ReplaceAll(c.Where, "/", "-") + ".mount"
+	return strings.Replace(c.Where, "/", "-", -1)[1:] + ".mount"
 }

--- a/lib/system/mount/service.go
+++ b/lib/system/mount/service.go
@@ -17,12 +17,27 @@ limitations under the License.
 package mount
 
 import (
+	"strings"
+
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/systemservice"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
+
+// Mount creates and starts a new systemd mount.
+func Mount(config ServiceConfig) error {
+	serviceManager, err := systemservice.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = MountService(config, config.ServiceName(), serviceManager)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
 
 // MountService creates a new mount based on the given configuration.
 // The mount is created as a systemd mount unit named service.
@@ -78,4 +93,9 @@ type ServiceConfig struct {
 	Filesystem string
 	// Options lists mount options to use when mounting
 	Options []string
+}
+
+// ServiceName returns name of the mount service.
+func (c ServiceConfig) ServiceName() string {
+	return strings.ReplaceAll(c.Where, "/", "-") + ".mount"
 }

--- a/lib/system/mount/service.go
+++ b/lib/system/mount/service.go
@@ -39,6 +39,19 @@ func Mount(config ServiceConfig) error {
 	return nil
 }
 
+// Unmount uninstalls specified systemd mount service.
+func Unmount(serviceName string) error {
+	serviceManager, err := systemservice.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = UnmountService(serviceName, serviceManager)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // MountService creates a new mount based on the given configuration.
 // The mount is created as a systemd mount unit named service.
 func MountService(config ServiceConfig, service string, services systemservice.ServiceManager) error {

--- a/lib/system/mount/service.go
+++ b/lib/system/mount/service.go
@@ -17,11 +17,10 @@ limitations under the License.
 package mount
 
 import (
-	"strings"
-
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/systemservice"
 
+	"github.com/coreos/go-systemd/unit"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
@@ -114,5 +113,5 @@ type ServiceConfig struct {
 // separated by dashes, so the name for "/var/lib/gravity" mount would become
 // "var-lib-gravity.mount".
 func (c ServiceConfig) ServiceName() string {
-	return strings.Replace(c.Where, "/", "-", -1)[1:] + ".mount"
+	return unit.UnitNamePathEscape(c.Where) + ".mount"
 }

--- a/lib/system/state/state.go
+++ b/lib/system/state/state.go
@@ -60,7 +60,10 @@ func ConfigureStateDirectory(stateDir, devicePath string) (err error) {
 	// Even if the directory exists, mount it on the specified device.
 	// If this is not possible, the operation will fail as expected.
 	var filesystem string
-	filesystem, err = system.FormatDevice(context.TODO(), devicePath, logrus.StandardLogger())
+	filesystem, err = system.FormatDevice(context.TODO(), system.FormatRequest{
+		Path: devicePath,
+		Log:  logrus.StandardLogger(),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/system/state/state.go
+++ b/lib/system/state/state.go
@@ -62,7 +62,7 @@ func ConfigureStateDirectory(stateDir, devicePath string) (err error) {
 	// Even if the directory exists, mount it on the specified device.
 	// If this is not possible, the operation will fail as expected.
 	var filesystem string
-	filesystem, err = formatDevice(devicePath)
+	filesystem, err = FormatDevice(devicePath)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -86,7 +86,7 @@ func ConfigureStateDirectory(stateDir, devicePath string) (err error) {
 	return nil
 }
 
-func formatDevice(path string) (filesystem string, err error) {
+func FormatDevice(path string) (filesystem string, err error) {
 	type formatter struct {
 		fsType string
 		args   []string

--- a/lib/system/state/state.go
+++ b/lib/system/state/state.go
@@ -17,10 +17,8 @@ limitations under the License.
 package state
 
 import (
-	"bytes"
 	"context"
 	"os"
-	"os/exec"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/storage"
@@ -28,9 +26,9 @@ import (
 	"github.com/gravitational/gravity/lib/system/mount"
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/utils"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // ConfigureStateDirectory sets up the state directory stateDir
@@ -62,7 +60,7 @@ func ConfigureStateDirectory(stateDir, devicePath string) (err error) {
 	// Even if the directory exists, mount it on the specified device.
 	// If this is not possible, the operation will fail as expected.
 	var filesystem string
-	filesystem, err = FormatDevice(devicePath)
+	filesystem, err = system.FormatDevice(context.TODO(), devicePath, logrus.StandardLogger())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -84,50 +82,4 @@ func ConfigureStateDirectory(stateDir, devicePath string) (err error) {
 	}
 
 	return nil
-}
-
-func FormatDevice(path string) (filesystem string, err error) {
-	type formatter struct {
-		fsType string
-		args   []string
-	}
-	formatters := []formatter{
-		{"xfs", []string{"mkfs.xfs", "-f"}},
-		{"ext4", []string{"mkfs.ext4", "-F"}},
-	}
-
-	filesystem, err = system.GetFilesystem(context.TODO(), path, utils.Runner)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	if filesystem != "" {
-		log.Infof("File system on %q is %v.", path, filesystem)
-		return filesystem, nil
-	}
-
-	// format the device if the specified device does not have a file system yet
-	log.Infof("Device %q has no file system.", path)
-
-	var fmt formatter
-	var out bytes.Buffer
-	for _, fmt = range formatters {
-		out.Reset()
-		args := append(fmt.args, path)
-		log.Debugf("Formatting %q as %v.", path, fmt.fsType)
-		cmd := exec.Command(args[0], args[1:]...)
-		if err = utils.ExecL(cmd, &out, log.StandardLogger()); err != nil {
-			log.Warnf("Failed to format %q as %q: %v (%v).",
-				path, fmt.fsType, out.String(), err)
-		}
-		if err == nil {
-			filesystem = fmt.fsType
-			break
-		}
-	}
-	if err != nil {
-		return "", trace.Wrap(err, "failed to format %q as %q: %v",
-			path, fmt.fsType, out.String())
-	}
-	return filesystem, nil
 }

--- a/lib/system/state/state.go
+++ b/lib/system/state/state.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import (
 	"github.com/gravitational/gravity/lib/system/mount"
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/utils"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // ConfigureStateDirectory sets up the state directory stateDir

--- a/lib/systemservice/service.go
+++ b/lib/systemservice/service.go
@@ -57,6 +57,8 @@ type NewServiceRequest struct {
 	Name string `json:"Name"`
 	// NoBlock means we won't block and wait until service starts
 	NoBlock bool `json:"-"`
+	// NoStart means do not start the unit
+	NoStart bool `json:"-"`
 }
 
 // NewMountServiceRequest describes a request to create a new systemd mount service
@@ -81,6 +83,8 @@ type NewPackageServiceRequest struct {
 	ConfigPackage loc.Locator `json:"-"`
 	// NoBlock means async operation
 	NoBlock bool `json:"-"`
+	// NoStart means do not start the unit
+	NoStart bool `json:"-"`
 }
 
 // ServiceSpec is a generic service specification
@@ -192,6 +196,16 @@ type PackageServiceStatus struct {
 	Status string
 }
 
+// MountStatus describes status of a mount service.
+type MountStatus struct {
+	// Name is the mount service name.
+	Name string
+	// MointPoint is the mount service mount point.
+	MountPoint string
+	// Status is the mount service status.
+	Status string
+}
+
 // ServiceManager is an interface for collaborating with system
 // service managers, e.g. systemd for host packages
 type ServiceManager interface {
@@ -209,6 +223,9 @@ type ServiceManager interface {
 
 	// ListPackageServices lists installed services
 	ListPackageServices() ([]PackageServiceStatus, error)
+
+	// ListMounts lists all mount services
+	ListMounts() ([]MountStatus, error)
 
 	// StartPackageService starts package service
 	StartPackageService(pkg loc.Locator, noBlock bool) error

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -119,6 +119,10 @@ func parseUnit(unit string) *loc.Locator {
 }
 
 // parseMount parses mount point from the mount service name.
+//
+// Systemd mount unit name consists of all mount point path elements
+// separated by dashes so mount service with name "var-lib-gravity.mount"
+// has a mount point /var/lib/gravity.
 func parseMount(mount string) string {
 	name := strings.TrimSuffix(mount, systemdMountSuffix)
 	parts := strings.Split(name, "-")

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/utils"
 
+	"github.com/coreos/go-systemd/unit"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
@@ -125,9 +126,7 @@ func parseUnit(unit string) *loc.Locator {
 // has a mount point /var/lib/gravity.
 func parseMount(mount string) string {
 	name := strings.TrimSuffix(mount, systemdMountSuffix)
-	parts := strings.Split(name, "-")
-	parts = append([]string{"/"}, parts...)
-	return filepath.Join(parts...)
+	return unit.UnitNamePathUnescape(name)
 }
 
 func (u *systemdUnit) serviceName() string {

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -561,6 +561,9 @@ func (r phaseBuilder) cleanup() *update.Phase {
 	return &root
 }
 
+func (r phaseBuilder) dockerDevicemapper() *update.Phase {
+}
+
 type phaseBuilder struct {
 	planConfig
 }

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -475,9 +475,9 @@ func (r phaseBuilder) node(server storage.Server, parent update.ParentPhase, for
 	}
 }
 
-// dockerDevice builds a phase that takes care of repurposing device used
+// dockerDevicePhase builds a phase that takes care of repurposing device used
 // by Docker devicemapper driver for overlay data.
-func (r phaseBuilder) dockerDevice(node storage.UpdateServer) update.Phase {
+func dockerDevicePhase(node storage.UpdateServer) update.Phase {
 	// This phase will remove devicemapper environment (pv, vg, lv) from
 	// the devicemapper device.
 	devicemapper := update.Phase{
@@ -558,7 +558,7 @@ func (r phaseBuilder) commonNode(server, leadMaster storage.UpdateServer, suppor
 		},
 	}
 	if server.ShouldMigrateDockerDevice() {
-		phases = append(phases, r.dockerDevice(server))
+		phases = append(phases, dockerDevicePhase(server))
 	}
 	if supportsTaints {
 		phases = append(phases, update.Phase{

--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/gravity/lib/app"
 	apptest "github.com/gravitational/gravity/lib/app/service/test"
 	"github.com/gravitational/gravity/lib/archive"
+	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
@@ -66,7 +67,7 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 				Enabled:    true,
 			},
 		},
-		dnsConfig:  storage.DefaultDNSConfig,
+		dnsConfig: storage.DefaultDNSConfig,
 		// Use an alternative (other than first) master node as leader
 		leadMaster: updates[1],
 	}
@@ -78,7 +79,7 @@ func (s *PlanSuite) TestPlanWithRuntimeUpdate(c *check.C) {
 	update.ResolvePlan(obtainedPlan)
 
 	// verify
-	c.Assert(*obtainedPlan, check.DeepEquals, storage.OperationPlan{
+	c.Assert(*obtainedPlan, compare.DeepEquals, storage.OperationPlan{
 		OperationID:    config.operation.ID,
 		OperationType:  config.operation.Type,
 		AccountID:      config.operation.AccountID,
@@ -439,6 +440,60 @@ func (r *params) masters(otherMasters []storage.UpdateServer) storage.OperationP
 	}
 }
 
+func (r *params) dockerPhase(node storage.UpdateServer) storage.OperationPhase {
+	t := func(format string) string {
+		if node.IsMaster() {
+			return fmt.Sprintf(format, "masters", node.Hostname)
+		}
+		return fmt.Sprintf(format, "nodes", node.Hostname)
+	}
+	return storage.OperationPhase{
+		ID: t("/%v/%v/docker"),
+		Description: fmt.Sprintf("Repurpose devicemapper device %v for overlay data",
+			node.GetDockerDevice()),
+		Requires: []string{t("/%v/%v/system-upgrade")},
+		Phases: []storage.OperationPhase{
+			{
+				ID:       t("/%v/%v/docker/devicemapper"),
+				Executor: dockerDevicemapper,
+				Description: fmt.Sprintf("Remove devicemapper environment from %v",
+					node.GetDockerDevice()),
+				Data: &storage.OperationPhaseData{
+					Server: &node.Server,
+				},
+			},
+			{
+				ID:          t("/%v/%v/docker/format"),
+				Executor:    dockerFormat,
+				Description: fmt.Sprintf("Format %v", node.GetDockerDevice()),
+				Data: &storage.OperationPhaseData{
+					Server: &node.Server,
+				},
+			},
+			{
+				ID:       t("/%v/%v/docker/mount"),
+				Executor: dockerMount,
+				Description: fmt.Sprintf("Create mount for %v",
+					node.GetDockerDevice()),
+				Data: &storage.OperationPhaseData{
+					Server: &node.Server,
+				},
+			},
+			{
+				ID:          t("/%v/%v/docker/planet"),
+				Executor:    planetStart,
+				Description: "Start the new Planet container",
+				Data: &storage.OperationPhaseData{
+					Server: &node.Server,
+					Update: &storage.UpdateOperationData{
+						Servers: []storage.UpdateServer{node},
+					},
+				},
+			},
+		},
+	}
+}
+
 func (r *params) leaderMasterPhase() storage.OperationPhase {
 	t := func(format string) string {
 		return fmt.Sprintf(format, r.leadMaster.Hostname)
@@ -489,6 +544,7 @@ func (r *params) leaderMasterPhase() storage.OperationPhase {
 				},
 				Requires: []string{t("/masters/%v/drain")},
 			},
+			r.dockerPhase(r.leadMaster),
 			{
 				ID:          t("/masters/%v/uncordon"),
 				Executor:    uncordonNode,
@@ -497,7 +553,7 @@ func (r *params) leaderMasterPhase() storage.OperationPhase {
 					Server:     &r.leadMaster.Server,
 					ExecServer: &r.leadMaster.Server,
 				},
-				Requires: []string{t("/masters/%v/system-upgrade")},
+				Requires: []string{t("/masters/%v/docker")},
 			},
 		},
 	}
@@ -533,6 +589,7 @@ func (r *params) otherMasterPhase(server storage.UpdateServer) storage.Operation
 				},
 				Requires: []string{t("/masters/%v/drain")},
 			},
+			r.dockerPhase(server),
 			{
 				ID:          t("/masters/%v/uncordon"),
 				Executor:    uncordonNode,
@@ -541,7 +598,7 @@ func (r *params) otherMasterPhase(server storage.UpdateServer) storage.Operation
 					Server:     &server.Server,
 					ExecServer: &r.leadMaster.Server,
 				},
-				Requires: []string{t("/masters/%v/system-upgrade")},
+				Requires: []string{t("/masters/%v/docker")},
 			},
 			{
 				ID:          t("/masters/%v/endpoints"),
@@ -609,6 +666,7 @@ func (r *params) nodePhase(server storage.UpdateServer) storage.OperationPhase {
 				},
 				Requires: []string{t("/nodes/%v/drain")},
 			},
+			r.dockerPhase(server),
 			{
 				ID:          t("/nodes/%v/uncordon"),
 				Executor:    uncordonNode,
@@ -617,7 +675,7 @@ func (r *params) nodePhase(server storage.UpdateServer) storage.OperationPhase {
 					Server:     &server.Server,
 					ExecServer: &r.leadMaster.Server,
 				},
-				Requires: []string{t("/nodes/%v/system-upgrade")},
+				Requires: []string{t("/nodes/%v/docker")},
 			},
 			{
 				ID:          t("/nodes/%v/endpoints"),
@@ -998,24 +1056,41 @@ var runtimePackage = storage.RuntimePackage{
 }
 var gravityInstalledLoc = loc.MustParseLocator("gravitational.io/gravity:1.0.0")
 var gravityUpdateLoc = loc.MustParseLocator("gravitational.io/gravity:2.0.0")
+var dockerDevice = storage.Docker{
+	Device: storage.Device{
+		Name: storage.DeviceName("vdb"),
+	},
+}
 var servers = []storage.Server{
 	{
 		AdvertiseIP: "192.168.0.1",
 		Hostname:    "node-1",
 		Role:        "node",
 		ClusterRole: string(schema.ServiceRoleMaster),
+		Docker:      dockerDevice,
 	},
 	{
 		AdvertiseIP: "192.168.0.2",
 		Hostname:    "node-2",
 		Role:        "node",
 		ClusterRole: string(schema.ServiceRoleMaster),
+		Docker:      dockerDevice,
 	},
 	{
 		AdvertiseIP: "192.168.0.3",
 		Hostname:    "node-3",
 		Role:        "node",
 		ClusterRole: string(schema.ServiceRoleNode),
+		Docker:      dockerDevice,
+	},
+}
+
+var dockerUpdate = storage.DockerUpdate{
+	Installed: storage.DockerConfig{
+		StorageDriver: constants.DockerStorageDriverDevicemapper,
+	},
+	Update: &storage.DockerConfig{
+		StorageDriver: constants.DockerStorageDriverOverlay2,
 	},
 }
 
@@ -1023,14 +1098,17 @@ var updates = []storage.UpdateServer{
 	{
 		Server:  servers[0],
 		Runtime: runtimePackage,
+		Docker:  dockerUpdate,
 	},
 	{
 		Server:  servers[1],
 		Runtime: runtimePackage,
+		Docker:  dockerUpdate,
 	},
 	{
 		Server:  servers[2],
 		Runtime: runtimePackage,
+		Docker:  dockerUpdate,
 	},
 }
 

--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -1089,7 +1089,7 @@ var dockerUpdate = storage.DockerUpdate{
 	Installed: storage.DockerConfig{
 		StorageDriver: constants.DockerStorageDriverDevicemapper,
 	},
-	Update: &storage.DockerConfig{
+	Update: storage.DockerConfig{
 		StorageDriver: constants.DockerStorageDriverOverlay2,
 	},
 }

--- a/lib/update/cluster/executor.go
+++ b/lib/update/cluster/executor.go
@@ -77,6 +77,12 @@ const (
 	updateEtcdRestartGravity = "etcd_restart_gravity"
 	// cleanupNode is the phase to clean up a node after the upgrade
 	cleanupNode = "cleanup_node"
+	// dockerDevicemapper is the phase that mounts/unmounts devicemapper devices.
+	dockerDevicemapper = "devicemapper"
+	// dockerFormat is the phase that formats devices.
+	dockerFormat = "format"
+	// dockerMount is the phase that mounts/unmounts devices.
+	dockerMount = "mount"
 )
 
 // fsmSpec returns the function that returns an appropriate phase executor
@@ -158,6 +164,12 @@ func fsmSpec(c Config) fsm.FSMSpecFunc {
 			return libphase.NewPhaseUpgradeGravitySiteRestart(p.Phase, c.Client, logger)
 		case cleanupNode:
 			return libphase.NewGarbageCollectPhase(p, remote, logger)
+		case dockerDevicemapper:
+			return libphase.NewDockerDevicemapper(p, logger)
+		case dockerFormat:
+			return libphase.NewDockerFormat(p, logger)
+		case dockerMount:
+			return libphase.NewDockerMount(p, logger)
 		default:
 			return nil, trace.BadParameter(
 				"phase %q requires executor %q (potential mismatch between upgrade versions)",

--- a/lib/update/cluster/executor.go
+++ b/lib/update/cluster/executor.go
@@ -167,13 +167,13 @@ func fsmSpec(c Config) fsm.FSMSpecFunc {
 		case cleanupNode:
 			return libphase.NewGarbageCollectPhase(p, remote, logger)
 		case dockerDevicemapper:
-			return libphase.NewDockerDevicemapper(p, logger)
+			return libphase.NewDockerDevicemapper(p, remote, logger)
 		case dockerFormat:
-			return libphase.NewDockerFormat(p, logger)
+			return libphase.NewDockerFormat(p, remote, logger)
 		case dockerMount:
-			return libphase.NewDockerMount(p, logger)
+			return libphase.NewDockerMount(p, remote, logger)
 		case planetStart:
-			return libphase.NewPlanetStart(p, logger)
+			return libphase.NewPlanetStart(p, remote, logger)
 		default:
 			return nil, trace.BadParameter(
 				"phase %q requires executor %q (potential mismatch between upgrade versions)",

--- a/lib/update/cluster/executor.go
+++ b/lib/update/cluster/executor.go
@@ -83,6 +83,8 @@ const (
 	dockerFormat = "format"
 	// dockerMount is the phase that mounts/unmounts devices.
 	dockerMount = "mount"
+	// planetStart is the phase that starts Planet systemd unit.
+	planetStart = "planet_start"
 )
 
 // fsmSpec returns the function that returns an appropriate phase executor
@@ -170,6 +172,8 @@ func fsmSpec(c Config) fsm.FSMSpecFunc {
 			return libphase.NewDockerFormat(p, logger)
 		case dockerMount:
 			return libphase.NewDockerMount(p, logger)
+		case planetStart:
+			return libphase.NewPlanetStart(p, logger)
 		default:
 			return nil, trace.BadParameter(
 				"phase %q requires executor %q (potential mismatch between upgrade versions)",

--- a/lib/update/cluster/phases/docker.go
+++ b/lib/update/cluster/phases/docker.go
@@ -102,7 +102,7 @@ func (d *dockerDevicemapper) PreCheck(ctx context.Context) error {
 func (*dockerDevicemapper) PostCheck(context.Context) error { return nil }
 
 // dockerFormat is a phase executor that formats Docker device/partition
-// to a filesystem suitable for overlay data.
+// with a filesystem suitable for overlay data.
 type dockerFormat struct {
 	// FieldLogger is used for logging.
 	logrus.FieldLogger
@@ -115,7 +115,7 @@ type dockerFormat struct {
 }
 
 // NewDockerFormat returns phase executor that formats Docker device/partition
-// to a filesystem suitable for overlay data.
+// with a filesystem suitable for overlay data.
 func NewDockerFormat(p fsm.ExecutorParams, remote fsm.Remote, log logrus.FieldLogger) (*dockerFormat, error) {
 	node := *p.Phase.Data.Server
 	return &dockerFormat{

--- a/lib/update/cluster/phases/docker.go
+++ b/lib/update/cluster/phases/docker.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/devicemapper"
+	statedir "github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/system/mount"
+	"github.com/gravitational/gravity/lib/system/state"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// DockerDevicemapper is a phase executor that deals with Docker devicemapper devices.
+type DockerDevicemapper struct {
+	logrus.FieldLogger
+}
+
+// Execute unmounts and removes Docker devicemapper devices.
+func (d *DockerDevicemapper) Execute(ctx context.Context) error {
+	d.Info("Removing devicemapper configuration.")
+	err := devicemapper.Unmount(os.Stderr, d.FieldLogger)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Rollback configures Docker devicemapper devices back.
+func (d *DockerDevicemapper) Rollback(ctx context.Context) error {
+	return trace.NotImplemented("not implemented")
+}
+
+// DockerFormat is a phase executor that deals with formatting Docker devices.
+type DockerFormat struct {
+	logrus.FieldLogger
+	Device string
+}
+
+// Execute creates filesystem on a Docker data device.
+func (d *DockerFormat) Execute(ctx context.Context) error {
+	d.Info("Formatting device %v.", d.Device)
+	_, err := state.FormatDevice(d.Device)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Rollback removes filesystem from the Docker data device.
+func (d *DockerFormat) Rollback(ctx context.Context) error {
+	return trace.NotImplemented("not implemented")
+}
+
+// DockerMount is a phase executor that deals with Docker data directory mounts.
+type DockerMount struct {
+	logrus.FieldLogger
+	Device string
+}
+
+// Execute creates a systemd mount for Docker data directory.
+func (d *DockerMount) Execute(ctx context.Context) error {
+	stateDir, err := statedir.GetStateDir()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	config := mount.ServiceConfig{
+		What:       storage.DeviceName(d.Device),
+		Where:      filepath.Join(stateDir, defaults.PlanetDir, defaults.DockerDir),
+		Filesystem: "ext4",
+		Options:    []string{"defaults"},
+	}
+	d.Infof("Mounting %v to %v.", config.What, config.Where)
+	err = mount.Mount(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Rollback removes the systemd mount for Docker data directory.
+func (d *DockerMount) Rollback(ctx context.Context) error {
+	return trace.NotImplemented("not implemented")
+}

--- a/lib/update/cluster/phases/system.go
+++ b/lib/update/cluster/phases/system.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,16 +43,22 @@ import (
 type planetStart struct {
 	// FieldLogger is used for logging.
 	log.FieldLogger
+	// Node is the node where Planet service should be started.
+	Node storage.UpdateServer
 	// Package is the Planet package to start the service for.
 	Package loc.Locator
+	// Remote allows to invoke remote commands.
+	Remote fsm.Remote
 }
 
 // NewPlanetStart returns executor that starts specified Planet service.
-func NewPlanetStart(p fsm.ExecutorParams, log log.FieldLogger) (*planetStart, error) {
+func NewPlanetStart(p fsm.ExecutorParams, remote fsm.Remote, log log.FieldLogger) (*planetStart, error) {
 	node := p.Phase.Data.Update.Servers[0]
 	return &planetStart{
 		FieldLogger: log,
+		Node:        node,
 		Package:     node.Runtime.Update.Package,
+		Remote:      remote,
 	}, nil
 }
 
@@ -91,8 +97,10 @@ func (p *planetStart) Rollback(ctx context.Context) error {
 	return nil
 }
 
-// PreCheck is no-op.
-func (*planetStart) PreCheck(context.Context) error { return nil }
+// PreCheck makes sure the phase runs on the correct node.
+func (p *planetStart) PreCheck(ctx context.Context) error {
+	return trace.Wrap(p.Remote.CheckServer(ctx, p.Node.Server))
+}
 
 // PostCheck is no-op.
 func (*planetStart) PostCheck(context.Context) error { return nil }

--- a/lib/update/cluster/phases/system.go
+++ b/lib/update/cluster/phases/system.go
@@ -180,9 +180,7 @@ func (p *updatePhaseSystem) Execute(ctx context.Context) error {
 		config.Runtime.ConfigPackage = &storage.PackageUpdate{
 			To: p.Server.Runtime.Update.ConfigPackage,
 		}
-		if p.Server.Docker {
-			config.Runtime.NoStart = true
-		}
+		config.Runtime.NoStart = p.Server.ShouldMigrateDockerDevice()
 	}
 	if p.Server.Teleport.Update != nil {
 		// Consider teleport update only in effect when the update package

--- a/lib/update/cluster/plan.go
+++ b/lib/update/cluster/plan.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/archive"
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
@@ -456,14 +457,9 @@ func configUpdates(
 			},
 			Docker: storage.DockerUpdate{
 				Installed: *installedDocker,
+				Update: checks.DockerConfigFromSchemaValue(
+					update.SystemDocker()),
 			},
-		}
-		updateDocker := update.SystemOptions.DockerConfig()
-		if updateDocker != nil {
-			updateServer.Docker.Update = &storage.DockerConfig{
-				StorageDriver: updateDocker.StorageDriver,
-				Args:          updateDocker.Args,
-			}
 		}
 		needsPlanetUpdate, needsTeleportUpdate, err := systemNeedsUpdate(
 			server.Role, server.ClusterRole,

--- a/lib/update/cluster/plan.go
+++ b/lib/update/cluster/plan.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
@@ -162,6 +163,11 @@ func NewOperationPlan(config PlanConfig) (*storage.OperationPlan, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	dockerStorageUpgrade, err := isDockerStorageChanging(config, *updateApp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	links, err := config.Backend.GetOpsCenterLinks(config.Operation.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -203,21 +209,22 @@ func NewOperationPlan(config PlanConfig) (*storage.OperationPlan, error) {
 			DNSConfig:      config.DNSConfig,
 			GravityPackage: *gravityPackage,
 		},
-		operator:         config.Operator,
-		operation:        *config.Operation,
-		servers:          updates,
-		installedRuntime: *installedRuntime,
-		installedApp:     *installedApp,
-		updateRuntime:    *updateRuntime,
-		updateApp:        *updateApp,
-		links:            links,
-		trustedClusters:  trustedClusters,
-		packageService:   config.Packages,
-		shouldUpdateEtcd: shouldUpdateEtcd,
-		updateCoreDNS:    updateCoreDNS,
-		updateDNSAppEarly: updateDNSAppEarly,
-		roles:             roles,
-		leadMaster:        *leader,
+		operator:             config.Operator,
+		operation:            *config.Operation,
+		servers:              updates,
+		installedRuntime:     *installedRuntime,
+		installedApp:         *installedApp,
+		updateRuntime:        *updateRuntime,
+		updateApp:            *updateApp,
+		links:                links,
+		trustedClusters:      trustedClusters,
+		packageService:       config.Packages,
+		shouldUpdateEtcd:     shouldUpdateEtcd,
+		updateCoreDNS:        updateCoreDNS,
+		updateDNSAppEarly:    updateDNSAppEarly,
+		dockerStorageUpgrade: dockerStorageUpgrade,
+		roles:                roles,
+		leadMaster:           *leader,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -294,6 +301,9 @@ type planConfig struct {
 	// updateDNSAppEarly indicates whether we need to update the DNS app earlier than normal
 	//	Only applicable for 5.3.0 -> 5.3.2
 	updateDNSAppEarly bool
+	// dockerStorageUpgrade flag indicates whether Docker storage driver
+	// is being upgraded from devicemapper to overlay
+	dockerStorageUpgrade bool
 	// roles is the existing cluster roles
 	roles []teleservices.Role
 	// leader refers to the master server running the update operation
@@ -600,6 +610,26 @@ func shouldUpdateDNSAppEarly(client *kubernetes.Clientset) (bool, error) {
 			return true, nil
 		}
 		return true, trace.Wrap(err)
+	}
+	return false, nil
+}
+
+// isDockerStorageChanging returns true if the Docker storage driver is changing
+// from devicemapper to overlay during this upgrade operation.
+func isDockerStorageChanging(config PlanConfig, updateApp app.Application) (bool, error) {
+	newConfig := updateApp.Manifest.SystemOptions.DockerConfig()
+	if newConfig == nil {
+		return false, nil
+	}
+	existingConfig, err := opsservice.GetDockerConfig(config.Operator, (*ops.SiteOperation)(config.Operation).ClusterKey())
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if newConfig.StorageDriver == existingConfig.StorageDriver {
+		return false, nil
+	}
+	if utils.StringInSlice(constants.DockerSupportedTargetDrivers, newConfig.StorageDriver) {
+		return true, nil
 	}
 	return false, nil
 }

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -171,6 +171,9 @@ func outputPlan(plan storage.OperationPlan, format constants.Format) (err error)
 	case constants.EncodingText:
 		fsm.FormatOperationPlanText(os.Stdout, plan)
 		err = explainPlan(plan.Phases)
+	case constants.EncodingShort:
+		fsm.FormatOperationPlanShort(os.Stdout, plan)
+		err = explainPlan(plan.Phases)
 	default:
 		return trace.BadParameter("unknown output format %q", format)
 	}

--- a/vendor/github.com/coreos/go-systemd/unit/deserialize.go
+++ b/vendor/github.com/coreos/go-systemd/unit/deserialize.go
@@ -1,0 +1,276 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+)
+
+const (
+	// SYSTEMD_LINE_MAX mimics the maximum line length that systemd can use.
+	// On typical systemd platforms (i.e. modern Linux), this will most
+	// commonly be 2048, so let's use that as a sanity check.
+	// Technically, we should probably pull this at runtime:
+	//    SYSTEMD_LINE_MAX = int(C.sysconf(C.__SC_LINE_MAX))
+	// but this would introduce an (unfortunate) dependency on cgo
+	SYSTEMD_LINE_MAX = 2048
+
+	// characters that systemd considers indicate a newline
+	SYSTEMD_NEWLINE = "\r\n"
+)
+
+var (
+	ErrLineTooLong = fmt.Errorf("line too long (max %d bytes)", SYSTEMD_LINE_MAX)
+)
+
+// Deserialize parses a systemd unit file into a list of UnitOption objects.
+func Deserialize(f io.Reader) (opts []*UnitOption, err error) {
+	lexer, optchan, errchan := newLexer(f)
+	go lexer.lex()
+
+	for opt := range optchan {
+		opts = append(opts, &(*opt))
+	}
+
+	err = <-errchan
+	return opts, err
+}
+
+func newLexer(f io.Reader) (*lexer, <-chan *UnitOption, <-chan error) {
+	optchan := make(chan *UnitOption)
+	errchan := make(chan error, 1)
+	buf := bufio.NewReader(f)
+
+	return &lexer{buf, optchan, errchan, ""}, optchan, errchan
+}
+
+type lexer struct {
+	buf     *bufio.Reader
+	optchan chan *UnitOption
+	errchan chan error
+	section string
+}
+
+func (l *lexer) lex() {
+	var err error
+	defer func() {
+		close(l.optchan)
+		close(l.errchan)
+	}()
+	next := l.lexNextSection
+	for next != nil {
+		if l.buf.Buffered() >= SYSTEMD_LINE_MAX {
+			// systemd truncates lines longer than LINE_MAX
+			// https://bugs.freedesktop.org/show_bug.cgi?id=85308
+			// Rather than allowing this to pass silently, let's
+			// explicitly gate people from encountering this
+			line, err := l.buf.Peek(SYSTEMD_LINE_MAX)
+			if err != nil {
+				l.errchan <- err
+				return
+			}
+			if bytes.IndexAny(line, SYSTEMD_NEWLINE) == -1 {
+				l.errchan <- ErrLineTooLong
+				return
+			}
+		}
+
+		next, err = next()
+		if err != nil {
+			l.errchan <- err
+			return
+		}
+	}
+}
+
+type lexStep func() (lexStep, error)
+
+func (l *lexer) lexSectionName() (lexStep, error) {
+	sec, err := l.buf.ReadBytes(']')
+	if err != nil {
+		return nil, errors.New("unable to find end of section")
+	}
+
+	return l.lexSectionSuffixFunc(string(sec[:len(sec)-1])), nil
+}
+
+func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		garbage, _, err := l.toEOL()
+		if err != nil {
+			return nil, err
+		}
+
+		garbage = bytes.TrimSpace(garbage)
+		if len(garbage) > 0 {
+			return nil, fmt.Errorf("found garbage after section name %s: %v", l.section, garbage)
+		}
+
+		return l.lexNextSectionOrOptionFunc(section), nil
+	}
+}
+
+func (l *lexer) ignoreLineFunc(next lexStep) lexStep {
+	return func() (lexStep, error) {
+		for {
+			line, _, err := l.toEOL()
+			if err != nil {
+				return nil, err
+			}
+
+			line = bytes.TrimSuffix(line, []byte{' '})
+
+			// lack of continuation means this line has been exhausted
+			if !bytes.HasSuffix(line, []byte{'\\'}) {
+				break
+			}
+		}
+
+		// reached end of buffer, safe to exit
+		return next, nil
+	}
+}
+
+func (l *lexer) lexNextSection() (lexStep, error) {
+	r, _, err := l.buf.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return nil, err
+	}
+
+	if r == '[' {
+		return l.lexSectionName, nil
+	} else if isComment(r) {
+		return l.ignoreLineFunc(l.lexNextSection), nil
+	}
+
+	return l.lexNextSection, nil
+}
+
+func (l *lexer) lexNextSectionOrOptionFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		r, _, err := l.buf.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return nil, err
+		}
+
+		if unicode.IsSpace(r) {
+			return l.lexNextSectionOrOptionFunc(section), nil
+		} else if r == '[' {
+			return l.lexSectionName, nil
+		} else if isComment(r) {
+			return l.ignoreLineFunc(l.lexNextSectionOrOptionFunc(section)), nil
+		}
+
+		l.buf.UnreadRune()
+		return l.lexOptionNameFunc(section), nil
+	}
+}
+
+func (l *lexer) lexOptionNameFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		var partial bytes.Buffer
+		for {
+			r, _, err := l.buf.ReadRune()
+			if err != nil {
+				return nil, err
+			}
+
+			if r == '\n' || r == '\r' {
+				return nil, errors.New("unexpected newline encountered while parsing option name")
+			}
+
+			if r == '=' {
+				break
+			}
+
+			partial.WriteRune(r)
+		}
+
+		name := strings.TrimSpace(partial.String())
+		return l.lexOptionValueFunc(section, name, bytes.Buffer{}), nil
+	}
+}
+
+func (l *lexer) lexOptionValueFunc(section, name string, partial bytes.Buffer) lexStep {
+	return func() (lexStep, error) {
+		for {
+			line, eof, err := l.toEOL()
+			if err != nil {
+				return nil, err
+			}
+
+			if len(bytes.TrimSpace(line)) == 0 {
+				break
+			}
+
+			partial.Write(line)
+
+			// lack of continuation means this value has been exhausted
+			idx := bytes.LastIndex(line, []byte{'\\'})
+			if idx == -1 || idx != (len(line)-1) {
+				break
+			}
+
+			if !eof {
+				partial.WriteRune('\n')
+			}
+
+			return l.lexOptionValueFunc(section, name, partial), nil
+		}
+
+		val := partial.String()
+		if strings.HasSuffix(val, "\n") {
+			// A newline was added to the end, so the file didn't end with a backslash.
+			// => Keep the newline
+			val = strings.TrimSpace(val) + "\n"
+		} else {
+			val = strings.TrimSpace(val)
+		}
+		l.optchan <- &UnitOption{Section: section, Name: name, Value: val}
+
+		return l.lexNextSectionOrOptionFunc(section), nil
+	}
+}
+
+// toEOL reads until the end-of-line or end-of-file.
+// Returns (data, EOFfound, error)
+func (l *lexer) toEOL() ([]byte, bool, error) {
+	line, err := l.buf.ReadBytes('\n')
+	// ignore EOF here since it's roughly equivalent to EOL
+	if err != nil && err != io.EOF {
+		return nil, false, err
+	}
+
+	line = bytes.TrimSuffix(line, []byte{'\r'})
+	line = bytes.TrimSuffix(line, []byte{'\n'})
+
+	return line, err == io.EOF, nil
+}
+
+func isComment(r rune) bool {
+	return r == '#' || r == ';'
+}

--- a/vendor/github.com/coreos/go-systemd/unit/escape.go
+++ b/vendor/github.com/coreos/go-systemd/unit/escape.go
@@ -1,0 +1,116 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements systemd-escape [--unescape] [--path]
+
+package unit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	allowed = `:_.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`
+)
+
+// If isPath is true:
+//   We remove redundant '/'s, the leading '/', and trailing '/'.
+//   If the result is empty, a '/' is inserted.
+//
+// We always:
+//  Replace the following characters with `\x%x`:
+//   Leading `.`
+//   `-`, `\`, and anything not in this set: `:-_.\[0-9a-zA-Z]`
+//  Replace '/' with '-'.
+func escape(unescaped string, isPath bool) string {
+	e := []byte{}
+	inSlashes := false
+	start := true
+	for i := 0; i < len(unescaped); i++ {
+		c := unescaped[i]
+		if isPath {
+			if c == '/' {
+				inSlashes = true
+				continue
+			} else if inSlashes {
+				inSlashes = false
+				if !start {
+					e = append(e, '-')
+				}
+			}
+		}
+
+		if c == '/' {
+			e = append(e, '-')
+		} else if start && c == '.' || strings.IndexByte(allowed, c) == -1 {
+			e = append(e, []byte(fmt.Sprintf(`\x%x`, c))...)
+		} else {
+			e = append(e, c)
+		}
+		start = false
+	}
+	if isPath && len(e) == 0 {
+		e = append(e, '-')
+	}
+	return string(e)
+}
+
+// If isPath is true:
+//   We always return a string beginning with '/'.
+//
+// We always:
+//  Replace '-' with '/'.
+//  Replace `\x%x` with the value represented in hex.
+func unescape(escaped string, isPath bool) string {
+	u := []byte{}
+	for i := 0; i < len(escaped); i++ {
+		c := escaped[i]
+		if c == '-' {
+			c = '/'
+		} else if c == '\\' && len(escaped)-i >= 4 && escaped[i+1] == 'x' {
+			n, err := strconv.ParseInt(escaped[i+2:i+4], 16, 8)
+			if err == nil {
+				c = byte(n)
+				i += 3
+			}
+		}
+		u = append(u, c)
+	}
+	if isPath && (len(u) == 0 || u[0] != '/') {
+		u = append([]byte("/"), u...)
+	}
+	return string(u)
+}
+
+// UnitNameEscape escapes a string as `systemd-escape` would
+func UnitNameEscape(unescaped string) string {
+	return escape(unescaped, false)
+}
+
+// UnitNameUnescape unescapes a string as `systemd-escape --unescape` would
+func UnitNameUnescape(escaped string) string {
+	return unescape(escaped, false)
+}
+
+// UnitNamePathEscape escapes a string as `systemd-escape --path` would
+func UnitNamePathEscape(unescaped string) string {
+	return escape(unescaped, true)
+}
+
+// UnitNamePathUnescape unescapes a string as `systemd-escape --path --unescape` would
+func UnitNamePathUnescape(escaped string) string {
+	return unescape(escaped, true)
+}

--- a/vendor/github.com/coreos/go-systemd/unit/option.go
+++ b/vendor/github.com/coreos/go-systemd/unit/option.go
@@ -1,0 +1,54 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"fmt"
+)
+
+type UnitOption struct {
+	Section string
+	Name    string
+	Value   string
+}
+
+func NewUnitOption(section, name, value string) *UnitOption {
+	return &UnitOption{Section: section, Name: name, Value: value}
+}
+
+func (uo *UnitOption) String() string {
+	return fmt.Sprintf("{Section: %q, Name: %q, Value: %q}", uo.Section, uo.Name, uo.Value)
+}
+
+func (uo *UnitOption) Match(other *UnitOption) bool {
+	return uo.Section == other.Section &&
+		uo.Name == other.Name &&
+		uo.Value == other.Value
+}
+
+func AllMatch(u1 []*UnitOption, u2 []*UnitOption) bool {
+	length := len(u1)
+	if length != len(u2) {
+		return false
+	}
+
+	for i := 0; i < length; i++ {
+		if !u1[i].Match(u2[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/github.com/coreos/go-systemd/unit/serialize.go
+++ b/vendor/github.com/coreos/go-systemd/unit/serialize.go
@@ -1,0 +1,75 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"io"
+)
+
+// Serialize encodes all of the given UnitOption objects into a
+// unit file. When serialized the options are sorted in their
+// supplied order but grouped by section.
+func Serialize(opts []*UnitOption) io.Reader {
+	var buf bytes.Buffer
+
+	if len(opts) == 0 {
+		return &buf
+	}
+
+	// Index of sections -> ordered options
+	idx := map[string][]*UnitOption{}
+	// Separately preserve order in which sections were seen
+	sections := []string{}
+	for _, opt := range opts {
+		sec := opt.Section
+		if _, ok := idx[sec]; !ok {
+			sections = append(sections, sec)
+		}
+		idx[sec] = append(idx[sec], opt)
+	}
+
+	for i, sect := range sections {
+		writeSectionHeader(&buf, sect)
+		writeNewline(&buf)
+
+		opts := idx[sect]
+		for _, opt := range opts {
+			writeOption(&buf, opt)
+			writeNewline(&buf)
+		}
+		if i < len(sections)-1 {
+			writeNewline(&buf)
+		}
+	}
+
+	return &buf
+}
+
+func writeNewline(buf *bytes.Buffer) {
+	buf.WriteRune('\n')
+}
+
+func writeSectionHeader(buf *bytes.Buffer, section string) {
+	buf.WriteRune('[')
+	buf.WriteString(section)
+	buf.WriteRune(']')
+}
+
+func writeOption(buf *bytes.Buffer, opt *UnitOption) {
+	buf.WriteString(opt.Name)
+	buf.WriteRune('=')
+	buf.WriteString(opt.Value)
+}


### PR DESCRIPTION
Closes https://github.com/gravitational/gravity.e/issues/4147.

### Overview

This PR addresses the issue with devicemapper disk/partition not being reused when upgrading to overlay storage driver.

### How it works

* Upgrade detects if the cluster is using dedicated devicemapper device/partition.
* If it does, an additional upgrade phase runs after old planet stops but the new one hasn't started yet:
  * Devicemapper data on the device/partition is destroyed.
  * The device/partition is formatted.
  * The device/partition is mounted under Docker data directory.
  * New Planet is started.
* Rollback performs reverse actions for the steps above.

### Implementation notes

* Because all the stuff with formatting/mounting device/partition has to happen before new Planet starts, I've updated the "system-upgrade" phase to upgrade the package but do not start it in this case.
* When testing this, I was using 5.2 as the base version. We might need to re-test this from 5.0 when Dima's added direct 5.0->5.5 upgrade support.
