### PR TITLE
Fix invalid token length in vagrant deployment scripts

### DIFF
--- a/vagrant/ansible/deploy.yaml
+++ b/vagrant/ansible/deploy.yaml
@@ -43,12 +43,12 @@
         --flavor={{flavor}} \
         --cluster=dev.test \
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
-        --token=token
+        --token=token123
       {% else %}
       /tmp/gravity join \
         {{hostvars[groups['nodes'][0]]['ansible_default_ipv4']['address']}} \
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
-        --token=token
+        --token=token123
       {% endif %}
 
 

--- a/vagrant/ansible/install.yaml
+++ b/vagrant/ansible/install.yaml
@@ -15,11 +15,11 @@
         --flavor={{flavor}} \
         --cluster=dev.test \
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
-        --token=token
+        --token=token123
       {% else %}
       /tmp/gravity join \
         {{hostvars[groups['nodes'][0]]['ansible_default_ipv4']['address']}} \
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
-        --token=token
+        --token=token123
       {% endif %}
 


### PR DESCRIPTION
The token length should be greater than 6 characters. This PR fixes the token length in vagrant deployment scripts (dev env).