### PR TITLE
Fix resources subfolder deletion in initContainer

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -375,13 +375,13 @@ TMPDIR={{.StateDir}} {{.StateDir}}/gravity --state-dir={{.StateDir}} app unpack 
 	--insecure --ops-url=$ops_url \
 	{{.Package}} {{.ResourcesDir}};
 mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources || true
+rmdir --ignore-fail-on-non-empty {{.ResourcesDir}}/resources
 `))
 
 var initInstallScriptTemplate = template.Must(template.New("sh").Parse(`
 TMPDIR={{.StateDir}} /opt/bin/gravity app unpack --service-uid={{.ServiceUser.UID}} {{.Package}} {{.ResourcesDir}}
 mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources || true
+rmdir --ignore-fail-on-non-empty {{.ResourcesDir}}/resources
 `))
 
 type initScriptContext struct {

--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -35,7 +35,7 @@ import (
 	teleutils "github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // configureJob augments the provided job spec with the proper metadata (e.g. to ensure unique name),
@@ -375,13 +375,13 @@ TMPDIR={{.StateDir}} {{.StateDir}}/gravity --state-dir={{.StateDir}} app unpack 
 	--insecure --ops-url=$ops_url \
 	{{.Package}} {{.ResourcesDir}};
 mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources
+rm -r {{.ResourcesDir}}/resources || true
 `))
 
 var initInstallScriptTemplate = template.Must(template.New("sh").Parse(`
 TMPDIR={{.StateDir}} /opt/bin/gravity app unpack --service-uid={{.ServiceUser.UID}} {{.Package}} {{.ResourcesDir}}
 mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources
+rm -r {{.ResourcesDir}}/resources || true
 `))
 
 type initScriptContext struct {


### PR DESCRIPTION
Fixes #452 

In #452 if the application directory contains a resources subfolder, hooks will fail. So change this to attempt to remove the resources folder, but ignore failures if the folder isn't empty after the mv. 