### PR TITLE
Couple of fixes.

### DIFF
--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -164,7 +164,7 @@ spec:
           httpGet:
             path: /healthz
             port: 3010
-          initialDelaySeconds: 600
+          initialDelaySeconds: 120
           timeoutSeconds: 5
         readinessProbe:
           httpGet:

--- a/lib/report/k8s.go
+++ b/lib/report/k8s.go
@@ -76,8 +76,13 @@ func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner) Col
 				name := fmt.Sprintf("k8s-logs-%v-%v-%v", namespace, pod, container)
 				commands = append(commands, Cmd(name, utils.PlanetCommand(kubectl.Command("logs", pod,
 					"--namespace", namespace,
-					fmt.Sprintf("-c=%v", container)))...),
-				)
+					fmt.Sprintf("-c=%v", container)))...))
+				// Also collect logs for the previous instance
+				// of the container if there's any.
+				name = fmt.Sprintf("%v-prev", name)
+				commands = append(commands, Cmd(name, utils.PlanetCommand(kubectl.Command("logs", pod,
+					"--namespace", namespace, "-p",
+					fmt.Sprintf("-c=%v", container)))...))
 			}
 		}
 	}


### PR DESCRIPTION
Fix a couple of things discovered when helping a customer recently.

* Reduce liveness probe delay on gravity-site to 2 minutes. Closes https://github.com/gravitational/gravity.e/issues/4154.
* Add logs for terminated containers to debug report. Closes https://github.com/gravitational/gravity.e/issues/4153.