### PR TITLE
[5.5] unpack application resources without the 'resources' directory

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -373,15 +373,11 @@ cp /opt/bin/gravity {{.StateDir}}/
 TMPDIR={{.StateDir}} {{.StateDir}}/gravity --state-dir={{.StateDir}} app unpack \
 	--service-uid={{.ServiceUser.UID}} \
 	--insecure --ops-url=$ops_url \
-	{{.Package}} {{.ResourcesDir}};
-mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources
+	{{.Package}} {{.ResourcesDir}}
 `))
 
 var initInstallScriptTemplate = template.Must(template.New("sh").Parse(`
 TMPDIR={{.StateDir}} /opt/bin/gravity app unpack --service-uid={{.ServiceUser.UID}} {{.Package}} {{.ResourcesDir}}
-mv {{.ResourcesDir}}/resources/* {{.ResourcesDir}}
-rm -r {{.ResourcesDir}}/resources
 `))
 
 type initScriptContext struct {

--- a/lib/app/service/manifest.go
+++ b/lib/app/service/manifest.go
@@ -41,7 +41,7 @@ import (
 // to remove the directory after it is no longer needed using the returned cleanup handler.
 // The resulting cleanup handler is guaranteed to be non-nil so it's always safe to call
 func manifestFromUnpackedSource(source io.Reader) (manifest []byte, dir string, cleanup cleanup, err error) {
-	dir, cleanup, err = unpackedSource(source, false)
+	dir, cleanup, err = unpackedSource(source)
 	if err != nil {
 		return nil, "", cleanup, trace.Wrap(err)
 	}
@@ -52,32 +52,6 @@ func manifestFromUnpackedSource(source io.Reader) (manifest []byte, dir string, 
 	}
 
 	return manifest, dir, cleanup, nil
-}
-
-// manifestFromSource reads an application manifest from the specified tarball
-// without unpacking it.
-func manifestFromSource(source io.Reader) (manifest []byte, err error) {
-	decompressed, err := dockerarchive.DecompressStream(source)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	reader := tar.NewReader(decompressed)
-	root := "."
-	if err = archive.TarGlob(reader, root, []string{"*.*"}, func(match string, file io.Reader) (err error) {
-		if filepath.Base(match) == defaults.ManifestFileName {
-			manifest, err = ioutil.ReadAll(file)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-		}
-		return nil
-	}); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if manifest == nil {
-		return nil, trace.NotFound("no application manifest %v found in tarball", defaults.ManifestFileName)
-	}
-	return manifest, nil
 }
 
 func manifestFromDir(dir string) (manifest []byte, err error) {
@@ -100,9 +74,10 @@ func manifestFromDir(dir string) (manifest []byte, err error) {
 // It is caller's responsibility to remove the directory after it is no longer needed
 // using the returned cleanup handler.
 // The resulting cleanup handler is guaranteed to be non-nil so it's always safe to call
-func unpackedSource(source io.Reader, excludeRegistry bool) (dir string, cleanup cleanup, err error) {
+func unpackedSource(source io.Reader) (dir string, cleanup cleanup, err error) {
 	dir, err = ioutil.TempDir("", "gravity")
-	log.Infof("creating temp directory %q", dir)
+	logger := log.WithField("dir", dir)
+	logger.Info("Create temporary directory.")
 	if err != nil {
 		return "", emptyCleanup, trace.Wrap(trace.ConvertSystemError(err),
 			"failed to create directory %q", dir)
@@ -110,19 +85,44 @@ func unpackedSource(source io.Reader, excludeRegistry bool) (dir string, cleanup
 	cleanup = func() {
 		err := os.RemoveAll(dir)
 		if err != nil {
-			log.Warningf("failed to remove directory %q: %v", dir, err)
+			logger.WithError(err).Warn("Failed to remove directory.")
 		}
 	}
-
-	tarOptions := archive.DefaultOptions()
-	if excludeRegistry {
-		tarOptions.ExcludePatterns = []string{"registry"}
-	}
-
-	if err = dockerarchive.Untar(source, dir, tarOptions); err != nil {
+	if err = dockerarchive.Untar(source, dir, archive.DefaultOptions()); err != nil {
 		return dir, cleanup, trace.Wrap(err)
 	}
 	return dir, cleanup, nil
+}
+
+func unpackedResources(appPackage io.Reader) (rc io.ReadCloser, err error) {
+	reader, writer := io.Pipe()
+	decompressed, err := dockerarchive.DecompressStream(appPackage)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	go func() {
+		tarball := archive.NewTarAppender(writer)
+		handler := renderItemFromTarball(tarball)
+		defer func() {
+			tarball.Close()
+			decompressed.Close()
+		}()
+		err := archive.TarGlobWithPrefix(tar.NewReader(decompressed), defaults.ResourcesDir, handler)
+		if err != nil {
+			log.WithError(err).Warn("Failed to unpack resources.")
+		}
+		writer.CloseWithError(err)
+	}()
+	return reader, nil
+}
+
+func renderItemFromTarball(tarball *archive.TarAppender) archive.TarGlobHandler {
+	return func(header *tar.Header, f *tar.Reader) error {
+		return tarball.Add(&archive.Item{
+			Header: *header,
+			Data:   ioutil.NopCloser(f),
+		})
+	}
 }
 
 // toApp translates an application representation from storage format

--- a/lib/app/service/manifest.go
+++ b/lib/app/service/manifest.go
@@ -95,11 +95,11 @@ func unpackedSource(source io.Reader) (dir string, cleanup cleanup, err error) {
 }
 
 func unpackedResources(appPackage io.Reader) (rc io.ReadCloser, err error) {
-	reader, writer := io.Pipe()
 	decompressed, err := dockerarchive.DecompressStream(appPackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	reader, writer := io.Pipe()
 	go func() {
 		tarball := archive.NewTarAppender(writer)
 		handler := renderItemFromTarball(tarball)

--- a/lib/app/service/manifest_test.go
+++ b/lib/app/service/manifest_test.go
@@ -17,39 +17,18 @@ limitations under the License.
 package service
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gravitational/gravity/lib/archive"
 
-	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
-
-func init() {
-	if testing.Verbose() {
-		log.SetOutput(os.Stderr)
-		log.SetLevel(log.InfoLevel)
-	}
-}
 
 func TestService(t *testing.T) { TestingT(t) }
 
 type ManifestSuite struct{}
 
 var _ = Suite(&ManifestSuite{})
-
-func (r *ManifestSuite) TestReadsManifestFromTarball(c *C) {
-	files := []*archive.Item{
-		archive.DirItem("resources"),
-		archive.ItemFromString("resources/app.yaml", manifestBytes),
-	}
-	input := archive.MustCreateMemArchive(files)
-	manifest, err := manifestFromSource(input)
-	c.Assert(err, IsNil)
-	c.Assert(manifest, NotNil)
-}
 
 func (r *ManifestSuite) TestReadsManifestFromUnpacked(c *C) {
 	files := []*archive.Item{
@@ -61,13 +40,6 @@ func (r *ManifestSuite) TestReadsManifestFromUnpacked(c *C) {
 	defer cleanup()
 	c.Assert(err, IsNil)
 	c.Assert(manifest, NotNil)
-}
-
-func (r *ManifestSuite) TestRequiresApplicationManifest(c *C) {
-	input := archive.MustCreateMemArchive(nil)
-	_, err := manifestFromSource(input)
-	c.Assert(err, NotNil)
-	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%T", err))
 }
 
 const manifestBytes = `apiVersion: bundle.gravitational.io/v2

--- a/lib/app/service/resources_test.go
+++ b/lib/app/service/resources_test.go
@@ -39,5 +39,9 @@ func (r *ResourceSuite) TestTranslatesResources(c *C) {
 	c.Assert(err, IsNil)
 	defer rc.Close()
 
-	archive.AssertArchiveHasFiles(c, rc, nil, "app.yaml", "resources.yaml", "config/config.yaml")
+	archive.AssertArchiveHasFiles(c, rc, nil,
+		"resources/app.yaml",
+		"resources/resources.yaml",
+		"resources/config/config.yaml",
+	)
 }

--- a/lib/app/service/resources_test.go
+++ b/lib/app/service/resources_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"time"
+
+	"github.com/gravitational/gravity/lib/app"
+	apptest "github.com/gravitational/gravity/lib/app/service/test"
+	"github.com/gravitational/gravity/lib/archive"
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/pack"
+
+	. "gopkg.in/check.v1"
+)
+
+type ResourceSuite struct {
+	pack pack.PackageService
+	apps app.Applications
+}
+
+var _ = Suite(&ResourceSuite{})
+
+func (r *ResourceSuite) SetUpTest(c *C) {
+	_, r.pack, r.apps = setupServices(c)
+	err := r.pack.UpsertRepository("example.com", time.Time{})
+	c.Assert(err, IsNil)
+}
+
+func (r *ResourceSuite) TestTranslatesResources(c *C) {
+	appPackage := loc.MustParseLocator("example.com/app:1.0.0")
+	runtimePackage := loc.MustParseLocator("gravitational.io/planet:0.0.1")
+	apptest.CreatePackage(r.pack, runtimePackage, nil, c)
+	apptest.CreateRuntimeApplication(r.apps, c)
+	apptest.CreateDummyApplication(r.apps, appPackage, c)
+
+	_, reader, err := r.pack.ReadPackage(appPackage)
+	c.Assert(err, IsNil)
+
+	rc, err := unpackedResources(reader)
+	c.Assert(err, IsNil)
+	defer rc.Close()
+
+	archive.AssertArchiveHasFiles(c, rc, nil, "app.yaml", "resources.yaml", "config/config.yaml")
+}

--- a/lib/app/service/test/builder.go
+++ b/lib/app/service/test/builder.go
@@ -162,8 +162,13 @@ spec:
     role: server`
 	files := []*archive.Item{
 		archive.DirItem("resources"),
+		archive.DirItem("resources/config"),
 		archive.ItemFromString("resources/app.yaml", manifestBytes),
 		archive.ItemFromString("resources/resources.yaml", resourceBytes),
+		archive.ItemFromString("resources/config/config.yaml", "configuration"),
+		archive.DirItem("registry"),
+		archive.DirItem("registry/docker"),
+		archive.ItemFromString("registry/docker/TODO", ""),
 	}
 
 	return CreateApplicationFromData(apps, loc, files, c)

--- a/lib/app/suite/suite.go
+++ b/lib/app/suite/suite.go
@@ -129,7 +129,10 @@ func (r *AppsSuite) Resources(c *C) {
 	c.Assert(err, IsNil)
 	defer reader.Close()
 
-	archive.AssertArchiveHasFiles(c, reader, nil, "resource-0.yaml", "app.yaml")
+	archive.AssertArchiveHasFiles(c, reader, nil,
+		"resources/resource-0.yaml",
+		"resources/app.yaml",
+	)
 
 	// import another version and check that resources have been updated
 	const manifestBytes = `apiVersion: bundle.gravitational.io/v2

--- a/lib/app/suite/suite.go
+++ b/lib/app/suite/suite.go
@@ -129,8 +129,7 @@ func (r *AppsSuite) Resources(c *C) {
 	c.Assert(err, IsNil)
 	defer reader.Close()
 
-	archive.AssertArchiveHasFiles(c, reader, []string{"registry"},
-		"resources", "resources/resource-0.yaml", "resources/app.yaml")
+	archive.AssertArchiveHasFiles(c, reader, nil, "resource-0.yaml", "app.yaml")
 
 	// import another version and check that resources have been updated
 	const manifestBytes = `apiVersion: bundle.gravitational.io/v2

--- a/lib/archive/archive.go
+++ b/lib/archive/archive.go
@@ -121,7 +121,7 @@ func Extract(r io.Reader, dir string) error {
 // Note, files from tarDir are written directly to dir omitting tarDir.
 // The resulting files and directories are created using the current user context.
 func ExtractWithPrefix(r io.Reader, dir, tarDirPrefix string) error {
-	return trace.Wrap(TarGlobWithPrefix(tar.NewReader(r), tarDirPrefix, func(match *tar.Header, r *tar.Reader) error {
+	err := TarGlobWithPrefix(tar.NewReader(r), tarDirPrefix, func(match *tar.Header, r *tar.Reader) error {
 		relpath, err := filepath.Rel(tarDirPrefix, match.Name)
 		if err != nil {
 			return trace.Wrap(err)
@@ -141,7 +141,8 @@ func ExtractWithPrefix(r io.Reader, dir, tarDirPrefix string) error {
 			return trace.Wrap(err)
 		}
 		return nil
-	}))
+	})
+	return trace.Wrap(err)
 }
 
 // HasFile returns nil if the specified tarball contains specified file

--- a/lib/rpc/server/suite_test.go
+++ b/lib/rpc/server/suite_test.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"net"
-	"os"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -33,13 +32,6 @@ type S struct {
 }
 
 var _ = check.Suite(&S{})
-
-func init() {
-	if testing.Verbose() {
-		log.SetLevel(log.DebugLevel)
-		log.SetOutput(os.Stderr)
-	}
-}
 
 func (r *S) SetUpSuite(c *check.C) {
 	r.Logger = log.StandardLogger()

--- a/tool/gravity/cli/app.go
+++ b/tool/gravity/cli/app.go
@@ -424,11 +424,7 @@ func unpackAppResources(env *localenv.LocalEnvironment, loc loc.Locator, dir, op
 		}
 		defer reader.Close()
 
-		if err := dockerarchive.Untar(reader, dir, archive.DefaultOptions()); err != nil {
-			return trace.Wrap(err)
-		}
-
-		return nil
+		return archive.ExtractWithPrefix(reader, dir, defaults.ResourcesDir)
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -441,8 +437,7 @@ func unpackAppResources(env *localenv.LocalEnvironment, loc loc.Locator, dir, op
 			return trace.BadParameter("invalid numeric user ID %q: %v", serviceUID, err)
 		}
 	}
-	err = resources.UpdateSecurityContextInDir(filepath.Join(dir, defaults.ResourcesDir),
-		systeminfo.User{UID: uid})
+	err = resources.UpdateSecurityContextInDir(dir, systeminfo.User{UID: uid})
 	if err != nil {
 		return trace.Wrap(err, "failed to render application resources")
 	}


### PR DESCRIPTION
In #452, if the application resource directory itself contains a `resources` sub-directory, hook init containers fail.
To fix this, this PR changes the semantics of `app unpack` sub-command to unpack application resources from the tarball's `resources` directory directly into the specified directory without the `resources` directory itself. This should be a safe (and sensible!) change as the hook's init container code is the only client of `app unpack`.

Fixes #452.