### PR TITLE
Add command to set the phase state.

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -709,11 +709,14 @@ var (
 	EncodingPEM Format = "pem"
 	// EncodingText is for the plaint-text encoding format
 	EncodingText Format = "text"
+	// EncodingShort is for short output format
+	EncodingShort Format = "short"
 	// EncodingYAML is for the YAML encoding format
 	EncodingYAML Format = "yaml"
 	// OutputFormats is a list of recognized output formats for gravity CLI commands
 	OutputFormats = []Format{
 		EncodingText,
+		EncodingShort,
 		EncodingJSON,
 		EncodingYAML,
 	}

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -89,6 +89,38 @@ func printPhase(w io.Writer, phase storage.OperationPhase, indent int) {
 	}
 }
 
+// FormatOperationPlanShort formats provided operation plan as text with
+// fewer number of columns.
+func FormatOperationPlanShort(w io.Writer, plan storage.OperationPlan) {
+	var t tabwriter.Writer
+	t.Init(w, 0, 10, 5, ' ', 0)
+	common.PrintTableHeader(&t, []string{"Phase", "State", "Updated"})
+	for _, phase := range plan.Phases {
+		printPhaseShort(&t, phase, 0)
+	}
+	t.Flush()
+}
+
+func printPhaseShort(w io.Writer, phase storage.OperationPhase, indent int) {
+	marker := "*"
+	if phase.GetState() == storage.OperationPhaseStateInProgress {
+		marker = constants.InProgressMark
+	} else if phase.GetState() == storage.OperationPhaseStateCompleted {
+		marker = constants.SuccessMark
+	} else if phase.GetState() == storage.OperationPhaseStateFailed || phase.GetState() == storage.OperationPhaseStateRolledBack {
+		marker = constants.FailureMark
+	}
+	fmt.Fprintf(w, "%v%v %v\t%v\t%v\n",
+		strings.Repeat("  ", indent),
+		marker,
+		formatName(phase.ID),
+		formatState(phase.GetState()),
+		formatTimestamp(phase.GetLastUpdateTime()))
+	for _, subPhase := range phase.Phases {
+		printPhaseShort(w, subPhase, indent+1)
+	}
+}
+
 func formatNode(phase storage.OperationPhase) string {
 	if phase.Data == nil || phase.Data.ExecServer == nil {
 		return "-"

--- a/lib/install/client/client.go
+++ b/lib/install/client/client.go
@@ -63,7 +63,7 @@ func (r *Client) Run(ctx context.Context) error {
 func (r *Client) ExecutePhase(ctx context.Context, phase Phase) error {
 	r.WithField("phase", phase).Info("Execute.")
 	return r.execute(ctx, &installpb.ExecuteRequest{
-		Phase: &installpb.ExecuteRequest_Phase{
+		Phase: &installpb.Phase{
 			Key:   installpb.KeyToProto(phase.Key),
 			ID:    phase.ID,
 			Force: phase.Force,
@@ -71,11 +71,24 @@ func (r *Client) ExecutePhase(ctx context.Context, phase Phase) error {
 	})
 }
 
+// SetPhase sets the specified phase state without executing it
+func (r *Client) SetPhase(ctx context.Context, phase Phase, state string) error {
+	r.WithField("phase", phase).WithField("state", state).Info("Set.")
+	_, err := r.client.SetState(ctx, &installpb.SetStateRequest{
+		Phase: &installpb.Phase{
+			Key: installpb.KeyToProto(phase.Key),
+			ID:  phase.ID,
+		},
+		State: state,
+	})
+	return trace.Wrap(err)
+}
+
 // RollbackPhase rolls back the specified phase
 func (r *Client) RollbackPhase(ctx context.Context, phase Phase) error {
 	r.WithField("phase", phase).Info("Rollback.")
 	return r.execute(ctx, &installpb.ExecuteRequest{
-		Phase: &installpb.ExecuteRequest_Phase{
+		Phase: &installpb.Phase{
 			Key:      installpb.KeyToProto(phase.Key),
 			ID:       phase.ID,
 			Force:    phase.Force,

--- a/lib/install/proto/installer.pb.go
+++ b/lib/install/proto/installer.pb.go
@@ -59,7 +59,84 @@ var ProgressResponse_Status_value = map[string]int32{
 }
 
 func (ProgressResponse_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{5, 0}
+	return fileDescriptor_675879a591bd3155, []int{7, 0}
+}
+
+// Phase represents an operation plan phase
+type Phase struct {
+	// ID specifies the phase ID
+	ID string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Key identifies the operation
+	Key *OperationKey `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	// Rollback specifies whether this is a rollback
+	Rollback bool `protobuf:"varint,3,opt,name=rollback,proto3" json:"rollback,omitempty"`
+	// Force specifies whether the phase execution/rollback should be rerun
+	// regardless of phase state
+	Force                bool     `protobuf:"varint,4,opt,name=force,proto3" json:"force,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Phase) Reset()         { *m = Phase{} }
+func (m *Phase) String() string { return proto.CompactTextString(m) }
+func (*Phase) ProtoMessage()    {}
+func (*Phase) Descriptor() ([]byte, []int) {
+	return fileDescriptor_675879a591bd3155, []int{0}
+}
+func (m *Phase) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Phase) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Phase.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Phase) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Phase.Merge(m, src)
+}
+func (m *Phase) XXX_Size() int {
+	return m.Size()
+}
+func (m *Phase) XXX_DiscardUnknown() {
+	xxx_messageInfo_Phase.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Phase proto.InternalMessageInfo
+
+func (m *Phase) GetID() string {
+	if m != nil {
+		return m.ID
+	}
+	return ""
+}
+
+func (m *Phase) GetKey() *OperationKey {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *Phase) GetRollback() bool {
+	if m != nil {
+		return m.Rollback
+	}
+	return false
+}
+
+func (m *Phase) GetForce() bool {
+	if m != nil {
+		return m.Force
+	}
+	return false
 }
 
 // ExecuteRequest describes a request to execute install operation
@@ -67,17 +144,17 @@ type ExecuteRequest struct {
 	// Phase optionally specifies the configuration for executing or rolling
 	// back a specific phase.
 	// If unspecified, the operation is executed from the beginning
-	Phase                *ExecuteRequest_Phase `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
+	Phase                *Phase   `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *ExecuteRequest) Reset()         { *m = ExecuteRequest{} }
 func (m *ExecuteRequest) String() string { return proto.CompactTextString(m) }
 func (*ExecuteRequest) ProtoMessage()    {}
 func (*ExecuteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{0}
+	return fileDescriptor_675879a591bd3155, []int{1}
 }
 func (m *ExecuteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -106,40 +183,36 @@ func (m *ExecuteRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ExecuteRequest proto.InternalMessageInfo
 
-func (m *ExecuteRequest) GetPhase() *ExecuteRequest_Phase {
+func (m *ExecuteRequest) GetPhase() *Phase {
 	if m != nil {
 		return m.Phase
 	}
 	return nil
 }
 
-type ExecuteRequest_Phase struct {
-	// ID specifies the phase ID
-	ID string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Key identifies the operation
-	Key *OperationKey `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
-	// Rollback specifies whether this is a rollback
-	Rollback bool `protobuf:"varint,3,opt,name=rollback,proto3" json:"rollback,omitempty"`
-	// Force specifies whether the phase execution/rollback should be rerun
-	// regardless of phase state
-	Force                bool     `protobuf:"varint,4,opt,name=force,proto3" json:"force,omitempty"`
+// SetStateRequest describes a request to explicitly set phase state
+type SetStateRequest struct {
+	// Phase describes the phase to set the state for
+	Phase *Phase `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"`
+	// State is the new phase state
+	State                string   `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ExecuteRequest_Phase) Reset()         { *m = ExecuteRequest_Phase{} }
-func (m *ExecuteRequest_Phase) String() string { return proto.CompactTextString(m) }
-func (*ExecuteRequest_Phase) ProtoMessage()    {}
-func (*ExecuteRequest_Phase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{0, 0}
+func (m *SetStateRequest) Reset()         { *m = SetStateRequest{} }
+func (m *SetStateRequest) String() string { return proto.CompactTextString(m) }
+func (*SetStateRequest) ProtoMessage()    {}
+func (*SetStateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_675879a591bd3155, []int{2}
 }
-func (m *ExecuteRequest_Phase) XXX_Unmarshal(b []byte) error {
+func (m *SetStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *ExecuteRequest_Phase) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SetStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_ExecuteRequest_Phase.Marshal(b, m, deterministic)
+		return xxx_messageInfo_SetStateRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalTo(b)
@@ -149,44 +222,30 @@ func (m *ExecuteRequest_Phase) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
-func (m *ExecuteRequest_Phase) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ExecuteRequest_Phase.Merge(m, src)
+func (m *SetStateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetStateRequest.Merge(m, src)
 }
-func (m *ExecuteRequest_Phase) XXX_Size() int {
+func (m *SetStateRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *ExecuteRequest_Phase) XXX_DiscardUnknown() {
-	xxx_messageInfo_ExecuteRequest_Phase.DiscardUnknown(m)
+func (m *SetStateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetStateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ExecuteRequest_Phase proto.InternalMessageInfo
+var xxx_messageInfo_SetStateRequest proto.InternalMessageInfo
 
-func (m *ExecuteRequest_Phase) GetID() string {
+func (m *SetStateRequest) GetPhase() *Phase {
 	if m != nil {
-		return m.ID
-	}
-	return ""
-}
-
-func (m *ExecuteRequest_Phase) GetKey() *OperationKey {
-	if m != nil {
-		return m.Key
+		return m.Phase
 	}
 	return nil
 }
 
-func (m *ExecuteRequest_Phase) GetRollback() bool {
+func (m *SetStateRequest) GetState() string {
 	if m != nil {
-		return m.Rollback
+		return m.State
 	}
-	return false
-}
-
-func (m *ExecuteRequest_Phase) GetForce() bool {
-	if m != nil {
-		return m.Force
-	}
-	return false
+	return ""
 }
 
 // CompleteRequest describes a request to manually complete the operation
@@ -202,7 +261,7 @@ func (m *CompleteRequest) Reset()         { *m = CompleteRequest{} }
 func (m *CompleteRequest) String() string { return proto.CompactTextString(m) }
 func (*CompleteRequest) ProtoMessage()    {}
 func (*CompleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{1}
+	return fileDescriptor_675879a591bd3155, []int{3}
 }
 func (m *CompleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -249,7 +308,7 @@ func (m *AbortRequest) Reset()         { *m = AbortRequest{} }
 func (m *AbortRequest) String() string { return proto.CompactTextString(m) }
 func (*AbortRequest) ProtoMessage()    {}
 func (*AbortRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{2}
+	return fileDescriptor_675879a591bd3155, []int{4}
 }
 func (m *AbortRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -291,7 +350,7 @@ func (m *ShutdownRequest) Reset()         { *m = ShutdownRequest{} }
 func (m *ShutdownRequest) String() string { return proto.CompactTextString(m) }
 func (*ShutdownRequest) ProtoMessage()    {}
 func (*ShutdownRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{3}
+	return fileDescriptor_675879a591bd3155, []int{5}
 }
 func (m *ShutdownRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -340,7 +399,7 @@ func (m *DebugReportRequest) Reset()         { *m = DebugReportRequest{} }
 func (m *DebugReportRequest) String() string { return proto.CompactTextString(m) }
 func (*DebugReportRequest) ProtoMessage()    {}
 func (*DebugReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{4}
+	return fileDescriptor_675879a591bd3155, []int{6}
 }
 func (m *DebugReportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -393,7 +452,7 @@ func (m *ProgressResponse) Reset()         { *m = ProgressResponse{} }
 func (m *ProgressResponse) String() string { return proto.CompactTextString(m) }
 func (*ProgressResponse) ProtoMessage()    {}
 func (*ProgressResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{5}
+	return fileDescriptor_675879a591bd3155, []int{7}
 }
 func (m *ProgressResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -456,7 +515,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{6}
+	return fileDescriptor_675879a591bd3155, []int{8}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -509,7 +568,7 @@ func (m *OperationKey) Reset()         { *m = OperationKey{} }
 func (m *OperationKey) String() string { return proto.CompactTextString(m) }
 func (*OperationKey) ProtoMessage()    {}
 func (*OperationKey) Descriptor() ([]byte, []int) {
-	return fileDescriptor_675879a591bd3155, []int{7}
+	return fileDescriptor_675879a591bd3155, []int{9}
 }
 func (m *OperationKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -561,8 +620,9 @@ func (m *OperationKey) GetID() string {
 
 func init() {
 	proto.RegisterEnum("installer.ProgressResponse_Status", ProgressResponse_Status_name, ProgressResponse_Status_value)
+	proto.RegisterType((*Phase)(nil), "installer.Phase")
 	proto.RegisterType((*ExecuteRequest)(nil), "installer.ExecuteRequest")
-	proto.RegisterType((*ExecuteRequest_Phase)(nil), "installer.ExecuteRequest.Phase")
+	proto.RegisterType((*SetStateRequest)(nil), "installer.SetStateRequest")
 	proto.RegisterType((*CompleteRequest)(nil), "installer.CompleteRequest")
 	proto.RegisterType((*AbortRequest)(nil), "installer.AbortRequest")
 	proto.RegisterType((*ShutdownRequest)(nil), "installer.ShutdownRequest")
@@ -575,50 +635,51 @@ func init() {
 func init() { proto.RegisterFile("installer.proto", fileDescriptor_675879a591bd3155) }
 
 var fileDescriptor_675879a591bd3155 = []byte{
-	// 680 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0x4d, 0x6f, 0xd3, 0x40,
-	0x10, 0x8d, 0x93, 0x26, 0x4d, 0x26, 0x6d, 0x93, 0x6e, 0x51, 0x09, 0x2e, 0x38, 0xc1, 0x07, 0x54,
-	0x24, 0x94, 0x42, 0x10, 0x12, 0x42, 0xa8, 0x52, 0xbe, 0x54, 0x45, 0x2d, 0x49, 0xb4, 0xa5, 0xe2,
-	0x58, 0x39, 0xce, 0xd4, 0x8d, 0xea, 0x78, 0x8d, 0xbd, 0x56, 0xa9, 0xc4, 0x0f, 0xa8, 0xfa, 0x0b,
-	0xb8, 0xf4, 0x44, 0x0f, 0xdc, 0xb9, 0x71, 0x07, 0x71, 0xe4, 0xc0, 0xb9, 0x42, 0xe1, 0x8f, 0x20,
-	0xaf, 0x9d, 0xc4, 0x0d, 0x0a, 0xdc, 0x3c, 0xb3, 0x6f, 0xde, 0x78, 0xde, 0xec, 0x5b, 0xc8, 0x0d,
-	0x2c, 0x97, 0x6b, 0xa6, 0x89, 0x4e, 0xd9, 0x76, 0x18, 0x67, 0x24, 0x33, 0x49, 0xc8, 0x1b, 0x06,
-	0x63, 0x86, 0x89, 0x5b, 0xe2, 0xa0, 0xe7, 0x1d, 0x6d, 0xe1, 0xd0, 0xe6, 0x67, 0x01, 0x4e, 0x06,
-	0x83, 0x19, 0x2c, 0xf8, 0x56, 0xbf, 0x4a, 0xb0, 0xd2, 0x7c, 0x87, 0xba, 0xc7, 0x91, 0xe2, 0x5b,
-	0x0f, 0x5d, 0x4e, 0x9e, 0x41, 0xd2, 0x3e, 0xd6, 0x5c, 0x2c, 0x48, 0x25, 0x69, 0x33, 0x5b, 0x29,
-	0x96, 0xa7, 0x7d, 0x6e, 0x22, 0xcb, 0x5d, 0x1f, 0x46, 0x03, 0xb4, 0xfc, 0x1e, 0x92, 0x22, 0x26,
-	0xeb, 0x10, 0x1f, 0xf4, 0x45, 0x71, 0xa6, 0x96, 0x1a, 0x5d, 0x17, 0xe3, 0xad, 0x06, 0x8d, 0x0f,
-	0xfa, 0xe4, 0x21, 0x24, 0x4e, 0xf0, 0xac, 0x10, 0x17, 0xac, 0xb7, 0x23, 0xac, 0x1d, 0x1b, 0x1d,
-	0x8d, 0x0f, 0x98, 0xb5, 0x8b, 0x67, 0xd4, 0xc7, 0x10, 0x19, 0xd2, 0x0e, 0x33, 0xcd, 0x9e, 0xa6,
-	0x9f, 0x14, 0x12, 0x25, 0x69, 0x33, 0x4d, 0x27, 0x31, 0xb9, 0x05, 0xc9, 0x23, 0xe6, 0xe8, 0x58,
-	0x58, 0x10, 0x07, 0x41, 0xa0, 0xbe, 0x84, 0x5c, 0x9d, 0x0d, 0x6d, 0x13, 0xa7, 0x73, 0x84, 0xfd,
-	0xa4, 0xff, 0xf7, 0x53, 0x57, 0x60, 0xa9, 0xda, 0x63, 0x0e, 0x0f, 0x4b, 0xd5, 0x2d, 0xc8, 0xed,
-	0x1f, 0x7b, 0xbc, 0xcf, 0x4e, 0xad, 0x31, 0xdb, 0x5d, 0xc8, 0xe8, 0x61, 0x83, 0x60, 0xb8, 0x34,
-	0x9d, 0x26, 0xd4, 0x4d, 0x20, 0x0d, 0xec, 0x79, 0x06, 0x45, 0x7b, 0x4a, 0x43, 0x08, 0x2c, 0xd8,
-	0x1a, 0x3f, 0x0e, 0xb4, 0xa0, 0xe2, 0x5b, 0xfd, 0x16, 0x87, 0x7c, 0xd7, 0x61, 0x86, 0x83, 0xae,
-	0x4b, 0xd1, 0xb5, 0x99, 0xe5, 0x22, 0x29, 0xc0, 0xe2, 0x10, 0x5d, 0x57, 0x33, 0x30, 0xc4, 0x8e,
-	0x43, 0xf2, 0x02, 0x52, 0x2e, 0xd7, 0xb8, 0xe7, 0x0a, 0xdd, 0x56, 0x2a, 0x6a, 0x64, 0x8e, 0x59,
-	0x9a, 0xf2, 0xbe, 0x40, 0xd2, 0xb0, 0x82, 0x3c, 0x80, 0x24, 0x3a, 0x0e, 0x73, 0x84, 0x84, 0xd9,
-	0x4a, 0x3e, 0xba, 0x48, 0x3f, 0x4f, 0x83, 0x63, 0xf5, 0xb3, 0x04, 0xa9, 0xa0, 0x94, 0x28, 0xb0,
-	0x78, 0xd0, 0xde, 0x6d, 0x77, 0xde, 0xb4, 0xf3, 0x31, 0x79, 0xf5, 0xe2, 0xb2, 0xb4, 0x1c, 0x1c,
-	0x1c, 0x58, 0x27, 0x16, 0x3b, 0xb5, 0x88, 0x0a, 0x99, 0x7a, 0xe7, 0x55, 0x77, 0xaf, 0xf9, 0xba,
-	0xd9, 0xc8, 0x4b, 0xf2, 0xda, 0xc5, 0x65, 0x29, 0x17, 0x20, 0xc6, 0xea, 0xf7, 0xc9, 0x13, 0x58,
-	0x9d, 0x60, 0x0e, 0xbb, 0xcd, 0x76, 0xa3, 0xd5, 0xde, 0xc9, 0xc7, 0x65, 0xf9, 0xe2, 0xb2, 0xb4,
-	0x3e, 0x83, 0xed, 0xa2, 0xd5, 0x1f, 0x58, 0x86, 0xdf, 0xb6, 0x5a, 0xeb, 0x50, 0x9f, 0x34, 0x11,
-	0x6d, 0x2b, 0x96, 0x82, 0x7d, 0x99, 0x9c, 0x7f, 0x54, 0x62, 0x9f, 0xae, 0x94, 0xd8, 0x97, 0x2b,
-	0x25, 0xfc, 0x55, 0xf5, 0x3e, 0x24, 0xc5, 0x14, 0xf3, 0xc5, 0x53, 0xcf, 0x25, 0x58, 0x8a, 0x2e,
-	0x9b, 0x3c, 0x02, 0xd0, 0x74, 0x9d, 0x79, 0x16, 0x3f, 0x9c, 0x5c, 0xd1, 0xe5, 0xd1, 0x75, 0x31,
-	0x53, 0x0d, 0xb2, 0xad, 0x06, 0xcd, 0x84, 0x80, 0x56, 0x9f, 0x54, 0x60, 0x49, 0x37, 0x3d, 0x97,
-	0xa3, 0x73, 0x68, 0x69, 0x43, 0x14, 0x1b, 0xc8, 0xd4, 0x72, 0xa3, 0xeb, 0x62, 0xb6, 0x1e, 0xe4,
-	0xdb, 0xda, 0x10, 0x69, 0x56, 0x9f, 0x06, 0xe1, 0xe5, 0x4f, 0xcc, 0x5e, 0xfe, 0xca, 0xcf, 0x38,
-	0x24, 0xab, 0x06, 0x5a, 0x9c, 0xd4, 0x61, 0x31, 0xb4, 0x11, 0xb9, 0x33, 0xd7, 0x5a, 0xf2, 0xc6,
-	0x3f, 0xf6, 0xfc, 0x58, 0x22, 0xdb, 0x90, 0x1e, 0x8b, 0x48, 0xe4, 0x08, 0x74, 0xc6, 0x03, 0xf2,
-	0x7a, 0x39, 0x78, 0x08, 0xca, 0xe3, 0x87, 0xa0, 0xdc, 0xf4, 0x1f, 0x02, 0xf2, 0x1c, 0x92, 0x42,
-	0x5b, 0x12, 0xf5, 0x45, 0xd4, 0x02, 0x73, 0x2b, 0xb7, 0x21, 0x3d, 0xb6, 0xc6, 0x8d, 0xce, 0x33,
-	0x7e, 0x99, 0x5b, 0xbf, 0x07, 0x6b, 0x3b, 0x68, 0xf9, 0x3b, 0xc1, 0x88, 0x63, 0xc8, 0xbd, 0x08,
-	0xd5, 0xdf, 0x4e, 0x9a, 0xc7, 0x56, 0xcb, 0x7f, 0x1f, 0x29, 0xd2, 0x8f, 0x91, 0x22, 0xfd, 0x1a,
-	0x29, 0xd2, 0x87, 0xdf, 0x4a, 0xac, 0x97, 0x12, 0x88, 0xa7, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff,
-	0xc1, 0x8a, 0xc7, 0x67, 0x1e, 0x05, 0x00, 0x00,
+	// 703 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xcd, 0x6e, 0x12, 0x51,
+	0x14, 0x66, 0xa0, 0x50, 0x38, 0xb4, 0x85, 0xde, 0x9a, 0x8a, 0x53, 0x9d, 0xe2, 0x2c, 0x0c, 0x26,
+	0x86, 0x2a, 0x6e, 0x1a, 0x63, 0x4c, 0xf8, 0x4b, 0x43, 0x5a, 0x81, 0x5c, 0x6c, 0x5c, 0x36, 0xc3,
+	0x70, 0x3a, 0x25, 0x85, 0xb9, 0xe3, 0xcc, 0x9d, 0xd4, 0x26, 0x3e, 0x40, 0xd3, 0xb5, 0x0b, 0x37,
+	0x5d, 0xd9, 0x85, 0x7b, 0x77, 0x3e, 0x80, 0x71, 0xe9, 0x13, 0x34, 0x06, 0x5f, 0xc4, 0xcc, 0xdc,
+	0x01, 0x06, 0x0c, 0x35, 0xee, 0xe6, 0x9c, 0xf3, 0x7d, 0xe7, 0x77, 0xbe, 0x0b, 0x99, 0xbe, 0xe9,
+	0x70, 0x6d, 0x30, 0x40, 0xbb, 0x68, 0xd9, 0x8c, 0x33, 0x92, 0x9a, 0x38, 0xe4, 0x2d, 0x83, 0x31,
+	0x63, 0x80, 0x3b, 0x7e, 0xa0, 0xeb, 0x1e, 0xef, 0xe0, 0xd0, 0xe2, 0xe7, 0x02, 0x27, 0x83, 0xc1,
+	0x0c, 0x26, 0xbe, 0xd5, 0x0f, 0x10, 0x6f, 0x9f, 0x68, 0x0e, 0x92, 0x4d, 0x88, 0xf6, 0x7b, 0x39,
+	0x29, 0x2f, 0x15, 0x52, 0x95, 0xc4, 0xe8, 0x66, 0x3b, 0xda, 0xa8, 0xd1, 0x68, 0xbf, 0x47, 0x1e,
+	0x43, 0xec, 0x14, 0xcf, 0x73, 0xd1, 0xbc, 0x54, 0x48, 0x97, 0xee, 0x16, 0xa7, 0x35, 0x5b, 0x16,
+	0xda, 0x1a, 0xef, 0x33, 0x73, 0x1f, 0xcf, 0xa9, 0x87, 0x21, 0x32, 0x24, 0x6d, 0x36, 0x18, 0x74,
+	0x35, 0xfd, 0x34, 0x17, 0xcb, 0x4b, 0x85, 0x24, 0x9d, 0xd8, 0xe4, 0x0e, 0xc4, 0x8f, 0x99, 0xad,
+	0x63, 0x6e, 0xc9, 0x0f, 0x08, 0x43, 0xdd, 0x85, 0xb5, 0xfa, 0x7b, 0xd4, 0x5d, 0x8e, 0x14, 0xdf,
+	0xb9, 0xe8, 0x70, 0xf2, 0x08, 0xe2, 0x96, 0xd7, 0x8f, 0xdf, 0x49, 0xba, 0x94, 0x0d, 0x15, 0xf4,
+	0xfb, 0xa4, 0x22, 0xac, 0xb6, 0x20, 0xd3, 0x41, 0xde, 0xe1, 0xda, 0x7f, 0x53, 0xbd, 0x56, 0x1c,
+	0x8f, 0xe7, 0xcf, 0x94, 0xa2, 0xc2, 0x50, 0x5f, 0x42, 0xa6, 0xca, 0x86, 0xd6, 0x00, 0xa7, 0x09,
+	0x83, 0xd1, 0xa5, 0x7f, 0x8f, 0xae, 0xae, 0xc1, 0x4a, 0xb9, 0xcb, 0x6c, 0x1e, 0x50, 0xd5, 0x1d,
+	0xc8, 0x74, 0x4e, 0x5c, 0xde, 0x63, 0x67, 0xe6, 0x38, 0xdb, 0x7d, 0x48, 0xe9, 0x41, 0x01, 0xb1,
+	0xe7, 0x24, 0x9d, 0x3a, 0xd4, 0x02, 0x90, 0x1a, 0x76, 0x5d, 0x83, 0xa2, 0x35, 0x4d, 0x43, 0x08,
+	0x2c, 0x59, 0x1a, 0x3f, 0x11, 0x67, 0xa1, 0xfe, 0xb7, 0xfa, 0x3d, 0x0a, 0xd9, 0xb6, 0xcd, 0x0c,
+	0x1b, 0x1d, 0x87, 0xa2, 0x63, 0x31, 0xd3, 0x41, 0x92, 0x83, 0xe5, 0x21, 0x3a, 0x8e, 0x66, 0x60,
+	0x80, 0x1d, 0x9b, 0xe4, 0x05, 0x24, 0xbc, 0x01, 0x5d, 0xc7, 0x1f, 0x77, 0xad, 0xa4, 0x86, 0xd7,
+	0x32, 0x97, 0xa6, 0xd8, 0xf1, 0x91, 0x34, 0x60, 0x78, 0x1b, 0x45, 0xdb, 0x66, 0xb6, 0x7f, 0xcd,
+	0xd9, 0x8d, 0xd6, 0x3d, 0x3f, 0x15, 0x61, 0xf5, 0xab, 0x04, 0x09, 0x41, 0x25, 0x0a, 0x2c, 0x1f,
+	0x36, 0xf7, 0x9b, 0xad, 0xb7, 0xcd, 0x6c, 0x44, 0x5e, 0xbf, 0xbc, 0xca, 0xaf, 0x8a, 0xc0, 0xa1,
+	0x79, 0x6a, 0xb2, 0x33, 0x93, 0xa8, 0x90, 0xaa, 0xb6, 0x5e, 0xb7, 0x0f, 0xea, 0x6f, 0xea, 0xb5,
+	0xac, 0x24, 0x6f, 0x5c, 0x5e, 0xe5, 0x33, 0x02, 0x31, 0xde, 0x7e, 0x8f, 0x3c, 0x83, 0xf5, 0x09,
+	0xe6, 0xa8, 0x5d, 0x6f, 0xd6, 0x1a, 0xcd, 0xbd, 0x6c, 0x54, 0x96, 0x2f, 0xaf, 0xf2, 0x9b, 0x73,
+	0xd8, 0x36, 0x9a, 0xbd, 0xbe, 0x69, 0x78, 0x65, 0xcb, 0x95, 0x16, 0xf5, 0x92, 0xc6, 0xc2, 0x65,
+	0xfd, 0xa3, 0x60, 0x4f, 0x26, 0x17, 0x9f, 0x95, 0xc8, 0x97, 0x6b, 0x25, 0xf2, 0xed, 0x5a, 0x09,
+	0x5a, 0x55, 0x1f, 0x42, 0xdc, 0x9f, 0x62, 0xf1, 0xf2, 0xd4, 0x0b, 0x09, 0x56, 0xc2, 0xc7, 0x26,
+	0x4f, 0x00, 0x34, 0x5d, 0x67, 0xae, 0xc9, 0x8f, 0x26, 0x6a, 0x59, 0x1d, 0xdd, 0x6c, 0xa7, 0xca,
+	0xc2, 0xdb, 0xa8, 0xd1, 0x54, 0x00, 0x68, 0xf4, 0x48, 0x09, 0x56, 0xf4, 0x81, 0xeb, 0x70, 0xb4,
+	0x8f, 0x4c, 0x6d, 0x18, 0xfc, 0x70, 0x95, 0xcc, 0xe8, 0x66, 0x3b, 0x5d, 0x15, 0xfe, 0xa6, 0x36,
+	0x44, 0x9a, 0xd6, 0xa7, 0x46, 0xa0, 0xc3, 0xd8, 0xbc, 0x0e, 0x4b, 0x1f, 0x63, 0x10, 0x2f, 0x1b,
+	0x68, 0x72, 0x52, 0x85, 0xe5, 0x40, 0x34, 0xe4, 0x5e, 0xf8, 0x22, 0x33, 0x42, 0x92, 0xb7, 0x6e,
+	0xb9, 0xf3, 0x53, 0x89, 0xbc, 0x82, 0xe4, 0x78, 0x89, 0x44, 0x0e, 0x41, 0xe7, 0x34, 0x20, 0x6f,
+	0x16, 0xc5, 0x4b, 0x52, 0x1c, 0xbf, 0x24, 0xc5, 0xba, 0xf7, 0x92, 0x78, 0xfc, 0xb1, 0xfe, 0x66,
+	0xf8, 0x73, 0xa2, 0x5c, 0xc8, 0xdf, 0x85, 0xb8, 0x7f, 0x1b, 0x12, 0xd6, 0x55, 0x58, 0x42, 0xb7,
+	0x56, 0x0e, 0xa4, 0x35, 0x5b, 0x79, 0x56, 0x6f, 0x0b, 0xf9, 0x07, 0xb0, 0xb1, 0x87, 0xa6, 0x77,
+	0x53, 0x0c, 0x29, 0x8e, 0x3c, 0x08, 0xa5, 0xfa, 0x5b, 0x89, 0x8b, 0xb2, 0x55, 0xb2, 0x3f, 0x46,
+	0x8a, 0xf4, 0x73, 0xa4, 0x48, 0xbf, 0x46, 0x8a, 0xf4, 0xe9, 0xb7, 0x12, 0xe9, 0x26, 0x7c, 0xc4,
+	0xf3, 0x3f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x84, 0xba, 0xa8, 0x13, 0x9f, 0x05, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -640,6 +701,8 @@ type AgentClient interface {
 	Execute(ctx context.Context, in *ExecuteRequest, opts ...grpc.CallOption) (Agent_ExecuteClient, error)
 	// Complete marks the operation as completed
 	Complete(ctx context.Context, in *CompleteRequest, opts ...grpc.CallOption) (*types.Empty, error)
+	// SetState sets the specified phase state without executing it
+	SetState(ctx context.Context, in *SetStateRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	// Abort requests that the installer service aborts
 	Abort(ctx context.Context, in *AbortRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	// Shutdown requests that the installer service shuts down gracefully
@@ -697,6 +760,15 @@ func (c *agentClient) Complete(ctx context.Context, in *CompleteRequest, opts ..
 	return out, nil
 }
 
+func (c *agentClient) SetState(ctx context.Context, in *SetStateRequest, opts ...grpc.CallOption) (*types.Empty, error) {
+	out := new(types.Empty)
+	err := c.cc.Invoke(ctx, "/installer.Agent/SetState", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *agentClient) Abort(ctx context.Context, in *AbortRequest, opts ...grpc.CallOption) (*types.Empty, error) {
 	out := new(types.Empty)
 	err := c.cc.Invoke(ctx, "/installer.Agent/Abort", in, out, opts...)
@@ -733,6 +805,8 @@ type AgentServer interface {
 	Execute(*ExecuteRequest, Agent_ExecuteServer) error
 	// Complete marks the operation as completed
 	Complete(context.Context, *CompleteRequest) (*types.Empty, error)
+	// SetState sets the specified phase state without executing it
+	SetState(context.Context, *SetStateRequest) (*types.Empty, error)
 	// Abort requests that the installer service aborts
 	Abort(context.Context, *AbortRequest) (*types.Empty, error)
 	// Shutdown requests that the installer service shuts down gracefully
@@ -780,6 +854,24 @@ func _Agent_Complete_Handler(srv interface{}, ctx context.Context, dec func(inte
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AgentServer).Complete(ctx, req.(*CompleteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Agent_SetState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetStateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServer).SetState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/installer.Agent/SetState",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServer).SetState(ctx, req.(*SetStateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -847,6 +939,10 @@ var _Agent_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Agent_Complete_Handler,
 		},
 		{
+			MethodName: "SetState",
+			Handler:    _Agent_SetState_Handler,
+		},
+		{
 			MethodName: "Abort",
 			Handler:    _Agent_Abort_Handler,
 		},
@@ -869,7 +965,7 @@ var _Agent_serviceDesc = grpc.ServiceDesc{
 	Metadata: "installer.proto",
 }
 
-func (m *ExecuteRequest) Marshal() (dAtA []byte, err error) {
+func (m *Phase) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -879,38 +975,7 @@ func (m *ExecuteRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *ExecuteRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if m.Phase != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintInstaller(dAtA, i, uint64(m.Phase.Size()))
-		n1, err := m.Phase.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
-}
-
-func (m *ExecuteRequest_Phase) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ExecuteRequest_Phase) MarshalTo(dAtA []byte) (int, error) {
+func (m *Phase) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -925,11 +990,11 @@ func (m *ExecuteRequest_Phase) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintInstaller(dAtA, i, uint64(m.Key.Size()))
-		n2, err := m.Key.MarshalTo(dAtA[i:])
+		n1, err := m.Key.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i += n1
 	}
 	if m.Rollback {
 		dAtA[i] = 0x18
@@ -957,6 +1022,74 @@ func (m *ExecuteRequest_Phase) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *ExecuteRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ExecuteRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Phase != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintInstaller(dAtA, i, uint64(m.Phase.Size()))
+		n2, err := m.Phase.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *SetStateRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SetStateRequest) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Phase != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintInstaller(dAtA, i, uint64(m.Phase.Size()))
+		n3, err := m.Phase.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if len(m.State) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintInstaller(dAtA, i, uint64(len(m.State)))
+		i += copy(dAtA[i:], m.State)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *CompleteRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -976,11 +1109,11 @@ func (m *CompleteRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintInstaller(dAtA, i, uint64(m.Key.Size()))
-		n3, err := m.Key.MarshalTo(dAtA[i:])
+		n4, err := m.Key.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n4
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1097,11 +1230,11 @@ func (m *ProgressResponse) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintInstaller(dAtA, i, uint64(m.Error.Size()))
-		n4, err := m.Error.MarshalTo(dAtA[i:])
+		n5, err := m.Error.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n5
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1184,23 +1317,7 @@ func encodeVarintInstaller(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
-func (m *ExecuteRequest) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if m.Phase != nil {
-		l = m.Phase.Size()
-		n += 1 + l + sovInstaller(uint64(l))
-	}
-	if m.XXX_unrecognized != nil {
-		n += len(m.XXX_unrecognized)
-	}
-	return n
-}
-
-func (m *ExecuteRequest_Phase) Size() (n int) {
+func (m *Phase) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -1219,6 +1336,42 @@ func (m *ExecuteRequest_Phase) Size() (n int) {
 	}
 	if m.Force {
 		n += 2
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ExecuteRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Phase != nil {
+		l = m.Phase.Size()
+		n += 1 + l + sovInstaller(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *SetStateRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Phase != nil {
+		l = m.Phase.Size()
+		n += 1 + l + sovInstaller(uint64(l))
+	}
+	l = len(m.State)
+	if l > 0 {
+		n += 1 + l + sovInstaller(uint64(l))
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1361,97 +1514,7 @@ func sovInstaller(x uint64) (n int) {
 func sozInstaller(x uint64) (n int) {
 	return sovInstaller(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *ExecuteRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowInstaller
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ExecuteRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ExecuteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Phase", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowInstaller
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthInstaller
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthInstaller
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Phase == nil {
-				m.Phase = &ExecuteRequest_Phase{}
-			}
-			if err := m.Phase.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipInstaller(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthInstaller
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthInstaller
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *ExecuteRequest_Phase) Unmarshal(dAtA []byte) error {
+func (m *Phase) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1588,6 +1651,218 @@ func (m *ExecuteRequest_Phase) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Force = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInstaller(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ExecuteRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInstaller
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ExecuteRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ExecuteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Phase", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInstaller
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Phase == nil {
+				m.Phase = &Phase{}
+			}
+			if err := m.Phase.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipInstaller(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SetStateRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowInstaller
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SetStateRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SetStateRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Phase", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInstaller
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Phase == nil {
+				m.Phase = &Phase{}
+			}
+			if err := m.Phase.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowInstaller
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthInstaller
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.State = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipInstaller(dAtA[iNdEx:])

--- a/lib/install/proto/installer.proto
+++ b/lib/install/proto/installer.proto
@@ -31,6 +31,9 @@ service Agent {
     // Complete marks the operation as completed
     rpc Complete(CompleteRequest) returns (google.protobuf.Empty);
 
+    // SetState sets the specified phase state without executing it
+    rpc SetState(SetStateRequest) returns (google.protobuf.Empty);
+
     // Abort requests that the installer service aborts
     rpc Abort(AbortRequest) returns (google.protobuf.Empty);
 
@@ -41,23 +44,33 @@ service Agent {
     rpc GenerateDebugReport(DebugReportRequest) returns (google.protobuf.Empty);
 }
 
+// Phase represents an operation plan phase
+message Phase {
+    // ID specifies the phase ID
+    string id = 1 [(gogoproto.customname) = "ID"];
+    // Key identifies the operation
+    OperationKey key = 2;
+    // Rollback specifies whether this is a rollback
+    bool rollback = 3;
+    // Force specifies whether the phase execution/rollback should be rerun
+    // regardless of phase state
+    bool force = 4;
+}
+
 // ExecuteRequest describes a request to execute install operation
 message ExecuteRequest {
-    message Phase {
-        // ID specifies the phase ID
-        string id = 1 [(gogoproto.customname) = "ID"];
-        // Key identifies the operation
-        OperationKey key = 2;
-        // Rollback specifies whether this is a rollback
-        bool rollback = 3;
-        // Force specifies whether the phase execution/rollback should be rerun
-        // regardless of phase state
-        bool force = 4;
-    }
     // Phase optionally specifies the configuration for executing or rolling
     // back a specific phase.
     // If unspecified, the operation is executed from the beginning
     Phase phase = 1;
+}
+
+// SetStateRequest describes a request to explicitly set phase state
+message SetStateRequest {
+    // Phase describes the phase to set the state for
+    Phase phase = 1;
+    // State is the new phase state
+    string state = 2;
 }
 
 // CompleteRequest describes a request to manually complete the operation

--- a/lib/install/proto/proto.go
+++ b/lib/install/proto/proto.go
@@ -70,8 +70,13 @@ func (r *ExecuteRequest) HasSpecificPhase() bool {
 	return r.Phase != nil && !r.Phase.IsResume()
 }
 
+// OperationKey returns operation key from request.
+func (r *SetStateRequest) OperationKey() ops.SiteOperationKey {
+	return KeyFromProto(r.Phase.Key)
+}
+
 // IsResume determines if this phase describes a resume operation
-func (r *ExecuteRequest_Phase) IsResume() bool {
+func (r *Phase) IsResume() bool {
 	return r.ID == fsm.RootPhase
 }
 

--- a/lib/install/server/server.go
+++ b/lib/install/server/server.go
@@ -100,6 +100,14 @@ func (r *Server) Execute(req *installpb.ExecuteRequest, stream installpb.Agent_E
 	return r.executor.Execute(req, stream)
 }
 
+// SetState sets the specified phase state without executing it.
+//
+// Implements installpb.AgentServer.
+func (r *Server) SetState(ctx context.Context, req *installpb.SetStateRequest) (*types.Empty, error) {
+	r.WithField("req", req).Info("Set.")
+	return installpb.Empty, r.executor.SetPhase(req)
+}
+
 // Complete manually completes the operation given with req.
 // Implements installpb.AgentServer
 func (r *Server) Complete(ctx context.Context, req *installpb.CompleteRequest) (*types.Empty, error) {
@@ -152,6 +160,8 @@ type Executor interface {
 	Completer
 	// Execute executes an operation specified with req.
 	Execute(req *installpb.ExecuteRequest, stream installpb.Agent_ExecuteServer) error
+	// SetPhase sets the phase state without executing it.
+	SetPhase(req *installpb.SetStateRequest) error
 	// Complete manually completes the operation given with operationKey.
 	Complete(operationKey ops.SiteOperationKey) error
 }

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -334,3 +334,17 @@ const (
 	// OperationPhaseStateRolledBack means that the phase or all of its subphases have been rolled back
 	OperationPhaseStateRolledBack = "rolled_back"
 )
+
+// IsValidOperationPhaseState returns true if the provided phase state is valid.
+func IsValidOperationPhaseState(state string) bool {
+	return utils.StringInSlice(OperationPhaseStates, state)
+}
+
+// OperationPhaseStates is a list of all supported phase states.
+var OperationPhaseStates = []string{
+	OperationPhaseStateUnstarted,
+	OperationPhaseStateInProgress,
+	OperationPhaseStateCompleted,
+	OperationPhaseStateFailed,
+	OperationPhaseStateRolledBack,
+}

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -100,6 +100,14 @@ func (r *Updater) RunPhase(ctx context.Context, phase string, phaseTimeout time.
 	}))
 }
 
+// SetPhase sets phase state without executing it.
+func (r *Updater) SetPhase(ctx context.Context, phase, state string) error {
+	return r.machine.ChangePhaseState(ctx, fsm.StateChange{
+		Phase: phase,
+		State: state,
+	})
+}
+
 // RollbackPhase rolls back the specified phase.
 func (r *Updater) RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error {
 	ctx, cancel := context.WithTimeout(ctx, phaseTimeout)

--- a/lib/vacuum/vacuum.go
+++ b/lib/vacuum/vacuum.go
@@ -103,6 +103,18 @@ func (r *Collector) RunPhase(ctx context.Context, phase string, phaseTimeout tim
 	}))
 }
 
+// SetPhase sets the specified phase state without executing it.
+func (r *Collector) SetPhase(ctx context.Context, phase, state string) error {
+	machine, err := r.init()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return machine.ChangePhaseState(ctx, libfsm.StateChange{
+		Phase: phase,
+		State: state,
+	})
+}
+
 // Create creates the garbage collection operation but does not start it.
 func (r *Collector) Create(ctx context.Context) error {
 	_, err := r.init()

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -97,6 +97,20 @@ func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	return trace.Wrap(err)
 }
 
+func setConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
+	updater, err := getConfigUpdater(env, updateEnv, operation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updater.Close()
+	return updater.SetPhase(context.TODO(), params.PhaseID, params.State)
+}
+
 func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -76,6 +76,8 @@ type Application struct {
 	PlanExecuteCmd PlanExecuteCmd
 	// PlanRollbackCmd rolls back a phase of an active operation
 	PlanRollbackCmd PlanRollbackCmd
+	// PlanSetCmd sets the specified phase state without executing it
+	PlanSetCmd PlanSetCmd
 	// ResumeCmd resumes active operation
 	ResumeCmd ResumeCmd
 	// PlanResumeCmd resumes active operation
@@ -503,6 +505,8 @@ type PlanDisplayCmd struct {
 	*kingpin.CmdClause
 	// Output is output format
 	Output *constants.Format
+	// Short is a shorthand for short output format
+	Short *bool
 }
 
 // PlanExecuteCmd executes a phase of an active operation
@@ -525,6 +529,15 @@ type PlanRollbackCmd struct {
 	Force *bool
 	// PhaseTimeout is the rollback timeout
 	PhaseTimeout *time.Duration
+}
+
+// PlanSetCmd sets the specified phase state without executing it
+type PlanSetCmd struct {
+	*kingpin.CmdClause
+	// Phase is the phase to set state for
+	Phase *string
+	// State is the new phase state
+	State *string
 }
 
 // PlanResumeCmd resumes active operation

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -87,6 +87,20 @@ func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
+func setEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
+	updater, err := getEnvironUpdater(env, updateEnv, operation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updater.Close()
+	return updater.SetPhase(context.TODO(), params.PhaseID, params.State)
+}
+
 func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -171,10 +171,12 @@ func outputPlan(plan storage.OperationPlan, format constants.Format) (err error)
 	case constants.EncodingText:
 		fsm.FormatOperationPlanText(os.Stdout, plan)
 		err = explainPlan(plan.Phases)
+	case constants.EncodingShort:
+		fsm.FormatOperationPlanShort(os.Stdout, plan)
+		err = explainPlan(plan.Phases)
 	default:
 		return trace.BadParameter("unknown output format %q", format)
 	}
-
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/tool/common"
 
@@ -142,6 +143,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation.").Default()
 	g.PlanDisplayCmd.Output = common.Format(g.PlanDisplayCmd.Flag("output", fmt.Sprintf("Output format: %v.", constants.OutputFormats)).Short('o').Default(string(constants.EncodingText)))
+	g.PlanDisplayCmd.Short = g.PlanDisplayCmd.Flag("short", "Short output format.").Bool()
 
 	g.PlanExecuteCmd.CmdClause = g.PlanCmd.Command("execute", "Execute the specified operation phase.")
 	g.PlanExecuteCmd.Phase = g.PlanExecuteCmd.Flag("phase", "Phase ID to execute.").String()
@@ -152,6 +154,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanRollbackCmd.Phase = g.PlanRollbackCmd.Flag("phase", "Phase ID to rollback.").String()
 	g.PlanRollbackCmd.Force = g.PlanRollbackCmd.Flag("force", "Force rollback of the specified phase.").Bool()
 	g.PlanRollbackCmd.PhaseTimeout = g.PlanRollbackCmd.Flag("timeout", "Phase rollback timeout.").Default(defaults.PhaseTimeout).Hidden().Duration()
+
+	g.PlanSetCmd.CmdClause = g.PlanCmd.Command("set", "Set the specified phase state without executing it.").Hidden()
+	g.PlanSetCmd.Phase = g.PlanSetCmd.Flag("phase", "Phase ID to set the state for.").Required().String()
+	g.PlanSetCmd.State = g.PlanSetCmd.Flag("state", fmt.Sprintf("The new phase state, one of: %v.", storage.OperationPhaseStates)).Required().String()
 
 	g.PlanResumeCmd.CmdClause = g.PlanCmd.Command("resume", "Resume the last aborted operation.")
 	g.PlanResumeCmd.Force = g.PlanResumeCmd.Flag("force", "Force execution of the specified phase.").Bool()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	appapi "github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/httplib"
@@ -366,6 +367,12 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
 				OperationID:      *g.PlanCmd.OperationID,
 			})
+	case g.PlanSetCmd.FullCommand():
+		return setPhase(localEnv, g, SetPhaseParams{
+			OperationID: *g.PlanCmd.OperationID,
+			PhaseID:     *g.PlanSetCmd.Phase,
+			State:       *g.PlanSetCmd.State,
+		})
 	case g.PlanResumeCmd.FullCommand():
 		return resumeOperation(localEnv, g,
 			PhaseParams{
@@ -374,7 +381,6 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				SkipVersionCheck: *g.PlanCmd.SkipVersionCheck,
 				OperationID:      *g.PlanCmd.OperationID,
 			})
-
 	case g.PlanRollbackCmd.FullCommand():
 		return rollbackPhase(localEnv, g,
 			PhaseParams{
@@ -385,8 +391,12 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				OperationID:      *g.PlanCmd.OperationID,
 			})
 	case g.PlanDisplayCmd.FullCommand():
+		outputFormat := *g.PlanDisplayCmd.Output
+		if *g.PlanDisplayCmd.Short {
+			outputFormat = constants.EncodingShort
+		}
 		return displayOperationPlan(localEnv, g,
-			*g.PlanCmd.OperationID, *g.PlanDisplayCmd.Output)
+			*g.PlanCmd.OperationID, outputFormat)
 	case g.PlanCompleteCmd.FullCommand():
 		return completeOperationPlan(localEnv, g, *g.PlanCmd.OperationID)
 	case g.LeaveCmd.FullCommand():

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -116,7 +116,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	deployCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)
 	defer cancel()
 	logger.WithField("request", req).Debug("Deploying agents on nodes.")
-	localEnv.Println("Deploying agents on nodes")
+	localEnv.PrintStep("Deploying upgrade agents on the nodes")
 	creds, err := deployAgents(deployCtx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR adds a new hidden subcommand that sets the specified phase state without executing it which is oftentimes useful when repairing failed upgrades or other operations. Implementation-wise this follows how execute/rollback/complete are implemented due to all the differences in how FSMs for different operations work. The new command looks like this:

```
gravity plan set --phase=/checks --state=completed
```

I've also forward-ported a change to add "short" display format for operation plan from 5.5 which I added while working on the Docker device issue.

Closes https://github.com/gravitational/gravity.e/issues/3215.