### PR TITLE
Fix update operation audit events.

### DIFF
--- a/lib/localenv/teleport.go
+++ b/lib/localenv/teleport.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/httplib"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/events"
 
 	"github.com/gravitational/teleport/lib/client"
@@ -66,4 +67,15 @@ func (env *LocalEnvironment) EmitAuditEvent(ctx context.Context, event teleevent
 	} else {
 		events.Emit(ctx, operator, event, fields)
 	}
+}
+
+// EmitOperationEvent emits audit event for the provided operation.
+func (env *LocalEnvironment) EmitOperationEvent(ctx context.Context, operation ops.SiteOperation) error {
+	event, err := events.EventForOperation(operation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fields := events.FieldsForOperation(operation)
+	env.EmitAuditEvent(ctx, event, fields)
+	return nil
 }

--- a/lib/ops/events/events.go
+++ b/lib/ops/events/events.go
@@ -46,6 +46,16 @@ func Emit(ctx context.Context, operator ops.Operator, event events.Event, fields
 	}
 }
 
+// EmitForOperation emits audit event for the provided operation.
+func EmitForOperation(ctx context.Context, operator ops.Operator, operation ops.SiteOperation) error {
+	event, err := EventForOperation(operation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	Emit(ctx, operator, event, FieldsForOperation(operation))
+	return nil
+}
+
 func emit(ctx context.Context, operator ops.Operator, event events.Event, fields Fields) error {
 	cluster, err := operator.GetLocalSite()
 	if err != nil {

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/events"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
@@ -119,15 +120,32 @@ func (r *Updater) Complete(fsmErr error) error {
 	if fsmErr == nil {
 		fsmErr = trace.Errorf("completed manually")
 	}
-	err := r.machine.Complete(fsmErr)
-	if err != nil {
+	if err := r.machine.Complete(fsmErr); err != nil {
 		return trace.Wrap(err)
 	}
-	err = r.Operator.ActivateSite(ops.ActivateSiteRequest{
+	if err := r.emitAuditEvent(context.TODO()); err != nil {
+		log.WithError(err).Warn("Failed to emit audit event.")
+	}
+	return r.Operator.ActivateSite(ops.ActivateSiteRequest{
 		AccountID:  r.Operation.ClusterKey().AccountID,
 		SiteDomain: r.Operation.ClusterKey().SiteDomain,
 	})
-	return trace.Wrap(err)
+}
+
+func (r *Updater) emitAuditEvent(ctx context.Context) error {
+	clusterOperator, err := localenv.ClusterOperator()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	operation, err := r.Operator.GetSiteOperation(r.Operation.Key())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = events.EmitForOperation(ctx, clusterOperator, *operation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // GetPlan returns the up-to-date operation plan

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -131,6 +131,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	localEnv.EmitOperationEvent(ctx, *operation)
 	return updater, nil
 }
 


### PR DESCRIPTION
This PR fixes a couple of issues with audit events for the upgrade operation:

1. These events were missing "user" field.
2. The "upgrade.completed" event was always failing to emit.

Both of these issues were a result of the upgrade using "local" cluster operator. This PR instead makes sure events are emitted using cluster operator client which fixes both issues. Closes https://github.com/gravitational/gravity.e/issues/4162.