### PR TITLE
[5.5] Update gravity-site RBAC in monitoring namespace.

### DIFF
--- a/assets/site-app/resources/monitoring.yaml
+++ b/assets/site-app/resources/monitoring.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,6 +11,10 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - create
+  - update
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -18,6 +23,8 @@ rules:
   - get
   - list
   - create
+  - update
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Fixes permissions for `gravity resource create/rm` for smtp and alert resources.