### PR TITLE
Dmitri/5.5.x/4146 tele build

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1213,12 +1213,28 @@
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
+  digest = "1:ca955a9cd5b50b0f43d2cc3aeb35c951473eeca41b34eb67507f1dbcc0542394"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:075fe2b22b9fcec90cecd98546c2096d73a3ab9458261f5647512fba3e0420eb"
   name = "github.com/kr/pty"
   packages = ["."]
   pruneopts = "UT"
   revision = "2c10821df3c3cf905230d078702dfbe9404c9b23"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:15b5cc79aad436d47019f814fde81a10221c740dc8ddf769221a65097fb6c2e9"
+  name = "github.com/kr/text"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:7a20d4221f44dadcdfe5a510725d3f26185a7ac680c207755f73963473337e44"
@@ -1939,11 +1955,11 @@
   source = "github.com/gravitational/kingpin"
 
 [[projects]]
-  digest = "1:a59b147b633c9b4f5f0eba6ddc282810fec9c592c41fc3e6c1fef74af01705dc"
+  digest = "1:af715ae33cc1f5695c4b2a4e4b21d008add8802a99e15bb467ac7c32edb5000d"
   name = "gopkg.in/check.v1"
   packages = ["."]
   pruneopts = "UT"
-  revision = "64131543e7896d5bcc6bd5a76287eb75ea96c673"
+  revision = "788fd78401277ebd861206a03c884797c6ec5541"
 
 [[projects]]
   digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -247,6 +247,10 @@ ignored = [
   name = "github.com/hashicorp/terraform"
   version = "=v0.11.7"
 
+[[constraint]]
+  name = "gopkg.in/check.v1"
+  revision = "788fd78401277ebd861206a03c884797c6ec5541"
+
 [[override]]
   name = "github.com/ugorji/go"
   version = "=v1.1.1"

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -155,7 +155,7 @@ endef
 .PHONY: build
 build:
 	@if [ "$(OS)" = "darwin" ]; then $(MAKE) build-on-host; else $(MAKE) build-in-container; fi
-	ln -sf $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+	ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
 
 #
 # generate gRPC code

--- a/lib/app/app.go
+++ b/lib/app/app.go
@@ -272,6 +272,9 @@ type InstallerRequest struct {
 	CACert string `json:"ca_cert,omitempty"`
 	// EncryptionKey is encryption key to encrypt installer packages with
 	EncryptionKey string `json:"encryption_key,omitempty"`
+	// AdditionalDependencies specifies additional dependencies to pull when building
+	// the installer
+	AdditionalDependencies Dependencies `json:"additional_dependencies"`
 }
 
 // Check validates this request
@@ -292,11 +295,12 @@ func (r InstallerRequest) ToRaw() (*InstallerRequestRaw, error) {
 		return nil, trace.Wrap(err)
 	}
 	return &InstallerRequestRaw{
-		Account:        r.Account,
-		Application:    r.Application,
-		TrustedCluster: json.RawMessage(bytes),
-		CACert:         r.CACert,
-		EncryptionKey:  r.EncryptionKey,
+		Account:                r.Account,
+		Application:            r.Application,
+		TrustedCluster:         json.RawMessage(bytes),
+		CACert:                 r.CACert,
+		EncryptionKey:          r.EncryptionKey,
+		AdditionalDependencies: r.AdditionalDependencies,
 	}, nil
 }
 
@@ -313,6 +317,9 @@ type InstallerRequestRaw struct {
 	CACert string `json:"ca_cert,omitempty"`
 	// EncryptionKey is encryption key to encrypt installer packages with
 	EncryptionKey string `json:"encryption_key,omitempty"`
+	// AdditionalDependencies specifies additional dependencies to pull when building
+	// the installer
+	AdditionalDependencies Dependencies `json:"additional_dependencies"`
 }
 
 // ToNative converts the request from API-friendly to its regular format
@@ -322,11 +329,12 @@ func (r InstallerRequestRaw) ToNative() (*InstallerRequest, error) {
 		return nil, trace.Wrap(err)
 	}
 	return &InstallerRequest{
-		Account:        r.Account,
-		Application:    r.Application,
-		TrustedCluster: cluster,
-		CACert:         r.CACert,
-		EncryptionKey:  r.EncryptionKey,
+		Account:                r.Account,
+		Application:            r.Application,
+		TrustedCluster:         cluster,
+		CACert:                 r.CACert,
+		EncryptionKey:          r.EncryptionKey,
+		AdditionalDependencies: r.AdditionalDependencies,
 	}, nil
 }
 

--- a/lib/app/dependency.go
+++ b/lib/app/dependency.go
@@ -78,14 +78,16 @@ func (r Dependencies) AsPackages() (result []loc.Locator) {
 	return result
 }
 
-// UniqPackages returns packages without duplicates
+// UniqPackages returns packages without duplicates.
+// packages is sorted in-place as a result of this operation
 func UniqPackages(packages []pack.PackageEnvelope) []pack.PackageEnvelope {
 	sort.Sort(packagesByLocator(packages))
 	n := set.Uniq(packagesByLocator(packages))
 	return packages[:n]
 }
 
-// UniqApps returns apps without duplicates
+// UniqApps returns apps without duplicates.
+// apps is sorted in-place as a result of this operation
 func UniqApps(apps []Application) []Application {
 	sort.Sort(appsByLocator(apps))
 	n := set.Uniq(appsByLocator(apps))

--- a/lib/app/dependency.go
+++ b/lib/app/dependency.go
@@ -24,22 +24,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// GetDependencies transitively collects dependencies for the specified application package
-func GetDependencies(app Application, apps Applications) (result *Dependencies, err error) {
-	dependencies, err := GetFullDependencies(GetDependenciesRequest{
-		App:  app,
-		Apps: apps,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return dependencies, nil
-}
-
 // VerifyDependencies verifies that all dependencies for the specified application are available
 // in the provided package service.
 func VerifyDependencies(app Application, apps Applications, packages pack.PackageService) error {
-	_, err := GetFullDependencies(GetDependenciesRequest{
+	_, err := GetDependencies(GetDependenciesRequest{
 		App:  app,
 		Apps: apps,
 		Pack: packages,
@@ -47,8 +35,8 @@ func VerifyDependencies(app Application, apps Applications, packages pack.Packag
 	return trace.Wrap(err)
 }
 
-// GetFullDependencies transitively collects dependencies for the specified application package
-func GetFullDependencies(req GetDependenciesRequest) (result *Dependencies, err error) {
+// GetDependencies transitively collects dependencies for the specified application package
+func GetDependencies(req GetDependenciesRequest) (result *Dependencies, err error) {
 	if err := req.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -65,9 +53,13 @@ func GetFullDependencies(req GetDependenciesRequest) (result *Dependencies, err 
 // GetDependenciesRequest describes a request to transitively enumerate packages dependencies
 // for a specific application package
 type GetDependenciesRequest struct {
-	App  Application
+	// App specifies the application to fetch dependencies for
+	App Application
+	// Apps specifies the application service
 	Apps Applications
+	// Pack specifies the package service
 	Pack pack.PackageService
+	// FieldLogger specifies the logger
 	log.FieldLogger
 }
 

--- a/lib/app/dependency.go
+++ b/lib/app/dependency.go
@@ -102,7 +102,7 @@ func (r GetDependenciesRequest) getDependencies(app Application, state *state) e
 	packageDeps := loc.Deduplicate(app.Manifest.Dependencies.GetPackages())
 	packageDeps = append(packageDeps, app.Manifest.NodeProfiles.RuntimePackages()...)
 	for _, dependency := range packageDeps {
-		if state.isPackage(dependency) {
+		if state.hasPackage(dependency) {
 			continue
 		}
 		envelope, err := r.Pack.ReadPackageEnvelope(dependency)
@@ -119,7 +119,7 @@ func (r GetDependenciesRequest) getDependencies(app Application, state *state) e
 	}
 	appDeps = append(appDeps, app.Manifest.Dependencies.GetApps()...)
 	for _, dependency := range appDeps {
-		if state.isApp(dependency) {
+		if state.hasApp(dependency) {
 			continue
 		}
 		app, err := r.Apps.GetApp(dependency)
@@ -142,12 +142,12 @@ func (r GetDependenciesRequest) getDependencies(app Application, state *state) e
 	return nil
 }
 
-func (r *state) isPackage(pkg loc.Locator) bool {
+func (r *state) hasPackage(pkg loc.Locator) bool {
 	_, ok := r.packages[pkg]
 	return ok
 }
 
-func (r *state) isApp(pkg loc.Locator) bool {
+func (r *state) hasApp(pkg loc.Locator) bool {
 	_, ok := r.apps[pkg]
 	return ok
 }

--- a/lib/app/dependency_test.go
+++ b/lib/app/dependency_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/pack"
+
+	. "gopkg.in/check.v1"
+)
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+func (*S) TestDeduplicatesPackages(c *C) {
+	packages := UniqPackages([]pack.PackageEnvelope{
+		{Locator: loc.MustParseLocator("example.com/package1:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package1:0.0.2")},
+		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
+		{Locator: loc.MustParseLocator("server.com/package:0.0.1")},
+	})
+	c.Assert(packages, DeepEquals, []pack.PackageEnvelope{
+		{Locator: loc.MustParseLocator("example.com/package1:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package1:0.0.2")},
+		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
+		{Locator: loc.MustParseLocator("server.com/package:0.0.1")},
+	})
+}
+
+func (*S) TestDeduplicatesEmpty(c *C) {
+	packages := UniqPackages([]pack.PackageEnvelope{})
+	c.Assert(packages, DeepEquals, []pack.PackageEnvelope{})
+}
+
+func (*S) TestDeduplicatesApps(c *C) {
+	apps := UniqApps([]Application{
+		{Package: loc.MustParseLocator("example.com/app1:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app1:0.0.2")},
+		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
+		{Package: loc.MustParseLocator("server.com/app:0.0.1")},
+	})
+	c.Assert(apps, DeepEquals, []Application{
+		{Package: loc.MustParseLocator("example.com/app1:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app1:0.0.2")},
+		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
+		{Package: loc.MustParseLocator("server.com/app:0.0.1")},
+	})
+}

--- a/lib/app/dependency_test.go
+++ b/lib/app/dependency_test.go
@@ -29,11 +29,11 @@ var _ = Suite(&S{})
 
 func (*S) TestDeduplicatesPackages(c *C) {
 	packages := UniqPackages([]pack.PackageEnvelope{
-		{Locator: loc.MustParseLocator("example.com/package1:0.0.1")},
 		{Locator: loc.MustParseLocator("example.com/package1:0.0.2")},
-		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
-		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
 		{Locator: loc.MustParseLocator("server.com/package:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package1:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
+		{Locator: loc.MustParseLocator("example.com/package:0.0.1")},
 	})
 	c.Assert(packages, DeepEquals, []pack.PackageEnvelope{
 		{Locator: loc.MustParseLocator("example.com/package1:0.0.1")},
@@ -50,11 +50,11 @@ func (*S) TestDeduplicatesEmpty(c *C) {
 
 func (*S) TestDeduplicatesApps(c *C) {
 	apps := UniqApps([]Application{
-		{Package: loc.MustParseLocator("example.com/app1:0.0.1")},
-		{Package: loc.MustParseLocator("example.com/app1:0.0.2")},
-		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
-		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
 		{Package: loc.MustParseLocator("server.com/app:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app1:0.0.2")},
+		{Package: loc.MustParseLocator("example.com/app1:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
+		{Package: loc.MustParseLocator("example.com/app:0.0.1")},
 	})
 	c.Assert(apps, DeepEquals, []Application{
 		{Package: loc.MustParseLocator("example.com/app1:0.0.1")},

--- a/lib/app/docker/distribution.go
+++ b/lib/app/docker/distribution.go
@@ -120,7 +120,10 @@ func alive(path string, handler http.Handler) http.Handler {
 			return
 		}
 
-		handler.ServeHTTP(w, r)
+		ctx, cancel := defaultContext()
+		defer cancel()
+
+		handler.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
@@ -149,7 +152,7 @@ func defaultContext() (context.Context, context.CancelFunc) {
 }
 
 func newLogger() registrycontext.Logger {
-	logger := log.WithField("source", "local-docker-registry")
+	logger := log.New().WithField("source", "local-docker-registry")
 	logger.Logger.SetLevel(log.WarnLevel)
 	logger.Logger.SetHooks(make(log.LevelHooks))
 	hook, err := sysloghook.NewSyslogHook("", "", syslog.LOG_WARNING, "")

--- a/lib/app/docker/distribution.go
+++ b/lib/app/docker/distribution.go
@@ -149,16 +149,16 @@ func defaultContext() (context.Context, context.CancelFunc) {
 }
 
 func newLogger() registrycontext.Logger {
-	logger := log.New()
-	logger.SetLevel(log.WarnLevel)
-	logger.SetHooks(make(log.LevelHooks))
+	logger := log.WithField("source", "local-docker-registry")
+	logger.Logger.SetLevel(log.WarnLevel)
+	logger.Logger.SetHooks(make(log.LevelHooks))
 	hook, err := sysloghook.NewSyslogHook("", "", syslog.LOG_WARNING, "")
 	if err != nil {
-		logger.Out = os.Stderr
+		logger.Logger.Out = os.Stderr
 	} else {
-		logger.AddHook(hook)
-		logger.Out = ioutil.Discard
+		logger.Logger.AddHook(hook)
+		logger.Logger.Out = ioutil.Discard
 	}
 	// distribution expects an instance of log.Entry
-	return logger.WithField("source", "local-docker-registry")
+	return logger
 }

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -237,7 +237,7 @@ func pullDependencies(
 	localApps, remoteApps *applications,
 	log log.FieldLogger,
 ) error {
-	dependencies, err := appservice.GetFullDependencies(appservice.GetDependenciesRequest{
+	dependencies, err := appservice.GetDependencies(appservice.GetDependenciesRequest{
 		App:  app,
 		Apps: remoteApps,
 		Pack: remoteApps.Packages,

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -245,14 +245,12 @@ func pullDependencies(
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	dependencies.Packages = append(dependencies.Packages, additional.Packages...)
-	dependencies.Apps = append(dependencies.Apps, additional.Apps...)
-
-	if err = pullPackages(dependencies.Packages, localApps.Packages, remoteApps.Packages, log); err != nil {
+	packages := appservice.UniqPackages(append(dependencies.Packages, additional.Packages...))
+	if err = pullPackages(packages, localApps.Packages, remoteApps.Packages, log); err != nil {
 		return trace.Wrap(err)
 	}
-
-	apps := append(dependencies.Apps, app)
+	apps := append(dependencies.Apps, additional.Apps...)
+	apps = appservice.UniqApps(append(dependencies.Apps, app))
 	if err = pullApplications(apps, localApps, remoteApps, log); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -250,7 +250,7 @@ func pullDependencies(
 		return trace.Wrap(err)
 	}
 	apps := append(dependencies.Apps, additional.Apps...)
-	apps = appservice.UniqApps(append(dependencies.Apps, app))
+	apps = appservice.UniqApps(append(apps, app))
 	if err = pullApplications(apps, localApps, remoteApps, log); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/app/service/pull.go
+++ b/lib/app/service/pull.go
@@ -222,7 +222,7 @@ func pullPackage(req PackagePullRequest) (*pack.PackageEnvelope, error) {
 
 	if env != nil {
 		if req.SkipIfExists {
-			return nil, nil
+			return env, nil
 		}
 		if !req.Upsert {
 			logger.Info("Package already exists.")
@@ -327,7 +327,7 @@ func pullApp(req AppPullRequest, state *pullState) (*app.Application, error) {
 	logger := req.WithField("app", req.Package)
 	if application != nil {
 		if req.SkipIfExists {
-			return nil, nil
+			return application, nil
 		}
 		if !req.Upsert {
 			logger.Info("Application already exists.")

--- a/lib/app/service/pull.go
+++ b/lib/app/service/pull.go
@@ -435,12 +435,11 @@ type pullState struct {
 	packages map[loc.Locator]struct{}
 }
 
-// copyRuntimeLabels copies labels from runtimeLabels to labels for each
-// label non-existent in labels
-func copyRuntimeLabels(labels map[string]string, runtimeLabels map[string]string) {
-	for label, value := range runtimeLabels {
-		if _, exists := labels[label]; !exists {
-			labels[label] = value
+// copyRuntimeLabels copies values from src to dst for each key not in dst
+func copyRuntimeLabels(dst map[string]string, src map[string]string) {
+	for label, value := range src {
+		if _, exists := dst[label]; !exists {
+			dst[label] = value
 		}
 	}
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -132,6 +132,8 @@ type VendorRequest struct {
 	// ProgressReporter is a special writer, if set, vendorer will output user-friendly
 	// information during vendoring
 	ProgressReporter utils.Progress
+	// IntermediateRuntimes lists optional intermediate runtimes for the update
+	IntermediateRuntimes []schema.IntermediateRuntime
 }
 
 // vendorer is a helper struct that encapsulates all services needed to vendor/rewrite images in
@@ -240,6 +242,9 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 	}
 	if req.VendorRuntime {
 		manifestRewrites = append(manifestRewrites, fetchRuntimeImages(&runtimeImages))
+	}
+	if len(req.IntermediateRuntimes) != 0 {
+		manifestRewrites = append(manifestRewrites, updateIntermediateRuntimes(req.IntermediateRuntimes))
 	}
 
 	err = resourceFiles.RewriteManifest(manifestRewrites...)
@@ -570,6 +575,13 @@ func makeRewriteWormholeJobFunc() resources.ManifestRewriteFunc {
 				return trace.Wrap(err)
 			}
 		}
+		return nil
+	}
+}
+
+func updateIntermediateRuntimes(runtimes []schema.IntermediateRuntime) resources.ManifestRewriteFunc {
+	return func(m *schema.Manifest) error {
+		m.SetIntermediateRuntimes(runtimes)
 		return nil
 	}
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -132,8 +132,6 @@ type VendorRequest struct {
 	// ProgressReporter is a special writer, if set, vendorer will output user-friendly
 	// information during vendoring
 	ProgressReporter utils.Progress
-	// IntermediateRuntimes lists optional intermediate runtimes for the update
-	IntermediateRuntimes []schema.IntermediateRuntime
 }
 
 // vendorer is a helper struct that encapsulates all services needed to vendor/rewrite images in
@@ -242,9 +240,6 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 	}
 	if req.VendorRuntime {
 		manifestRewrites = append(manifestRewrites, fetchRuntimeImages(&runtimeImages))
-	}
-	if len(req.IntermediateRuntimes) != 0 {
-		manifestRewrites = append(manifestRewrites, updateIntermediateRuntimes(req.IntermediateRuntimes))
 	}
 
 	err = resourceFiles.RewriteManifest(manifestRewrites...)
@@ -575,13 +570,6 @@ func makeRewriteWormholeJobFunc() resources.ManifestRewriteFunc {
 				return trace.Wrap(err)
 			}
 		}
-		return nil
-	}
-}
-
-func updateIntermediateRuntimes(runtimes []schema.IntermediateRuntime) resources.ManifestRewriteFunc {
-	return func(m *schema.Manifest) error {
-		m.SetIntermediateRuntimes(runtimes)
 		return nil
 	}
 }

--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -71,11 +71,8 @@ func Build(ctx context.Context, builder *Builder) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = builder.SyncPackageCache(runtimeVersion)
+		err = builder.SyncPackageCache(*runtimeVersion, builder.IntermediateRuntimes...)
 		if err != nil {
-			if trace.IsNotFound(err) {
-				return trace.NotFound("base image version %v not found", runtimeVersion)
-			}
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -71,7 +71,7 @@ func Build(ctx context.Context, builder *Builder) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = builder.SyncPackageCache(*runtimeVersion, builder.IntermediateRuntimes...)
+		err = builder.SyncPackageCache(*runtimeVersion, builder.UpgradeVia...)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -497,6 +497,9 @@ There are a few ways to resolve the issue:
 	return nil
 }
 
+// collectUpgradeDependencies computes and returns a set of package dependencies for each
+// configured intermediate runtime version.
+// result contains combined dependencies marked with a label per runtime version.
 func (b *Builder) collectUpgradeDependencies() (result *libapp.Dependencies, err error) {
 	apps, err := b.Env.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
@@ -583,10 +586,10 @@ func filterUpgradePackageDependencies(packages []pack.PackageEnvelope) (result [
 		if pkg.Locator.Repository != defaults.SystemAccountOrg {
 			continue
 		}
-		switch {
-		case pkg.Locator.Name == constants.TeleportPackage,
-			pkg.Locator.Name == constants.GravityPackage,
-			pkg.Locator.Name == constants.PlanetPackage:
+		switch pkg.Locator.Name {
+		case constants.TeleportPackage,
+			constants.GravityPackage,
+			constants.PlanetPackage:
 		default:
 			continue
 		}

--- a/lib/builder/generator.go
+++ b/lib/builder/generator.go
@@ -17,8 +17,6 @@ limitations under the License.
 package builder
 
 import (
-	"io"
-
 	"github.com/gravitational/gravity/lib/app"
 )
 
@@ -26,15 +24,14 @@ import (
 type Generator interface {
 	// Generate generates an installer tarball for the specified application
 	// using the provided builder and returns its data as a stream
-	Generate(*Builder, app.Application) (io.ReadCloser, error)
+	NewInstallerRequest(*Builder, app.Application) (*app.InstallerRequest, error)
 }
 
 type generator struct{}
 
-// Generate generates an installer tarball for the specified application
-// using the provided builder and returns its data as a stream
-func (g *generator) Generate(builder *Builder, application app.Application) (io.ReadCloser, error) {
-	return builder.Apps.GetAppInstaller(app.InstallerRequest{
+// NewInstallerRequest returns a request to build an installer for the specified application
+func (g *generator) NewInstallerRequest(builder *Builder, application app.Application) (*app.InstallerRequest, error) {
+	return &app.InstallerRequest{
 		Application: application.Package,
-	})
+	}, nil
 }

--- a/lib/builder/generator.go
+++ b/lib/builder/generator.go
@@ -22,8 +22,8 @@ import (
 
 // Generator defines a method for generating standalone installers
 type Generator interface {
-	// Generate generates an installer tarball for the specified application
-	// using the provided builder and returns its data as a stream
+	// NewInstallerRequest returns a new request to generate an installer
+	// for the specified application
 	NewInstallerRequest(*Builder, app.Application) (*app.InstallerRequest, error)
 }
 

--- a/lib/builder/syncer.go
+++ b/lib/builder/syncer.go
@@ -38,7 +38,8 @@ import (
 type Syncer interface {
 	// Sync makes sure that local cache has all required dependencies for the
 	// selected runtime
-	Sync(builder *Builder, runtimeVersion semver.Version) error
+	// Returns a list of dependencies that were added as a result of the operation
+	Sync(builder *Builder, req SyncRequest) error
 }
 
 // NewSyncerFunc defines function that creates syncer for a builder
@@ -49,6 +50,14 @@ type NewSyncerFunc func(*Builder) (Syncer, error)
 // Satisfies NewSyncerFunc type.
 func NewSyncer(b *Builder) (Syncer, error) {
 	return newS3Syncer()
+}
+
+// SyncRequest defines a request to pull a specific version of the runtime application package
+type SyncRequest struct {
+	// RuntimeVersion specifies the version of runtime to pull
+	RuntimeVersion semver.Version
+	// Labels specifies additional runtime labels to add to pulled packages
+	Labels map[string]string
 }
 
 // s3Syncer synchronizes local package cache with S3 bucket
@@ -70,11 +79,11 @@ func newS3Syncer() (*s3Syncer, error) {
 
 // Sync makes sure that local cache has all required dependencies for the
 // selected runtime
-func (s *s3Syncer) Sync(builder *Builder, runtimeVersion semver.Version) error {
+func (s *s3Syncer) Sync(builder *Builder, req SyncRequest) error {
 	tarball, err := s.hub.Get(loc.Locator{
 		Repository: defaults.SystemAccountOrg,
 		Name:       defaults.TelekubePackage,
-		Version:    runtimeVersion.String(),
+		Version:    req.RuntimeVersion.String(),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -111,6 +120,7 @@ func (s *s3Syncer) Sync(builder *Builder, runtimeVersion semver.Version) error {
 		DstApp:       cacheApps,
 		Parallel:     builder.VendorReq.Parallel,
 		SkipIfExists: true,
+		Labels:       req.Labels,
 	}, builder.Manifest)
 }
 
@@ -131,7 +141,7 @@ func NewPackSyncer(pack pack.PackageService, apps app.Applications, repo string)
 }
 
 // Sync pulls dependencies from the package/app service not available locally
-func (s *packSyncer) Sync(builder *Builder, runtimeVersion semver.Version) error {
+func (s *packSyncer) Sync(builder *Builder, req SyncRequest) error {
 	cacheApps, err := builder.Env.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -144,6 +154,7 @@ func (s *packSyncer) Sync(builder *Builder, runtimeVersion semver.Version) error
 		DstApp:       cacheApps,
 		Parallel:     builder.VendorReq.Parallel,
 		SkipIfExists: true,
+		Labels:       req.Labels,
 	}, builder.Manifest)
 	if err != nil {
 		if utils.IsNetworkError(err) || trace.IsEOF(err) {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1177,7 +1177,11 @@ var BaseTaintsVersion = semver.Must(semver.NewVersion("4.36.0"))
 
 // BaseUpdateVersion sets the minimum version that this binary
 // can update
-var BaseUpdateVersion = semver.Must(semver.NewVersion("3.51.0"))
+var BaseUpdateVersion = semver.Must(semver.NewVersion("5.0.0"))
+
+// BaseIntermediateRuntimeVersion sets the base version of the runtime application for updates.
+// Clusters with versions below this will require an intermediate runtime package update
+var BaseIntermediateRuntimeVersion = semver.Must(semver.NewVersion("5.2.3"))
 
 // DockerRegistryAddr returns the address of docker registry running on server
 func DockerRegistryAddr(server string) string {

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -573,6 +573,7 @@ func generateInstallToken(service ops.Operator, accountID, installToken string) 
 func GetApp(service appservice.Applications) (*appservice.Application, error) {
 	apps, err := service.ListApps(appservice.ListAppsRequest{
 		Repository: defaults.SystemAccountOrg,
+		Type:       storage.AppUser,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -75,8 +75,8 @@ func (s *LocatorSuite) TestLocatorFail(c *C) {
 		"example:0.0.1",                 // missing repository
 		"example.com/example:blabla",    // not a sem ver
 		"example.com/example com:0.0.2", // unallowed chars
-		"", //emtpy
-		"arffewfaef aefeafaesf e", //garbage
+		"",                              //emtpy
+		"arffewfaef aefeafaesf e",       //garbage
 		"-:.",
 	}
 	for i, tc := range tcs {

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -776,7 +776,7 @@ func (h *WebHandler) createSite(w http.ResponseWriter, r *http.Request, p httpro
 		return trace.Wrap(err)
 	}
 
-	if err = app.VerifyDependencies(userApp, h.cfg.Applications, h.cfg.Packages); err != nil {
+	if err = app.VerifyDependencies(*userApp, h.cfg.Applications, h.cfg.Packages); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/pack/constants.go
+++ b/lib/pack/constants.go
@@ -44,6 +44,8 @@ const (
 	PurposePlanetConfig = "planet-config"
 	// PurposeRuntime marks a package as a runtime container package
 	PurposeRuntime = "runtime"
+	// PurposeRuntimeUpgrade marks a package as part of an intermediate upgrade step
+	PurposeRuntimeUpgrade = "intermediate-upgrade"
 	// PurposeTeleportMasterConfig marks package with teleport master config
 	PurposeTeleportMasterConfig = "teleport-master-config"
 	// PurposeTeleportNodeConfig marks package with teleport node config
@@ -97,3 +99,11 @@ var (
 		InstalledLabel: InstalledLabel,
 	}
 )
+
+// RuntimeUpgradeLabels returns the labels to mark a package as part of an upgrade step
+// for the specified runtime version
+func RuntimeUpgradeLabels(version string) Labels {
+	return Labels{
+		PurposeRuntimeUpgrade: version,
+	}
+}

--- a/lib/schema/compat.go
+++ b/lib/schema/compat.go
@@ -18,7 +18,9 @@ limitations under the License.
 // mismatch and as such is discouraged for future use.
 package schema
 
-import "github.com/gravitational/trace"
+import (
+	"github.com/gravitational/trace"
+)
 
 // IsAWSProvider determines if specified provider string refers to AWS provider
 func IsAWSProvider(provider string) bool {

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -69,8 +69,6 @@ type Manifest struct {
 	Hooks *Hooks `json:"hooks,omitempty"`
 	// SystemOptions contains various global settings
 	SystemOptions *SystemOptions `json:"systemOptions,omitempty"`
-	// SystemUpdate defines optional metadata for cluster update
-	SystemUpdate *SystemUpdate `json:"systemUpdate,omitempty"`
 	// Extensions allows to enable/disable various custom features
 	Extensions *Extensions `json:"extensions,omitempty"`
 	// WebConfig allows to specify config.js used by UI to customize installer
@@ -980,14 +978,6 @@ func (r *SystemOptions) RuntimeArgs() []string {
 	return r.Args
 }
 
-// SetIntermediateRuntimes defines the intermediate runtimes for the manifest
-func (m *Manifest) SetIntermediateRuntimes(runtimes []IntermediateRuntime) {
-	if m.SystemUpdate == nil {
-		m.SystemUpdate = &SystemUpdate{}
-	}
-	m.SystemUpdate.Runtimes = runtimes
-}
-
 // SystemOptions defines various global settings
 type SystemOptions struct {
 	// ExternalService specifies additional configuration for the runtime package
@@ -1048,24 +1038,6 @@ func (r *Runtime) UnmarshalJSON(data []byte) error {
 type SystemDependencies struct {
 	// Runtime describes the runtime package
 	Runtime *Dependency `json:"runtimePackage,omitempty"`
-}
-
-// SystemUpdate defines optional metadata for update
-type SystemUpdate struct {
-	// Runtimes lists optional intermediate runtime package
-	// dependencies
-	Runtimes []IntermediateRuntime `json:"runtimes,omitempty"`
-}
-
-// IntermediateRuntime describes an intermediate runtime application dependency.
-// The intermediate runtime contains the metadata to successfully build an upgrade step
-// using the given runtime application (namely, the kubernetes runtime it embeds) as a
-// bridge when hopping over multiple Kubernetes versions
-type IntermediateRuntime struct {
-	// Version specifies the runtime application package version
-	Version string `json:"version"`
-	// Dependencies lists runtime application dependencies required for the update
-	Dependencies Dependencies `json:"dependencies"`
 }
 
 // Docker describes docker options

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -558,6 +558,22 @@ const manifestSchema = `
           }
         },
         "systemOptions": {"$ref": "#/definitions/systemOptions"},
+        "systemUpdate": {
+          "type": "object",
+          "properties": {
+            "runtimes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "version": {"type": "string"},
+                  "dependencies": {"$ref": "#/definitions/dependencies"}
+                }
+              }
+            }
+          }
+        },
         "extensions": {
           "type": "object",
           "additionalProperties": false,
@@ -704,6 +720,20 @@ const manifestSchema = `
       "additionalProperties": false,
       "properties": {
         "disabled": {"type": "boolean"}
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "packages": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "apps": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
       }
     }
   }

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -705,20 +705,6 @@ const manifestSchema = `
       "properties": {
         "disabled": {"type": "boolean"}
       }
-    },
-    "dependencies": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "packages": {
-          "type": "array",
-          "items": {"type": "string"}
-        },
-        "apps": {
-          "type": "array",
-          "items": {"type": "string"}
-        }
-      }
     }
   }
 }

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -558,22 +558,6 @@ const manifestSchema = `
           }
         },
         "systemOptions": {"$ref": "#/definitions/systemOptions"},
-        "systemUpdate": {
-          "type": "object",
-          "properties": {
-            "runtimes": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "version": {"type": "string"},
-                  "dependencies": {"$ref": "#/definitions/dependencies"}
-                }
-              }
-            }
-          }
-        },
         "extensions": {
           "type": "object",
           "additionalProperties": false,

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -100,7 +100,7 @@ func Retry(period time.Duration, maxAttempts int, fn func() error) error {
 		}
 		time.Sleep(period)
 	}
-	log.Errorf("All attempts failed:\n%v.", trace.DebugReport(err))
+	log.WithError(err).Warn("All attempts failed.")
 	return err
 }
 
@@ -244,7 +244,7 @@ func RetryWithInterval(ctx context.Context, interval backoff.BackOff, fn func() 
 		err = errOrig.Err
 	}
 	if err != nil {
-		log.Errorf("All attempts failed: %v.", trace.DebugReport(err))
+		log.WithError(err).Warn("All attempts failed.")
 		return trace.Wrap(err)
 	}
 	return nil

--- a/tool/gravity/cli/ops.go
+++ b/tool/gravity/cli/ops.go
@@ -153,6 +153,11 @@ func uploadUpdate(env *localenv.LocalEnvironment, opsURL string) error {
 		return trace.Wrap(err)
 	}
 
+	err = pack.CheckUpdatePackage(cluster.App.Package, *appPackage)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	env.PrintStep("Importing application %v v%v", appPackage.Name, appPackage.Version)
 	_, err = appservice.PullApp(appservice.AppPullRequest{
 		SrcPack: tarballPackages,

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -44,21 +44,24 @@ type BuildParameters struct {
 	Silent bool
 	// Insecure turns on insecure verify mode
 	Insecure bool
+	// IntermediateRuntimes lists intermediate runtime versions to embed
+	IntermediateRuntimes []string
 }
 
 // build builds an installer tarball according to the provided parameters
 func build(ctx context.Context, params BuildParameters, req service.VendorRequest) (err error) {
 	installerBuilder, err := builder.New(builder.Config{
-		Context:          ctx,
-		StateDir:         params.StateDir,
-		Insecure:         params.Insecure,
-		ManifestPath:     params.ManifestPath,
-		OutPath:          params.OutPath,
-		Overwrite:        params.Overwrite,
-		Repository:       params.Repository,
-		SkipVersionCheck: params.SkipVersionCheck,
-		VendorReq:        req,
-		Progress:         utils.NewProgress(ctx, "Build", 6, params.Silent),
+		Context:              ctx,
+		StateDir:             params.StateDir,
+		Insecure:             params.Insecure,
+		ManifestPath:         params.ManifestPath,
+		OutPath:              params.OutPath,
+		Overwrite:            params.Overwrite,
+		Repository:           params.Repository,
+		SkipVersionCheck:     params.SkipVersionCheck,
+		VendorReq:            req,
+		Progress:             utils.NewProgress(ctx, "Build", 6, params.Silent),
+		IntermediateRuntimes: params.IntermediateRuntimes,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -44,24 +44,24 @@ type BuildParameters struct {
 	Silent bool
 	// Insecure turns on insecure verify mode
 	Insecure bool
-	// IntermediateRuntimes lists intermediate runtime versions to embed
-	IntermediateRuntimes []string
+	// UpgradeVia lists intermediate runtime versions to embed inside the installer
+	UpgradeVia []string
 }
 
 // build builds an installer tarball according to the provided parameters
 func build(ctx context.Context, params BuildParameters, req service.VendorRequest) (err error) {
 	installerBuilder, err := builder.New(builder.Config{
-		Context:              ctx,
-		StateDir:             params.StateDir,
-		Insecure:             params.Insecure,
-		ManifestPath:         params.ManifestPath,
-		OutPath:              params.OutPath,
-		Overwrite:            params.Overwrite,
-		Repository:           params.Repository,
-		SkipVersionCheck:     params.SkipVersionCheck,
-		VendorReq:            req,
-		Progress:             utils.NewProgress(ctx, "Build", 6, params.Silent),
-		IntermediateRuntimes: params.IntermediateRuntimes,
+		Context:          ctx,
+		StateDir:         params.StateDir,
+		Insecure:         params.Insecure,
+		ManifestPath:     params.ManifestPath,
+		OutPath:          params.OutPath,
+		Overwrite:        params.Overwrite,
+		Repository:       params.Repository,
+		SkipVersionCheck: params.SkipVersionCheck,
+		VendorReq:        req,
+		Progress:         utils.NewProgress(ctx, "Build", 6, params.Silent),
+		UpgradeVia:       params.UpgradeVia,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -77,6 +77,10 @@ type BuildCmd struct {
 	SkipVersionCheck *bool
 	// Parallel defines the number of tasks to execute concurrently
 	Parallel *int
+	// UpgradeVia specifies the list of intermediate runtime versions to build
+	// an installer with support for going from version x to version z when
+	// the direct upgrades won't work
+	UpgradeVia *[]string
 	// Quiet allows to suppress console output
 	Quiet *bool
 }

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -77,9 +77,8 @@ type BuildCmd struct {
 	SkipVersionCheck *bool
 	// Parallel defines the number of tasks to execute concurrently
 	Parallel *int
-	// UpgradeVia specifies the list of intermediate runtime versions to build
-	// an installer with support for going from version x to version z when
-	// the direct upgrades won't work
+	// UpgradeVia lists intermediate runtime versions to build support for
+	// in the installer
 	UpgradeVia *[]string
 	// Quiet allows to suppress console output
 	Quiet *bool

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -54,6 +54,7 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.SkipVersionCheck = tele.BuildCmd.Flag("skip-version-check", "Skip version compatibility check").Hidden().Bool()
 	tele.BuildCmd.Parallel = tele.BuildCmd.Flag("parallel", "Specifies the number of concurrent tasks. If < 0, the number of tasks is not restricted, if unspecified, then tasks are capped at the number of logical CPU cores").Int()
 	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any extra output to stdout").Short('q').Bool()
+	tele.BuildCmd.UpgradeVia = tele.BuildCmd.Flag("upgrade-via", "Use runtime version as intermediate in upgrade. Can be specified multiple times.").Hidden().Strings()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "Display a list of user applications published in remote Ops Center")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes").Short('r').Hidden().Bool()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -51,14 +51,15 @@ func Run(tele Application) error {
 		return printVersion(*tele.VersionCmd.Output)
 	case tele.BuildCmd.FullCommand():
 		return build(context.Background(), BuildParameters{
-			StateDir:         *tele.StateDir,
-			ManifestPath:     *tele.BuildCmd.ManifestPath,
-			OutPath:          *tele.BuildCmd.OutFile,
-			Overwrite:        *tele.BuildCmd.Overwrite,
-			Repository:       *tele.BuildCmd.Repository,
-			SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
-			Silent:           *tele.BuildCmd.Quiet,
-			Insecure:         *tele.Insecure,
+			StateDir:             *tele.StateDir,
+			ManifestPath:         *tele.BuildCmd.ManifestPath,
+			OutPath:              *tele.BuildCmd.OutFile,
+			Overwrite:            *tele.BuildCmd.Overwrite,
+			Repository:           *tele.BuildCmd.Repository,
+			SkipVersionCheck:     *tele.BuildCmd.SkipVersionCheck,
+			Silent:               *tele.BuildCmd.Quiet,
+			Insecure:             *tele.Insecure,
+			IntermediateRuntimes: *tele.BuildCmd.UpgradeVia,
 		}, service.VendorRequest{
 			PackageName:            *tele.BuildCmd.Name,
 			PackageVersion:         *tele.BuildCmd.Version,

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -51,15 +51,15 @@ func Run(tele Application) error {
 		return printVersion(*tele.VersionCmd.Output)
 	case tele.BuildCmd.FullCommand():
 		return build(context.Background(), BuildParameters{
-			StateDir:             *tele.StateDir,
-			ManifestPath:         *tele.BuildCmd.ManifestPath,
-			OutPath:              *tele.BuildCmd.OutFile,
-			Overwrite:            *tele.BuildCmd.Overwrite,
-			Repository:           *tele.BuildCmd.Repository,
-			SkipVersionCheck:     *tele.BuildCmd.SkipVersionCheck,
-			Silent:               *tele.BuildCmd.Quiet,
-			Insecure:             *tele.Insecure,
-			IntermediateRuntimes: *tele.BuildCmd.UpgradeVia,
+			StateDir:         *tele.StateDir,
+			ManifestPath:     *tele.BuildCmd.ManifestPath,
+			OutPath:          *tele.BuildCmd.OutFile,
+			Overwrite:        *tele.BuildCmd.Overwrite,
+			Repository:       *tele.BuildCmd.Repository,
+			SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
+			Silent:           *tele.BuildCmd.Quiet,
+			Insecure:         *tele.Insecure,
+			UpgradeVia:       *tele.BuildCmd.UpgradeVia,
 		}, service.VendorRequest{
 			PackageName:            *tele.BuildCmd.Name,
 			PackageVersion:         *tele.BuildCmd.Version,

--- a/tool/tele/main.go
+++ b/tool/tele/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/gravity/tool/tele/cli"
 
 	teleutils "github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -34,7 +33,7 @@ func main() {
 	stdlog.SetOutput(log.StandardLogger().Writer())
 	app := kingpin.New("tele", "Gravity tool for building and publishing application bundles")
 	if err := run(app); err != nil {
-		log.Error(trace.DebugReport(err))
+		log.WithError(err).Warn("Command failed.")
 		common.PrintError(err)
 		os.Exit(255)
 	}


### PR DESCRIPTION
This PR implements support for `tele build --upgrade-via=<runtime-version>` which enables to embed another runtime version inside the resulting installer.
The package dependencies of the specified runtime package are marked with a `intermediate-upgrade:<runtime-version>` label to be able to filter on the runtime version when building an operation plan for upgrade.

Since the changes are relatively stand-alone, I'd like to commit them before working on the upgrade part.

Requires https://github.com/gravitational/gravity.e/pull/4195.