### PR TITLE
Additional hook variables.

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -35,7 +35,7 @@ import (
 	teleutils "github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // configureJob augments the provided job spec with the proper metadata (e.g. to ensure unique name),
@@ -103,6 +103,16 @@ func configureMetadata(job *batchv1.Job, p Params) error {
 			v1.EnvVar{
 				Name:  constants.ServiceUserEnvVar,
 				Value: p.ServiceUser.UID,
+			},
+		)
+		job.Spec.Template.Spec.Containers[i].EnvFrom = append(
+			job.Spec.Template.Spec.Containers[i].EnvFrom,
+			v1.EnvFromSource{
+				ConfigMapRef: &v1.ConfigMapEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "cluster",
+					},
+				},
 			},
 		)
 		// set image pull policy if none specified

--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -110,7 +110,7 @@ func configureMetadata(job *batchv1.Job, p Params) error {
 			v1.EnvFromSource{
 				ConfigMapRef: &v1.ConfigMapEnvSource{
 					LocalObjectReference: v1.LocalObjectReference{
-						Name: "cluster",
+						Name: constants.ClusterInfoMap,
 					},
 				},
 			},

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -551,6 +551,15 @@ const (
 	// ClusterConfigurationMap is the name of the ConfigMap that hosts cluster configuration resource
 	ClusterConfigurationMap = "cluster-configuration"
 
+	// ClusterInfoMap is the name of the ConfigMap that contains cluster information.
+	ClusterInfoMap = "cluster-info"
+	// ClusterNameEnv is the environment variable that contains cluster domain name.
+	ClusterNameEnv = "GRAVITY_CLUSTER_NAME"
+	// ClusterProviderEnv is the environment variable that contains cluster provider.
+	ClusterProviderEnv = "GRAVITY_CLUSTER_PROVIDER"
+	// ClusterFlavorEnv is the environment variable that contains initial cluster flavor.
+	ClusterFlavorEnv = "GRAVITY_CLUSTER_FLAVOR"
+
 	// SMTPSecret specifies the name of the Secret with cluster SMTP configuration
 	SMTPSecret = "smtp-configuration-update"
 

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -555,7 +555,7 @@ const (
 	ClusterInfoMap = "cluster-info"
 	// ClusterNameEnv is the environment variable that contains cluster domain name.
 	ClusterNameEnv = "GRAVITY_CLUSTER_NAME"
-	// ClusterProviderEnv is the environment variable that contains cluster provider.
+	// ClusterProviderEnv is the environment variable that contains cluster cloud provider.
 	ClusterProviderEnv = "GRAVITY_CLUSTER_PROVIDER"
 	// ClusterFlavorEnv is the environment variable that contains initial cluster flavor.
 	ClusterFlavorEnv = "GRAVITY_CLUSTER_FLAVOR"

--- a/lib/install/config.go
+++ b/lib/install/config.go
@@ -227,6 +227,7 @@ func (r *clusterFactory) NewCluster() ops.NewSiteRequest {
 		Email:        fmt.Sprintf("installer@%v", r.SiteDomain),
 		Provider:     r.CloudProvider,
 		DomainName:   r.SiteDomain,
+		Flavor:       r.Flavor.Name,
 		InstallToken: r.Token.Token,
 		ServiceUser: storage.OSUser{
 			Name: r.ServiceUser.Name,

--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -99,8 +99,17 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 				config.Operator,
 				client)
 
-		case p.Phase.ID == phases.ResourcesPhase:
-			return phases.NewResources(p,
+		case p.Phase.ID == phases.SystemResourcesPhase:
+			client, err := getKubeClient(p)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return phases.NewSystemResources(p,
+				config.Operator,
+				client)
+
+		case p.Phase.ID == phases.UserResourcesPhase:
+			return phases.NewUserResources(p,
 				config.Operator)
 
 		case strings.HasPrefix(p.Phase.ID, phases.ExportPhase):

--- a/lib/install/phases/constants.go
+++ b/lib/install/phases/constants.go
@@ -43,8 +43,10 @@ const (
 	RBACPhase = "/rbac"
 	// CorednsPhase is a phase that generates coredns configuration for the cluster
 	CorednsPhase = "/coredns"
-	// ResourcesPhase is a phase that creates user supplied Kubernetes resources
-	ResourcesPhase = "/resources"
+	// SystemResourcesPhase is a phase that creates system Kubernetes resources
+	SystemResourcesPhase = "/system-resources"
+	// UserResourcesPhase is a phase that creates user supplied Kubernetes resources
+	UserResourcesPhase = "/user-resources"
 	// GravityResourcesPhase is a phase that creates user supplied Gravity resources
 	GravityResourcesPhase = "/gravity-resources"
 	// ExportPhase is a phase that exports application layers to registries

--- a/lib/install/phases/resources.go
+++ b/lib/install/phases/resources.go
@@ -33,10 +33,76 @@ import (
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
-// NewResources returns an executor that creates user-supplied Kubernetes resources
-func NewResources(p fsm.ExecutorParams, operator ops.Operator) (*resourcesExecutor, error) {
+// NewSystemResources returns executor that creates system Kubernetes resources.
+func NewSystemResources(p fsm.ExecutorParams, operator ops.Operator, client *kubernetes.Clientset) (fsm.PhaseExecutor, error) {
+	logger := &fsm.Logger{
+		FieldLogger: logrus.WithField(constants.FieldPhase, p.Phase.ID),
+		Key:         opKey(p.Plan),
+		Operator:    operator,
+	}
+	return &systemResources{
+		FieldLogger:    logger,
+		ExecutorParams: p,
+		Client:         client,
+		Cluster:        *p.Phase.Data.Cluster,
+	}, nil
+}
+
+// systemResources is executor that creates system Kubernetes resources.
+type systemResources struct {
+	// FieldLogger is used for logging.
+	logrus.FieldLogger
+	// ExecutorParams contains common executor parameters.
+	fsm.ExecutorParams
+	// Client is the installed cluster's Kubernetes client.
+	Client *kubernetes.Clientset
+	// Cluster is the cluster that is being installed.
+	Cluster storage.Site
+}
+
+// Execute generates coredns configuration
+func (r *systemResources) Execute(ctx context.Context) error {
+	r.Progress.NextStep("Configuring system Kubernetes resources")
+	r.Info("Configuring system Kubernetes resources.")
+	_, err := r.Client.CoreV1().ConfigMaps(constants.KubeSystemNamespace).Create(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: constants.KubeSystemNamespace,
+		},
+		Data: map[string]string{
+			"GRAVITY_CLUSTER_NAME":     r.Cluster.Domain,
+			"GRAVITY_CLUSTER_PROVIDER": r.Cluster.Provider,
+			"GRAVITY_CLUSTER_FLAVOR":   r.Cluster.Flavor,
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Rollback deletes the coredns configmap that was created in the execute step
+func (r *systemResources) Rollback(context.Context) error {
+	err := r.Client.CoreV1().ConfigMaps(constants.KubeSystemNamespace).Delete("cluster", &metav1.DeleteOptions{})
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// PreCheck is no-op for this phase.
+func (r *systemResources) PreCheck(context.Context) error { return nil }
+
+// PostCheck is no-op for this phase.
+func (r *systemResources) PostCheck(context.Context) error { return nil }
+
+// NewUserResources returns an executor that creates user-supplied Kubernetes resources
+func NewUserResources(p fsm.ExecutorParams, operator ops.Operator) (*userResourcesExecutor, error) {
 	if p.Phase.Data == nil || p.Phase.Data.Install == nil {
 		return nil, trace.BadParameter("phase data is mandatory")
 	}
@@ -48,14 +114,14 @@ func NewResources(p fsm.ExecutorParams, operator ops.Operator) (*resourcesExecut
 		Operator: operator,
 		Server:   p.Phase.Data.Server,
 	}
-	return &resourcesExecutor{
+	return &userResourcesExecutor{
 		FieldLogger:    logger,
 		ExecutorParams: p,
 		resources:      p.Phase.Data.Install.Resources,
 	}, nil
 }
 
-type resourcesExecutor struct {
+type userResourcesExecutor struct {
 	// FieldLogger is used for logging
 	logrus.FieldLogger
 	// ExecutorParams is common executor params
@@ -64,7 +130,7 @@ type resourcesExecutor struct {
 }
 
 // Execute executes the resources phase
-func (p *resourcesExecutor) Execute(ctx context.Context) error {
+func (p *userResourcesExecutor) Execute(ctx context.Context) error {
 	const filename = "resources.yaml"
 	p.Progress.NextStep("Creating user-supplied Kubernetes resources")
 	stateDir, err := state.GetStateDir()
@@ -94,12 +160,12 @@ func (p *resourcesExecutor) Execute(ctx context.Context) error {
 }
 
 // Rollback is no-op for this phase
-func (*resourcesExecutor) Rollback(ctx context.Context) error {
+func (*userResourcesExecutor) Rollback(ctx context.Context) error {
 	return nil
 }
 
 // PreCheck makes sure this phase is executed on a master node
-func (p *resourcesExecutor) PreCheck(ctx context.Context) error {
+func (p *userResourcesExecutor) PreCheck(ctx context.Context) error {
 	err := fsm.CheckMasterServer(p.Plan.Servers)
 	if err != nil {
 		return trace.Wrap(err)
@@ -108,7 +174,7 @@ func (p *resourcesExecutor) PreCheck(ctx context.Context) error {
 }
 
 // PostCheck is no-op for this phase
-func (*resourcesExecutor) PostCheck(ctx context.Context) error {
+func (*userResourcesExecutor) PostCheck(ctx context.Context) error {
 	return nil
 }
 

--- a/lib/install/plan.go
+++ b/lib/install/plan.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/install/plan.go
+++ b/lib/install/plan.go
@@ -82,9 +82,9 @@ func (r *Planner) GetOperationPlan(operator ops.Operator, cluster ops.Site, oper
 	builder.AddRBACPhase(plan)
 	builder.AddCorednsPhase(plan)
 
-	// if installing a regular app, the resources might have been
-	// provided by a user
-	builder.AddResourcesPhase(plan)
+	// create system and user-supplied Kubernetes resources
+	builder.AddSystemResourcesPhase(plan)
+	builder.AddUserResourcesPhase(plan)
 
 	// export applications to registries
 	builder.AddExportPhase(plan)

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -222,7 +222,8 @@ func (s *PlanSuite) TestPlan(c *check.C) {
 		{phases.WaitPhase, s.verifyWaitPhase},
 		{phases.RBACPhase, s.verifyRBACPhase},
 		{phases.CorednsPhase, s.verifyCorednsPhase},
-		{phases.UserResourcesPhase, s.verifyResourcesPhase},
+		{phases.SystemResourcesPhase, s.verifySystemResourcesPhase},
+		{phases.UserResourcesPhase, s.verifyUserResourcesPhase},
 		{phases.ExportPhase, s.verifyExportPhase},
 		{phases.InstallOverlayPhase, s.verifyInstallOverlayPhase},
 		{phases.HealthPhase, s.verifyHealthPhase},
@@ -477,7 +478,19 @@ func (s *PlanSuite) verifyCorednsPhase(c *check.C, phase storage.OperationPhase)
 	}, phase)
 }
 
-func (s *PlanSuite) verifyResourcesPhase(c *check.C, phase storage.OperationPhase) {
+func (s *PlanSuite) verifySystemResourcesPhase(c *check.C, phase storage.OperationPhase) {
+	cluster := ops.ConvertOpsSite(*s.cluster)
+	storage.DeepComparePhases(c, storage.OperationPhase{
+		ID: phases.SystemResourcesPhase,
+		Data: &storage.OperationPhaseData{
+			Server:  &s.masterNode,
+			Cluster: &cluster,
+		},
+		Requires: []string{phases.RBACPhase},
+	}, phase)
+}
+
+func (s *PlanSuite) verifyUserResourcesPhase(c *check.C, phase storage.OperationPhase) {
 	obtained := phase.Data.Install.Resources
 	expected := []byte(`
 {

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -479,12 +479,10 @@ func (s *PlanSuite) verifyCorednsPhase(c *check.C, phase storage.OperationPhase)
 }
 
 func (s *PlanSuite) verifySystemResourcesPhase(c *check.C, phase storage.OperationPhase) {
-	cluster := ops.ConvertOpsSite(*s.cluster)
 	storage.DeepComparePhases(c, storage.OperationPhase{
 		ID: phases.SystemResourcesPhase,
 		Data: &storage.OperationPhaseData{
-			Server:  &s.masterNode,
-			Cluster: &cluster,
+			Server: &s.masterNode,
 		},
 		Requires: []string{phases.RBACPhase},
 	}, phase)

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -222,7 +222,7 @@ func (s *PlanSuite) TestPlan(c *check.C) {
 		{phases.WaitPhase, s.verifyWaitPhase},
 		{phases.RBACPhase, s.verifyRBACPhase},
 		{phases.CorednsPhase, s.verifyCorednsPhase},
-		{phases.ResourcesPhase, s.verifyResourcesPhase},
+		{phases.UserResourcesPhase, s.verifyResourcesPhase},
 		{phases.ExportPhase, s.verifyExportPhase},
 		{phases.InstallOverlayPhase, s.verifyInstallOverlayPhase},
 		{phases.HealthPhase, s.verifyHealthPhase},
@@ -505,7 +505,7 @@ func (s *PlanSuite) verifyResourcesPhase(c *check.C, phase storage.OperationPhas
 	`)
 	phase.Data.Install.Resources = nil // Compare resources separately
 	storage.DeepComparePhases(c, storage.OperationPhase{
-		ID: phases.ResourcesPhase,
+		ID: phases.UserResourcesPhase,
 		Data: &storage.OperationPhaseData{
 			Server:  &s.masterNode,
 			Install: &storage.InstallOperationData{},

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -41,6 +41,8 @@ import (
 
 // PlanBuilder builds operation plan phases
 type PlanBuilder struct {
+	// Cluster is the cluster being installed
+	Cluster storage.Site
 	// Application is the app being installed
 	Application app.Application
 	// Runtime is the Runtime of the app being installed
@@ -349,14 +351,29 @@ func (b *PlanBuilder) AddRBACPhase(plan *storage.OperationPlan) {
 	})
 }
 
-// AddResourcesPhase appends K8s resources initialization phase to the provided plan
-func (b *PlanBuilder) AddResourcesPhase(plan *storage.OperationPlan) {
+// AddSystemResourcesPhase appends phase that creates system Kubernetes
+// resources to the provided plan.
+func (b *PlanBuilder) AddSystemResourcesPhase(plan *storage.OperationPlan) {
+	plan.Phases = append(plan.Phases, storage.OperationPhase{
+		ID:          phases.SystemResourcesPhase,
+		Description: "Create system Kubernetes resources",
+		Data: &storage.OperationPhaseData{
+			Server:  &b.Master,
+			Cluster: &b.Cluster,
+		},
+		Requires: []string{phases.RBACPhase},
+		Step:     4,
+	})
+}
+
+// AddUserResourcesPhase appends K8s resources initialization phase to the provided plan
+func (b *PlanBuilder) AddUserResourcesPhase(plan *storage.OperationPlan) {
 	if len(b.resources) == 0 {
 		// Nothing to add
 		return
 	}
 	plan.Phases = append(plan.Phases, storage.OperationPhase{
-		ID:          phases.ResourcesPhase,
+		ID:          phases.UserResourcesPhase,
 		Description: "Create user-supplied Kubernetes resources",
 		Data: &storage.OperationPhaseData{
 			Server: &b.Master,
@@ -615,6 +632,7 @@ func (c *Config) GetPlanBuilder(operator ops.Operator, cluster ops.Site, op ops.
 		return nil, trace.Wrap(err)
 	}
 	builder := &PlanBuilder{
+		Cluster: ops.ConvertOpsSite(cluster),
 		Application: app.Application{
 			Package:         cluster.App.Package,
 			PackageEnvelope: cluster.App.PackageEnvelope,

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -358,8 +358,7 @@ func (b *PlanBuilder) AddSystemResourcesPhase(plan *storage.OperationPlan) {
 		ID:          phases.SystemResourcesPhase,
 		Description: "Create system Kubernetes resources",
 		Data: &storage.OperationPhaseData{
-			Server:  &b.Master,
-			Cluster: &b.Cluster,
+			Server: &b.Master,
 		},
 		Requires: []string{phases.RBACPhase},
 		Step:     4,

--- a/lib/ops/kubernetes.go
+++ b/lib/ops/kubernetes.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import (
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/storage"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MakeClusterInfoMap creates a config map with information about the provided
+// cluster that will be made available to all hooks.
+func MakeClusterInfoMap(cluster storage.Site) *v1.ConfigMap {
+	provider := cluster.Provider
+	// The on-prem provider is exposed to the users as 'generic'.
+	if provider == schema.ProviderOnPrem {
+		provider = schema.ProviderGeneric
+	}
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ClusterInfoMap,
+			Namespace: constants.KubeSystemNamespace,
+		},
+		Data: map[string]string{
+			constants.ClusterNameEnv:     cluster.Domain,
+			constants.ClusterProviderEnv: provider,
+			constants.ClusterFlavorEnv:   cluster.Flavor,
+		},
+	}
+}

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1529,6 +1529,8 @@ type NewSiteRequest struct {
 	// Location describes the location where a new site is about to be deployed,
 	// for example AWS region name
 	Location string `json:"location"`
+	// Flavor is the name of the initial cluster flavor.
+	Flavor string `json:"flavor"`
 	// InstallToken is install token for site to create for agents
 	InstallToken string `json:"install_token"`
 	// ServiceUser specifies the user to use for planet container services
@@ -1619,6 +1621,8 @@ type Site struct {
 	FinalInstallStepComplete bool `json:"final_install_step_complete"`
 	// Location is a location where the site is deployed, for example AWS region name
 	Location string `json:"location"`
+	// Flavor is the initial cluster flavor.
+	Flavor string `json:"flavor"`
 	// UpdateInterval is how often the site checks for and downloads newer versions of the
 	// installed application
 	UpdateInterval time.Duration `json:"update_interval"`

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -614,6 +614,7 @@ func (o *Operator) CreateSite(r ops.NewSiteRequest) (*ops.Site, error) {
 		Provider:     r.Provider,
 		License:      r.License,
 		Labels:       labels,
+		Flavor:       r.Flavor,
 		App:          app.PackageEnvelope.ToPackage(),
 		Resources:    r.Resources,
 		Location:     r.Location,

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -688,6 +688,7 @@ func convertSite(in storage.Site, apps appservice.Applications) (*ops.Site, erro
 		Labels:                   in.Labels,
 		FinalInstallStepComplete: in.FinalInstallStepComplete,
 		Location:                 in.Location,
+		Flavor:                   in.Flavor,
 		UpdateInterval:           in.UpdateInterval,
 		NextUpdateCheck:          in.NextUpdateCheck,
 		ClusterState:             in.ClusterState,

--- a/lib/ops/site.go
+++ b/lib/ops/site.go
@@ -87,6 +87,7 @@ func ConvertOpsSite(in Site) storage.Site {
 		Resources:       in.Resources,
 		Labels:          in.Labels,
 		Location:        in.Location,
+		Flavor:          in.Flavor,
 		UpdateInterval:  in.UpdateInterval,
 		NextUpdateCheck: in.NextUpdateCheck,
 		ClusterState:    in.ClusterState,

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -114,8 +114,6 @@ type OperationPhaseData struct {
 	License []byte `json:"license,omitempty" yaml:"license,omitempty"`
 	// TrustedCluster is the resource data for a trusted cluster representing an Ops Center
 	TrustedCluster []byte `json:"trusted_cluster_resource,omitempty" yaml:"trusted_cluster_resource,omitempty"`
-	// Cluster is the cluster object e.g. the cluster that is being installed.
-	Cluster *Site `json:"cluster,omitempty" yaml:"cluster,omitempty"`
 	// ServiceUser specifies the optional service user to use as a context
 	// for file operations
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -114,6 +114,8 @@ type OperationPhaseData struct {
 	License []byte `json:"license,omitempty" yaml:"license,omitempty"`
 	// TrustedCluster is the resource data for a trusted cluster representing an Ops Center
 	TrustedCluster []byte `json:"trusted_cluster_resource,omitempty" yaml:"trusted_cluster_resource,omitempty"`
+	// Cluster is the cluster object e.g. the cluster that is being installed.
+	Cluster *Site `json:"cluster,omitempty" yaml:"cluster,omitempty"`
 	// ServiceUser specifies the optional service user to use as a context
 	// for file operations
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -562,6 +562,8 @@ type Site struct {
 	Resources []byte `json:"resources"`
 	// Location is a location where the site is deployed, for example AWS region name
 	Location string `json:"location"`
+	// Flavor is the initial cluster flavor.
+	Flavor string `json:"flavor"`
 	// UpdateInterval is how often the site checks for and downloads newer versions of the
 	// installed application
 	UpdateInterval time.Duration `json:"update_interval"`

--- a/lib/update/cluster/executor.go
+++ b/lib/update/cluster/executor.go
@@ -104,7 +104,7 @@ func fsmSpec(c Config) fsm.FSMSpecFunc {
 		case updateInit:
 			return libphase.NewUpdatePhaseInit(p, c.Operator, c.Apps,
 				c.Backend, c.LocalBackend, c.ClusterPackages, c.Users,
-				logger)
+				c.Client, logger)
 		case updateChecks:
 			return libphase.NewUpdatePhaseChecks(p, c.Operator, c.Apps, c.Runner, logger)
 		case updateBootstrap:

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/install"
-	"github.com/gravitational/gravity/lib/install/phases"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
@@ -35,8 +34,8 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/users"
-	"github.com/gravitational/rigging"
 
+	"github.com/gravitational/rigging"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -297,7 +296,7 @@ func (p *updatePhaseInit) updateClusterInfoMap() error {
 		return trace.Wrap(err)
 	}
 	// Cluster info config map doesn't exist yet, create it.
-	configMap := phases.ClusterInfoMap(ops.ConvertOpsSite(p.Cluster))
+	configMap := ops.MakeClusterInfoMap(ops.ConvertOpsSite(p.Cluster))
 	_, err = p.Client.CoreV1().ConfigMaps(constants.KubeSystemNamespace).Create(configMap)
 	if err != nil {
 		return rigging.ConvertError(err)


### PR DESCRIPTION
This pull request makes sure that all hook containers receive environment variables with certain basic cluster information which people keep asking about. The variables which are currently available in hooks are cluster name, cluster provider and initial flavor name.

The way it works is a new config map (I called it `cluster-info`) is created during initial cluster installation (or during upgrade for older clusters) which then gets mounted into hook containers as environment.

This approach is more flexible and extensible than just injecting env vars directly and also helps with separation of concerns because "app service" (the one that creates hooks) doesn't know anything about the cluster.

I will update the documentation in another PR. Closes https://github.com/gravitational/gravity.e/issues/3599.