### PR TITLE
Fix flaky rpc/proxy test

### DIFF
--- a/lib/rpc/proxy/proxy.go
+++ b/lib/rpc/proxy/proxy.go
@@ -134,7 +134,10 @@ func (r *Proxy) serve(listener net.Listener) {
 
 		c2, err := r.link.Dial()
 		if err != nil {
-			r.WithError(err).Warn("Failed to dial: %v.")
+			r.WithFields(log.Fields{
+				log.ErrorKey: err,
+				"addr":       r.link,
+			}).Warn("Failed to dial local link.")
 			c1.Close()
 			return
 		}

--- a/lib/rpc/proxy/proxy.go
+++ b/lib/rpc/proxy/proxy.go
@@ -129,7 +129,7 @@ func (r *Proxy) serve(listener net.Listener) {
 				return
 			default:
 			}
-			r.WithError(err).Warnf("Failed to accept.")
+			r.WithError(err).Warn("Failed to accept.")
 			return
 		}
 		r.Infof("Accept connection from %v.", c1.RemoteAddr())

--- a/lib/rpc/proxy/proxy_test.go
+++ b/lib/rpc/proxy/proxy_test.go
@@ -134,7 +134,6 @@ func (r *localLink) Dial() (net.Conn, error) {
 }
 
 func (r *localLink) Close() error {
-	log.Info("Close local link.")
 	return r.local.Close()
 }
 


### PR DESCRIPTION
This PR attempts to fix an issue with flaky rpc/proxy tests observed in robotest.
It adds explicit `io.Closer` implementation for the proxy local link and moves to use `sync.WaitGroup` instead of channels to observe lifespan of internal connection handlers.