### PR TITLE
[6.0] Do not set auth gateway public addrs initially.

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -67,7 +67,7 @@ TELEKUBE_TSH_PKG := gravitational.io/tsh_$(OS)_$(ARCH):$(GRAVITY_TAG)
 
 # Version of tsh binary that gets published into distribution OpsCenter, may differ from
 # the one Gravity currently depends on
-TELEKUBE_TSH_TAG := v3.0.4
+TELEKUBE_TSH_TAG := v3.2.7
 
 # Extra flags that may be provided when publishing telekube artifacts (e.g. --insecure)
 TELEKUBE_PUBLISH_FLAGS ?=

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -127,9 +127,6 @@ func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// // Initially the local cluster name is set as a principal.
-	// authGateway.SetSSHPublicAddrs([]string{cluster.Domain})
-	// authGateway.SetKubernetesPublicAddrs([]string{cluster.Domain})
 	err = opsservice.UpsertAuthGateway(client, p.identity, authGateway)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -91,7 +91,7 @@ func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
 		// process which doesn't support auth gateway reconfiguration.
 		return nil, nil
 	}
-	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	_, err := p.backend.GetLocalSite(defaults.SystemAccountID)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			// There's no local cluster which likely means that process is
@@ -127,9 +127,9 @@ func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Initially the local cluster name is set as a principal.
-	authGateway.SetSSHPublicAddrs([]string{cluster.Domain})
-	authGateway.SetKubernetesPublicAddrs([]string{cluster.Domain})
+	// // Initially the local cluster name is set as a principal.
+	// authGateway.SetSSHPublicAddrs([]string{cluster.Domain})
+	// authGateway.SetKubernetesPublicAddrs([]string{cluster.Domain})
 	err = opsservice.UpsertAuthGateway(client, p.identity, authGateway)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
The fact that it's set to cluster name messes up Kubernetes integration b/c cluster name can be not resolvable.