### PR TITLE
[5.5.x] fix build on darwin

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -154,8 +154,13 @@ endef
 #
 .PHONY: build
 build:
-	@if [ "$(OS)" = "darwin" ]; then $(MAKE) build-on-host; else $(MAKE) build-in-container; fi
-	ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+	@if [ "$(OS)" = "darwin" ]; then \
+		$(MAKE) build-on-host; \
+		ln -sf $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR); \
+	else \
+		$(MAKE) build-in-container; \
+		ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR); \
+	fi;
 
 #
 # generate gRPC code


### PR DESCRIPTION
Revert changes to `ln` for build on `darwin` due to command line incompatibility