### PR TITLE
[5/2.x] add offline rotation of secrets for intermediate upgrades

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -639,7 +639,7 @@ func (o *OperatorACL) ConfigurePackages(key SiteOperationKey) error {
 }
 
 func (o *OperatorACL) RotateSecrets(req RotateSecretsRequest) (*RotatePackageResponse, error) {
-	if err := o.ClusterAction(req.ClusterName, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+	if err := o.ClusterAction(req.Key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return o.operator.RotateSecrets(req)

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -741,22 +741,26 @@ func (r ConfigureNodeRequest) SiteKey() SiteKey {
 	}
 }
 
-// RotateSecretsRequest is a request to rotate server's secrets package
-type RotateSecretsRequest struct {
-	// AccountID is the account id of the local cluster
-	AccountID string `json:"account_id"`
-	// ClusterName is the local cluster name
-	ClusterName string `json:"cluster_name"`
-	// Server is the server to rotate secrets for
-	Server storage.Server `json:"server"`
+// CheckAndSetDefaults validates this request
+func (r RotateSecretsRequest) CheckAndSetDefaults() error {
+	if err := r.Key.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
-// SiteKey returns a cluster key from this request
-func (r RotateSecretsRequest) SiteKey() SiteKey {
-	return SiteKey{
-		AccountID:  r.AccountID,
-		SiteDomain: r.ClusterName,
-	}
+// RotateSecretsRequest is a request to rotate server's secrets package
+type RotateSecretsRequest struct {
+	// Key identifies the cluster
+	Key SiteKey `json:"key"`
+	// Server is the server to rotate secrets for
+	Server storage.Server `json:"server"`
+	// Package specifies the secrets package locator to use.
+	// If unspecified, one will be automatically generated
+	Package *loc.Locator `json:"package,omitempty"`
+	// DryRun specifies whether the API only generates the package name
+	// without actually creating the package
+	DryRun bool `json:"dry_run"`
 }
 
 // CheckAndSetDefaults validates this request
@@ -781,7 +785,7 @@ type RotatePlanetConfigRequest struct {
 	Manifest schema.Manifest `json:"manifest"`
 	// Package specifies the configuration package locator to use.
 	// It is generated automatically if unspecified
-	Package *loc.Locator `json:"package"`
+	Package *loc.Locator `json:"package,omitempty"`
 	// DryRun specifies whether the API only generates the package name
 	// without actually creating the package
 	DryRun bool `json:"dry_run"`

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -227,7 +227,7 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 			return trace.Wrap(err)
 		}
 	} else {
-		err := s.configurePlanetNodeSecrets(opCtx, provisionedServer, secretsPackage)
+		err := s.configurePlanetNodeSecrets(opCtx, provisionedServer, *secretsPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -378,7 +378,7 @@ func (s *site) configurePackages(ctx *operationContext) error {
 			return trace.Wrap(err)
 		}
 
-		if err := s.configurePlanetNodeSecrets(ctx, node, secretsPackage); err != nil {
+		if err := s.configurePlanetNodeSecrets(ctx, node, *secretsPackage); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -664,7 +664,7 @@ func (s *site) configurePlanetMasterSecrets(ctx *operationContext, p planetMaste
 	return trace.Wrap(err)
 }
 
-func (s *site) getPlanetNodeSecretsPackage(ctx *operationContext, node *ProvisionedServer, secretsPackage *loc.Locator) (*ops.RotatePackageResponse, error) {
+func (s *site) getPlanetNodeSecretsPackage(ctx *operationContext, node *ProvisionedServer, secretsPackage loc.Locator) (*ops.RotatePackageResponse, error) {
 	archive, err := s.readCertAuthorityPackage()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -738,13 +738,13 @@ func (s *site) getPlanetNodeSecretsPackage(ctx *operationContext, node *Provisio
 	}
 
 	return &ops.RotatePackageResponse{
-		Locator: *secretsPackage,
+		Locator: secretsPackage,
 		Reader:  reader,
 		Labels:  labels,
 	}, nil
 }
 
-func (s *site) configurePlanetNodeSecrets(ctx *operationContext, node *ProvisionedServer, secretsPackage *loc.Locator) error {
+func (s *site) configurePlanetNodeSecrets(ctx *operationContext, node *ProvisionedServer, secretsPackage loc.Locator) error {
 	resp, err := s.getPlanetNodeSecretsPackage(ctx, node, secretsPackage)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/ops/opsservice/systemupdate.go
+++ b/lib/ops/opsservice/systemupdate.go
@@ -18,6 +18,7 @@ package opsservice
 
 import (
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
 
@@ -27,12 +28,7 @@ import (
 
 // rotateSecrets generates a new set of TLS keys for the given node
 // as a package that will be automatically downloaded during upgrade
-func (s *site) rotateSecrets(ctx *operationContext, node *ProvisionedServer, installOp ops.SiteOperation) (*ops.RotatePackageResponse, error) {
-	secretsPackage, err := s.planetSecretsNextPackage(node)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func (s *site) rotateSecrets(ctx *operationContext, secretsPackage loc.Locator, node *ProvisionedServer, installOp ops.SiteOperation) (*ops.RotatePackageResponse, error) {
 	subnets := installOp.InstallExpand.Subnets
 	if subnets.IsEmpty() {
 		// Subnets are empty when updating an older installation
@@ -49,7 +45,7 @@ func (s *site) rotateSecrets(ctx *operationContext, node *ProvisionedServer, ins
 
 	masterParams := planetMasterParams{
 		master:            node,
-		secretsPackage:    secretsPackage,
+		secretsPackage:    &secretsPackage,
 		serviceSubnetCIDR: subnets.Service,
 	}
 	// if we have a connection to Ops Center set up, configure

--- a/lib/update/phase_init.go
+++ b/lib/update/phase_init.go
@@ -323,9 +323,8 @@ func (p *updatePhaseInit) createAdminAgent() error {
 func (p *updatePhaseInit) rotateSecrets(server storage.Server) error {
 	p.Infof("Generate new secrets configuration package for %v.", formatServer(server))
 	resp, err := p.Operator.RotateSecrets(ops.RotateSecretsRequest{
-		AccountID:   p.Operation.AccountID,
-		ClusterName: p.Operation.SiteDomain,
-		Server:      server,
+		Key:    p.Operation.ClusterKey(),
+		Server: server,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -84,6 +84,8 @@ type Application struct {
 	UpdateSystemCmd UpdateSystemCmd
 	// UpgradeCmd launches app upgrade
 	UpgradeCmd UpgradeCmd
+	// UpdateRotateSecretsCmd generates new secrets package
+	UpdateRotateSecretsCmd UpdateRotateSecretsCmd
 	// UpdateRotatePlanetConfigCmd generates new configuration package for planet
 	UpdateRotatePlanetConfigCmd UpdateRotatePlanetConfigCmd
 	// UpdateRotateTeleportConfigCmd generates new configuration package for teleport
@@ -534,6 +536,17 @@ type UpdateSystemCmd struct {
 	WithStatus *bool
 	// RuntimePackage specifies the runtime package to update to
 	RuntimePackage *loc.Locator
+}
+
+// UpdateRotateSecretsCmd generates a new secrets package
+type UpdateRotateSecretsCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the package to generate
+	Package *nullableLocator
+	// ServerAddr specifies this server's address
+	ServerAddr *string
+	// OperationID specifies the ID of the active update operation
+	OperationID *string
 }
 
 // UpdateRotatePlanetConfigCmd generates a new configuration package for planet

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -173,6 +173,11 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpdateSystemCmd.WithStatus = g.UpdateSystemCmd.Flag("with-status", "Verify the system status at the end of the operation").Bool()
 	g.UpdateSystemCmd.RuntimePackage = Locator(g.UpdateSystemCmd.Flag("runtime-package", "The name of the runtime package to update to").Required())
 
+	g.UpdateRotateSecretsCmd.CmdClause = g.UpdateCmd.Command("rotate-secrets", "Generate new secrets package").Hidden()
+	g.UpdateRotateSecretsCmd.Package = NullableLocator(g.UpdateRotateSecretsCmd.Flag("package", "Name of the package to generate"))
+	g.UpdateRotateSecretsCmd.ServerAddr = g.UpdateRotateSecretsCmd.Flag("addr", "Address of this node as used by the update operation").Required().String()
+	g.UpdateRotateSecretsCmd.OperationID = g.UpdateRotateSecretsCmd.Flag("id", "Update operation ID").Required().String()
+
 	g.UpdateRotatePlanetConfigCmd.CmdClause = g.UpdateCmd.Command("rotate-planet-config", "Generate new configuration package for planet").Hidden()
 	g.UpdateRotatePlanetConfigCmd.Package = NullableLocator(g.UpdateRotatePlanetConfigCmd.Flag("package", "Name of the package to generate"))
 	g.UpdateRotatePlanetConfigCmd.RuntimePackage = Locator(g.UpdateRotatePlanetConfigCmd.Flag("runtime-package", "Name of the runtime package to generate configuration for").Required())

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -382,6 +382,11 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		}
 	case g.UpdateUploadCmd.FullCommand():
 		return uploadUpdate(localEnv, *g.UpdateUploadCmd.OpsCenterURL)
+	case g.UpdateRotateSecretsCmd.FullCommand():
+		return rotateSecrets(localEnv,
+			g.UpdateRotateSecretsCmd.Package.Locator,
+			*g.UpdateRotateSecretsCmd.OperationID,
+			*g.UpdateRotateSecretsCmd.ServerAddr)
 	case g.UpdateRotatePlanetConfigCmd.FullCommand():
 		return rotatePlanetConfig(localEnv,
 			g.UpdateRotatePlanetConfigCmd.Package.Locator,


### PR DESCRIPTION
Add `gravity update rotate-secrets` symmetrical to `gravity update rotate-{planet,teleport}-config` for use in intermediate upgrades.
