### PR TITLE
Add ability to allow privileged containers via a manifest flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ GRAVITY_PKG_PATH ?= github.com/gravitational/gravity
 ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
-# Current Kubernetes version: 1.15.2
-K8S_VER := 1.15.2
+# Current Kubernetes version
+K8S_VER := 1.15.3
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
@@ -46,7 +46,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.2.7
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 7.0.3-$(K8S_VER_SUFFIX)
+PLANET_TAG := 7.0.5-$(K8S_VER_SUFFIX)-1-g542bdb2
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)

--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -4,12 +4,12 @@ Every Cluster created from a Gravity Cluster Image is a fully featured
 Kubernetes environment. It contains the following components:
 
 1. All user applications that have been packaged into the Cluster Image.
-2. All Kubernetes daemons like `kube-scheduler`, `kube-apiserver`, and others. 
+2. All Kubernetes daemons like `kube-scheduler`, `kube-apiserver`, and others.
 3. The Kubernetes CLI tool: `kubectl`.
 4. The Gravity Cluster "hypervisor", called `gravity`, for managing the Cluster.
 5. A web application to monitor and manage the Cluster state ("Control
 Panel")
-6. The Gravity Authentication Gateway for integrating Kubernetes authentication 
+6. The Gravity Authentication Gateway for integrating Kubernetes authentication
    and SSH access to Cluster nodes with corporate identity providers via SSO.
 
 You can also use familiar Kubernetes tools such as `kubectl` to perform regular
@@ -29,8 +29,8 @@ However, Gravity pre-configures Kubernetes to be as reliable as possible,
 greatly reducing the need for ongoing active management. To make this possible,
 the `gravity` hypervisor launches and manages all Kubernetes Linux daemons.
 
-When the `gravity` daemon starts, it creates its own "Master Container". The 
-Master Container itself is a containerized `systemd` instance. It launches the required Kubernetes daemons and contains their dependencies as well as monitoring and support tools. 
+When the `gravity` daemon starts, it creates its own "Master Container". The
+Master Container itself is a containerized `systemd` instance. It launches the required Kubernetes daemons and contains their dependencies as well as monitoring and support tools.
 
 Running Kubernetes services from inside the Master Container brings several
 advantages as opposed to installing Kubernetes components in a more traditional
@@ -254,23 +254,23 @@ hooks:
               app: myapp
 ```
 
-When the status hook fails, the Cluster transitions to a "degraded" state which is reflected in the Cluster web application by a red status indicator in the top bar. 
+When the status hook fails, the Cluster transitions to a "degraded" state which is reflected in the Cluster web application by a red status indicator in the top bar.
 Once the application recovers and the status hook completes successfully, the Cluster automatically moves back to a "healthy" state.
 
 ## Exploring a Cluster
 
-Any Gravity Cluster can be explored using the standard Kubernetes tool, `kubectl`, 
-which is installed and configured on every Cluster node. See the command's [overview](http://kubernetes.io/docs/user-guide/kubectl-overview/) and a 
+Any Gravity Cluster can be explored using the standard Kubernetes tool, `kubectl`,
+which is installed and configured on every Cluster node. See the command's [overview](http://kubernetes.io/docs/user-guide/kubectl-overview/) and a
 [full reference](https://kubernetes.io/docs/user-guide/kubectl/) to see what it can
 do, or simply use `kubectl --help`.
 
-Each Gravity Cluster also has a Cluster Control Panel web application to explore and 
-manage the Cluster. To log into the Cluster Control Panel you need to create an admin user. 
-Please see the [Custom Installer Screens](/pack/#/pack/#custom-installation-screen) 
+Each Gravity Cluster also has a Cluster Control Panel web application to explore and
+manage the Cluster. To log into the Cluster Control Panel you need to create an admin user.
+Please see the [Custom Installer Screens](/pack/#/pack/#custom-installation-screen)
 chapter for details on how to enable a post-install screen that will let you create a local user.
 
 If you are doing a CLI installation you will need to create a user resource in
-order to log into the Cluster Control Panel. See the 
+order to log into the Cluster Control Panel. See the
 [Configuring Cluster Access section](/config/#cluster-access) for more information.
 
 ## Updating a Cluster
@@ -300,7 +300,7 @@ the Gravity update process works:
    actions before or after the update, such as database migrations.
 
 An update can be triggered through Gravity Hub or from command line (CLI).
-The instructions below describe updating via the CLI. 
+The instructions below describe updating via the CLI.
 
 ### Uploading an Update
 
@@ -340,8 +340,8 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-An upgrade can be triggered either through Cluster Control Panel or using 
-command line. To trigger the upgrade from the Control Panel, select an appropriate 
+An upgrade can be triggered either through Cluster Control Panel or using
+command line. To trigger the upgrade from the Control Panel, select an appropriate
 version on the "Updates" tab click `Update`.
 
 To trigger the operation from the command line, copy the Cluster Image into one
@@ -361,7 +361,7 @@ drwxr-xr-x. 5 user user 4.0K Jan 14 09:08 packages
 -rwxr-xr-x. 1 user user  411 Jan 14 09:08 upload
 ```
 
-You can execute the `./upgrade` script to upload and upgrade in one go, 
+You can execute the `./upgrade` script to upload and upgrade in one go,
 or you can upload the update and then execute `gravity upgrade` command.
 
 Using `gravity upgrade` gives more Control over the upgrade procedure.
@@ -435,8 +435,8 @@ Some operations in a Gravity Cluster require cooperation from all Cluster nodes.
 Examples are installs, upgrades and garbage collection.
 Additionally, due to varying complexity and unforeseen conditions, these operations can and do fail in practice.
 
-To provide a foundation for coping with failures, the operations are built as 
-sets of smaller steps that can be re-executed or rolled back individually. 
+To provide a foundation for coping with failures, the operations are built as
+sets of smaller steps that can be re-executed or rolled back individually.
 This allows for an interactive fix and retry loop should any of the steps fail.
 
 Each operation starts with building an operational plan - a tree of actions to
@@ -522,22 +522,22 @@ An operation plan is effectively a tree of steps. Whenever you need to execute a
 $ sudo gravity plan execute --phase=/masters/node-1/drain
 ```
 
-Whole groups of steps can be executed if only the parent node's path has been 
-specified. For example, the following will execute all steps of the `/masters` 
+Whole groups of steps can be executed if only the parent node's path has been
+specified. For example, the following will execute all steps of the `/masters`
 node in the order listed:
 
 ```bash
 $ sudo gravity plan execute --phase=/masters
 ```
 
-Sometimes it is necessary to force execution of a particular step although it 
+Sometimes it is necessary to force execution of a particular step although it
 has already run. To do this, add the `--force` flag to the command line:
 
 ```bash
 $ sudo gravity plan execute --phase=/masters/node-1/drain --force
 ```
 
-If it is impossible to make progress with an operation due to an unforeseen 
+If it is impossible to make progress with an operation due to an unforeseen
 condition, the steps that have been executed to this point can be rolled back:
 
 ```bash
@@ -553,7 +553,7 @@ Note the reverse order of invocation. A group of steps can also be rolled back:
 $ sudo gravity plan rollback --phase=/masters
 ```
 
-Once all steps have been rolled back, the operation needs to be explicitly 
+Once all steps have been rolled back, the operation needs to be explicitly
 completed in order to mark it failed:
 
 ```bash
@@ -567,14 +567,14 @@ $ sudo gravity plan resume
 ```
 
 This will resume the operation at the last failed step and run it through to completion.
-In this case, there's no need to explicitly complete the operation afterwards. 
+In this case, there's no need to explicitly complete the operation afterwards.
 This is done automatically upon success.
 
 
 ## The Master Container
 
 As explained [above](#kubernetes-environment), Gravity runs Kubernetes inside a Master Container. The Master Container (also called "planet") makes sure that every single
-deployment of Gravity is the same and all nodes are identical to each other. The 
+deployment of Gravity is the same and all nodes are identical to each other. The
 Master Container includes all Kubernetes components and dependencies such as kube-apiserver, etcd and docker.
 
 To launch an interactive shell to get a system view of a Gravity Cluster, you
@@ -766,14 +766,14 @@ Flag | Description
 `--role` | _(Optional)_ Role of the joining node. Autodetected if not specified.
 `--state-dir` | _(Optional)_ Directory where all Gravity system data will be kept on this node. Defaults to `/var/lib/gravity`.
 
-Every node in a Cluster must have a role, defined in the Image Manifest. System 
-requirements can also be set for a role in the Image Manifest. 
+Every node in a Cluster must have a role, defined in the Image Manifest. System
+requirements can also be set for a role in the Image Manifest.
 Gravity will then check for the specified system requirements for the role before
 successfully adding a new node and return an error if the system requirements
-are not satisfied. 
+are not satisfied.
 
-As an example, Gravity can check to make sure nodes with a "database" role have 
-storage attached to them. 
+As an example, Gravity can check to make sure nodes with a "database" role have
+storage attached to them.
 
 **Adding a node via the Control Panel**
 ![Control Panel](/images/gravity-quickstart/gravity-adding-a-node.png)
@@ -786,8 +786,8 @@ A node can be removed by using the `gravity leave` or `gravity remove` commands.
 To decommission an active node from the Cluster while on a particular node
 run `gravity leave`.
 
-If successful, the `leave` command will output the ID of the initiated removal 
-operation. The operation progress can be monitored using the `gravity status` 
+If successful, the `leave` command will output the ID of the initiated removal
+operation. The operation progress can be monitored using the `gravity status`
 command.
 
 During the decommissioning, all application and Kubernetes services running
@@ -976,8 +976,8 @@ root$ gravity restore <data.tar.gz>
 ## Garbage Collection
 
 A Cluster can accumulate resources that it no longer has use for, like Gravity
-packages or docker images from previous versions of the application. These 
-resources unnecessarily waste disk space and are usually difficult to get rid 
+packages or docker images from previous versions of the application. These
+resources unnecessarily waste disk space and are usually difficult to get rid
 of manually.
 
 The `gravity` tool offers a subset of commands to run Cluster-wide garbage collection.
@@ -1005,7 +1005,7 @@ If started without parameters (i.e. not in manual mode) the command will run the
 After the operation has been started, the regular `gravity plan` can be used to display the plan of the
 ongoing operation.
 
-In the case of any intermediate failures, the command will abort and print the corresponding error message. After fixing the issue, the operation can be 
+In the case of any intermediate failures, the command will abort and print the corresponding error message. After fixing the issue, the operation can be
 resumed with:
 
 ```bsh
@@ -1083,7 +1083,7 @@ the following order:
 
 ## Managing Users
 
-You can invite new users and reset passwords for existing users by executing 
+You can invite new users and reset passwords for existing users by executing
 CLI commands on the Cluster nodes.
 
 ### Invite User
@@ -1130,8 +1130,8 @@ https://<host>/web/reset/<token>
 
 ## Securing a Cluster
 
-Gravity comes with a set of roles and bindings (for role-based access control or 
-RBAC) and a set of pod security policies. This lays the foundation for further 
+Gravity comes with a set of roles and bindings (for role-based access control or
+RBAC) and a set of pod security policies. This lays the foundation for further
 security configurations.
 
 ### Pod security policies
@@ -1148,6 +1148,11 @@ By default Gravity provides two security policies: `privileged` and `restricted`
 
   * A `privileged` policy is a permissive policy allowing unrestricted access within Cluster.
 
+!!! note "Privileged containers":
+    Note that by default privileged containers are not permitted in Gravity
+    clusters. To allow privileged containers, enable them in your cluster
+    manifest by setting `systemOptions.allowPrivileged` field to `true`.
+
 Two `ClusterRoles`: `restricted-psp-user` and `privileged-psp-user` enable access
 to the respective security policies.
 Additionally, the two default groups: `restricted-psp-users` and `privileged-psp-users`
@@ -1156,7 +1161,7 @@ can be used to assign privileges to users and other groups:
   * `restricted-psp-users` group grants access to the restricted role
   * `privileged-psp-users` group grants access to both roles
 
-Finer control can be exercised by modifying the existing or creating new security 
+Finer control can be exercised by modifying the existing or creating new security
 policies: Cluster roles and role bindings.
 
 For [example](https://github.com/kubernetes/examples/blob/master/staging/podsecuritypolicy/rbac/policies.yaml), to restrict the types of volumes Pods can use (among other things), create the following policy `psp-volumes.yaml`:

--- a/docs/6.x/faq.md
+++ b/docs/6.x/faq.md
@@ -123,11 +123,27 @@ sudo ./gravity install --vxlan-port=9473
 
 ## Kubernetes Pods Stuck in Terminating State
 
-Some linux distributions have included the kernel setting fs.may_detach_mounts with a default value of 0. This can cause conflicts with the docker daemon, where docker is then unable to unmount mount points within the container. Kubernetes will show pods as stuck in the terminating state if docker is unable to clean up one of the underlying containers.
+Some linux distributions have included the kernel setting `fs.may_detach_mounts` with a default value of 0. This can cause conflicts with the docker daemon, where docker is then unable to unmount mount points within the container. Kubernetes will show pods as stuck in the terminating state if docker is unable to clean up one of the underlying containers.
 
-If the installed kernel exposes the option fs.may_detach_mounts we recommend always setting this value to 1, or you may experience issues terminating pods in your cluster.
+If the installed kernel exposes the option `fs.may_detach_mounts` we recommend always setting this value to 1, or you may experience issues terminating pods in your cluster.
 
-```
+```shell
 sysctl -w fs.may_detach_mounts=1
 echo "fs.may_detach_mounts = 1" >> /etc/sysctl.d/10-may_detach_mounts.conf
 ```
+
+## Running Privileged Containers
+
+By default privileged containers are not allowed in Gravity clusters. In some
+cases privileged containers may be required though, specifically for applications
+that wish to utilize custom network plugins or dynamic volume provisioners.
+
+To allow privileged containers, set the following field in your cluster image
+manifest:
+
+```yaml
+systemOptions:
+  allowPrivileged: true
+```
+
+See [Securing a Cluster](/cluster/#securing-a-cluster) for more details.

--- a/docs/6.x/pack.md
+++ b/docs/6.x/pack.md
@@ -467,7 +467,7 @@ systemOptions:
 
   # When set to true, allows running privileged containers in the deployed
   # clusters, defaults to false
-  allowPrivileged: true
+  allowPrivileged: false
 
 #
 # This section allows to disable pre-packaged system extensions that

--- a/docs/6.x/pack.md
+++ b/docs/6.x/pack.md
@@ -16,14 +16,14 @@ If you wish to package a cloud-native application into a Cluster Image, the
 application must run on Kubernetes. This means:
 
 * The application is packaged into Docker containers.
-* You have Kubernetes resource definitions for application services, pods, etc. 
+* You have Kubernetes resource definitions for application services, pods, etc.
 
 You can optionally use Helm charts for your application(s).
 
 !!! tip:
         For easy Kubernetes development while porting applications to
-        Kubernetes, we recommend [minikube](https://github.com/kubernetes/minikube), 
-        a Kubernetes distribution optimized to run on a developer's machine. 
+        Kubernetes, we recommend [minikube](https://github.com/kubernetes/minikube),
+        a Kubernetes distribution optimized to run on a developer's machine.
 
 ## Getting the Tools
 
@@ -33,7 +33,7 @@ Image. To get started, you need to [download Gravity](https://gravitational.com/
 !!! tip "Gravity Versions":
     For new users who are just exploring Gravity, we recommend the latest "pre-release" build. Make sure to select "Show pre-releases" selector. Production users must use the latest stable release.
 
-To create a Cluster Image, you will be using `tele`, the Gravity build tool. 
+To create a Cluster Image, you will be using `tele`, the Gravity build tool.
 Below is the list of `tele` commands:
 
 | Command        | Description |
@@ -49,7 +49,7 @@ Before creating a Cluster Image, you must create an _Image Manifest_ file. An
 Image Manifest uses the YAML file format to describe the image build and installation
 process and the system requirements for the Cluster. See the [Image Manifest](/pack/#image-manifest) section below for more details.
 
-After an Image Manifest is created, execute the `tele build` command to build 
+After an Image Manifest is created, execute the `tele build` command to build
 a Cluster Image.
 
 ```bsh
@@ -87,7 +87,7 @@ plugging them into a CI/CD pipeline.
 
 ```bsh
 # This Dockerfile builds a Docker image called `tele-buildbox`.  The
-# resulting container image will contain `tele` tool and can be used 
+# resulting container image will contain `tele` tool and can be used
 # to create Cluster images from within a container.
 
 FROM quay.io/gravitational/debian-grande:stretch
@@ -134,10 +134,10 @@ docker run -e OPS_URL=<opscenter url> \
 ## Image Manifest
 
 The Image Manifest is a YAML file that is passed as an input to `tele build`
-command. 
+command.
 
 The manifest concept was partially inspired by Dockerfiles and one can think of
-Image Manifest as a "dockerfile" for an entire Kubernetes Cluster, and the 
+Image Manifest as a "dockerfile" for an entire Kubernetes Cluster, and the
 resulting Cluster Image can be seen as a "container" for an entire Cluster.
 
 Below is an incomplete list of configurable settings. We have also included a sample Image Manifest further below with all the configurable settings.
@@ -171,13 +171,13 @@ The file format was designed to mimic a Kubernetes resource as much as possible
 and several Kubernetes concepts are used for efficiency, for example:
 
 1. Use standard Kubernetes [config maps](http://kubernetes.io/docs/user-guide/configmap/)
-   to manage application configuration. The Image Manifest should not be used 
+   to manage application configuration. The Image Manifest should not be used
    for this purpose.
 
 2. To customize the installation process, create regular [Kubernetes Services](http://kubernetes.io/docs/user-guide/services/)
    and tell Gravitiy to invoke them with the Image Manifest.
 
-3. You can define custom Cluster life cycle hooks like _install_, _uninstall_ or _update_ 
+3. You can define custom Cluster life cycle hooks like _install_, _uninstall_ or _update_
    using the Image Manifest, but the hooks themselves should be implemented as a regular
    [kubernetes jobs](http://kubernetes.io/docs/user-guide/jobs/).
 
@@ -190,13 +190,13 @@ manifest capabilities will be deprecated.
 
 Several Image Manifest fields, in addition to allowing literal strings
 for values, can also have their values populate from URIs during the build
-process. For this to work, they must begin with a URI schema, i.e. `file://` 
-or `https://`. The following fields can fetch their values from URIs: `.releaseNotes`, 
+process. For this to work, they must begin with a URI schema, i.e. `file://`
+or `https://`. The following fields can fetch their values from URIs: `.releaseNotes`,
 `.logo`, `.installer.eula.source`, `.installer.flavors.description`,
 `.providers.aws.terraform.script`, `.providers.aws.terraform.instanceScript`,
-`.hooks.*.job`. 
+`.hooks.*.job`.
 
-Below is the full Image Manifest format. The only mandatory data is the `metadata:` section. The other fields can be omitted and `tele build` will try to use 
+Below is the full Image Manifest format. The only mandatory data is the `metadata:` section. The other fields can be omitted and `tele build` will try to use
 sensible defaults.
 
 
@@ -268,20 +268,20 @@ providers:
 # Use the section below to customize the Cluster installer behavior
 #
 installer:
-  # The end user license agreement (EULA). When set, a user will be presented with 
+  # The end user license agreement (EULA). When set, a user will be presented with
   # the EULA text before the start of the installation and forced to accept it.
   # This capability is often used when Cluster images are used to distribute downloadable
   # enterprise software.
   eula:
     source: file://eula.txt
 
-  # If the installation flavors are defined, a Cluster user will be presented with a 
+  # If the installation flavors are defined, a Cluster user will be presented with a
   # prompt and the Cluster flavor will be selecte based on their answer.
   #
-  # A "Cluster flavor" consists of a name and a set of server profiles, along with the 
+  # A "Cluster flavor" consists of a name and a set of server profiles, along with the
   # number of servers for every profile.
   #
-  # The example below declares two flavors: "small" and "large", based on how many page 
+  # The example below declares two flavors: "small" and "large", based on how many page
   # views per second the Cluster user wants to serve.
   #
   flavors:
@@ -356,7 +356,7 @@ nodeProfiles:
 
       # This section allows to run custom pre-flight checks on a node before
       # allowing Cluster installation to continue (scripts must return 0 for success)
-      # Stdout/stderr output from pre-flight check scripts will be mirrored in 
+      # Stdout/stderr output from pre-flight check scripts will be mirrored in
       # the installation log.
       customChecks:
         - description: Custom check
@@ -444,7 +444,7 @@ nodeProfiles:
 license:
   enabled: true
 
-# 
+#
 # This section allows to configure the runtime behavior of a Kubernetes Cluster
 #
 systemOptions:
@@ -465,13 +465,16 @@ systemOptions:
     args: ["--system-reserved=memory=500Mi"]
     hairpinMode: "promiscuous-bridge"
 
+  # When set to true, allows running privileged containers in the deployed
+  # clusters, defaults to false
+  allowPrivileged: true
 
 #
 # This section allows to disable pre-packaged system extensions that
 # Gravitational includes into the base images by default (see below for more information).
 #
 extensions:
-  # This setting will not install system logging service and hide "logs tab" 
+  # This setting will not install system logging service and hide "logs tab"
   # in the Cluster UI
   logs:
     disabled: false
@@ -577,7 +580,7 @@ hooks:
   networkRollback:
 ```
 
-See [here](/requirements/#identifying-os-distributions-in-manifest) for a version 
+See [here](/requirements/#identifying-os-distributions-in-manifest) for a version
 matrix to help with specifying OS distribution requirements for a node profile.
 
 ## Cluster Hooks
@@ -772,13 +775,13 @@ installer:
 ## System Extensions
 
 By default, a Cluster Image contains several system services to provide
-Cluster logging, monitoring and application catalog (via Tiller) functionality. 
+Cluster logging, monitoring and application catalog (via Tiller) functionality.
 You may want to disable any of these components if you prefer to replace them with a solution of your choice. To do that, define the following section in the
 Image Manifest:
 
 ```yaml
 extensions:
-  # This setting will not install system logging service and hide "logs tab" 
+  # This setting will not install system logging service and hide "logs tab"
   # in the Cluster Control Panel UI
   logs:
     disabled: true
@@ -802,7 +805,7 @@ extensions:
 When Gravity creates a Cluster from a Cluster Image, it installs a
 special system container on each host, visible as the `gravity` daemon. It contains all of Kubernetes services, performs automatic management and isolates them from other pre-existing daemons running on Cluster hosts.
 
-All system services inside the container run under a special system user 
+All system services inside the container run under a special system user
 called `planet` with a UID of `1000`.
 
 Starting with LTS 4.54, Gravity allows the system user to be configured during
@@ -812,8 +815,8 @@ nodes of a Cluster.
 In order to configure the `planet` service user, you have the following options:
 
   * Create a user with the same UID on all Cluster nodes upfront.
-  * Specify a user ID on the installer's command line and a user named `planet` 
-    (and a group with the same name) will automatically be created with the given 
+  * Specify a user ID on the installer's command line and a user named `planet`
+    (and a group with the same name) will automatically be created with the given
     ID during installation.
 
 Here's an example of using a custom system user/group before starting the installation:
@@ -865,13 +868,13 @@ hook.
 ## Custom System Container
 
 When Gravity creates a Kubernetes Cluster from a Cluster Image, it installs a
-special system container or "Master Container" on each host. It is called "planet" 
-and visible as the `gravity` daemon. 
+special system container or "Master Container" on each host. It is called "planet"
+and visible as the `gravity` daemon.
 
 The Master Container contains all of Kubernetes services, performs automatic management and
-isolates them from other pre-existing daemons running on Cluster hosts. 
+isolates them from other pre-existing daemons running on Cluster hosts.
 
-`planet` is a Docker image maintained by Gravitational. At this moment `planet` 
+`planet` is a Docker image maintained by Gravitational. At this moment `planet`
 image is based on Debian 9. `planet` base image is published to a public Docker registry at
 `quay.io/gravitational/planet` so you can customize `planet` environment for
 your Clusters by using Gravitational's image as a base. Here's an example of a
@@ -907,5 +910,5 @@ nodeProfiles:
 
 When building a Cluster Image, `tele build` will discover `custom-planet:1.0.0`
 Docker image and vendor it along with other dependencies. During the Cluster
-installation all nodes with the role `worker` will use the custom "planet" Docker 
+installation all nodes with the role `worker` will use the custom "planet" Docker
 image instead of the default one.

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -503,6 +503,12 @@ func (env *LocalEnvironment) AppServiceLocal(config AppConfig) (service appbase.
 			return nil, trace.Wrap(err)
 		}
 	}
+
+	backend := env.Backend
+	if config.Backend != nil {
+		backend = config.Backend
+	}
+
 	var packages pack.PackageService
 	if config.Packages != nil {
 		packages = config.Packages
@@ -511,7 +517,7 @@ func (env *LocalEnvironment) AppServiceLocal(config AppConfig) (service appbase.
 	}
 
 	return appservice.New(appservice.Config{
-		Backend:      env.Backend,
+		Backend:      backend,
 		Packages:     packages,
 		DockerClient: dockerClient,
 		ImageService: imageService,
@@ -579,6 +585,9 @@ type AppConfig struct {
 	// Packages allow to override default env.Packages when creating
 	// an app service
 	Packages pack.PackageService
+	// Backend allows to override default env.Backend when creating
+	// an app service
+	Backend storage.Backend
 }
 
 // NewOpsClient creates a new client to Operator service using the specified

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1035,6 +1035,10 @@ func (s *site) getPlanetConfig(config planetConfig) (args []string, err error) {
 	// If the manifest contains an install hook to install a separate overlay network, disable flannel inside planet
 	if manifest.Hooks != nil && manifest.Hooks.NetworkInstall != nil {
 		args = append(args, "--disable-flannel=true")
+	}
+
+	if manifest.SystemOptions != nil && manifest.SystemOptions.AllowPrivileged {
+		args = append(args, "--allow-privileged=true")
 	}
 
 	for k, v := range overrideArgs {

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1001,6 +1001,9 @@ type SystemOptions struct {
 	BaseImage string `json:"baseImage,omitempty"`
 	// Dependencies defines additional package dependencies
 	Dependencies SystemDependencies `json:"dependencies"`
+	// AllowPrivileged controls whether privileged containers will be allowed
+	// in the cluster.
+	AllowPrivileged bool `json:"allowPrivileged,omitempty"`
 }
 
 // Runtime describes the application runtime

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -644,6 +644,7 @@ const manifestSchema = `
       "additionalProperties": false,
       "properties": {
         "baseImage": {"type": "string"},
+        "allowPrivileged": {"type": "boolean"},
         "args": {
           "type": "array",
           "items": {"type": "string"}

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -321,26 +321,7 @@ func checkForUpdate(
 		return nil, trace.Wrap(err)
 	}
 
-	clusterEnv, err := localenv.NewClusterEnvironment()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	clusterPackages, err := env.ClusterPackages()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Create the *local* app service that uses the cluster's backend and
-	// packages.
-	//
-	// The local service is needed to handle cases such as newly introduced
-	// manifest field which gravity-site which may be running the old code
-	// does not recognize.
-	apps, err := env.AppServiceLocal(localenv.AppConfig{
-		Backend:  clusterEnv.Backend,
-		Packages: clusterPackages,
-	})
+	apps, err := env.AppServiceCluster()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/ops.go
+++ b/tool/gravity/cli/ops.go
@@ -131,26 +131,12 @@ func uploadUpdate(env *localenv.LocalEnvironment, opsURL string) error {
 		}
 	}
 
-	clusterEnv, err := localenv.NewClusterEnvironment()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	clusterPackages, err := defaultEnv.ClusterPackages()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// Create the *local* app service that uses the cluster's backend and
-	// packages.
-	//
-	// The local service is needed to handle cases such as newly introduced
-	// manifest field which gravity-site which may be running the old code
-	// does not recognize.
-	clusterApps, err := defaultEnv.AppServiceLocal(localenv.AppConfig{
-		Backend:  clusterEnv.Backend,
-		Packages: clusterPackages,
-	})
+	clusterApps, err := defaultEnv.AppServiceCluster()
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR adds an additional boolean manifest field `systemOptions.allowPrivileged` that enables privileged containers in the cluster. Requires https://github.com/gravitational/planet/pull/476. Closes https://github.com/gravitational/gravity/issues/619.