### PR TITLE
(5.5) Wait for kube-system namespace.

### DIFF
--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -287,7 +287,7 @@ func (b *PlanBuilder) AddNodesPhase(plan *storage.OperationPlan) error {
 func (b *PlanBuilder) AddWaitPhase(plan *storage.OperationPlan) {
 	plan.Phases = append(plan.Phases, storage.OperationPhase{
 		ID:          phases.WaitPhase,
-		Description: "Wait for kubernetes to become available",
+		Description: "Wait for Kubernetes to become available",
 		Requires:    fsm.RequireIfPresent(plan, phases.MastersPhase, phases.NodesPhase),
 		Data: &storage.OperationPhaseData{
 			Server: &b.Master,


### PR DESCRIPTION
Backport https://github.com/gravitational/gravity/pull/493 to 5.5. Turns out I fixed this issue a couple of months ago but it didn't make it into 5.5.

Closes https://github.com/gravitational/gravity.e/issues/4207.