### PR TITLE
[5.5.x] package dependency/pull updates

### DIFF
--- a/lib/app/pull.go
+++ b/lib/app/pull.go
@@ -185,7 +185,7 @@ func (r Puller) pullPackage(loc loc.Locator) error {
 			return trace.Wrap(err)
 		}
 	}
-	logger.Debug("Pull package.")
+	logger.Info("Pull package.")
 	reader := ioutil.NopCloser(utils.NopReader())
 	if r.MetadataOnly {
 		env, err = r.SrcPack.ReadPackageEnvelope(loc)
@@ -260,7 +260,7 @@ func (r Puller) pullApp(loc loc.Locator) error {
 			return trace.Wrap(err)
 		}
 	}
-	logger.Debug("Pull application.")
+	logger.Info("Pull application.")
 	var env *pack.PackageEnvelope
 	reader := ioutil.NopCloser(utils.NopReader())
 	if r.MetadataOnly {
@@ -289,6 +289,14 @@ func (r Puller) pullApp(loc loc.Locator) error {
 	return trace.Wrap(err)
 }
 
+// onConflictDependencies returns the conflict handler for dealing with package
+// conflicts in application dependencies. When an application is pulled (or pushed)
+// from a service, the behavior regarding the conflicts is as following:
+//  * if a dependent (application) package already exists in the destination service,
+//    the operation does nothing or upserts the package (subject to upsert attribute)
+//  * if the top-level application package already exists in the destination service,
+//    the operation will ether fail with the corresponding error or upsert the package
+//    (subject to upsert attribute)
 func onConflictDependencies(upsert bool) conflictHandler {
 	if upsert {
 		return onConflictContinue

--- a/lib/builder/syncer.go
+++ b/lib/builder/syncer.go
@@ -100,13 +100,12 @@ func (s *s3Syncer) Sync(ctx context.Context, builder *Builder, runtimeVersion se
 		return trace.Wrap(err)
 	}
 	puller := libapp.Puller{
-		FieldLogger:  builder.FieldLogger,
-		SrcPack:      env.Packages,
-		SrcApp:       tarballApps,
-		DstPack:      builder.Env.Packages,
-		DstApp:       cacheApps,
-		Parallel:     builder.VendorReq.Parallel,
-		SkipIfExists: true,
+		FieldLogger: builder.FieldLogger,
+		SrcPack:     env.Packages,
+		SrcApp:      tarballApps,
+		DstPack:     builder.Env.Packages,
+		DstApp:      cacheApps,
+		Parallel:    builder.VendorReq.Parallel,
 	}
 	return puller.PullAppDeps(ctx, builder.appForRuntime(runtimeVersion))
 }
@@ -134,13 +133,12 @@ func (s *packSyncer) Sync(ctx context.Context, builder *Builder, runtimeVersion 
 		return trace.Wrap(err)
 	}
 	puller := libapp.Puller{
-		FieldLogger:  builder.FieldLogger,
-		SrcPack:      s.pack,
-		SrcApp:       s.apps,
-		DstPack:      builder.Env.Packages,
-		DstApp:       cacheApps,
-		Parallel:     builder.VendorReq.Parallel,
-		SkipIfExists: true,
+		FieldLogger: builder.FieldLogger,
+		SrcPack:     s.pack,
+		SrcApp:      s.apps,
+		DstPack:     builder.Env.Packages,
+		DstApp:      cacheApps,
+		Parallel:    builder.VendorReq.Parallel,
 	}
 	err = puller.PullAppDeps(ctx, builder.appForRuntime(runtimeVersion))
 	if err != nil {


### PR DESCRIPTION
 * Enable parallel pull for application packages.
 * Update package conflict handling during pulls to avoid introducing inflexible control attributes (`SkipIfExists`). This also reverts the application pull logic behavior.