### PR TITLE
(5.5) Make sure leader agent runs on current node.

### DIFF
--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -109,6 +109,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 		clusterName:  cluster.Domain,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
+		leader:       leader,
 		nodeParams:   constants.RPCAgentSyncPlanFunction,
 	})
 	deployCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)


### PR DESCRIPTION
Looks like this logic got lost somehow in-between b/c it's present in 5.2 and 6.0.