### PR TITLE
[5.2.x] translate the teleport configuration package to specific server

### DIFF
--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -146,7 +146,11 @@ func (s *ProvisionedServer) InGravity(dir ...string) string {
 var suffixer = strings.NewReplacer(".", "", ":", "")
 
 func PackageSuffix(node remoteServer, domain string) string {
-	data := fmt.Sprintf("%v.%v", node.Address(), domain)
+	return PackageSuffixForAddr(node.Address(), domain)
+}
+
+func PackageSuffixForAddr(addr, domain string) string {
+	data := fmt.Sprintf("%v.%v", addr, domain)
 	return suffixer.Replace(data)
 }
 

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
@@ -309,8 +310,20 @@ func rotateTeleportConfig(env *localenv.LocalEnvironment, pkg *loc.Locator, oper
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	env.Println(configPackage.String())
+	configPackageForServer := teleportConfigPackageForServer(*configPackage, serverAddr, cluster.Domain)
+	env.Println(configPackageForServer.String())
 	return nil
+}
+
+// teleportConfigPackageForServer translates the local teleport configuration package
+// to reference the package on server given with addr.
+// Returns the new package name
+func teleportConfigPackageForServer(configPackage loc.Locator, addr, clusterName string) loc.Locator {
+	return loc.Locator{
+		Repository: configPackage.Repository,
+		Name:       configPackage.Name,
+		Version:    fmt.Sprintf("0.0.1-%v", opsservice.PackageSuffixForAddr(addr, clusterName)),
+	}
 }
 
 func checkCanUpdate(cluster ops.Site, operator ops.Operator, manifest schema.Manifest) error {


### PR DESCRIPTION
when reporting the package as a result of rotate API - the expectation is that rotating configuration package works from an arbitrary master node and it's not the case for `5.2.x` with binary-based rotation.