### PR TITLE
[5.2.x] bump go to 1.12.9 to fix proto compilation issue

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/debian-venti:go1.10.3-stretch
+FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
 
 ARG PROTOC_VER
 ARG PROTOC_PLATFORM


### PR DESCRIPTION
The original problem is that the github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/genswagger has been updated a couple of days ago with code only compatible with go1.12 and we `go get -u` it inside the buildbox to build GRPC packages.
Will need to tailor the Makefile to avoid such failures in future by not `go get`ting but this should suffice for now.