### PR TITLE
 CVE-2019-11251 (5.5.x)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ GRAVITY_PKG_PATH ?= github.com/gravitational/gravity
 ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
-# Current Kubernetes version: 1.13.10
-K8S_VER := 1.13.10
+# Current Kubernetes version
+K8S_VER := 1.13.11
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
@@ -42,7 +42,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.0.5
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 5.5.26-$(K8S_VER_SUFFIX)
+PLANET_TAG := 5.5.27-$(K8S_VER_SUFFIX)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)

--- a/lib/update/cluster/phases/etcd.go
+++ b/lib/update/cluster/phases/etcd.go
@@ -128,7 +128,7 @@ func NewPhaseUpgradeEtcdShutdown(phase storage.OperationPhase, client *kubeapi.C
 
 func (p *PhaseUpgradeEtcdShutdown) Execute(ctx context.Context) error {
 	p.Info("Shutdown etcd.")
-	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "disable")
+	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "disable", "--stop-api")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -297,7 +297,7 @@ func (p *PhaseUpgradeEtcdRestart) Execute(ctx context.Context) error {
 
 func (p *PhaseUpgradeEtcdRestart) Rollback(ctx context.Context) error {
 	p.Info("Reenable etcd upgrade service.")
-	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "disable")
+	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "disable", "--stop-api")
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
- bump kubernetes for CVE-2019-11251
- Invoke etcd stability workaround during etcd upgrades