### PR TITLE
[5.2.x] select teleport configuration package compatible with the branch

### DIFF
--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -260,4 +260,7 @@ var (
 	// WebAssetsPackageLocator is the package with web assets
 	WebAssetsPackageLocator = MustParseLocator(
 		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, "web-assets", ZeroVersion))
+
+	// BaseVersion defines the base version of a package
+	BaseVersion = semver.New("0.0.1")
 )


### PR DESCRIPTION
Otherwise it is possible that the state import uses the "wrong" configuration package (and it does fail now that the teleport configuration format has been updated in one of the recent PRs). 