### PR TITLE
[5.5.x] teleport configuration naming changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ ARCH := $(shell uname -m)
 CURRENT_COMMIT := $(shell git rev-parse HEAD)
 VERSION_FLAGS := -X github.com/gravitational/gravity/vendor/github.com/gravitational/version.gitCommit=$(CURRENT_COMMIT) \
 	-X github.com/gravitational/gravity/vendor/github.com/gravitational/version.version=$(GRAVITY_VERSION) \
-	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG)
+	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG) \
+	-X github.com/gravitational/gravity/lib/defaults.TeleportVersionString=$(TELEPORT_TAG)
 GRAVITY_LINKFLAGS = "$(VERSION_FLAGS) $(GOLFLAGS)"
 
 TELEKUBE_GRAVITY_PKG := gravitational.io/gravity_$(OS)_$(ARCH):$(GRAVITY_TAG)

--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -158,6 +158,8 @@ spec:
               configMapKeyRef:
                 name: gravity-opscenter
                 key: teleport.yaml
+          - name: GRAVITY_TELEPORT_VERSION
+            value: "${TELEPORT_TAG}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -158,8 +158,6 @@ spec:
               configMapKeyRef:
                 name: gravity-opscenter
                 key: teleport.yaml
-          - name: GRAVITY_TELEPORT_VERSION
-            value: "${TELEPORT_TAG}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -382,9 +382,8 @@ tiller-app:
 site-app:
 	$(eval TMPDIR := $(shell mktemp -d --tmpdir=$(GRAVITY_BUILDDIR)))
 	@echo -e "\n----> Building site-app...\n"
-	env | grep -i teleport
 	cp -r $(ASSETSDIR)/site-app/* $(TMPDIR)
-	sed -e "s/\$${TELEPORT_TAG}/$(TELEPORT_TAG)/" $(TMPDIR)/resources/site.yaml
+	sed --expression "s/\$${TELEPORT_TAG}/$(TELEPORT_TAG)/" --in-place $(TMPDIR)/resources/site.yaml
 	cp $(GRAVITY_BUILDDIR)/gravity $(TMPDIR)/images/site
 	cd $(TMPDIR) && VERSION=$(GRAVITY_TAG) GRAVITY="$(GRAVITY)" OPS_URL=$(OPS_URL) make import
 	$(GRAVITY) package export $(SITE_APP_PKG) $(SITE_APP_OUT)

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -383,7 +383,6 @@ site-app:
 	$(eval TMPDIR := $(shell mktemp -d --tmpdir=$(GRAVITY_BUILDDIR)))
 	@echo -e "\n----> Building site-app...\n"
 	cp -r $(ASSETSDIR)/site-app/* $(TMPDIR)
-	sed --expression "s/\$${TELEPORT_TAG}/$(TELEPORT_TAG)/" --in-place $(TMPDIR)/resources/site.yaml
 	cp $(GRAVITY_BUILDDIR)/gravity $(TMPDIR)/images/site
 	cd $(TMPDIR) && VERSION=$(GRAVITY_TAG) GRAVITY="$(GRAVITY)" OPS_URL=$(OPS_URL) make import
 	$(GRAVITY) package export $(SITE_APP_PKG) $(SITE_APP_OUT)

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -381,7 +381,10 @@ tiller-app:
 .PHONY: site-app
 site-app:
 	$(eval TMPDIR := $(shell mktemp -d --tmpdir=$(GRAVITY_BUILDDIR)))
+	@echo -e "\n----> Building site-app...\n"
+	env | grep -i teleport
 	cp -r $(ASSETSDIR)/site-app/* $(TMPDIR)
+	sed -e "s/\$${TELEPORT_TAG}/$(TELEPORT_TAG)/" $(TMPDIR)/resources/site.yaml
 	cp $(GRAVITY_BUILDDIR)/gravity $(TMPDIR)/images/site
 	cd $(TMPDIR) && VERSION=$(GRAVITY_TAG) GRAVITY="$(GRAVITY)" OPS_URL=$(OPS_URL) make import
 	$(GRAVITY) package export $(SITE_APP_PKG) $(SITE_APP_OUT)

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -416,10 +416,6 @@ const (
 	// EnvGravityTeleportConfig is environment variable setting debugging mode
 	EnvGravityTeleportConfig = "GRAVITY_TELEPORT_CONFIG"
 
-	// EnvGravityTeleportVersion is the environment variable that specifies the version of
-	// the bundled teleport
-	EnvGravityTeleportVersion = "GRAVITY_TELEPORT_VERSION"
-
 	// EnvNetworkingType specifies the name of environment variable for defining networking type for kubernetes
 	EnvNetworkingType = "KUBERNETES_NETWORKING"
 

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -416,6 +416,10 @@ const (
 	// EnvGravityTeleportConfig is environment variable setting debugging mode
 	EnvGravityTeleportConfig = "GRAVITY_TELEPORT_CONFIG"
 
+	// EnvGravityTeleportVersion is the environment variable that specifies the version of
+	// the bundled teleport
+	EnvGravityTeleportVersion = "GRAVITY_TELEPORT_VERSION"
+
 	// EnvNetworkingType specifies the name of environment variable for defining networking type for kubernetes
 	EnvNetworkingType = "KUBERNETES_NETWORKING"
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1134,6 +1134,12 @@ var (
 		"hmac-sha2-256-etm@openssh.com",
 		"hmac-sha2-256",
 	}
+
+	// TeleportVersionString specifies the version of the bundled teleport package
+	TeleportVersionString = "<build param>"
+
+	// TeleportVersion specifies the version of the bundled teleport package as a semver
+	TeleportVersion = semver.New(TeleportVersionString)
 )
 
 // HookSecurityContext returns default securityContext for hook pods

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1136,7 +1136,7 @@ var (
 	}
 
 	// TeleportVersionString specifies the version of the bundled teleport package
-	TeleportVersionString = "<build param>"
+	TeleportVersionString = "0.0.1" // Will be replaced with actual version at link time
 
 	// TeleportVersion specifies the version of the bundled teleport package as a semver
 	TeleportVersion = semver.New(TeleportVersionString)

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -847,6 +847,8 @@ type RotateTeleportConfigRequest struct {
 	Server storage.Server `json:"server"`
 	// MasterIPs lists IP addresses of all cluster master servers
 	MasterIPs []string `json:"masters"`
+	// TeleportPackage specifies the teleport package locator
+	TeleportPackage loc.Locator `json:"teleport_package"`
 	// Master specifies the configuration package to use for the cluster controller teleport service.
 	// If unspecified, one will be automatically generated
 	Master *loc.Locator `json:"master,omitempty"`

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1462,31 +1462,6 @@ func (s *site) planetConfigPackage(node remoteServer, version string) loc.Locato
 	}
 }
 
-// FIXME: remove me
-// // serverPackages returns a list of package locators specific to the provided server
-// func (s *site) serverPackages(server *ProvisionedServer) ([]loc.Locator, error) {
-// 	masterConfigPackage := s.teleportMasterConfigPackage(server)
-// 	nodeConfigPackage := s.teleportNodeConfigPackage(server)
-// 	if err != nil {
-// 		return nil, trace.Wrap(err)
-// 	}
-// 	planetPackage, err := s.app.Manifest.RuntimePackageForProfile(server.Role)
-// 	if err != nil {
-// 		return nil, trace.Wrap(err)
-// 	}
-// 	planetSecretsPackage, err := s.planetSecretsPackage(server, planetPackage.Version)
-// 	if err != nil {
-// 		return nil, trace.Wrap(err)
-// 	}
-// 	planetConfigPackage := s.planetConfigPackage(server, planetPackage.Version)
-// 	return []loc.Locator{
-// 		masterConfigPackage,
-// 		nodeConfigPackage,
-// 		planetSecretsPackage,
-// 		planetConfigPackage,
-// 	}, nil
-// }
-
 func (s *site) addCloudConfig(config clusterconfig.Interface) (args []string) {
 	if s.cloudProviderName() == "" {
 		return nil

--- a/lib/ops/opsservice/packages.go
+++ b/lib/ops/opsservice/packages.go
@@ -1,0 +1,143 @@
+package opsservice
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/loc"
+)
+
+// planetSecretsNextPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetSecretsNextPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetSecretsNextPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetSecretsPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetNextConfigPackage generates a new planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetNextConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetConfigPackage generates a planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// teleportNextNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextNodeConfigPackage(node remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportNodeConfigPackage(node remoteServer) loc.Locator {
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+// teleportNextMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextMasterConfigPackage(master remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportMasterConfigPackage(master remoteServer) loc.Locator {
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+func teleportMasterConfigPackage(master remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportMasterConfigPackage,
+			PackageSuffix(master, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+func planetSecretsPackage(node *ProvisionedServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       fmt.Sprintf("planet-%v-secrets", node.AdvertiseIP),
+		Version:    planetVersion,
+	}
+}
+
+// planetConfigPackage creates a planet configuration package reference
+// using the specified version as a package version and the given node to add unique
+// suffix to the name.
+// This is in contrast to the old naming with PackageSuffix used as a prerelease part
+// of the version which made them hard to match when looking for an update.
+func planetConfigPackage(node remoteServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.PlanetConfigPackage,
+			PackageSuffix(node, clusterName)),
+		Version: planetVersion,
+	}
+}
+
+func teleportNodeConfigPackage(node remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportNodeConfigPackage,
+			PackageSuffix(node, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+// suffixer replaces characters unacceptable as a package suffix
+var suffixer = strings.NewReplacer(".", "", ":", "")
+
+func PackageSuffix(node remoteServer, domain string) string {
+	data := fmt.Sprintf("%v.%v", node.Address(), domain)
+	return suffixer.Replace(data)
+}

--- a/lib/ops/opsservice/packages.go
+++ b/lib/ops/opsservice/packages.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package opsservice
 
 import (
@@ -20,7 +36,7 @@ func (s *site) planetSecretsNextPackage(node *ProvisionedServer, planetVersion s
 	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
 }
 
-// planetSecretsNextPackage generates a new planet secrets package name for the specified
+// planetSecretsPackage generates a new planet secrets package name for the specified
 // node and planet package version.
 //
 // The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>'
@@ -108,11 +124,6 @@ func planetSecretsPackage(node *ProvisionedServer, repository, clusterName, plan
 	}
 }
 
-// planetConfigPackage creates a planet configuration package reference
-// using the specified version as a package version and the given node to add unique
-// suffix to the name.
-// This is in contrast to the old naming with PackageSuffix used as a prerelease part
-// of the version which made them hard to match when looking for an update.
 func planetConfigPackage(node remoteServer, repository, clusterName, planetVersion string) loc.Locator {
 	return loc.Locator{
 		Repository: repository,
@@ -137,7 +148,9 @@ func teleportNodeConfigPackage(node remoteServer, repository, clusterName, telep
 // suffixer replaces characters unacceptable as a package suffix
 var suffixer = strings.NewReplacer(".", "", ":", "")
 
-func PackageSuffix(node remoteServer, domain string) string {
-	data := fmt.Sprintf("%v.%v", node.Address(), domain)
+// PackageSuffix returns a new package suffix used in package names
+// from the specified node address and given cluster name
+func PackageSuffix(node remoteServer, clusterName string) string {
+	data := fmt.Sprintf("%v.%v", node.Address(), clusterName)
 	return suffixer.Replace(data)
 }

--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -149,14 +149,6 @@ func (s *ProvisionedServer) InGravity(dir ...string) string {
 	return filepath.Join(append([]string{s.StateDir()}, dir...)...)
 }
 
-// suffixer replaces characters unacceptable as a package suffix
-var suffixer = strings.NewReplacer(".", "", ":", "")
-
-func PackageSuffix(node remoteServer, domain string) string {
-	data := fmt.Sprintf("%v.%v", node.Address(), domain)
-	return suffixer.Replace(data)
-}
-
 func FQDN(domain, hostname, ip string) string {
 	// in case hostname comes already with this domain suffix,
 	// we assume that it's set by provisioner or user in on-prem

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -660,25 +660,23 @@ func (s *site) serfNodeLeave(runner *serverRunner) error {
 }
 
 func (s *site) isTeleportMasterConfigPackageFor(server *ProvisionedServer, loc loc.Locator) bool {
-	// Version omitted on purpose - only repository/name are used for matching
-	configPackage := s.teleportMasterConfigPackage(server, "")
+	configPackage := s.teleportMasterConfigPackage(server)
 	return configPackage.Name == loc.Name && configPackage.Repository == loc.Repository
 }
 
 func (s *site) isTeleportNodeConfigPackageFor(server *ProvisionedServer, loc loc.Locator) bool {
-	// Version omitted on purpose - only repository/name are used for matching
-	configPackage := s.teleportNodeConfigPackage(server, "")
+	configPackage := s.teleportNodeConfigPackage(server)
 	return configPackage.Name == loc.Name && configPackage.Repository == loc.Repository
 }
 
 func (s *site) isPlanetConfigPackageFor(server *ProvisionedServer, loc loc.Locator) bool {
-	// Version omitted on purpose - only repository/name are used for matching
+	// Version omitted on purpose since only repository/name are used for comparison
 	configPackage := s.planetConfigPackage(server, "")
 	return configPackage.Name == loc.Name && configPackage.Repository == loc.Repository
 }
 
 func (s *site) isPlanetSecretsPackageFor(server *ProvisionedServer, loc loc.Locator) bool {
-	// Version omitted on purpose - only repository/name are used for matching
+	// Version omitted on purpose since only repository/name are used for comparison
 	configPackage := s.planetSecretsPackage(server, "")
 	return configPackage.Name == loc.Name && configPackage.Repository == loc.Repository
 }

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -568,7 +568,7 @@ func (s *site) deletePackages(server *ProvisionedServer) error {
 			packages = append(packages, env.Locator)
 			return nil
 		}
-		// Consider packages where the node address is part of the package name
+		// Also consider node-specific packages
 		if s.isTeleportMasterConfigPackageFor(server, env.Locator) ||
 			s.isTeleportNodeConfigPackageFor(server, env.Locator) ||
 			s.isPlanetConfigPackageFor(server, env.Locator) ||

--- a/lib/pack/utils.go
+++ b/lib/pack/utils.go
@@ -384,20 +384,6 @@ func FindLatestPackage(packages PackageService, filter loc.Locator) (*loc.Locato
 	return loc, trace.Wrap(err)
 }
 
-// FindLatestPackageByName returns latest package with the specified name (across all repositories)
-func FindLatestPackageByName(packages PackageService, name string) (*loc.Locator, error) {
-	loc, err := FindLatestPackageCustom(FindLatestPackageRequest{
-		Packages: packages,
-		Match: func(e PackageEnvelope) bool {
-			return e.Locator.Name == name
-		}},
-	)
-	if err != nil && trace.IsNotFound(err) {
-		return nil, trace.NotFound("latest package with name %q not found", name)
-	}
-	return loc, trace.Wrap(err)
-}
-
 // FindLatestPackageCustom searches for the latest version of the package given with req
 func FindLatestPackageCustom(req FindLatestPackageRequest) (pkg *loc.Locator, err error) {
 	if err := req.checkAndSetDefaults(); err != nil {

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -112,14 +112,10 @@ func (i *importer) Close() error {
 
 // getMasterTeleportConfig extracts configuration from teleport package
 func (i *importer) getMasterTeleportConfig(clusterName string) (*telecfg.FileConfig, error) {
-	teleportVersion, err := semver.NewVersion(os.Getenv(constants.EnvGravityTeleportVersion))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	configPackage, err := pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
 		Packages:   i.packages,
 		Repository: clusterName,
-		Match:      matchTeleportConfigPackage(*teleportVersion),
+		Match:      matchTeleportConfigPackage(*defaults.TeleportVersion),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -404,18 +404,18 @@ func (p *Process) getTeleportConfigFromImportState() (*telecfg.FileConfig, error
 		return nil, nil
 	}
 
-	cluster, err := p.operator.GetLocalSite()
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	importer, err := newImporter(p.cfg.ImportDir, *cluster)
+	importer, err := newImporter(p.cfg.ImportDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer importer.Close()
 
-	telecfg, err := importer.getMasterTeleportConfig()
+	telecfg, err := importer.getMasterTeleportConfig(cluster.App.Manifest, cluster.Domain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -435,13 +435,8 @@ func (p *Process) ImportState(importDir string) (err error) {
 		return nil
 	}
 
-	cluster, err := p.operator.GetLocalSite()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	p.Debugf("Init from %q.", importDir)
-	importer, err := newImporter(importDir, *cluster)
+	importer, err := newImporter(importDir)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -404,7 +404,12 @@ func (p *Process) getTeleportConfigFromImportState() (*telecfg.FileConfig, error
 		return nil, nil
 	}
 
-	importer, err := newImporter(p.cfg.ImportDir)
+	cluster, err := p.operator.GetLocalSite()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	importer, err := newImporter(p.cfg.ImportDir, *cluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -430,8 +435,13 @@ func (p *Process) ImportState(importDir string) (err error) {
 		return nil
 	}
 
+	cluster, err := p.operator.GetLocalSite()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	p.Debugf("Init from %q.", importDir)
-	importer, err := newImporter(importDir)
+	importer, err := newImporter(importDir, *cluster)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -415,7 +415,7 @@ func (p *Process) getTeleportConfigFromImportState() (*telecfg.FileConfig, error
 	}
 	defer importer.Close()
 
-	telecfg, err := importer.getMasterTeleportConfig(cluster.App.Manifest, cluster.Domain)
+	telecfg, err := importer.getMasterTeleportConfig(cluster.Domain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/rpc/server/peers.go
+++ b/lib/rpc/server/peers.go
@@ -102,7 +102,7 @@ func (r *peers) tryPeer(ctx context.Context, peer *peer) error {
 }
 
 func (r *peers) monitorPeers() {
-	log := r.WithField("health.checker", r)
+	log := r.WithField("health.checker", r.String())
 	log.Info("Monitoring peers.")
 	defer log.Info("Health checker loop closing.")
 	for {

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -235,10 +235,11 @@ func (p *updatePhaseBootstrapLeader) rotatePlanetConfig(server storage.UpdateSer
 
 func (p *updatePhaseBootstrapLeader) rotateTeleportConfig(server storage.UpdateServer) error {
 	masterConf, nodeConf, err := p.packageRotator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-		Key:         p.bootstrap.Operation.Key(),
-		Server:      server.Server,
-		NodePackage: server.Teleport.Update.NodeConfigPackage,
-		MasterIPs:   p.masterIPs,
+		Key:             p.bootstrap.Operation.Key(),
+		Server:          server.Server,
+		TeleportPackage: server.Teleport.Update.Package,
+		NodePackage:     server.Teleport.Update.NodeConfigPackage,
+		MasterIPs:       p.masterIPs,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/update/cluster/steps.go
+++ b/lib/update/cluster/steps.go
@@ -205,9 +205,10 @@ func (r phaseBuilder) intermediateConfigUpdates(
 		}
 		if updateTeleport != nil {
 			_, nodeConfig, err := operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-				Key:    r.operation.Key(),
-				Server: server,
-				DryRun: true,
+				Key:             r.operation.Key(),
+				Server:          server,
+				TeleportPackage: *updateTeleport,
+				DryRun:          true,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
@@ -287,9 +288,10 @@ func (r phaseBuilder) configUpdates(
 		}
 		if needsTeleportUpdate {
 			_, nodeConfig, err := r.operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-				Key:    r.operation.Key(),
-				Server: server,
-				DryRun: true,
+				Key:             r.operation.Key(),
+				Server:          server,
+				TeleportPackage: r.updateTeleport,
+				DryRun:          true,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR updates the naming scheme for teleport configuration packages to match planet config/secrets package naming in that the package version equals to that of the bundled package (`teleport` or `planet`) and all config updates are performed by issuing increments in semver metadata.

Updates https://github.com/gravitational/gravity.e/issues/4219.