### PR TITLE
Add ability for tele to accept credentials on CLI.

### DIFF
--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -72,8 +72,6 @@ type Config struct {
 	Overwrite bool
 	// Repository represents the source package repository
 	Repository string
-	// StaticCredentials is the credentials set on the CLI
-	StaticCredentials *credentials.Credentials
 	// SkipVersionCheck allows to skip tele/runtime compatibility check
 	SkipVersionCheck bool
 	// VendorReq combines vendoring options
@@ -84,8 +82,10 @@ type Config struct {
 	NewSyncer NewSyncerFunc
 	// GetRepository is a function that returns package source repository
 	GetRepository GetRepositoryFunc
-	// Credentials provides access to user credentials
-	Credentials credentials.Service
+	// CredentialsService provides access to user credentials
+	CredentialsService credentials.Service
+	// Credentials is the credentials set on the CLI
+	Credentials *credentials.Credentials
 	// FieldLogger is used for logging
 	logrus.FieldLogger
 	// Progress allows builder to report build progress
@@ -129,10 +129,10 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.GetRepository == nil {
 		c.GetRepository = getRepository
 	}
-	if c.Credentials == nil {
-		c.Credentials, err = credentials.New(credentials.Config{
+	if c.CredentialsService == nil {
+		c.CredentialsService, err = credentials.New(credentials.Config{
 			LocalKeyStoreDir: c.StateDir,
-			Static:           c.StaticCredentials,
+			Credentials:      c.Credentials,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -428,7 +428,7 @@ func (b *Builder) makeBuildEnv() (*localenv.LocalEnvironment, error) {
 			StateDir:         b.StateDir,
 			LocalKeyStoreDir: b.StateDir,
 			Insecure:         b.Insecure,
-			Credentials:      b.StaticCredentials,
+			Credentials:      b.Credentials,
 		})
 	}
 	// otherwise use default locations for cache / key store
@@ -444,7 +444,7 @@ func (b *Builder) makeBuildEnv() (*localenv.LocalEnvironment, error) {
 	return localenv.NewLocalEnvironment(localenv.LocalEnvironmentArgs{
 		StateDir:    cacheDir,
 		Insecure:    b.Insecure,
-		Credentials: b.StaticCredentials,
+		Credentials: b.Credentials,
 	})
 }
 

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -72,6 +72,8 @@ type Config struct {
 	Overwrite bool
 	// Repository represents the source package repository
 	Repository string
+	// StaticCredentials is the credentials set on the CLI
+	StaticCredentials *credentials.Credentials
 	// SkipVersionCheck allows to skip tele/runtime compatibility check
 	SkipVersionCheck bool
 	// VendorReq combines vendoring options
@@ -130,6 +132,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Credentials == nil {
 		c.Credentials, err = credentials.New(credentials.Config{
 			LocalKeyStoreDir: c.StateDir,
+			Static:           c.StaticCredentials,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -425,6 +428,7 @@ func (b *Builder) makeBuildEnv() (*localenv.LocalEnvironment, error) {
 			StateDir:         b.StateDir,
 			LocalKeyStoreDir: b.StateDir,
 			Insecure:         b.Insecure,
+			Credentials:      b.StaticCredentials,
 		})
 	}
 	// otherwise use default locations for cache / key store
@@ -438,8 +442,9 @@ func (b *Builder) makeBuildEnv() (*localenv.LocalEnvironment, error) {
 	}
 	b.Infof("Using package cache from %v.", cacheDir)
 	return localenv.NewLocalEnvironment(localenv.LocalEnvironmentArgs{
-		StateDir: cacheDir,
-		Insecure: b.Insecure,
+		StateDir:    cacheDir,
+		Insecure:    b.Insecure,
+		Credentials: b.StaticCredentials,
 	})
 }
 

--- a/lib/localenv/credentials/credentials.go
+++ b/lib/localenv/credentials/credentials.go
@@ -20,6 +20,7 @@ limitations under the License.
 //   * Gravity local key store.
 //   * Teleport local key store.
 //   * Bolt database backend.
+//   * Preconfigured set of credentials provided on the command line.
 package credentials
 
 import (
@@ -105,8 +106,8 @@ type Config struct {
 	TeleportKeyStoreDir string
 	// Backend is the optional backend for login entries stored in database.
 	Backend storage.Backend
-	// Static is the static preconfigured credentials entry.
-	Static *Credentials
+	// Credentials is the preconfigured credentials entry.
+	Credentials *Credentials
 }
 
 // New creates a new credentials service with the provided config.
@@ -149,10 +150,10 @@ func (s *credentialsService) For(clusterURL string) (*Credentials, error) {
 		return nil, trace.Wrap(err)
 	}
 	// If the preconfigured credentials are set, try to use them.
-	if s.Static != nil && utils.StringInSlice([]string{url.normalized, url.original}, s.Static.URL) {
-		if s.Static.Entry.Password != "" {
-			s.Debugf("Returning static credentials for %v.", s.Static.URL)
-			return s.Static, nil
+	if s.Credentials != nil && utils.StringInSlice([]string{url.normalized, url.original}, s.Credentials.URL) {
+		if s.Credentials.Entry.Password != "" {
+			s.Debugf("Returning static credentials for %v.", s.Credentials.URL)
+			return s.Credentials, nil
 		}
 	}
 	// Search the local Gravity keystore first (~/.gravity/config).
@@ -229,8 +230,8 @@ func (s *credentialsService) getTeleportKeyStore() (*client.FSLocalKeyStore, err
 
 // currentCluster returns the currently active cluster.
 func (s *credentialsService) currentCluster() (string, error) {
-	if s.Static != nil {
-		return s.Static.URL, nil
+	if s.Credentials != nil {
+		return s.Credentials.URL, nil
 	}
 	localKeyStore, err := s.getLocalKeyStore()
 	if err != nil {

--- a/lib/localenv/credentials/credentials.go
+++ b/lib/localenv/credentials/credentials.go
@@ -187,7 +187,28 @@ func (s *credentialsService) For(clusterURL string) (*Credentials, error) {
 		s.Debugf("Returning default credentials for %v.", clusterURL)
 		return defaultCredentials, nil
 	}
-	return nil, trace.AccessDenied("no credentials for %v", clusterURL)
+	return nil, newCredentialsNotFoundError("no credentials for %v", clusterURL)
+}
+
+// credentialsNotFoundError is returned if requested credentials weren't found.
+type credentialsNotFoundError struct {
+	message string
+}
+
+// newCredentialsNotFoundError returns a new instance of credentials not found error.
+func newCredentialsNotFoundError(format string, args ...interface{}) *credentialsNotFoundError {
+	return &credentialsNotFoundError{message: fmt.Sprintf(format, args...)}
+}
+
+// Error returns the error's message.
+func (e *credentialsNotFoundError) Error() string {
+	return e.message
+}
+
+// IsCredentialsNotFoundError returns true if the provided error is the credentials not found.
+func IsCredentialsNotFoundError(err error) bool {
+	_, ok := err.(*credentialsNotFoundError)
+	return ok
 }
 
 // Current returns the currently active user credentials.

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -79,6 +79,10 @@ type LocalEnvironmentArgs struct {
 	// ReadonlyBackend specifies if the backend should be opened
 	// read-only.
 	ReadonlyBackend bool
+	// Credentials is the predefined static credentials entry
+	Credentials *credentials.Credentials
+	// Close allows to perform extra cleanup actions
+	Close func() error
 }
 
 // Addr returns the first listen address of the DNS server
@@ -189,6 +193,7 @@ func (env *LocalEnvironment) init() error {
 	env.Credentials, err = credentials.New(credentials.Config{
 		LocalKeyStoreDir: env.LocalKeyStoreDir,
 		Backend:          env.Backend,
+		Static:           env.LocalEnvironmentArgs.Credentials,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -200,6 +205,10 @@ func (env *LocalEnvironment) init() error {
 // Close closes backend and object storage used in LocalEnvironment
 func (env *LocalEnvironment) Close() error {
 	var errors []error
+	if env.LocalEnvironmentArgs.Close != nil {
+		errors = append(errors, env.LocalEnvironmentArgs.Close())
+		env.LocalEnvironmentArgs.Close = nil
+	}
 	if env.Backend != nil {
 		errors = append(errors, env.Backend.Close())
 		env.Backend = nil

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -193,7 +193,7 @@ func (env *LocalEnvironment) init() error {
 	env.Credentials, err = credentials.New(credentials.Config{
 		LocalKeyStoreDir: env.LocalKeyStoreDir,
 		Backend:          env.Backend,
-		Static:           env.LocalEnvironmentArgs.Credentials,
+		Credentials:      env.LocalEnvironmentArgs.Credentials,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/localenv/localenv_test.go
+++ b/lib/localenv/localenv_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/localenv/credentials"
 	"github.com/gravitational/gravity/lib/utils"
 
-	"github.com/gravitational/trace"
 	"gopkg.in/check.v1"
 )
 
@@ -59,11 +59,11 @@ func (s *LocalEnvSuite) TestParsedUnparsedOpsCenters(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
+	c.Assert(credentials.IsCredentialsNotFoundError(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	login, err = env.Credentials.For(parsedOpsCenter)
-	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
+	c.Assert(credentials.IsCredentialsNotFoundError(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)
@@ -74,7 +74,7 @@ func (s *LocalEnvSuite) TestParsedUnparsedOpsCenters(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err = env.Credentials.For(parsedOpsCenter)
-	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
+	c.Assert(credentials.IsCredentialsNotFoundError(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(parsedOpsCenter, username, password)
@@ -119,7 +119,7 @@ func (s *LocalEnvSuite) TestLocalEnvSingleStateDir(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
+	c.Assert(credentials.IsCredentialsNotFoundError(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)
@@ -162,7 +162,7 @@ func (s *LocalEnvSuite) TestLocalEnvSeparateStateAndKeyStoreDir(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
+	c.Assert(credentials.IsCredentialsNotFoundError(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)

--- a/lib/localenv/localenv_test.go
+++ b/lib/localenv/localenv_test.go
@@ -59,11 +59,11 @@ func (s *LocalEnvSuite) TestParsedUnparsedOpsCenters(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	login, err = env.Credentials.For(parsedOpsCenter)
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)
@@ -74,7 +74,7 @@ func (s *LocalEnvSuite) TestParsedUnparsedOpsCenters(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err = env.Credentials.For(parsedOpsCenter)
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(parsedOpsCenter, username, password)
@@ -119,7 +119,7 @@ func (s *LocalEnvSuite) TestLocalEnvSingleStateDir(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)
@@ -162,7 +162,7 @@ func (s *LocalEnvSuite) TestLocalEnvSeparateStateAndKeyStoreDir(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	login, err := env.Credentials.For(opsCenter)
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(trace.IsAccessDenied(err), check.Equals, true)
 	c.Assert(login, check.IsNil)
 
 	err = env.Credentials.UpsertLoginEntry(opsCenter, username, password)

--- a/lib/localenv/tarballenv.go
+++ b/lib/localenv/tarballenv.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localenv
+
+import (
+	"io"
+	"path/filepath"
+
+	libapp "github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/pack/encryptedpack"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/license"
+	"github.com/gravitational/trace"
+)
+
+// NewTarballEnvironment creates new environment for the cluster image
+// unpacked at the configured location
+func NewTarballEnvironment(config TarballEnvironmentArgs) (*TarballEnvironment, error) {
+	if err := config.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := NewLocalEnvironment(LocalEnvironmentArgs{
+		StateDir: config.StateDir,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err != nil {
+			env.Close()
+		}
+	}()
+	var packages pack.PackageService = env.Packages
+	if config.License != "" {
+		parsed, err := license.ParseLicense(config.License)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		encryptionKey := parsed.GetPayload().EncryptionKey
+		if len(encryptionKey) != 0 {
+			packages = encryptedpack.New(packages, string(encryptionKey))
+		}
+	}
+	apps, err := env.AppServiceLocal(AppConfig{
+		Packages: packages,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TarballEnvironment{
+		Closer:   env,
+		Packages: packages,
+		Apps:     apps,
+	}, nil
+}
+
+// TarballEnvironmentArgs defines configuration for the environment
+type TarballEnvironmentArgs struct {
+	// StateDir specifies optional state directory.
+	// If unspecified, current process's working directory is used
+	StateDir string
+	// License specifies optional license payload to decode packages
+	License string
+}
+
+func (r *TarballEnvironmentArgs) checkAndSetDefaults() error {
+	if r.StateDir == "" {
+		r.StateDir = filepath.Dir(utils.Exe.Path)
+	}
+	return nil
+}
+
+// TarballEnvironment describes application environment in the directory
+// with unpacked installer
+type TarballEnvironment struct {
+	io.Closer
+	// Packages specifies the local package service
+	Packages pack.PackageService
+	// Apps specifies the local application service
+	Apps libapp.Applications
+}

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -36,8 +36,6 @@ type BuildParameters struct {
 	OutPath string
 	// Overwrite indicates whether or not to overwrite an existing installer file
 	Overwrite bool
-	// Repository represents the source package repository
-	Repository string
 	// SkipVersionCheck indicates whether or not to perform the version check of the tele binary with the application's runtime at build time
 	SkipVersionCheck bool
 	// Silent is whether builder should report progress to the console
@@ -47,7 +45,7 @@ type BuildParameters struct {
 }
 
 // build builds an installer tarball according to the provided parameters
-func build(ctx context.Context, params BuildParameters, req service.VendorRequest) (err error) {
+func build(ctx context.Context, params BuildParameters, req service.VendorRequest) error {
 	installerBuilder, err := builder.New(builder.Config{
 		Context:          ctx,
 		StateDir:         params.StateDir,
@@ -55,7 +53,6 @@ func build(ctx context.Context, params BuildParameters, req service.VendorReques
 		ManifestPath:     params.ManifestPath,
 		OutPath:          params.OutPath,
 		Overwrite:        params.Overwrite,
-		Repository:       params.Repository,
 		SkipVersionCheck: params.SkipVersionCheck,
 		VendorReq:        req,
 		Progress:         utils.NewProgress(ctx, "Build", 6, params.Silent),

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -59,8 +59,6 @@ type BuildCmd struct {
 	OutFile *string
 	// Overwrite overwrites existing tarball
 	Overwrite *bool
-	// Repository is where packages are downloaded from
-	Repository *string
 	// Name allows to override app name
 	Name *string
 	// Version allows to override app version

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -44,7 +44,6 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.ManifestPath = tele.BuildCmd.Arg("path", fmt.Sprintf("Path to the cluster image manifest file (must be named %q), or unpacked Helm chart to build an application image out of.", defaults.ManifestFileName)).Default(defaults.ManifestFileName).String()
 	tele.BuildCmd.OutFile = tele.BuildCmd.Flag("output", "Cluster or application image file name. Defaults to <name>-<version>.tar.").Short('o').String()
 	tele.BuildCmd.Overwrite = tele.BuildCmd.Flag("overwrite", "Overwrite the existing image file.").Short('f').Bool()
-	tele.BuildCmd.Repository = tele.BuildCmd.Flag("repository", "Optional address of Gravity Hub to download dependencies from.").Hidden().String()
 	tele.BuildCmd.Name = tele.BuildCmd.Flag("name", "Optional cluster image name, overrides the one specified in the manifest file.").Hidden().String()
 	tele.BuildCmd.Version = tele.BuildCmd.Flag("version", "Optional cluster image version, overrides the one specified in the manifest file.").Hidden().String()
 	tele.BuildCmd.VendorPatterns = tele.BuildCmd.Flag("glob", "File pattern to search for container image references.").Default(defaults.VendorPattern).Hidden().Strings()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -55,7 +55,6 @@ func Run(tele Application) error {
 			ManifestPath:     *tele.BuildCmd.ManifestPath,
 			OutPath:          *tele.BuildCmd.OutFile,
 			Overwrite:        *tele.BuildCmd.Overwrite,
-			Repository:       *tele.BuildCmd.Repository,
 			SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
 			Silent:           *tele.BuildCmd.Quiet,
 			Insecure:         *tele.Insecure,


### PR DESCRIPTION
Supporting changes for https://github.com/gravitational/gravity.e/pull/4220.

This PR extends CredentialsService to support "static" credentials - i.e. a preconfigured credentials entry, for example set on the CLI. This is needed for ability to provide credentials to tele commands in the enterprise version, see PR linked above.

Refs https://github.com/gravitational/gravity.e/issues/4198.