### PR TITLE
[6.1.x] Provide all error context upon operation failure

### DIFF
--- a/lib/install/dispatcher/buffered/dispatcher.go
+++ b/lib/install/dispatcher/buffered/dispatcher.go
@@ -72,7 +72,7 @@ func (r *Dispatcher) startMessageBufferLoop() {
 		defer r.wg.Done()
 		var notifyC chan *installpb.ProgressResponse
 		var first *installpb.ProgressResponse
-		// Pending accumulates the progress messages we could not send
+		// pending accumulates the progress messages we could not send
 		// to the receiver.
 		// It is unbounded but the installer is not expected to have a large
 		// number of progress messages so it is an acceptable compromise

--- a/lib/install/engine/interactive/wizard.go
+++ b/lib/install/engine/interactive/wizard.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package interactive implements wizard-base installation workflow
+// package interactive implements wizard-based installation workflow
 package interactive
 
 import (

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -112,7 +112,7 @@ func (i *Installer) Execute(req *installpb.ExecuteRequest, stream installpb.Agen
 			if result.Error != nil {
 				// Phase finished with an error.
 				// See https://github.com/grpc/grpc-go/blob/v1.22.0/codes/codes.go#L78
-				return status.Error(codes.Aborted, trace.UserMessage(result.Error))
+				return status.Error(codes.Aborted, formatAbortError(result.Error))
 			}
 			if result.CompletionEvent != nil {
 				err := stream.Send(result.CompletionEvent.AsProgressResponse())

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -17,6 +17,7 @@ package install
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -62,6 +63,7 @@ func GetAppPackage(service app.Applications) (*loc.Locator, error) {
 func GetApp(service app.Applications) (*app.Application, error) {
 	apps, err := service.ListApps(app.ListAppsRequest{
 		Repository: defaults.SystemAccountOrg,
+		Type:       storage.AppUser,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -491,4 +493,17 @@ func newInvalidCertError(err error) error {
 	return trace.BadParameter("%s. Please make sure that clocks are synchronized between the nodes "+
 		"by using ntp, chrony or other time-synchronization programs.",
 		trace.UserMessage(err))
+}
+
+func formatAbortError(err error) string {
+	switch err := err.(type) {
+	case trace.Error:
+		userMessage := trace.UserMessage(err)
+		if err.OrigError() != nil {
+			userMessage = fmt.Sprintf("%v (%v)", userMessage, trace.UserMessage(err.OrigError()))
+		}
+		return userMessage
+	default:
+		return trace.UserMessage(err)
+	}
 }

--- a/lib/rpc/server/agent_group.go
+++ b/lib/rpc/server/agent_group.go
@@ -44,7 +44,7 @@ func NewAgentGroup(config AgentGroupConfig, from []Peer) (*AgentGroup, error) {
 	// FIXME: arbitrary channel size
 	watchCh := make(chan WatchEvent, 10)
 	peersConfig := peersConfig{
-		FieldLogger:       config.FieldLogger.WithField(trace.Component, "peers"),
+		FieldLogger:       config.FieldLogger.WithField(trace.Component, "agent-group"),
 		ReconnectStrategy: config.ReconnectStrategy,
 		watchCh:           watchCh,
 		checkTimeout:      config.HealthCheckTimeout,

--- a/lib/rpc/server/peer.go
+++ b/lib/rpc/server/peer.go
@@ -62,7 +62,7 @@ func NewPeer(config PeerConfig, serverAddr string) (*PeerServer, error) {
 		creds:      config.Client,
 	}
 	peersConfig := peersConfig{
-		FieldLogger:       config.WithField(trace.Component, "peers"),
+		FieldLogger:       config.WithField(trace.Component, "server-peer"),
 		watchCh:           config.WatchCh,
 		checkTimeout:      config.HealthCheckTimeout,
 		ReconnectStrategy: config.ReconnectStrategy,

--- a/lib/rpc/server/peers.go
+++ b/lib/rpc/server/peers.go
@@ -109,7 +109,7 @@ func (r *peers) tryPeer(ctx context.Context, peer *peer) error {
 }
 
 func (r *peers) monitorPeers() {
-	log := r.WithField("health.checker", r)
+	log := r.WithField("health.checker", r.String())
 	log.Info("Monitoring peers.")
 	defer log.Info("Health checker loop closing.")
 	for {

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -368,6 +368,15 @@ type ExitCodeError interface {
 	OrigError() error
 }
 
+// NewPreconditionFailedError returns a new error signifying a failed
+// precondition
+func NewPreconditionFailedError(err error) error {
+	return exitCodeError{
+		code: defaults.FailedPreconditionExitCode,
+		err:  err,
+	}
+}
+
 // NewExitCodeError returns a new error with the specified exit code
 func NewExitCodeError(exitCode int) error {
 	if exitCode == 0 {

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -450,6 +450,7 @@ func (i *InstallConfig) getApp() (app *app.Application, err error) {
 	}
 	app, err = install.GetApp(env.Apps)
 	if err != nil {
+		i.WithError(err).Warn("Failed to find application package.")
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("the specified state dir %v does not "+
 				"contain application data, please provide a path to the "+

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -95,7 +95,7 @@ func startInstallFromService(env *localenv.LocalEnvironment, config InstallConfi
 	go TerminationHandler(interrupt, env)
 	listener, err := NewServiceListener()
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(utils.NewPreconditionFailedError(err))
 	}
 	defer func() {
 		if err != nil {
@@ -104,7 +104,7 @@ func startInstallFromService(env *localenv.LocalEnvironment, config InstallConfi
 	}()
 	installerConfig, err := newInstallerConfig(ctx, env, config)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(utils.NewPreconditionFailedError(err))
 	}
 	var installer *install.Installer
 	switch config.Mode {
@@ -116,7 +116,7 @@ func startInstallFromService(env *localenv.LocalEnvironment, config InstallConfi
 		return trace.BadParameter("unknown mode %q", config.Mode)
 	}
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(utils.NewPreconditionFailedError(err))
 	}
 	interrupt.AddStopper(installer)
 	return trace.Wrap(installer.Run(listener))

--- a/tool/gravity/main.go
+++ b/tool/gravity/main.go
@@ -20,6 +20,7 @@ import (
 	stdlog "log"
 	"os"
 
+	"github.com/gravitational/gravity/lib/install/proto"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/tool/common"
 	"github.com/gravitational/gravity/tool/gravity/cli"
@@ -39,9 +40,11 @@ func main() {
 
 	app := kingpin.New("gravity", "Gravity cluster management tool.")
 	if err := run(app); err != nil {
-		log.WithError(err).Warn("Command failed.")
 		if errCode, ok := trace.Unwrap(err).(utils.ExitCodeError); ok {
-			common.PrintError(errCode.OrigError())
+			if errCode != installer.ErrCompleted {
+				log.WithError(err).Warn("Command failed.")
+				common.PrintError(errCode.OrigError())
+			}
 			os.Exit(errCode.ExitCode())
 		}
 		common.PrintError(err)


### PR DESCRIPTION
 * Fix a couple of typos.
 * Return precondition failed errors for initialization failures in service for better visibility in client.
 * Return all error context upon operation failure to the client.

Updates https://github.com/gravitational/gravity.e/issues/4205.
Requires https://github.com/gravitational/gravity.e/pull/4226.