### PR TITLE
[5.5.x] fix node mismatch when using encrypted installer

### DIFF
--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -440,7 +440,7 @@ func (i *Installer) waitForAgents() error {
 			}
 			report, err := i.Operator.GetSiteInstallOperationAgentReport(i.OperationKey)
 			if err != nil {
-				log.Warningf("Failed to get agent report: %v.", err)
+				log.Warnf("Failed to get agent report: %v.", trace.UserMessage(err))
 				continue
 			}
 			if !i.canContinue(report) {

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -308,7 +308,8 @@ func NewAgentPeerStore(backend storage.Backend, users users.Users,
 
 // NewPeer adds a new peer
 func (r *AgentPeerStore) NewPeer(ctx netcontext.Context, req pb.PeerJoinRequest, peer rpcserver.Peer) error {
-	r.Infof("NewPeer(%v).", peer.Addr())
+	logger := r.WithField("peer", peer.Addr())
+	logger.Info("NewPeer.")
 
 	token, user, err := r.authenticatePeer(req.Config.Token)
 	if err != nil {
@@ -319,6 +320,7 @@ func (r *AgentPeerStore) NewPeer(ctx netcontext.Context, req pb.PeerJoinRequest,
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	logger.WithField("info", info.String()).Info("Peer system information.")
 
 	group, err := r.getOrCreateGroup(ops.SiteOperationKey{
 		AccountID:   user.GetAccountID(),
@@ -347,7 +349,7 @@ func (r *AgentPeerStore) NewPeer(ctx netcontext.Context, req pb.PeerJoinRequest,
 
 // RemovePeer removes the specified peer from the store
 func (r *AgentPeerStore) RemovePeer(ctx netcontext.Context, req pb.PeerLeaveRequest, peer rpcserver.Peer) error {
-	r.Infof("RemovePeer(%v).", peer.Addr())
+	r.WithField("peer", peer.Addr()).Info("RemovePeer.")
 
 	token, user, err := r.authenticatePeer(req.Config.Token)
 	if err != nil {
@@ -394,6 +396,10 @@ func (r *AgentPeerStore) authenticatePeer(token string) (*storage.ProvisioningTo
 
 func (r *AgentPeerStore) validatePeer(ctx context.Context, group *agentGroup, info storage.System,
 	req pb.PeerJoinRequest, clusterName string) error {
+	if group.hasPeer(req.Addr, info.GetHostname()) {
+		return nil
+	}
+
 	if err := r.checkHostname(ctx, group, req.Addr, info.GetHostname(), clusterName); err != nil {
 		return trace.Wrap(err)
 	}
@@ -426,7 +432,7 @@ func (r *AgentPeerStore) checkHostname(ctx context.Context, group *agentGroup, a
 		return trace.AccessDenied("One of existing servers already has hostname %q: %q.", hostname, existingServers)
 	}
 
-	if group.hasPeer(addr, hostname) {
+	if group.hasConflictingPeer(addr, hostname) {
 		return trace.AccessDenied("One of existing peers already has hostname %q.", hostname)
 	}
 
@@ -550,8 +556,21 @@ func (r *agentGroup) remove(ctx netcontext.Context, p rpcserver.Peer, hostname s
 }
 
 // hasPeer determines whether the group already has a peer with the specified
-// hostname but a different address
+// address and hostname
 func (r *agentGroup) hasPeer(addr, hostname string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for existingAddr, existingHostname := range r.hostnames {
+		if existingHostname == hostname && existingAddr == addr {
+			return true
+		}
+	}
+	return false
+}
+
+// hasConflictingPeer determines whether the group already has a peer with the specified
+// hostname but a different address
+func (r *agentGroup) hasConflictingPeer(addr, hostname string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for existingAddr, existingHostname := range r.hostnames {

--- a/lib/rpc/proto/utils.go
+++ b/lib/rpc/proto/utils.go
@@ -18,6 +18,7 @@ package proto
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/net/context"
@@ -74,4 +75,14 @@ func ErrorToMessage(err error) *Message {
 
 func DecodeError(err *Error) error {
 	return errors.New(err.Message)
+}
+
+// Describe describes this request as text
+func (r *PeerJoinRequest) Describe() string {
+	return fmt.Sprintf("PeerJoinRequest(addr=%v, config=%v)", r.Addr, r.Config)
+}
+
+// Describe describes this request as text
+func (r *PeerLeaveRequest) Describe() string {
+	return fmt.Sprintf("PeerLeaveRequest(addr=%v, config=%v)", r.Addr, r.Config)
 }

--- a/lib/rpc/server/agent.go
+++ b/lib/rpc/server/agent.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/storage"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/types"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -56,8 +55,7 @@ func (srv *agentServer) Command(req *pb.CommandArgs, stream pb.Agent_CommandServ
 
 // PeerJoin accepts a new peer
 func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (*types.Empty, error) {
-	fmt := spew.ConfigState{Indent: "  ", DisableCapacities: true, DisablePointerAddresses: true}
-	srv.Debugf("PeerJoin(%v).", fmt.Sdump(req))
+	srv.WithField("req", req.Describe()).Debug("PeerJoin.")
 	err := srv.PeerStore.NewPeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,
@@ -71,8 +69,7 @@ func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (
 
 // PeerLeave receives a "leave" request from a peer and initiates its shutdown
 func (srv *agentServer) PeerLeave(ctx context.Context, req *pb.PeerLeaveRequest) (*types.Empty, error) {
-	fmt := spew.ConfigState{Indent: "  ", DisableCapacities: true, DisablePointerAddresses: true}
-	srv.Debugf("PeerLeave(%v).", fmt.Sdump(req))
+	srv.WithField("req", req.Describe()).Debug("PeerLeave.")
 	err := srv.PeerStore.RemovePeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -37,14 +37,15 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/utils"
-	"k8s.io/helm/pkg/repo"
 
 	teleservices "github.com/gravitational/teleport/lib/services"
 	teleutils "github.com/gravitational/teleport/lib/utils"
 
+	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/tstranex/u2f"
+	"k8s.io/helm/pkg/repo"
 )
 
 // Accounts collection modifies and updates account entries,
@@ -1698,6 +1699,12 @@ func (r Device) MarshalJSON() ([]byte, error) {
 
 // Path returns the absolute path to the device node in /dev
 func (r Device) Path() string { return r.Name.Path() }
+
+// Strings describes this device as text
+func (r Device) String() string {
+	return fmt.Sprintf("device(%v, type=%v, size=%v)",
+		r.Name, r.Type, humanize.Bytes(r.SizeMB*1000000))
+}
 
 // DeviceType defines a device type
 type DeviceType string

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -126,13 +126,6 @@ func (r *Engine) Complete(fsmErr error) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = r.operator.ActivateSite(ops.ActivateSiteRequest{
-		AccountID:  r.Operation.AccountID,
-		SiteDomain: r.Operation.SiteDomain,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	r.WithField("operation", r.Operation).Debug("Marked operation complete.")
 	return nil
 }
@@ -205,5 +198,4 @@ type Dispatcher interface {
 type operator interface {
 	CreateProgressEntry(ops.SiteOperationKey, ops.ProgressEntry) error
 	SetOperationState(ops.SiteOperationKey, ops.SetOperationStateRequest) error
-	ActivateSite(ops.ActivateSiteRequest) error
 }

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -119,15 +119,7 @@ func (r *Updater) Complete(fsmErr error) error {
 	if fsmErr == nil {
 		fsmErr = trace.Errorf("completed manually")
 	}
-	err := r.machine.Complete(fsmErr)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = r.Operator.ActivateSite(ops.ActivateSiteRequest{
-		AccountID:  r.Operation.ClusterKey().AccountID,
-		SiteDomain: r.Operation.ClusterKey().SiteDomain,
-	})
-	return trace.Wrap(err)
+	return r.machine.Complete(fsmErr)
 }
 
 // GetPlan returns the up-to-date operation plan


### PR DESCRIPTION
 * Do not count a peer re-sending the join request as a new node.
 * Use specific formatting implementation instead of generic dump based on spew for readability.

Updates https://github.com/gravitational/gravity.e/issues/4227.