### PR TITLE
Add ability to specify default provider.

### DIFF
--- a/lib/expand/bootstrap.go
+++ b/lib/expand/bootstrap.go
@@ -169,7 +169,7 @@ func (p *Peer) newAgent(ctx operationContext) (*rpcserver.PeerServer, error) {
 			"addr":          p.AdvertiseAddr,
 		}),
 		AdvertiseAddr: p.AdvertiseAddr,
-		CloudProvider: p.CloudProvider,
+		CloudProvider: ctx.Cluster.Provider,
 		ServerAddr:    peerAddr,
 		Credentials:   ctx.Creds,
 		RuntimeConfig: p.RuntimeConfig,

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -265,8 +265,6 @@ type PeerConfig struct {
 	// ServerAddr is optional address of the agent server.
 	// It will be derived from agent instructions if unspecified
 	ServerAddr string
-	// CloudProvider is the node cloud provider
-	CloudProvider string
 	// WatchCh is channel that relays peer reconnect events
 	WatchCh chan rpcserver.WatchEvent
 	// RuntimeConfig is peer's runtime configuration

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -373,6 +373,14 @@ func (m Manifest) PackageDependencies(profile string) (deps []loc.Locator, err e
 	return loc.Deduplicate(append(m.Dependencies.GetPackages(), *runtimePackage)), nil
 }
 
+// DefaultProvider returns the default cloud provider or an empty string.
+func (m Manifest) DefaultProvider() string {
+	if m.Providers != nil {
+		return m.Providers.Default
+	}
+	return ""
+}
+
 // Header is manifest header
 type Header struct {
 	metav1.TypeMeta
@@ -886,6 +894,8 @@ type NodeProviderAWS struct {
 
 // Providers defines global provider-specific settings
 type Providers struct {
+	// Default specifies the default provider.
+	Default string `json:"default,omitempty"`
 	// AWS defines AWS-specific settings
 	AWS AWS `json:"aws,omitempty"`
 	// Azure defines Azure-specific settings

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -314,6 +314,7 @@ const manifestSchema = `
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "default": {"type": "string"},
             "aws": {"$ref": "#/definitions/providerAWS"},
             "azure": {"$ref": "#/definitions/providerAzure"},
             "generic": {"$ref": "#/definitions/providerGeneric"}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -106,7 +106,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.JoinCmd.SystemDevice = g.JoinCmd.Flag("system-device", "Device to use for system data directory.").Hidden().String()
 	g.JoinCmd.ServerAddr = g.JoinCmd.Flag("server-addr", "Address of the agent server.").Hidden().String()
 	g.JoinCmd.Mounts = configure.KeyValParam(g.JoinCmd.Flag("mount", "One or several mounts in form <mount-name>:<path>, e.g. data:/var/lib/data."))
-	g.JoinCmd.CloudProvider = g.JoinCmd.Flag("cloud-provider", fmt.Sprintf("Cloud provider integration: %v. Auto-detected if not specified.", schema.SupportedProviders)).String()
+	g.JoinCmd.CloudProvider = g.JoinCmd.Flag("cloud-provider", "[DEPRECATED] This flag has no effect and will be removed in a future version.").String()
 	g.JoinCmd.OperationID = g.JoinCmd.Flag("operation-id", "ID of the operation that was created via UI.").Hidden().String()
 	g.JoinCmd.FromService = g.JoinCmd.Flag("from-service", "Run in service mode.").Hidden().Bool()
 


### PR DESCRIPTION
* Add a new manifest field `.providers.default` which specifies the provider to use if none is supplied on the command-line. If the default provider is not specified, the old auto-detect logic kicks in.
* Deprecate `--cloud-provider` flag for the join command. It will now query the provider from the cluster/installer. The flag is still there for backwards compatibility but is ignored.

Closes https://github.com/gravitational/gravity/issues/647.