### PR TITLE
[5.5.x] do not treat context expiration as terminal when validating agent connection

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -213,6 +213,10 @@ const (
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 
+	// EnvPeerConnectTimeout is the environment variable that overrides the value of the
+	// agent timeout for the validating connect
+	EnvPeerConnectTimeout = "GRAVITY_AGENT_CONNECT_TIMEOUT"
+
 	// GravityPackagePrefix defines base prefix of gravity package
 	GravityPackagePrefix = "gravitational.io/gravity"
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -215,7 +215,7 @@ const (
 
 	// EnvPeerConnectTimeout is the environment variable that overrides the value of the
 	// agent timeout for the validating connect
-	EnvPeerConnectTimeout = "GRAVITY_AGENT_CONNECT_TIMEOUT"
+	EnvPeerConnectTimeout = "GRAVITY_PEER_CONNECT_TIMEOUT"
 
 	// GravityPackagePrefix defines base prefix of gravity package
 	GravityPackagePrefix = "gravitational.io/gravity"

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -497,7 +497,7 @@ func (p *Peer) getAgent(opCtx operationContext) (*rpcserver.PeerServer, error) {
 	// make sure that connection to the RPC server can be established
 	err = validateConnection(p.Context, agent)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return agent, trace.Wrap(err)
 	}
 	return agent, nil
 }
@@ -867,9 +867,5 @@ func validateConnection(ctx context.Context, agent *rpcserver.PeerServer) error 
 	}
 	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
 	defer cancel()
-	err = agent.ValidateConnection(ctx)
-	if err != nil && !trace.IsLimitExceeded(err) {
-		return trace.Wrap(err)
-	}
-	return nil
+	return agent.ValidateConnection(ctx)
 }

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -84,8 +84,8 @@ func CheckInPlanet() bool {
 	return runningInsideContainer
 }
 
-// GetenvWithDefault returns the value the environment variables given
-// with name or defaultValue is the variable does not exist
+// GetenvWithDefault returns the value of the environment variable given
+// with name or defaultValue if the variable does not exist
 func GetenvWithDefault(name, defaultValue string) string {
 	if value, ok := os.LookupEnv(name); ok {
 		return value

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -84,6 +84,15 @@ func CheckInPlanet() bool {
 	return runningInsideContainer
 }
 
+// GetenvWithDefault returns the value the environment variables given
+// with name or defaultValue is the variable does not exist
+func GetenvWithDefault(name, defaultValue string) string {
+	if value, ok := os.LookupEnv(name); ok {
+		return value
+	}
+	return defaultValue
+}
+
 // runningInsideContainer specifies if this process is executing inside
 // planet container
 var runningInsideContainer bool

--- a/tool/gravity/main.go
+++ b/tool/gravity/main.go
@@ -20,6 +20,7 @@ import (
 	stdlog "log"
 	"os"
 
+	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/tool/common"
 	"github.com/gravitational/gravity/tool/gravity/cli"
 
@@ -31,6 +32,7 @@ import (
 
 func main() {
 	teleutils.InitLogger(teleutils.LoggingForCLI, log.InfoLevel)
+	utils.InitGRPCLogger()
 	stdlog.SetOutput(log.StandardLogger().Writer())
 	app := kingpin.New("gravity", "Cluster management tool")
 	if err := run(app); err != nil {


### PR DESCRIPTION
 * Make agent connect timeout configurable via environment (`GRAVITY_AGENT_CONNECT_TIMEOUT`).
 * Ignore deadline exceeded errors when validating connection. As the original motivation for validating the connection to the peer (server) has been early detecting of terminal conditions, connection timeout should not be considered a terminal condition and the agent should be allowed to continue even if connection takes longer than the originally allotted time.

Requires https://github.com/gravitational/gravity.e/pull/4235.
Updates https://github.com/gravitational/gravity.e/issues/4229.