### PR TITLE
[5.5.x] do not consider non-existent directories for file system usage stats

### DIFF
--- a/lib/systeminfo/systeminfo.go
+++ b/lib/systeminfo/systeminfo.go
@@ -238,6 +238,10 @@ func collectFilesystemUsage(fs []storage.Filesystem) (result storage.FilesystemS
 	for _, mount := range fs {
 		usage := sigar.FileSystemUsage{}
 		if err := usage.Get(mount.DirName); err != nil {
+			if os.IsNotExist(err) {
+				// Skip the entry if the target directory does not exist
+				continue
+			}
 			return nil, trace.Wrap(err)
 		}
 		result[mount.DirName] = storage.FilesystemUsage{TotalKB: usage.Total, FreeKB: usage.Free}


### PR DESCRIPTION
Skip entries if target directory does not exist when computing filesystem usage.

Requires forward port to 6.x, master.

Updates https://github.com/gravitational/gravity.e/issues/4232.