### PR TITLE
support loading upstream DNS servers when systemd-resolved stub resol…

### DIFF
--- a/lib/install/phases/coredns_test.go
+++ b/lib/install/phases/coredns_test.go
@@ -19,6 +19,7 @@ package phases
 import (
 	"testing"
 
+	"github.com/gravitational/gravity/lib/storage"
 	"gopkg.in/check.v1"
 )
 
@@ -107,6 +108,31 @@ func (*StartSuite) TestCoreDNSConf(c *check.C) {
 }
 `,
 		},
+		{
+			CorednsConfig{
+				Rotate: true,
+			},
+			`
+.:53 {
+  reload
+  errors
+  health
+  prometheus :9153
+  cache 30
+  loop
+  reload
+  loadbalance
+  hosts { 
+    fallthrough
+  }
+  kubernetes cluster.local in-addr.arpa ip6.arpa {
+    pods verified
+    fallthrough in-addr.arpa ip6.arpa
+  }
+  
+}
+`,
+		},
 	}
 
 	for _, tt := range configTable {
@@ -116,4 +142,54 @@ func (*StartSuite) TestCoreDNSConf(c *check.C) {
 		c.Assert(config, check.Equals, tt.expected)
 	}
 
+}
+
+func (*StartSuite) TestMergeUpstreamResolvers(c *check.C) {
+	var cases = []struct {
+		configs     []*storage.ResolvConf
+		expected    []string
+		description string
+	}{
+		{
+			configs: []*storage.ResolvConf{
+				{
+					Servers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+				},
+			},
+			expected:    []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			description: "basic configuration",
+		},
+		{
+			configs: []*storage.ResolvConf{
+				{
+					Servers: []string{"1.1.1.1"},
+				},
+				{
+					Servers: []string{"1.1.1.2"},
+				},
+			},
+			expected:    []string{"1.1.1.1", "1.1.1.2"},
+			description: "merge multiple resolv confs",
+		},
+		{
+			configs: []*storage.ResolvConf{
+				{
+					Servers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+				},
+				{
+					Servers: []string{"1.1.1.2", "1.1.1.4"},
+				},
+			},
+			expected:    []string{"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4"},
+			description: "merge multiple resolv confs discarding duplicates and preserving order",
+		},
+	}
+
+	for _, tt := range cases {
+		// ensure mergeUpstreamResolvers can handle a nil resolver
+		configs := append(tt.configs, nil)
+
+		upstream := mergeUpstreamResolvers(configs...)
+		c.Assert(upstream, check.DeepEquals, tt.expected)
+	}
 }

--- a/lib/systeminfo/dns.go
+++ b/lib/systeminfo/dns.go
@@ -36,7 +36,7 @@ func ResolvFromFile(filename string) (*storage.ResolvConf, error) {
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
 	defer f.Close()
 	cfg, err := ResolvFromReader(f)


### PR DESCRIPTION
…… (#627)

* support loading upstream DNS servers when systemd-resolved stub resolver is enabled

* use better variable name for upstream servers

* deduplicate upstream resolvers

* handle nil ResolvConf

Backport - I missed 6.2.x it would appear.