### PR TITLE
(6.2) Update teleport to fix issue with web sessions.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -906,7 +906,7 @@
 
 [[projects]]
   branch = "branch/3.2-g"
-  digest = "1:11c4b57add879bf3f3846c6c65703bf97b85ff534e78e6eabd46df78b76b7073"
+  digest = "1:4a91818747f47ffe1cffbfe616b09678a4e4d1d52b8adb19c434274a4e0bd148"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -962,7 +962,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "ce8bcea24a8f887859e01819cb94cd677c6b5265"
+  revision = "de3929eb86f7cc3411acde9ff93ed7c528e8f5d4"
 
 [[projects]]
   digest = "1:418247f700939c99867b42639d985686ba229fd9f8ee9e119c7cc3ffde6e0fe3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -279,4 +279,3 @@ ignored = [
 [[constraint]]
   name = "gopkg.in/check.v1"
   branch = "v1"
-

--- a/vendor/github.com/gravitational/teleport/lib/auth/auth.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/auth.go
@@ -29,7 +29,6 @@ import (
 	"crypto/subtle"
 	"crypto/x509"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"math/rand"
 	"net/url"
 	"sync"
@@ -53,6 +52,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	saml2 "github.com/russellhaering/gosaml2"
 	"github.com/tstranex/u2f"
+	"golang.org/x/crypto/ssh"
 )
 
 // AuthServerOption allows setting options as functional arguments to AuthServer
@@ -653,12 +653,12 @@ func (s *AuthServer) ExtendWebSession(user string, prevSessionID string, identit
 
 // CreateWebSession creates a new web session for user without any
 // checks, is used by admins
-func (s *AuthServer) CreateWebSession(user string, identity *tlsca.Identity) (services.WebSession, error) {
-	roles, traits, err := services.ExtractFromIdentity(s, identity)
+func (s *AuthServer) CreateWebSession(user string) (services.WebSession, error) {
+	u, err := s.GetUser(user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	sess, err := s.NewWebSession(user, roles, traits)
+	sess, err := s.NewWebSession(user, u.GetRoles(), u.GetTraits())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/vendor/github.com/gravitational/teleport/lib/auth/auth_with_roles.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/auth_with_roles.go
@@ -596,7 +596,7 @@ func (a *AuthWithRoles) CreateWebSession(user string) (services.WebSession, erro
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.CreateWebSession(user, &a.identity)
+	return a.authServer.CreateWebSession(user)
 }
 
 func (a *AuthWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {


### PR DESCRIPTION
This PR revendors teleport to fix a regression with creating web sessions in gravity.

Several bugs surfaced on gravity side as a result of this regression:

* UI giving "user not found" error after choosing password for a new user (see linked issue).
* Web installer UI not working (always giving login page).
* Session disconnects when accessing cluster terminal via hub.

Refs https://github.com/gravitational/gravity/issues/757.