### PR TITLE
[6.2.x] Sync up with 6.1.x to fix update w.r.t package versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ ARCH := $(shell uname -m)
 CURRENT_COMMIT := $(shell git rev-parse HEAD)
 VERSION_FLAGS := -X github.com/gravitational/gravity/vendor/github.com/gravitational/version.gitCommit=$(CURRENT_COMMIT) \
 	-X github.com/gravitational/gravity/vendor/github.com/gravitational/version.version=$(GRAVITY_VERSION) \
-	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG)
+	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG) \
+	-X github.com/gravitational/gravity/lib/defaults.TeleportVersionString=$(TELEPORT_TAG)
 GRAVITY_LINKFLAGS = "$(VERSION_FLAGS) $(GOLFLAGS)"
 
 TELEKUBE_GRAVITY_PKG := gravitational.io/gravity_$(OS)_$(ARCH):$(GRAVITY_TAG)

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -6,7 +6,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to exercise on
 UPGRADE_MAP[6.0.9]="ubuntu:16"
-UPGRADE_MAP[6.1.5]="ubuntu:16"
+UPGRADE_MAP[6.1.6]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1145,6 +1145,13 @@ var (
 		"hmac-sha2-256",
 	}
 
+	// TeleportVersionString specifies the version of the bundled teleport package
+	TeleportVersionString = "0.0.1" // Will be replaced with actual version at link time
+
+	// TeleportVersion specifies the version of the bundled teleport package as a semver
+	TeleportVersion = semver.New(TeleportVersionString)
+
+
 	// MetricsInterval is the default interval cluster metrics are displayed for.
 	MetricsInterval = time.Hour
 	// MetricsStep is the default interval b/w cluster metrics data points.

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -658,7 +658,7 @@ func (o *OperatorACL) ConfigurePackages(req ConfigurePackagesRequest) error {
 }
 
 func (o *OperatorACL) RotateSecrets(req RotateSecretsRequest) (*RotatePackageResponse, error) {
-	if err := o.ClusterAction(req.ClusterName, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+	if err := o.ClusterAction(req.Key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return o.operator.RotateSecrets(req)

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -875,7 +875,7 @@ type RotatePackageResponse struct {
 	// Reader is the package's contents
 	io.Reader `json:"-"`
 	// Labels specifies the labels for the new package
-	Labels map[string]string `json:"labels"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // ConfigureNodeRequest is a request to prepare a node for the upgrade
@@ -907,36 +907,42 @@ func (r ConfigureNodeRequest) SiteKey() SiteKey {
 	}
 }
 
+// CheckAndSetDefaults validates this request and sets defaults
+func (r RotateSecretsRequest) CheckAndSetDefaults() error {
+	if err := r.Key.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+	if r.RuntimePackage.IsEmpty() {
+		return trace.BadParameter("runtime package is required")
+	}
+	return nil
+}
+
 // RotateSecretsRequest is a request to rotate server's secrets package
 type RotateSecretsRequest struct {
-	// AccountID is the account id of the local cluster
-	AccountID string `json:"account_id"`
-	// ClusterName is the local cluster name
-	ClusterName string `json:"cluster_name"`
+	// Key identifies the cluster
+	Key SiteKey `json:"key"`
 	// Server is the server to rotate secrets for
 	Server storage.Server `json:"server"`
-	// Locator specifies the secrets package locator to use.
+	// RuntimePackage specifies the runtime package locator
+	RuntimePackage loc.Locator `json:"runtime_package"`
+	// Package specifies the secrets package to use.
 	// If unspecified, one will be automatically generated
-	Locator *loc.Locator `json:"locator,omitempty"`
+	Package *loc.Locator `json:"package,omitempty"`
 	// DryRun specifies whether only the package locator is generated
 	DryRun bool `json:"dry_run"`
 }
 
-// SiteKey returns a cluster key from this request
-func (r RotateSecretsRequest) SiteKey() SiteKey {
-	return SiteKey{
-		AccountID:  r.AccountID,
-		SiteDomain: r.ClusterName,
-	}
-}
-
-// Check validates this request
-func (r RotateTeleportConfigRequest) Check() error {
+// CheckAndSetDefaults validates this request and sets defaults
+func (r RotateTeleportConfigRequest) CheckAndSetDefaults() error {
 	if err := r.Key.Check(); err != nil {
 		return trace.Wrap(err)
 	}
 	if !r.DryRun && len(r.MasterIPs) == 0 {
 		return trace.BadParameter("list of master IPs is required")
+	}
+	if r.TeleportPackage.IsEmpty() {
+		return trace.BadParameter("teleport package is required")
 	}
 	return nil
 }
@@ -949,14 +955,27 @@ type RotateTeleportConfigRequest struct {
 	Server storage.Server `json:"server"`
 	// MasterIPs lists IP addresses of all cluster master servers
 	MasterIPs []string `json:"masters"`
-	// Master specifies the configuration package to use for the cluster controller teleport service.
+	// TeleportPackage specifies the teleport package locator
+	TeleportPackage loc.Locator `json:"teleport_package"`
+	// MasterPackage specifies the configuration package to use for the cluster controller teleport service.
 	// If unspecified, one will be automatically generated
-	Master *loc.Locator `json:"master,omitempty"`
-	// Node specifies the configuration package to use for the teleport service on host.
+	MasterPackage *loc.Locator `json:"master_package,omitempty"`
+	// NodePackage specifies the configuration package to use for the teleport service on host.
 	// If unspecified, one will be automatically generated
-	Node *loc.Locator `json:"node,omitempty"`
+	NodePackage *loc.Locator `json:"node_package,omitempty"`
 	// DryRun specifies whether only the package locator is generated
 	DryRun bool `json:"dry_run"`
+}
+
+// CheckAndSetDefaults validates this request and sets defaults
+func (r RotatePlanetConfigRequest) CheckAndSetDefaults() error {
+	if err := r.Key.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+	if r.RuntimePackage.IsEmpty() {
+		return trace.BadParameter("runtime package is required")
+	}
+	return nil
 }
 
 // RotatePlanetConfigRequest is a request to rotate planet server's configuration package
@@ -973,9 +992,9 @@ type RotatePlanetConfigRequest struct {
 	Config []byte `json:"cluster_config,omitempty"`
 	// RuntimePackage specifies the runtime package locator
 	RuntimePackage loc.Locator `json:"runtime_package"`
-	// Locator specifies the configuration package locator to use.
+	// Package specifies the configuration package locator to use.
 	// If unspecified, one will be automatically generated
-	Locator *loc.Locator `json:"locator,omitempty"`
+	Package *loc.Locator `json:"package,omitempty"`
 	// DryRun specifies whether only the package locator is generated
 	DryRun bool `json:"dry_run"`
 }

--- a/lib/ops/opsservice/packages.go
+++ b/lib/ops/opsservice/packages.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/loc"
+)
+
+// planetSecretsNextPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetSecretsNextPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetSecretsPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetSecretsPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetNextConfigPackage generates a new planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetNextConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetConfigPackage generates a planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// teleportNextNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextNodeConfigPackage(node remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportNodeConfigPackage(node remoteServer) loc.Locator {
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+// teleportNextMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextMasterConfigPackage(master remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportMasterConfigPackage(master remoteServer) loc.Locator {
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+func teleportMasterConfigPackage(master remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportMasterConfigPackage,
+			PackageSuffix(master, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+func planetSecretsPackage(node *ProvisionedServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       fmt.Sprintf("planet-%v-secrets", node.AdvertiseIP),
+		Version:    planetVersion,
+	}
+}
+
+func planetConfigPackage(node remoteServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.PlanetConfigPackage,
+			PackageSuffix(node, clusterName)),
+		Version: planetVersion,
+	}
+}
+
+func teleportNodeConfigPackage(node remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportNodeConfigPackage,
+			PackageSuffix(node, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+// suffixer replaces characters unacceptable as a package suffix
+var suffixer = strings.NewReplacer(".", "", ":", "")
+
+// PackageSuffix returns a new package suffix used in package names
+// from the specified node address and given cluster name
+func PackageSuffix(node remoteServer, clusterName string) string {
+	data := fmt.Sprintf("%v.%v", node.Address(), clusterName)
+	return suffixer.Replace(data)
+}

--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -149,14 +149,6 @@ func (s *ProvisionedServer) InGravity(dir ...string) string {
 	return filepath.Join(append([]string{s.StateDir()}, dir...)...)
 }
 
-// suffixer replaces characters unacceptable as a package suffix
-var suffixer = strings.NewReplacer(".", "", ":", "")
-
-func PackageSuffix(node remoteServer, domain string) string {
-	data := fmt.Sprintf("%v.%v", node.Address(), domain)
-	return suffixer.Replace(data)
-}
-
 func FQDN(domain, hostname, ip string) string {
 	// in case hostname comes already with this domain suffix,
 	// we assume that it's set by provisioner or user in on-prem

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -40,6 +40,10 @@ import (
 
 // RotateSecrets rotates secrets package for the server specified in the request
 func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.RotatePackageResponse, err error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	node := &ProvisionedServer{
 		Server: req.Server,
 		Profile: schema.NodeProfile{
@@ -47,24 +51,21 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 		},
 	}
 
-	cluster, err := o.openSite(req.SiteKey())
+	cluster, err := o.openSite(req.Key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	secretsPackage := req.Locator
-	if secretsPackage == nil {
-		secretsPackage, err = cluster.planetSecretsNextPackage(node)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	secretsPackage := cluster.planetSecretsNextPackage(node, req.RuntimePackage.Version)
+	if req.Package != nil {
+		secretsPackage = *req.Package
 	}
 
 	if req.DryRun {
-		return &ops.RotatePackageResponse{Locator: *secretsPackage}, nil
+		return &ops.RotatePackageResponse{Locator: secretsPackage}, nil
 	}
 
-	op, err := ops.GetCompletedInstallOperation(req.SiteKey(), o)
+	op, err := ops.GetCompletedInstallOperation(req.Key, o)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -74,7 +75,7 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err = cluster.rotateSecrets(ctx, *secretsPackage, node, *op)
+	resp, err = cluster.rotateSecrets(ctx, secretsPackage, node, *op)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -84,7 +85,7 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 
 // RotateTeleportConfig generates teleport configuration for the server specified in the provided request
 func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (masterConfig *ops.RotatePackageResponse, nodeConfig *ops.RotatePackageResponse, err error) {
-	if err := req.Check(); err != nil {
+	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -108,20 +109,14 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 		return nil, nil, trace.Wrap(err)
 	}
 
-	masterConfigPackage := req.Master
-	if masterConfigPackage == nil {
-		masterConfigPackage, err = cluster.teleportMasterConfigPackage(node)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
+	masterConfigPackage := cluster.teleportNextMasterConfigPackage(node, req.TeleportPackage.Version)
+	if req.MasterPackage != nil {
+		masterConfigPackage = *req.MasterPackage
 	}
 
-	nodeConfigPackage := req.Node
-	if nodeConfigPackage == nil {
-		nodeConfigPackage, err = cluster.teleportNodeConfigPackage(node)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
+	nodeConfigPackage := cluster.teleportNextNodeConfigPackage(node, req.TeleportPackage.Version)
+	if req.NodePackage != nil {
+		nodeConfigPackage = *req.NodePackage
 	}
 
 	ctx, err := cluster.newOperationContext(*operation)
@@ -130,7 +125,7 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 	}
 
 	if node.ClusterRole == string(schema.ServiceRoleMaster) {
-		masterConfig, err = cluster.getTeleportMasterConfig(ctx, *masterConfigPackage, node)
+		masterConfig, err = cluster.getTeleportMasterConfig(ctx, masterConfigPackage, node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -139,13 +134,13 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 		// isn't running.
 		nodeConfig, err = cluster.getTeleportNodeConfig(ctx,
 			append(req.MasterIPs, constants.Localhost),
-			*nodeConfigPackage,
+			nodeConfigPackage,
 			node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 	} else {
-		nodeConfig, err = cluster.getTeleportNodeConfig(ctx, req.MasterIPs, *nodeConfigPackage, node)
+		nodeConfig, err = cluster.getTeleportNodeConfig(ctx, req.MasterIPs, nodeConfigPackage, node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -177,6 +172,10 @@ func (o *Operator) getNodeProfile(operation ops.SiteOperation, node storage.Serv
 
 // RotatePlanetConfig rotates planet configuration package for the server specified in the request
 func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.RotatePackageResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clusterKey := req.Key.SiteKey()
 	cluster, err := o.openSite(clusterKey)
 	if err != nil {
@@ -194,16 +193,13 @@ func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.R
 		Profile: *nodeProfile,
 	}
 
-	configPackage := req.Locator
-	if configPackage == nil {
-		configPackage, err = cluster.planetNextConfigPackage(&node, req.RuntimePackage.Version)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	configPackage := cluster.planetNextConfigPackage(&node, req.RuntimePackage.Version)
+	if req.Package != nil {
+		configPackage = *req.Package
 	}
 
 	if req.DryRun {
-		return &ops.RotatePackageResponse{Locator: *configPackage}, nil
+		return &ops.RotatePackageResponse{Locator: configPackage}, nil
 	}
 
 	runner := &localRunner{}
@@ -270,7 +266,7 @@ func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.R
 		docker:        dockerConfig,
 		dockerRuntime: node.Docker,
 		planetPackage: req.RuntimePackage,
-		configPackage: *configPackage,
+		configPackage: configPackage,
 		env:           req.Env,
 	}
 

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -32,9 +32,10 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
 	"github.com/gravitational/gravity/lib/transfer"
+
+	"github.com/coreos/go-semver/semver"
 	telecfg "github.com/gravitational/teleport/lib/config"
 	teledefaults "github.com/gravitational/teleport/lib/defaults"
-
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -66,7 +67,8 @@ func newImporter(dir string) (*importer, error) {
 		FieldLogger: logrus.WithFields(logrus.Fields{
 			trace.Component:    "importer",
 			constants.FieldDir: dir,
-		})}
+		}),
+	}
 	err = func() error {
 		objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
 		if err != nil {
@@ -109,14 +111,17 @@ func (i *importer) Close() error {
 }
 
 // getMasterTeleportConfig extracts configuration from teleport package
-func (i *importer) getMasterTeleportConfig() (*telecfg.FileConfig, error) {
-	configPackage, err := pack.FindLatestPackageByName(i.packages,
-		constants.TeleportMasterConfigPackage)
+func (i *importer) getMasterTeleportConfig(clusterName string) (*telecfg.FileConfig, error) {
+	configPackage, err := pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
+		Packages:   i.packages,
+		Repository: clusterName,
+		Match:      matchTeleportConfigPackage(*defaults.TeleportVersion),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	i.Infof("Using teleport master config from %v.", configPackage)
+	i.WithField("package", configPackage).Info("Use teleport master config.")
 
 	_, reader, err := i.packages.ReadPackage(*configPackage)
 	if err != nil {
@@ -222,4 +227,26 @@ func (i *importer) importSite(b storage.Backend) error {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func matchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
+	return func(env pack.PackageEnvelope) bool {
+		if !env.HasLabel(pack.PurposeLabel, pack.PurposeTeleportMasterConfig) {
+			return false
+		}
+		ver, err := env.Locator.SemVer()
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				logrus.ErrorKey: err,
+				"package":       env.Locator,
+			}).Warn("Invalid semver.")
+			return false
+		}
+		verBase := semver.Version{
+			Major: ver.Major,
+			Minor: ver.Minor,
+			Patch: ver.Patch,
+		}
+		return verBase.Compare(teleportVersion) == 0
+	}
 }

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -430,13 +430,18 @@ func (p *Process) getTeleportConfigFromImportState() (*telecfg.FileConfig, error
 		return nil, nil
 	}
 
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	importer, err := newImporter(p.cfg.ImportDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer importer.Close()
 
-	telecfg, err := importer.getMasterTeleportConfig()
+	telecfg, err := importer.getMasterTeleportConfig(cluster.Domain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/rpc/proxy/proxy.go
+++ b/lib/rpc/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +34,6 @@ func New(link Link, log log.FieldLogger) *Proxy {
 	return &Proxy{
 		link:        link,
 		FieldLogger: log.WithField("proxy", link.String()),
-		teardownCh:  make(chan struct{}),
 		doneCh:      ctx.Done(),
 		cancel:      cancel,
 	}
@@ -47,9 +47,10 @@ type Proxy struct {
 	// and proxy loop stopped
 	doneCh <-chan struct{}
 	cancel context.CancelFunc
-	// teardownCh signals when the connection cleanup has completed
-	// and proxy loop has finished
-	teardownCh chan struct{}
+	// wg allows to track lifespan of internal processes
+	wg sync.WaitGroup
+	// notifyCh signals new connections
+	notifyCh chan<- struct{}
 }
 
 // Start starts the proxy
@@ -58,6 +59,7 @@ func (r *Proxy) Start() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	r.wg.Add(1)
 	go r.serve(listener)
 	r.Info("Proxy started.")
 	return nil
@@ -66,7 +68,8 @@ func (r *Proxy) Start() error {
 // Stop stops the proxy and drops all active connections
 func (r *Proxy) Stop() {
 	r.cancel()
-	<-r.teardownCh
+	r.link.Close()
+	r.wg.Wait()
 	r.Info("Proxy stopped.")
 }
 
@@ -77,6 +80,8 @@ type Link interface {
 	Listen() (net.Listener, error)
 	// Dials dials to the remote side of the link
 	Dial() (net.Conn, error)
+	// Close closes the local link
+	Close() error
 }
 
 // NetLink links two network endpoints.
@@ -92,6 +97,11 @@ type NetLink struct {
 // Implements Link
 func (r NetLink) Listen() (net.Listener, error) {
 	return r.Local, nil
+}
+
+// Close closes the local link
+func (r NetLink) Close() error {
+	return r.Local.Close()
 }
 
 // Dials dials the remote endpoint.
@@ -110,35 +120,47 @@ func (r NetLink) String() string {
 }
 
 func (r *Proxy) serve(listener net.Listener) {
-	defer close(r.teardownCh)
+	defer r.wg.Done()
 	for {
 		c1, err := listener.Accept()
 		if err != nil {
-			r.Errorf("Failed to accept: %v.", err)
+			select {
+			case <-r.doneCh:
+				return
+			default:
+			}
+			r.WithError(err).Warn("Failed to accept.")
 			return
 		}
 		r.Infof("Accept connection from %v.", c1.RemoteAddr())
 
 		c2, err := r.link.Dial()
 		if err != nil {
-			r.Errorf("Failed to dial: %v.", err)
+			r.WithFields(log.Fields{
+				log.ErrorKey: err,
+				"addr":       r.link,
+			}).Warn("Failed to dial local link.")
 			c1.Close()
 			return
 		}
-		r.Infof("Upstream connection to %v.", c2.RemoteAddr())
+		r.WithField("addr", c2.RemoteAddr()).Info("Upstream connection.")
 
+		r.wg.Add(3)
 		errCh := make(chan error, 2)
-		go proxyConn(c1, c2, errCh)
-		go proxyConn(c2, c1, errCh)
+		go r.proxyConn(c1, c2, errCh)
+		go r.proxyConn(c2, c1, errCh)
 		go r.watchConns(errCh, c1, c2, listener)
+
+		r.notifyNewConnection()
 	}
 }
 
 func (r *Proxy) watchConns(errCh <-chan error, closers ...io.Closer) {
+	defer r.wg.Done()
 	select {
 	case err := <-errCh:
 		if err != nil {
-			r.Warnf("Failed in proxyConn: %v.", err)
+			r.WithError(err).Warn("Failed in proxyConn.")
 		}
 	case <-r.doneCh:
 	}
@@ -147,7 +169,15 @@ func (r *Proxy) watchConns(errCh <-chan error, closers ...io.Closer) {
 	}
 }
 
-func proxyConn(c1 io.Writer, c2 io.Reader, errCh chan<- error) {
+func (r *Proxy) notifyNewConnection() {
+	select {
+	case r.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Proxy) proxyConn(c1 io.Writer, c2 io.Reader, errCh chan<- error) {
+	defer r.wg.Done()
 	_, err := io.Copy(c1, c2)
 	errCh <- err
 }

--- a/lib/rpc/proxy/proxy_test.go
+++ b/lib/rpc/proxy/proxy_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&S{})
 
 func (_ *S) TestProxiesConnections(c *C) {
 	link := newLocalLink()
-	proxy := New(link, log.StandardLogger())
+	proxy := New(link, log.WithField("test", "TestProxiesConnections"))
 	proxy.Start()
 	defer proxy.Stop()
 
@@ -46,7 +46,7 @@ func (_ *S) TestProxiesConnections(c *C) {
 
 	s := newServer(1)
 	go s.serve(link.upstream)
-	defer link.Close()
+	defer link.stop()
 
 	payload := []byte("test")
 	_, err = conn.Write(payload)
@@ -65,27 +65,34 @@ func (_ *S) TestProxiesConnections(c *C) {
 func (_ *S) TestCanStopProxyOnDemand(c *C) {
 	payload := []byte("test")
 	link := newLocalLink()
-	proxy := New(link, log.StandardLogger())
+	logger := log.WithField("test", ") TestCanStopProxyOnDemand")
+	proxy := New(link, logger)
+	notifyCh := make(chan struct{}, 1)
+	proxy.notifyCh = notifyCh
 	c.Assert(proxy.Start(), IsNil)
 	defer proxy.Stop()
 
 	s := newServer(2)
 	go s.serve(link.upstream)
-	defer link.Close()
+	defer link.stop()
 
 	conn, err := link.local.Dial()
 	c.Assert(err, IsNil)
 
+	// wait for new connection: this blocks until the proxy has accepted
+	// the connection and created handler loop
+	<-notifyCh
+
 	// Stop proxy so the write fails
 	proxy.Stop()
-	link.resetLocal()
 
 	_, err = conn.Write(payload)
 	c.Assert(err, ErrorMatches, "io: read/write on closed pipe")
 	conn.Close()
 
 	// Restart proxy to be able to write
-	proxy = New(link, log.StandardLogger())
+	link.resetLocal()
+	proxy = New(link, logger)
 	c.Assert(proxy.Start(), IsNil)
 	defer proxy.Stop()
 
@@ -97,7 +104,7 @@ func (_ *S) TestCanStopProxyOnDemand(c *C) {
 
 	select {
 	case <-s.recvCh:
-	// Skip the first write
+		// Skip the first write
 	case <-time.After(1 * time.Second):
 		c.Error("timeout waiting for write")
 	}
@@ -126,6 +133,10 @@ func (r *localLink) Dial() (net.Conn, error) {
 	return r.upstream.Dial()
 }
 
+func (r *localLink) Close() error {
+	return r.local.Close()
+}
+
 func (r *localLink) String() string {
 	return "localLink"
 }
@@ -134,7 +145,7 @@ func (r *localLink) resetLocal() {
 	r.local = inprocess.Listen()
 }
 
-func (r *localLink) Close() error {
+func (r *localLink) stop() error {
 	r.local.Close()
 	r.upstream.Close()
 	return nil

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -164,8 +164,8 @@ type UpdateServer struct {
 type RuntimePackage struct {
 	// Installed identifies the installed version of the runtime package
 	Installed loc.Locator `json:"installed"`
-	// RuntimeSecretsPackage specifies the new secrets package
-	SecretsPackage *loc.Locator `json:"runtime_secrets_package,omitempty"`
+	// SecretsPackage specifies the new secrets package
+	SecretsPackage *loc.Locator `json:"secrets_package,omitempty"`
 	// Update describes an update to the runtime package
 	Update *RuntimeUpdate `json:"update,omitempty"`
 }
@@ -192,8 +192,9 @@ type TeleportUpdate struct {
 	// Package identifies the package to update to.
 	// This can be the same as Installed in which case no update is performed
 	Package loc.Locator `json:"package"`
-	// NodeConfigPackage identifies the new host teleport configuration package
-	NodeConfigPackage loc.Locator `json:"node_config_package"`
+	// NodeConfigPackage identifies the new host teleport configuration package.
+	// If nil, no changes to configuration package required
+	NodeConfigPackage *loc.Locator `json:"node_config_package,omitempty"`
 }
 
 // InstallOperationData describes configuration for the install operation

--- a/lib/update/cluster/phases/coredns.go
+++ b/lib/update/cluster/phases/coredns.go
@@ -158,7 +158,7 @@ func (p *updatePhaseCoreDNS) generateCorefile(context.Context) error {
 			"Corefile": conf,
 		},
 	})
-	err = trace.ConvertSystemError(err)
+	err = rigging.ConvertError(err)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err)
 	}

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -104,7 +104,7 @@ func NewUpdatePhaseInit(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	operation, err := ops.GetLastUpdateOperation(cluster.Key(), operator)
+	operation, err := operator.GetSiteOperation(fsm.OperationKey(p.Plan))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -373,10 +373,10 @@ func (p *updatePhaseInit) createAdminAgent() error {
 func (p *updatePhaseInit) rotateSecrets(server storage.UpdateServer) error {
 	p.Infof("Generate new secrets configuration package for %v.", server)
 	resp, err := p.Operator.RotateSecrets(ops.RotateSecretsRequest{
-		AccountID:   p.Operation.AccountID,
-		ClusterName: p.Operation.SiteDomain,
-		Locator:     server.Runtime.SecretsPackage,
-		Server:      server.Server,
+		Key:            p.Operation.ClusterKey(),
+		Package:        server.Runtime.SecretsPackage,
+		RuntimePackage: server.Runtime.Update.Package,
+		Server:         server.Server,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -396,7 +396,7 @@ func (p *updatePhaseInit) rotatePlanetConfig(server storage.UpdateServer) error 
 		Server:         server.Server,
 		Manifest:       p.updateManifest,
 		RuntimePackage: server.Runtime.Update.Package,
-		Locator:        &server.Runtime.Update.ConfigPackage,
+		Package:        &server.Runtime.Update.ConfigPackage,
 		Config:         p.existingClusterConfig,
 		Env:            p.existingEnviron,
 	})
@@ -414,10 +414,11 @@ func (p *updatePhaseInit) rotatePlanetConfig(server storage.UpdateServer) error 
 
 func (p *updatePhaseInit) rotateTeleportConfig(server storage.UpdateServer) error {
 	masterConf, nodeConf, err := p.Operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-		Key:       p.Operation.Key(),
-		Server:    server.Server,
-		Node:      &server.Teleport.Update.NodeConfigPackage,
-		MasterIPs: masterIPs(p.Servers),
+		Key:             p.Operation.Key(),
+		Server:          server.Server,
+		TeleportPackage: server.Teleport.Update.Package,
+		NodePackage:     server.Teleport.Update.NodeConfigPackage,
+		MasterIPs:       masterIPs(p.Servers),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/update/cluster/phases/system.go
+++ b/lib/update/cluster/phases/system.go
@@ -92,6 +92,14 @@ func (p *updatePhaseSystem) PostCheck(context.Context) error {
 
 // Execute runs system update on the node
 func (p *updatePhaseSystem) Execute(ctx context.Context) error {
+	runtimeConfig, err := p.getInstalledConfigPackage(p.Server.Runtime.Installed)
+	if err != nil {
+		return trace.Wrap(err, "failed to locate runtime configuration package")
+	}
+	teleportConfig, err := p.getInstalledConfigPackage(p.Server.Teleport.Installed)
+	if err != nil {
+		return trace.Wrap(err, "failed to locate teleport configuration package")
+	}
 	config := system.Config{
 		ChangesetID: p.OperationID,
 		Backend:     p.Backend,
@@ -110,18 +118,25 @@ func (p *updatePhaseSystem) Execute(ctx context.Context) error {
 	if p.Server.Runtime.Update != nil {
 		config.Runtime.To = p.Server.Runtime.Update.Package
 		config.Runtime.ConfigPackage = &storage.PackageUpdate{
-			To: p.Server.Runtime.Update.ConfigPackage,
+			From: *runtimeConfig,
+			To:   p.Server.Runtime.Update.ConfigPackage,
 		}
 	}
 	if p.Server.Teleport.Update != nil {
 		// Consider teleport update only in effect when the update package
 		// has been specified. This is in contrast to runtime update, when
 		// we expect to update the configuration more often
+		configPackage := p.Server.Teleport.Update.NodeConfigPackage
+		if configPackage == nil {
+			// No update necessary
+			configPackage = teleportConfig
+		}
 		config.Teleport = &storage.PackageUpdate{
 			From: p.Server.Teleport.Installed,
 			To:   p.Server.Teleport.Update.Package,
 			ConfigPackage: &storage.PackageUpdate{
-				To: p.Server.Teleport.Update.NodeConfigPackage,
+				From: *teleportConfig,
+				To:   *configPackage,
 			},
 		}
 	}
@@ -136,6 +151,14 @@ func (p *updatePhaseSystem) Execute(ctx context.Context) error {
 	}
 	err = updater.Update(ctx, true)
 	return trace.Wrap(err)
+}
+
+func (p *updatePhaseSystem) getInstalledConfigPackage(loc loc.Locator) (*loc.Locator, error) {
+	configPackage, err := pack.FindInstalledConfigPackage(p.HostLocalPackages, loc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return configPackage, nil
 }
 
 // Rollback runs rolls back the system upgrade on the node

--- a/lib/update/cluster/plan.go
+++ b/lib/update/cluster/plan.go
@@ -428,15 +428,6 @@ func configUpdates(
 		return nil, trace.Wrap(err)
 	}
 	for _, server := range servers {
-		secretsUpdate, err := operator.RotateSecrets(ops.RotateSecretsRequest{
-			AccountID:   operation.AccountID,
-			ClusterName: operation.SiteDomain,
-			Server:      server,
-			DryRun:      true,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		installedRuntime, err := getRuntimePackage(installed, server.Role, schema.ServiceRole(server.ClusterRole))
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -444,8 +435,7 @@ func configUpdates(
 		updateServer := storage.UpdateServer{
 			Server: server,
 			Runtime: storage.RuntimePackage{
-				Installed:      *installedRuntime,
-				SecretsPackage: &secretsUpdate.Locator,
+				Installed: *installedRuntime,
 			},
 			Teleport: storage.TeleportPackage{
 				Installed: *installedTeleport,
@@ -462,6 +452,15 @@ func configUpdates(
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			secretsUpdate, err := operator.RotateSecrets(ops.RotateSecretsRequest{
+				Key:            operation.SiteKey(),
+				Server:         server,
+				RuntimePackage: *updateRuntime,
+				DryRun:         true,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
 			configUpdate, err := operator.RotatePlanetConfig(ops.RotatePlanetConfigRequest{
 				Key:            operation,
 				Server:         server,
@@ -472,6 +471,7 @@ func configUpdates(
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			updateServer.Runtime.SecretsPackage = &secretsUpdate.Locator
 			updateServer.Runtime.Update = &storage.RuntimeUpdate{
 				Package:       *updateRuntime,
 				ConfigPackage: configUpdate.Locator,
@@ -479,16 +479,17 @@ func configUpdates(
 		}
 		if needsTeleportUpdate {
 			_, nodeConfig, err := operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-				Key:    operation,
-				Server: server,
-				DryRun: true,
+				Key:             operation,
+				Server:          server,
+				TeleportPackage: *updateTeleport,
+				DryRun:          true,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			updateServer.Teleport.Update = &storage.TeleportUpdate{
 				Package:           *updateTeleport,
-				NodeConfigPackage: nodeConfig.Locator,
+				NodeConfigPackage: &nodeConfig.Locator,
 			}
 		}
 		updates = append(updates, updateServer)

--- a/lib/update/clusterconfig/phases/update.go
+++ b/lib/update/clusterconfig/phases/update.go
@@ -72,7 +72,7 @@ func (r *updateConfig) Execute(ctx context.Context) error {
 			Server:         update.Server,
 			Manifest:       r.manifest,
 			RuntimePackage: update.Runtime.Update.Package,
-			Locator:        &update.Runtime.Update.ConfigPackage,
+			Package:        &update.Runtime.Update.ConfigPackage,
 			Config:         r.operation.UpdateConfig.Config,
 		}
 		resp, err := r.operator.RotatePlanetConfig(req)

--- a/lib/update/environ/phases/update.go
+++ b/lib/update/environ/phases/update.go
@@ -72,7 +72,7 @@ func (r *updateConfig) Execute(ctx context.Context) error {
 			Server:         update.Server,
 			Manifest:       r.manifest,
 			RuntimePackage: update.Runtime.Update.Package,
-			Locator:        &update.Runtime.Update.ConfigPackage,
+			Package:        &update.Runtime.Update.ConfigPackage,
 			Env:            r.operation.UpdateEnviron.Env,
 		}
 		resp, err := r.operator.RotatePlanetConfig(req)

--- a/lib/update/system/system.go
+++ b/lib/update/system/system.go
@@ -148,7 +148,7 @@ type System struct {
 
 func (r *Config) checkAndSetDefaults() error {
 	if r.ChangesetID == "" {
-		return trace.BadParameter("ChangsetID is required")
+		return trace.BadParameter("ChangesetID is required")
 	}
 	if r.Backend == nil {
 		return trace.BadParameter("Backend is required")
@@ -191,10 +191,7 @@ func (r *PackageUpdates) checkAndSetDefaults() error {
 		r.RuntimeSecrets.Labels = pack.RuntimeSecretsPackageLabels
 	}
 	if r.Teleport != nil {
-		if r.Teleport.ConfigPackage == nil {
-			return trace.BadParameter("Teleport configuration package is required")
-		}
-		if len(r.Teleport.ConfigPackage.Labels) == 0 {
+		if r.Teleport.ConfigPackage != nil && len(r.Teleport.ConfigPackage.Labels) == 0 {
 			r.Teleport.ConfigPackage.Labels = pack.TeleportNodeConfigPackageLabels
 		}
 	}
@@ -242,7 +239,7 @@ func (r *System) reinstallPackage(update storage.PackageUpdate) ([]pack.LabelUpd
 	r.WithField("update", update).Info("Reinstalling package.")
 	switch {
 	case update.To.Name == constants.GravityPackage:
-		return updateGravityPackage(r.Packages, update.To)
+		return r.updateGravityPackage(update.To)
 	case pack.IsPlanetPackage(update.To, update.Labels):
 		updates, err := r.updatePlanetPackage(update)
 		return updates, trace.Wrap(err)
@@ -342,6 +339,10 @@ func (r *System) updateTeleportPackage(update storage.PackageUpdate) (labelUpdat
 	if update.ConfigPackage == nil {
 		return updates, nil
 	}
+	if update.ConfigPackage.From.IsEqualTo(update.ConfigPackage.To) {
+		// Short-circuit on idempotent configuration update
+		return updates, nil
+	}
 	return append(updates,
 		pack.LabelUpdate{
 			Locator: update.ConfigPackage.From,
@@ -419,7 +420,7 @@ func (r *System) reinstallService(update storage.PackageUpdate) (labelUpdates []
 
 	var configPackage loc.Locator
 	if update.ConfigPackage == nil {
-		existingConfig, err := pack.FindConfigPackage(r.Packages, update.From)
+		existingConfig, err := pack.FindInstalledConfigPackage(r.Packages, update.From)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -458,22 +459,26 @@ func (r *System) reinstallService(update storage.PackageUpdate) (labelUpdates []
 	return labelUpdates, nil
 }
 
-func updateGravityPackage(packages update.LocalPackageService, newPackage loc.Locator) (labelUpdates []pack.LabelUpdate, err error) {
+func (r *System) updateGravityPackage(newPackage loc.Locator) (labelUpdates []pack.LabelUpdate, err error) {
 	for _, targetPath := range state.GravityBinPaths {
-		labelUpdates, err = reinstallBinaryPackage(packages, newPackage, targetPath)
+		labelUpdates, err = reinstallBinaryPackage(r.Packages, newPackage, targetPath)
 		if err == nil {
 			break
 		}
+		r.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"path":          targetPath,
+		}).Warn("Failed to install gravity binary.")
 	}
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to install gravity binary in any of %v",
 			state.GravityBinPaths)
 	}
-	planetPath, err := getRuntimePackagePath(packages)
+	planetPath, err := getRuntimePackagePath(r.Packages)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to find planet package")
 	}
-	err = copyGravityToPlanet(newPackage, packages, planetPath)
+	err = copyGravityToPlanet(newPackage, r.Packages, planetPath)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to copy gravity inside planet")
 	}

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -106,7 +106,9 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 		return nil, trace.Wrap(err)
 	}
 	req := init.updateDeployRequest(deployAgentsRequest{
-		clusterState: cluster.ClusterState,
+		// Use server list from the operation plan to always have a consistent
+		// view of the cluster (i.e. with servers correctly reflecting cluster roles)
+		clusterState: clusterStateFromPlan(*plan),
 		clusterName:  cluster.Domain,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
@@ -162,4 +164,12 @@ type updater interface {
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	Complete(error) error
+}
+
+func clusterStateFromPlan(plan storage.OperationPlan) (result storage.ClusterState) {
+	result.Servers = make([]storage.Server, 0, len(plan.Servers))
+	for _, s := range plan.Servers {
+		result.Servers = append(result.Servers, s)
+	}
+	return result
 }


### PR DESCRIPTION
* Bring branch up-to-date with 6.1.x w.r.t updates
* Sync up with 6.1.x w.r.t to planet/teleport configuration package naming changes to fix the upgrades.
* Bump version of the base application for upgrade tests to 6.1.6 to exercise the issue

Updates https://github.com/gravitational/gravity.e/issues/4230.