### PR TITLE
Sync up with 6.1.x to fix update w.r.t package versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ ARCH := $(shell uname -m)
 CURRENT_COMMIT := $(shell git rev-parse HEAD)
 VERSION_FLAGS := -X github.com/gravitational/gravity/vendor/github.com/gravitational/version.gitCommit=$(CURRENT_COMMIT) \
 	-X github.com/gravitational/gravity/vendor/github.com/gravitational/version.version=$(GRAVITY_VERSION) \
-	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG)
+	-X github.com/gravitational/gravity/lib/defaults.WormholeImg=$(WORMHOLE_IMG) \
+	-X github.com/gravitational/gravity/lib/defaults.TeleportVersionString=$(TELEPORT_TAG)
 GRAVITY_LINKFLAGS = "$(VERSION_FLAGS) $(GOLFLAGS)"
 
 TELEKUBE_GRAVITY_PKG := gravitational.io/gravity_$(OS)_$(ARCH):$(GRAVITY_TAG)

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -5,7 +5,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to exercise on
-UPGRADE_MAP[6.1.5]="ubuntu:18"
+UPGRADE_MAP[6.1.6]="ubuntu:18"
 UPGRADE_MAP[6.2.0]="ubuntu:18"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1168,6 +1168,12 @@ var (
 		"hmac-sha2-256",
 	}
 
+	// TeleportVersionString specifies the version of the bundled teleport package
+	TeleportVersionString = "0.0.1" // Will be replaced with actual version at link time
+
+	// TeleportVersion specifies the version of the bundled teleport package as a semver
+	TeleportVersion = semver.New(TeleportVersionString)
+
 	// MetricsInterval is the default interval cluster metrics are displayed for.
 	MetricsInterval = time.Hour
 	// MetricsStep is the default interval b/w cluster metrics data points.

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -658,7 +658,7 @@ func (o *OperatorACL) ConfigurePackages(req ConfigurePackagesRequest) error {
 }
 
 func (o *OperatorACL) RotateSecrets(req RotateSecretsRequest) (*RotatePackageResponse, error) {
-	if err := o.ClusterAction(req.ClusterName, storage.KindCluster, teleservices.VerbUpdate); err != nil {
+	if err := o.ClusterAction(req.Key.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return o.operator.RotateSecrets(req)

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -198,18 +198,12 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	secretsPackage, err := s.planetSecretsPackage(provisionedServer)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	planetPackage, err := s.app.Manifest.RuntimePackage(provisionedServer.Profile)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	configPackage, err := s.planetConfigPackage(provisionedServer, planetPackage.Version)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	secretsPackage := s.planetSecretsPackage(provisionedServer, planetPackage.Version)
+	configPackage := s.planetConfigPackage(provisionedServer, planetPackage.Version)
 	env, err := s.service.GetClusterEnvironmentVariables(s.key)
 	if err != nil {
 		return trace.Wrap(err)
@@ -224,7 +218,7 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 		etcd:          *etcdConfig,
 		docker:        s.dockerConfig(),
 		planetPackage: *planetPackage,
-		configPackage: *configPackage,
+		configPackage: configPackage,
 		manifest:      s.app.Manifest,
 		env:           env.GetKeyValues(),
 		config:        config,
@@ -236,7 +230,7 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 		}
 		masterParams := planetMasterParams{
 			master:            provisionedServer,
-			secretsPackage:    secretsPackage,
+			secretsPackage:    &secretsPackage,
 			serviceSubnetCIDR: opCtx.operation.InstallExpand.Subnets.Service,
 		}
 		// if we have connection to an Ops Center set up, configure
@@ -253,23 +247,24 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 			electionEnabled: false,
 			addr:            s.teleport().GetPlanetLeaderIP(),
 		}
-		err = s.configurePlanetMaster(planetConfig, *secretsPackage, *configPackage)
+		err = s.configurePlanetMaster(planetConfig, secretsPackage, configPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		// Teleport nodes on masters prefer their local auth server
 		// but will try all other masters if the local gravity-site
 		// isn't running.
-		err = s.configureTeleportNode(opCtx, append([]string{constants.Localhost}, teleportMasterIPs...), provisionedServer)
+		err = s.configureTeleportNode(opCtx, append([]string{constants.Localhost}, teleportMasterIPs...),
+			provisionedServer)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	} else {
-		err = s.configurePlanetNodeSecrets(opCtx, provisionedServer, *secretsPackage)
+		err = s.configurePlanetNodeSecrets(opCtx, provisionedServer, secretsPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = s.configurePlanetNode(planetConfig, *secretsPackage, *configPackage)
+		err = s.configurePlanetNode(planetConfig, secretsPackage, configPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -332,24 +327,16 @@ func (s *site) configurePackages(ctx *operationContext, req ops.ConfigurePackage
 	}
 
 	for i, master := range masters {
-		secretsPackage, err := s.planetSecretsPackage(master)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
 		planetPackage, err := s.app.Manifest.RuntimePackage(master.Profile)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-
-		configPackage, err := s.planetConfigPackage(master, planetPackage.Version)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		secretsPackage := s.planetSecretsPackage(master, planetPackage.Version)
+		configPackage := s.planetConfigPackage(master, planetPackage.Version)
 
 		err = s.configurePlanetMasterSecrets(ctx, planetMasterParams{
 			master:            master,
-			secretsPackage:    secretsPackage,
+			secretsPackage:    &secretsPackage,
 			serviceSubnetCIDR: ctx.operation.InstallExpand.Subnets.Service,
 			sniHost:           s.service.cfg.SNIHost,
 		})
@@ -379,12 +366,12 @@ func (s *site) configurePackages(ctx *operationContext, req ops.ConfigurePackage
 			master:        masterConfig,
 			docker:        s.dockerConfig(),
 			planetPackage: *planetPackage,
-			configPackage: *configPackage,
+			configPackage: configPackage,
 			manifest:      s.app.Manifest,
 			env:           req.Env,
 			config:        clusterConfig,
 		}
-		err = s.configurePlanetMaster(config, *secretsPackage, *configPackage)
+		err = s.configurePlanetMaster(config, secretsPackage, configPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -396,7 +383,9 @@ func (s *site) configurePackages(ctx *operationContext, req ops.ConfigurePackage
 		// Teleport nodes on masters prefer their local auth server
 		// but will try all other masters if the local gravity-site
 		// isn't running.
-		if err := s.configureTeleportNode(ctx, append([]string{constants.Localhost}, p.MasterIPs()...), master); err != nil {
+		err = s.configureTeleportNode(ctx, append([]string{constants.Localhost}, p.MasterIPs()...),
+			master)
+		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -406,24 +395,18 @@ func (s *site) configurePackages(ctx *operationContext, req ops.ConfigurePackage
 			return trace.Wrap(err)
 		}
 
-		secretsPackage, err := s.planetSecretsPackage(node)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		if err := s.configurePlanetNodeSecrets(ctx, node, *secretsPackage); err != nil {
-			return trace.Wrap(err)
-		}
-
 		planetPackage, err := s.app.Manifest.RuntimePackage(node.Profile)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		configPackage, err := s.planetConfigPackage(node, planetPackage.Version)
-		if err != nil {
+		secretsPackage := s.planetSecretsPackage(node, planetPackage.Version)
+
+		if err := s.configurePlanetNodeSecrets(ctx, node, secretsPackage); err != nil {
 			return trace.Wrap(err)
 		}
+
+		configPackage := s.planetConfigPackage(node, planetPackage.Version)
 
 		nodeEtcdConfig, ok := etcdConfig[node.AdvertiseIP]
 		if !ok {
@@ -438,13 +421,13 @@ func (s *site) configurePackages(ctx *operationContext, req ops.ConfigurePackage
 			master:        masterConfig{addr: p.FirstMaster().AdvertiseIP},
 			docker:        s.dockerConfig(),
 			planetPackage: *planetPackage,
-			configPackage: *configPackage,
+			configPackage: configPackage,
 			manifest:      s.app.Manifest,
 			env:           req.Env,
 			config:        clusterConfig,
 		}
 
-		err = s.configurePlanetNode(config, *secretsPackage, *configPackage)
+		err = s.configurePlanetNode(config, secretsPackage, configPackage)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1171,11 +1154,8 @@ func (s *site) getTeleportMasterConfig(ctx *operationContext, configPackage loc.
 }
 
 func (s *site) configureTeleportMaster(ctx *operationContext, master *ProvisionedServer) error {
-	configPackage, err := s.teleportMasterConfigPackage(master)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	resp, err := s.getTeleportMasterConfig(ctx, *configPackage, master)
+	configPackage := s.teleportMasterConfigPackage(master)
+	resp, err := s.getTeleportMasterConfig(ctx, configPackage, master)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1197,13 +1177,6 @@ func toObject(in interface{}) (map[string]interface{}, error) {
 		return nil, trace.Wrap(err)
 	}
 	return out, nil
-}
-
-func (s *site) teleportMasterConfigPackage(master remoteServer) (*loc.Locator, error) {
-	configPackage, err := loc.ParseLocator(
-		fmt.Sprintf("%v/%v:0.0.%v-%v", s.siteRepoName(), constants.TeleportMasterConfigPackage,
-			time.Now().UTC().Unix(), PackageSuffix(master, s.domainName)))
-	return configPackage, trace.Wrap(err)
 }
 
 func (s *site) getTeleportNodeConfig(ctx *operationContext, masterIPs []string, configPackage loc.Locator, node *ProvisionedServer) (*ops.RotatePackageResponse, error) {
@@ -1295,11 +1268,8 @@ func (s *site) getTeleportNodeConfig(ctx *operationContext, masterIPs []string, 
 }
 
 func (s *site) configureTeleportNode(ctx *operationContext, masterIPs []string, node *ProvisionedServer) error {
-	configPackage, err := s.teleportNodeConfigPackage(node)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	resp, err := s.getTeleportNodeConfig(ctx, masterIPs, *configPackage, node)
+	configPackage := s.teleportNodeConfigPackage(node)
+	resp, err := s.getTeleportNodeConfig(ctx, masterIPs, configPackage, node)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1308,13 +1278,6 @@ func (s *site) configureTeleportNode(ctx *operationContext, masterIPs []string, 
 		return trace.Wrap(err)
 	}
 	return nil
-}
-
-func (s *site) teleportNodeConfigPackage(node remoteServer) (*loc.Locator, error) {
-	configPackage, err := loc.ParseLocator(
-		fmt.Sprintf("%v/%v:0.0.%v-%v", s.siteRepoName(), constants.TeleportNodeConfigPackage,
-			time.Now().UTC().Unix(), PackageSuffix(node, s.domainName)))
-	return configPackage, trace.Wrap(err)
 }
 
 func (s *site) configureSiteExportPackage(ctx *operationContext) (*loc.Locator, error) {
@@ -1422,64 +1385,6 @@ func (s *site) siteExportPackage() (*loc.Locator, error) {
 func (s *site) licensePackage() (*loc.Locator, error) {
 	return loc.ParseLocator(
 		fmt.Sprintf("%v/%v:0.0.1", s.siteRepoName(), constants.LicensePackage))
-}
-
-func (s *site) planetSecretsPackage(node *ProvisionedServer) (*loc.Locator, error) {
-	return loc.ParseLocator(
-		fmt.Sprintf("%v/planet-%v-secrets:0.0.1", s.siteRepoName(), node.AdvertiseIP))
-}
-
-func (s *site) planetSecretsNextPackage(node *ProvisionedServer) (*loc.Locator, error) {
-	return loc.ParseLocator(
-		fmt.Sprintf("%v/planet-%v-secrets:0.0.%v", s.siteRepoName(), node.AdvertiseIP, time.Now().UTC().Unix()))
-}
-
-// planetNextConfigPackage generates a new planet configuration package
-// locator guaranteed to be greater than version
-func (s *site) planetNextConfigPackage(node remoteServer, version string) (*loc.Locator, error) {
-	version = fmt.Sprintf("%v+%v", version, time.Now().UTC().Unix())
-	return s.planetConfigPackage(node, version)
-}
-
-// planetConfigPackage creates a planet configuration package reference
-// using the specified version as a package version and the given node to add unique
-// suffix to the name.
-// This is in contrast to the old naming with PackageSuffix used as a prerelease part
-// of the version which made them hard to match when looking for an update.
-func (s *site) planetConfigPackage(node remoteServer, version string) (*loc.Locator, error) {
-	return loc.ParseLocator(
-		fmt.Sprintf("%v/%v-%v:%v", s.siteRepoName(), constants.PlanetConfigPackage,
-			PackageSuffix(node, s.domainName), version))
-}
-
-// serverPackages returns a list of package locators specific to the provided server
-func (s *site) serverPackages(server *ProvisionedServer) ([]loc.Locator, error) {
-	masterConfigPackage, err := s.teleportMasterConfigPackage(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	nodeConfigPackage, err := s.teleportNodeConfigPackage(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	planetSecretsPackage, err := s.planetSecretsPackage(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	planetPackage, err := s.app.Manifest.RuntimePackageForProfile(server.Role)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	planetConfigPackage, err := s.planetConfigPackage(server, planetPackage.Version)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return []loc.Locator{
-		*masterConfigPackage,
-		*nodeConfigPackage,
-		*planetSecretsPackage,
-		*planetConfigPackage,
-	}, nil
 }
 
 func (s *site) addCloudConfig(config clusterconfig.Interface) (args []string) {

--- a/lib/ops/opsservice/packages.go
+++ b/lib/ops/opsservice/packages.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/loc"
+)
+
+// planetSecretsNextPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetSecretsNextPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetSecretsPackage generates a new planet secrets package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-<node-addr>-secrets:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetSecretsPackage(node *ProvisionedServer, planetVersion string) loc.Locator {
+	return planetSecretsPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetNextConfigPackage generates a new planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) planetNextConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	planetVersion = fmt.Sprintf("%v+%v", planetVersion, time.Now().UTC().Unix())
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// planetConfigPackage generates a planet configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/planet-config-<node-addr>:<planet-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) planetConfigPackage(node remoteServer, planetVersion string) loc.Locator {
+	return planetConfigPackage(node, s.domainName, s.domainName, planetVersion)
+}
+
+// teleportNextNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextNodeConfigPackage(node remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportNodeConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-node-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportNodeConfigPackage(node remoteServer) loc.Locator {
+	return teleportNodeConfigPackage(node, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+// teleportNextMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>(+<increment>)?'
+// where increment is an ever-increasing counter and node-addr is a combination of the node address
+// and cluster name
+func (s *site) teleportNextMasterConfigPackage(master remoteServer, teleportVersion string) loc.Locator {
+	teleportVersion = fmt.Sprintf("%v+%v", teleportVersion, time.Now().UTC().Unix())
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, teleportVersion)
+}
+
+// teleportMasterConfigPackage generates a new teleport configuration package name for the specified
+// node and planet package version.
+//
+// The package is named as '<cluster-name>/teleport-master-config-<node-addr>:<teleport-version>'
+// where node-addr is a combination of the node address and cluster name
+func (s *site) teleportMasterConfigPackage(master remoteServer) loc.Locator {
+	return teleportMasterConfigPackage(master, s.domainName, s.domainName, s.teleportPackage.Version)
+}
+
+func teleportMasterConfigPackage(master remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportMasterConfigPackage,
+			PackageSuffix(master, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+func planetSecretsPackage(node *ProvisionedServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       fmt.Sprintf("planet-%v-secrets", node.AdvertiseIP),
+		Version:    planetVersion,
+	}
+}
+
+func planetConfigPackage(node remoteServer, repository, clusterName, planetVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.PlanetConfigPackage,
+			PackageSuffix(node, clusterName)),
+		Version: planetVersion,
+	}
+}
+
+func teleportNodeConfigPackage(node remoteServer, repository, clusterName, teleportVersion string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name: fmt.Sprintf("%v-%v",
+			constants.TeleportNodeConfigPackage,
+			PackageSuffix(node, clusterName),
+		),
+		Version: teleportVersion,
+	}
+}
+
+// suffixer replaces characters unacceptable as a package suffix
+var suffixer = strings.NewReplacer(".", "", ":", "")
+
+// PackageSuffix returns a new package suffix used in package names
+// from the specified node address and given cluster name
+func PackageSuffix(node remoteServer, clusterName string) string {
+	data := fmt.Sprintf("%v.%v", node.Address(), clusterName)
+	return suffixer.Replace(data)
+}

--- a/lib/ops/opsservice/plan.go
+++ b/lib/ops/opsservice/plan.go
@@ -149,14 +149,6 @@ func (s *ProvisionedServer) InGravity(dir ...string) string {
 	return filepath.Join(append([]string{s.StateDir()}, dir...)...)
 }
 
-// suffixer replaces characters unacceptable as a package suffix
-var suffixer = strings.NewReplacer(".", "", ":", "")
-
-func PackageSuffix(node remoteServer, domain string) string {
-	data := fmt.Sprintf("%v.%v", node.Address(), domain)
-	return suffixer.Replace(data)
-}
-
 func FQDN(domain, hostname, ip string) string {
 	// in case hostname comes already with this domain suffix,
 	// we assume that it's set by provisioner or user in on-prem

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -40,6 +40,10 @@ import (
 
 // RotateSecrets rotates secrets package for the server specified in the request
 func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.RotatePackageResponse, err error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	node := &ProvisionedServer{
 		Server: req.Server,
 		Profile: schema.NodeProfile{
@@ -47,24 +51,21 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 		},
 	}
 
-	cluster, err := o.openSite(req.SiteKey())
+	cluster, err := o.openSite(req.Key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	secretsPackage := req.Locator
-	if secretsPackage == nil {
-		secretsPackage, err = cluster.planetSecretsNextPackage(node)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	secretsPackage := cluster.planetSecretsNextPackage(node, req.RuntimePackage.Version)
+	if req.Package != nil {
+		secretsPackage = *req.Package
 	}
 
 	if req.DryRun {
-		return &ops.RotatePackageResponse{Locator: *secretsPackage}, nil
+		return &ops.RotatePackageResponse{Locator: secretsPackage}, nil
 	}
 
-	op, err := ops.GetCompletedInstallOperation(req.SiteKey(), o)
+	op, err := ops.GetCompletedInstallOperation(req.Key, o)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -74,7 +75,7 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err = cluster.rotateSecrets(ctx, *secretsPackage, node, *op)
+	resp, err = cluster.rotateSecrets(ctx, secretsPackage, node, *op)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -84,7 +85,7 @@ func (o *Operator) RotateSecrets(req ops.RotateSecretsRequest) (resp *ops.Rotate
 
 // RotateTeleportConfig generates teleport configuration for the server specified in the provided request
 func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (masterConfig *ops.RotatePackageResponse, nodeConfig *ops.RotatePackageResponse, err error) {
-	if err := req.Check(); err != nil {
+	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -108,20 +109,14 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 		return nil, nil, trace.Wrap(err)
 	}
 
-	masterConfigPackage := req.Master
-	if masterConfigPackage == nil {
-		masterConfigPackage, err = cluster.teleportMasterConfigPackage(node)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
+	masterConfigPackage := cluster.teleportNextMasterConfigPackage(node, req.TeleportPackage.Version)
+	if req.MasterPackage != nil {
+		masterConfigPackage = *req.MasterPackage
 	}
 
-	nodeConfigPackage := req.Node
-	if nodeConfigPackage == nil {
-		nodeConfigPackage, err = cluster.teleportNodeConfigPackage(node)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
+	nodeConfigPackage := cluster.teleportNextNodeConfigPackage(node, req.TeleportPackage.Version)
+	if req.NodePackage != nil {
+		nodeConfigPackage = *req.NodePackage
 	}
 
 	ctx, err := cluster.newOperationContext(*operation)
@@ -130,7 +125,7 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 	}
 
 	if node.ClusterRole == string(schema.ServiceRoleMaster) {
-		masterConfig, err = cluster.getTeleportMasterConfig(ctx, *masterConfigPackage, node)
+		masterConfig, err = cluster.getTeleportMasterConfig(ctx, masterConfigPackage, node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -139,13 +134,13 @@ func (o *Operator) RotateTeleportConfig(req ops.RotateTeleportConfigRequest) (ma
 		// isn't running.
 		nodeConfig, err = cluster.getTeleportNodeConfig(ctx,
 			append(req.MasterIPs, constants.Localhost),
-			*nodeConfigPackage,
+			nodeConfigPackage,
 			node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 	} else {
-		nodeConfig, err = cluster.getTeleportNodeConfig(ctx, req.MasterIPs, *nodeConfigPackage, node)
+		nodeConfig, err = cluster.getTeleportNodeConfig(ctx, req.MasterIPs, nodeConfigPackage, node)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -177,6 +172,10 @@ func (o *Operator) getNodeProfile(operation ops.SiteOperation, node storage.Serv
 
 // RotatePlanetConfig rotates planet configuration package for the server specified in the request
 func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.RotatePackageResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	clusterKey := req.Key.SiteKey()
 	cluster, err := o.openSite(clusterKey)
 	if err != nil {
@@ -194,16 +193,13 @@ func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.R
 		Profile: *nodeProfile,
 	}
 
-	configPackage := req.Locator
-	if configPackage == nil {
-		configPackage, err = cluster.planetNextConfigPackage(&node, req.RuntimePackage.Version)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	configPackage := cluster.planetNextConfigPackage(&node, req.RuntimePackage.Version)
+	if req.Package != nil {
+		configPackage = *req.Package
 	}
 
 	if req.DryRun {
-		return &ops.RotatePackageResponse{Locator: *configPackage}, nil
+		return &ops.RotatePackageResponse{Locator: configPackage}, nil
 	}
 
 	runner := &localRunner{}
@@ -270,7 +266,7 @@ func (o *Operator) RotatePlanetConfig(req ops.RotatePlanetConfigRequest) (*ops.R
 		docker:        dockerConfig,
 		dockerRuntime: node.Docker,
 		planetPackage: req.RuntimePackage,
-		configPackage: *configPackage,
+		configPackage: configPackage,
 		env:           req.Env,
 	}
 

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -32,9 +32,10 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
 	"github.com/gravitational/gravity/lib/transfer"
+
+	"github.com/coreos/go-semver/semver"
 	telecfg "github.com/gravitational/teleport/lib/config"
 	teledefaults "github.com/gravitational/teleport/lib/defaults"
-
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -66,7 +67,8 @@ func newImporter(dir string) (*importer, error) {
 		FieldLogger: logrus.WithFields(logrus.Fields{
 			trace.Component:    "importer",
 			constants.FieldDir: dir,
-		})}
+		}),
+	}
 	err = func() error {
 		objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
 		if err != nil {
@@ -109,14 +111,17 @@ func (i *importer) Close() error {
 }
 
 // getMasterTeleportConfig extracts configuration from teleport package
-func (i *importer) getMasterTeleportConfig() (*telecfg.FileConfig, error) {
-	configPackage, err := pack.FindLatestPackageByName(i.packages,
-		constants.TeleportMasterConfigPackage)
+func (i *importer) getMasterTeleportConfig(clusterName string) (*telecfg.FileConfig, error) {
+	configPackage, err := pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
+		Packages:   i.packages,
+		Repository: clusterName,
+		Match:      matchTeleportConfigPackage(*defaults.TeleportVersion),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	i.Infof("Using teleport master config from %v.", configPackage)
+	i.WithField("package", configPackage).Info("Use teleport master config.")
 
 	_, reader, err := i.packages.ReadPackage(*configPackage)
 	if err != nil {
@@ -222,4 +227,26 @@ func (i *importer) importSite(b storage.Backend) error {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func matchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
+	return func(env pack.PackageEnvelope) bool {
+		if !env.HasLabel(pack.PurposeLabel, pack.PurposeTeleportMasterConfig) {
+			return false
+		}
+		ver, err := env.Locator.SemVer()
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				logrus.ErrorKey: err,
+				"package":       env.Locator,
+			}).Warn("Invalid semver.")
+			return false
+		}
+		verBase := semver.Version{
+			Major: ver.Major,
+			Minor: ver.Minor,
+			Patch: ver.Patch,
+		}
+		return verBase.Compare(teleportVersion) == 0
+	}
 }

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -430,13 +430,18 @@ func (p *Process) getTeleportConfigFromImportState() (*telecfg.FileConfig, error
 		return nil, nil
 	}
 
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	importer, err := newImporter(p.cfg.ImportDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer importer.Close()
 
-	telecfg, err := importer.getMasterTeleportConfig()
+	telecfg, err := importer.getMasterTeleportConfig(cluster.Domain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -164,8 +164,8 @@ type UpdateServer struct {
 type RuntimePackage struct {
 	// Installed identifies the installed version of the runtime package
 	Installed loc.Locator `json:"installed"`
-	// RuntimeSecretsPackage specifies the new secrets package
-	SecretsPackage *loc.Locator `json:"runtime_secrets_package,omitempty"`
+	// SecretsPackage specifies the new secrets package
+	SecretsPackage *loc.Locator `json:"secrets_package,omitempty"`
 	// Update describes an update to the runtime package
 	Update *RuntimeUpdate `json:"update,omitempty"`
 }
@@ -201,8 +201,9 @@ type TeleportUpdate struct {
 	// Package identifies the package to update to.
 	// This can be the same as Installed in which case no update is performed
 	Package loc.Locator `json:"package"`
-	// NodeConfigPackage identifies the new host teleport configuration package
-	NodeConfigPackage loc.Locator `json:"node_config_package"`
+	// NodeConfigPackage identifies the new host teleport configuration package.
+	// If nil, no changes to configuration package required
+	NodeConfigPackage *loc.Locator `json:"node_config_package,omitempty"`
 }
 
 // InstallOperationData describes configuration for the install operation

--- a/lib/update/cluster/phases/coredns.go
+++ b/lib/update/cluster/phases/coredns.go
@@ -158,7 +158,7 @@ func (p *updatePhaseCoreDNS) generateCorefile(context.Context) error {
 			"Corefile": conf,
 		},
 	})
-	err = trace.ConvertSystemError(err)
+	err = rigging.ConvertError(err)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err)
 	}

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -104,7 +104,7 @@ func NewUpdatePhaseInit(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	operation, err := ops.GetLastUpdateOperation(cluster.Key(), operator)
+	operation, err := operator.GetSiteOperation(fsm.OperationKey(p.Plan))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -373,10 +373,10 @@ func (p *updatePhaseInit) createAdminAgent() error {
 func (p *updatePhaseInit) rotateSecrets(server storage.UpdateServer) error {
 	p.Infof("Generate new secrets configuration package for %v.", server)
 	resp, err := p.Operator.RotateSecrets(ops.RotateSecretsRequest{
-		AccountID:   p.Operation.AccountID,
-		ClusterName: p.Operation.SiteDomain,
-		Locator:     server.Runtime.SecretsPackage,
-		Server:      server.Server,
+		Key:            p.Operation.ClusterKey(),
+		Package:        server.Runtime.SecretsPackage,
+		RuntimePackage: server.Runtime.Update.Package,
+		Server:         server.Server,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -396,7 +396,7 @@ func (p *updatePhaseInit) rotatePlanetConfig(server storage.UpdateServer) error 
 		Server:         server.Server,
 		Manifest:       p.updateManifest,
 		RuntimePackage: server.Runtime.Update.Package,
-		Locator:        &server.Runtime.Update.ConfigPackage,
+		Package:        &server.Runtime.Update.ConfigPackage,
 		Config:         p.existingClusterConfig,
 		Env:            p.existingEnviron,
 	})
@@ -414,10 +414,11 @@ func (p *updatePhaseInit) rotatePlanetConfig(server storage.UpdateServer) error 
 
 func (p *updatePhaseInit) rotateTeleportConfig(server storage.UpdateServer) error {
 	masterConf, nodeConf, err := p.Operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-		Key:       p.Operation.Key(),
-		Server:    server.Server,
-		Node:      &server.Teleport.Update.NodeConfigPackage,
-		MasterIPs: masterIPs(p.Servers),
+		Key:             p.Operation.Key(),
+		Server:          server.Server,
+		TeleportPackage: server.Teleport.Update.Package,
+		NodePackage:     server.Teleport.Update.NodeConfigPackage,
+		MasterIPs:       masterIPs(p.Servers),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/update/cluster/plan.go
+++ b/lib/update/cluster/plan.go
@@ -428,15 +428,6 @@ func configUpdates(
 		return nil, trace.Wrap(err)
 	}
 	for _, server := range servers {
-		secretsUpdate, err := operator.RotateSecrets(ops.RotateSecretsRequest{
-			AccountID:   operation.AccountID,
-			ClusterName: operation.SiteDomain,
-			Server:      server,
-			DryRun:      true,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		installedRuntime, err := getRuntimePackage(installed, server.Role, schema.ServiceRole(server.ClusterRole))
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -444,8 +435,7 @@ func configUpdates(
 		updateServer := storage.UpdateServer{
 			Server: server,
 			Runtime: storage.RuntimePackage{
-				Installed:      *installedRuntime,
-				SecretsPackage: &secretsUpdate.Locator,
+				Installed: *installedRuntime,
 			},
 			Teleport: storage.TeleportPackage{
 				Installed: *installedTeleport,
@@ -462,6 +452,15 @@ func configUpdates(
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			secretsUpdate, err := operator.RotateSecrets(ops.RotateSecretsRequest{
+				Key:            operation.SiteKey(),
+				Server:         server,
+				RuntimePackage: *updateRuntime,
+				DryRun:         true,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
 			configUpdate, err := operator.RotatePlanetConfig(ops.RotatePlanetConfigRequest{
 				Key:            operation,
 				Server:         server,
@@ -472,6 +471,7 @@ func configUpdates(
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			updateServer.Runtime.SecretsPackage = &secretsUpdate.Locator
 			updateServer.Runtime.Update = &storage.RuntimeUpdate{
 				Package:       *updateRuntime,
 				ConfigPackage: configUpdate.Locator,
@@ -479,16 +479,17 @@ func configUpdates(
 		}
 		if needsTeleportUpdate {
 			_, nodeConfig, err := operator.RotateTeleportConfig(ops.RotateTeleportConfigRequest{
-				Key:    operation,
-				Server: server,
-				DryRun: true,
+				Key:             operation,
+				Server:          server,
+				TeleportPackage: *updateTeleport,
+				DryRun:          true,
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			updateServer.Teleport.Update = &storage.TeleportUpdate{
 				Package:           *updateTeleport,
-				NodeConfigPackage: nodeConfig.Locator,
+				NodeConfigPackage: &nodeConfig.Locator,
 			}
 		}
 		updates = append(updates, updateServer)

--- a/lib/update/clusterconfig/phases/update.go
+++ b/lib/update/clusterconfig/phases/update.go
@@ -72,7 +72,7 @@ func (r *updateConfig) Execute(ctx context.Context) error {
 			Server:         update.Server,
 			Manifest:       r.manifest,
 			RuntimePackage: update.Runtime.Update.Package,
-			Locator:        &update.Runtime.Update.ConfigPackage,
+			Package:        &update.Runtime.Update.ConfigPackage,
 			Config:         r.operation.UpdateConfig.Config,
 		}
 		resp, err := r.operator.RotatePlanetConfig(req)

--- a/lib/update/environ/phases/update.go
+++ b/lib/update/environ/phases/update.go
@@ -72,7 +72,7 @@ func (r *updateConfig) Execute(ctx context.Context) error {
 			Server:         update.Server,
 			Manifest:       r.manifest,
 			RuntimePackage: update.Runtime.Update.Package,
-			Locator:        &update.Runtime.Update.ConfigPackage,
+			Package:        &update.Runtime.Update.ConfigPackage,
 			Env:            r.operation.UpdateEnviron.Env,
 		}
 		resp, err := r.operator.RotatePlanetConfig(req)

--- a/lib/update/system/system.go
+++ b/lib/update/system/system.go
@@ -161,9 +161,6 @@ type System struct {
 }
 
 func (r *Config) checkAndSetDefaults() error {
-	if r.ChangesetID == "" {
-		return trace.BadParameter("ChangesetID is required")
-	}
 	if r.Backend == nil {
 		return trace.BadParameter("Backend is required")
 	}

--- a/lib/update/system/system.go
+++ b/lib/update/system/system.go
@@ -161,6 +161,9 @@ type System struct {
 }
 
 func (r *Config) checkAndSetDefaults() error {
+	if r.ChangesetID == "" {
+		return trace.BadParameter("ChangesetID is required")
+	}
 	if r.Backend == nil {
 		return trace.BadParameter("Backend is required")
 	}
@@ -204,10 +207,7 @@ func (r *PackageUpdates) checkAndSetDefaults() error {
 		r.RuntimeSecrets.Labels = pack.RuntimeSecretsPackageLabels
 	}
 	if r.Teleport != nil {
-		if r.Teleport.ConfigPackage == nil {
-			return trace.BadParameter("Teleport configuration package is required")
-		}
-		if len(r.Teleport.ConfigPackage.Labels) == 0 {
+		if r.Teleport.ConfigPackage != nil && len(r.Teleport.ConfigPackage.Labels) == 0 {
 			r.Teleport.ConfigPackage.Labels = pack.TeleportNodeConfigPackageLabels
 		}
 	}
@@ -260,7 +260,7 @@ func (r *System) reinstallPackage(update storage.PackageUpdate) ([]pack.LabelUpd
 	r.WithField("update", update).Info("Reinstalling package.")
 	switch {
 	case update.To.Name == constants.GravityPackage:
-		return updateGravityPackage(r.Packages, update.To)
+		return r.updateGravityPackage(update.To)
 	case pack.IsPlanetPackage(update.To, update.Labels):
 		updates, err := r.updatePlanetPackage(update)
 		return updates, trace.Wrap(err)
@@ -365,6 +365,10 @@ func (r *System) updateTeleportPackage(update storage.PackageUpdate) (labelUpdat
 		}
 	}
 	if update.ConfigPackage == nil {
+		return updates, nil
+	}
+	if update.ConfigPackage.From.IsEqualTo(update.ConfigPackage.To) {
+		// Short-circuit on idempotent configuration update
 		return updates, nil
 	}
 	return append(updates,
@@ -499,7 +503,7 @@ func (r *System) reinstallService(update storage.PackageUpdate) (labelUpdates []
 
 	var configPackage loc.Locator
 	if update.ConfigPackage == nil {
-		existingConfig, err := pack.FindConfigPackage(r.Packages, update.From)
+		existingConfig, err := pack.FindInstalledConfigPackage(r.Packages, update.From)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -538,22 +542,26 @@ func (r *System) reinstallService(update storage.PackageUpdate) (labelUpdates []
 	return labelUpdates, nil
 }
 
-func updateGravityPackage(packages update.LocalPackageService, newPackage loc.Locator) (labelUpdates []pack.LabelUpdate, err error) {
+func (r *System) updateGravityPackage(newPackage loc.Locator) (labelUpdates []pack.LabelUpdate, err error) {
 	for _, targetPath := range state.GravityBinPaths {
-		labelUpdates, err = reinstallBinaryPackage(packages, newPackage, targetPath)
+		labelUpdates, err = reinstallBinaryPackage(r.Packages, newPackage, targetPath)
 		if err == nil {
 			break
 		}
+		r.WithFields(logrus.Fields{
+			logrus.ErrorKey: err,
+			"path":          targetPath,
+		}).Warn("Failed to install gravity binary.")
 	}
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to install gravity binary in any of %v",
 			state.GravityBinPaths)
 	}
-	planetPath, err := getRuntimePackagePath(packages)
+	planetPath, err := getRuntimePackagePath(r.Packages)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to find planet package")
 	}
-	err = copyGravityToPlanet(newPackage, packages, planetPath)
+	err = copyGravityToPlanet(newPackage, r.Packages, planetPath)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to copy gravity inside planet")
 	}

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -106,7 +106,9 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 		return nil, trace.Wrap(err)
 	}
 	req := init.updateDeployRequest(deployAgentsRequest{
-		clusterState: cluster.ClusterState,
+		// Use server list from the operation plan to always have a consistent
+		// view of the cluster (i.e. with servers correctly reflecting cluster roles)
+		clusterState: clusterStateFromPlan(*plan),
 		clusterName:  cluster.Domain,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
@@ -162,4 +164,12 @@ type updater interface {
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	Complete(error) error
+}
+
+func clusterStateFromPlan(plan storage.OperationPlan) (result storage.ClusterState) {
+	result.Servers = make([]storage.Server, 0, len(plan.Servers))
+	for _, s := range plan.Servers {
+		result.Servers = append(result.Servers, s)
+	}
+	return result
 }


### PR DESCRIPTION
* Bring branch up-to-date with 6.1.x w.r.t updates
* Sync up with 6.1.x w.r.t to planet/teleport configuration package naming changes to fix the upgrades.
* Bump version of the base application for upgrade tests to 6.1.6 to exercise the issue

Updates https://github.com/gravitational/gravity.e/issues/4230.