### PR TITLE
[6.1.x] followup to #768

### DIFF
--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -5,6 +5,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to exercise on
+UPGRADE_MAP[5.5.0]="ubuntu:16"
 UPGRADE_MAP[5.5.21]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/lib/rpc/proxy/proxy.go
+++ b/lib/rpc/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +34,6 @@ func New(link Link, log log.FieldLogger) *Proxy {
 	return &Proxy{
 		link:        link,
 		FieldLogger: log.WithField("proxy", link.String()),
-		teardownCh:  make(chan struct{}),
 		doneCh:      ctx.Done(),
 		cancel:      cancel,
 	}
@@ -47,9 +47,10 @@ type Proxy struct {
 	// and proxy loop stopped
 	doneCh <-chan struct{}
 	cancel context.CancelFunc
-	// teardownCh signals when the connection cleanup has completed
-	// and proxy loop has finished
-	teardownCh chan struct{}
+	// wg allows to track lifespan of internal processes
+	wg sync.WaitGroup
+	// notifyCh signals new connections
+	notifyCh chan<- struct{}
 }
 
 // Start starts the proxy
@@ -58,6 +59,7 @@ func (r *Proxy) Start() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	r.wg.Add(1)
 	go r.serve(listener)
 	r.Info("Proxy started.")
 	return nil
@@ -66,7 +68,8 @@ func (r *Proxy) Start() error {
 // Stop stops the proxy and drops all active connections
 func (r *Proxy) Stop() {
 	r.cancel()
-	<-r.teardownCh
+	r.link.Close()
+	r.wg.Wait()
 	r.Info("Proxy stopped.")
 }
 
@@ -77,6 +80,8 @@ type Link interface {
 	Listen() (net.Listener, error)
 	// Dials dials to the remote side of the link
 	Dial() (net.Conn, error)
+	// Close closes the local link
+	Close() error
 }
 
 // NetLink links two network endpoints.
@@ -92,6 +97,11 @@ type NetLink struct {
 // Implements Link
 func (r NetLink) Listen() (net.Listener, error) {
 	return r.Local, nil
+}
+
+// Close closes the local link
+func (r NetLink) Close() error {
+	return r.Local.Close()
 }
 
 // Dials dials the remote endpoint.
@@ -110,35 +120,47 @@ func (r NetLink) String() string {
 }
 
 func (r *Proxy) serve(listener net.Listener) {
-	defer close(r.teardownCh)
+	defer r.wg.Done()
 	for {
 		c1, err := listener.Accept()
 		if err != nil {
-			r.Errorf("Failed to accept: %v.", err)
+			select {
+			case <-r.doneCh:
+				return
+			default:
+			}
+			r.WithError(err).Warn("Failed to accept.")
 			return
 		}
 		r.Infof("Accept connection from %v.", c1.RemoteAddr())
 
 		c2, err := r.link.Dial()
 		if err != nil {
-			r.Errorf("Failed to dial: %v.", err)
+			r.WithFields(log.Fields{
+				log.ErrorKey: err,
+				"addr":       r.link,
+			}).Warn("Failed to dial local link.")
 			c1.Close()
 			return
 		}
-		r.Infof("Upstream connection to %v.", c2.RemoteAddr())
+		r.WithField("addr", c2.RemoteAddr()).Info("Upstream connection.")
 
+		r.wg.Add(3)
 		errCh := make(chan error, 2)
-		go proxyConn(c1, c2, errCh)
-		go proxyConn(c2, c1, errCh)
+		go r.proxyConn(c1, c2, errCh)
+		go r.proxyConn(c2, c1, errCh)
 		go r.watchConns(errCh, c1, c2, listener)
+
+		r.notifyNewConnection()
 	}
 }
 
 func (r *Proxy) watchConns(errCh <-chan error, closers ...io.Closer) {
+	defer r.wg.Done()
 	select {
 	case err := <-errCh:
 		if err != nil {
-			r.Warnf("Failed in proxyConn: %v.", err)
+			r.WithError(err).Warn("Failed in proxyConn.")
 		}
 	case <-r.doneCh:
 	}
@@ -147,7 +169,15 @@ func (r *Proxy) watchConns(errCh <-chan error, closers ...io.Closer) {
 	}
 }
 
-func proxyConn(c1 io.Writer, c2 io.Reader, errCh chan<- error) {
+func (r *Proxy) notifyNewConnection() {
+	select {
+	case r.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Proxy) proxyConn(c1 io.Writer, c2 io.Reader, errCh chan<- error) {
+	defer r.wg.Done()
 	_, err := io.Copy(c1, c2)
 	errCh <- err
 }

--- a/lib/rpc/proxy/proxy_test.go
+++ b/lib/rpc/proxy/proxy_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&S{})
 
 func (_ *S) TestProxiesConnections(c *C) {
 	link := newLocalLink()
-	proxy := New(link, log.StandardLogger())
+	proxy := New(link, log.WithField("test", "TestProxiesConnections"))
 	proxy.Start()
 	defer proxy.Stop()
 
@@ -46,7 +46,7 @@ func (_ *S) TestProxiesConnections(c *C) {
 
 	s := newServer(1)
 	go s.serve(link.upstream)
-	defer link.Close()
+	defer link.stop()
 
 	payload := []byte("test")
 	_, err = conn.Write(payload)
@@ -65,27 +65,34 @@ func (_ *S) TestProxiesConnections(c *C) {
 func (_ *S) TestCanStopProxyOnDemand(c *C) {
 	payload := []byte("test")
 	link := newLocalLink()
-	proxy := New(link, log.StandardLogger())
+	logger := log.WithField("test", ") TestCanStopProxyOnDemand")
+	proxy := New(link, logger)
+	notifyCh := make(chan struct{}, 1)
+	proxy.notifyCh = notifyCh
 	c.Assert(proxy.Start(), IsNil)
 	defer proxy.Stop()
 
 	s := newServer(2)
 	go s.serve(link.upstream)
-	defer link.Close()
+	defer link.stop()
 
 	conn, err := link.local.Dial()
 	c.Assert(err, IsNil)
 
+	// wait for new connection: this blocks until the proxy has accepted
+	// the connection and created handler loop
+	<-notifyCh
+
 	// Stop proxy so the write fails
 	proxy.Stop()
-	link.resetLocal()
 
 	_, err = conn.Write(payload)
 	c.Assert(err, ErrorMatches, "io: read/write on closed pipe")
 	conn.Close()
 
 	// Restart proxy to be able to write
-	proxy = New(link, log.StandardLogger())
+	link.resetLocal()
+	proxy = New(link, logger)
 	c.Assert(proxy.Start(), IsNil)
 	defer proxy.Stop()
 
@@ -97,7 +104,7 @@ func (_ *S) TestCanStopProxyOnDemand(c *C) {
 
 	select {
 	case <-s.recvCh:
-	// Skip the first write
+		// Skip the first write
 	case <-time.After(1 * time.Second):
 		c.Error("timeout waiting for write")
 	}
@@ -126,6 +133,10 @@ func (r *localLink) Dial() (net.Conn, error) {
 	return r.upstream.Dial()
 }
 
+func (r *localLink) Close() error {
+	return r.local.Close()
+}
+
 func (r *localLink) String() string {
 	return "localLink"
 }
@@ -134,7 +145,7 @@ func (r *localLink) resetLocal() {
 	r.local = inprocess.Listen()
 }
 
-func (r *localLink) Close() error {
+func (r *localLink) stop() error {
 	r.local.Close()
 	r.upstream.Close()
 	return nil

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -155,7 +155,6 @@ func (p *updatePhaseBootstrap) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// FIXME: will this interfere with queryPackageLabels?
 	err = p.updateExistingPackageLabels()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
 * Fix teleport config fetching code (lib/process/import.go) to support fetching of legacy teleport config packages if no packages are using new versioning scheme.
 * Add tests for the added functionality.
 * Bonus: fix flaky lib/rpc/proxy test by backporting changes from master.

Updates https://github.com/gravitational/gravity/pull/768 to fix an issue with upgrades over a version that does not use the new configuration package versioning scheme.