### PR TITLE
autojoin stale retry loop

### DIFF
--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -885,15 +885,19 @@ func retryUpdateJoinConfigFromCloudMetadata(ctx context.Context, config *autojoi
 		// Test that the serviceURL is reachable
 		// When re-installing a cluster into AWS, the serviceURL can point to an old cluster
 		// until the new cluster overwrites the SSM values. So test the ServiceURL is reachable before using it.
-		req, _ := http.NewRequest("GET", config.serviceURL, nil)
+		req, err := http.NewRequest("GET", config.serviceURL, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// TODO(Knisbet) replace with NewRequestWithContext when on golang 1.13
 		req = req.WithContext(ctx)
 		_, err = client.Do(req)
 		if err != nil {
-			return trace.WrapWithMessage(err, "Waiting for service URL to become available.").
+			return trace.Wrap(err, "Waiting for service URL to become available.").
 				AddField("service_url", config.serviceURL)
 		}
 
-		return err
+		return trace.Wrap(err)
 	}
 	return trace.Wrap(utils.RetryWithInterval(ctx, b, f))
 }

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -401,7 +401,7 @@ func autojoin(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, d
 		return autojoinFromService(env, environ, d)
 	}
 
-	err = updateJoinConfigFromCloudMetadata(context.TODO(), &d)
+	err = retryUpdateJoinConfigFromCloudMetadata(context.TODO(), &d)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This change codifies a workaround previously placed in the cloud-init config when creating a cluster via terraform on AWS.

The AWS autojoin integrations use AWS SSM to store the URL of the cluster and token used for joining the cluster by name. When a cluster is uninstalled and being re-installed, new parameters may not have replaced the old ones yet, causing nodes to attempt to join the stale cluster which will fail. The workaround in the bash script operated by testing that the URL in SSM is a valid cluster, and then only launching autojoin once this succeeded. 

I don't see a better way to do this, so I've essentially copied the same logic here, when retrieving the parameters from SSM, test them for validity by trying to connect to the URL and seeing if a successfully http result comes back. Loop indefinitely until that condition is met, which is appropriate behaviour for autojoin. 