### PR TITLE
release notes for cve-2019-11253

### DIFF
--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -7,11 +7,11 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 6.2.1         | No  | October 11th, 2019   | -                    | 1.16.0             | 3.2.12           |
-| 6.1.7         | No  | October 11th, 2019   | -                    | 1.15.4             | 3.2.12           |
-| 6.0.9         | No  | September 18th, 2019 | -                    | 1.14.7             | 3.2.12           |
-| 5.6.8         | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
-| 5.5.24        | Yes | October 15th, 2019    | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
+| 6.2.2         | No  | October 17th, 2019   | -                    | 1.16.0             | 3.2.12           |
+| 6.1.8         | No  | October 17th, 2019   | -                    | 1.15.4             | 3.2.12           |
+| 6.0.10        | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
+| 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
+| 5.5.24        | Yes | October 17th, 2019   | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 | 5.4.10*       | No  | March 26th, 2019     | -                    | 1.13.5             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7            |
 | 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
@@ -36,6 +36,43 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     See [Direct Upgrades From Older LTS Versions](/pack/#direct-upgrades-from-older-lts-versions) for details.
 
 ## 6.x Releases
+
+### 6.2.2 (October 17th, 2019)
+
+#### Bugfixes
+
+* Upgrade Kubernetes to `v1.16.02` (CVE-2019-11253) ([#808](https://github.com/gravitational/gravity/pull/808)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://github.com/kubernetes/kubernetes/issues/83253) for more information.
+
+### 6.1.8 (October 17th, 2019)
+
+#### Bugfixes
+
+* Upgrade Kubernetes to `v1.15.05` (CVE-2019-11253) ([#809](https://github.com/gravitational/gravity/pull/809)).
+* Fix an issue with upgrades related to fetching legacy teleport configuration ([#809](https://github.com/gravitational/gravity/pull/809)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://github.com/kubernetes/kubernetes/issues/83253) for more information.
+
+### 6.0.10 (October 17th, 2019)
+
+#### Improvements
+
+* Add support for discovering upstream DNS servers from systemd-resolved configuration ([#740](https://github.com/gravitational/gravity/pull/740)).
+* Improve `gravity report` to capture additional network configuration ([#769](https://github.com/gravitational/gravity/pull/769)).
+
+#### Bugfixes
+
+* Upgrade Kubernetes to `v1.14.08` (CVE-2019-11253) ([#810](https://github.com/gravitational/gravity/pull/810)).
+* Fix the issue with join failing with "bad username or password" when using auto-scaling groups on AWS ([#790](https://github.com/gravitational/gravity/pull/790)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://github.com/kubernetes/kubernetes/issues/83253) for more information.
 
 ### 6.2.1 (October 11th, 2019)
 
@@ -328,6 +365,16 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 ## 5.x Releases
 
+### 5.5.24 (October 17th, 2019)
+
+#### Bugfixes
+
+* Upgrade Kubernetes to `v1.13.12` (CVE-2019-11253) ([#811](https://github.com/gravitational/gravity/pull/811)).
+* Fixes an issue with timeouts while validating agent connections ([#777](https://github.com/gravitational/gravity/pull/777)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://github.com/kubernetes/kubernetes/issues/83253) for more information.
 
 ### 5.5.24 LTS (October 15th, 2019)
 

--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -11,7 +11,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | 6.1.8         | No  | October 17th, 2019   | -                    | 1.15.4             | 3.2.12           |
 | 6.0.10        | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
 | 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
-| 5.5.24        | Yes | October 17th, 2019   | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
+| 5.5.25        | Yes | October 17th, 2019   | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 | 5.4.10*       | No  | March 26th, 2019     | -                    | 1.13.5             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7            |
 | 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
@@ -365,7 +365,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 ## 5.x Releases
 
-### 5.5.24 (October 17th, 2019)
+### 5.5.25 (October 17th, 2019)
 
 #### Bugfixes
 

--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -9,9 +9,9 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 6.2.2         | No  | October 17th, 2019   | -                    | 1.16.0             | 3.2.12           |
 | 6.1.8         | No  | October 17th, 2019   | -                    | 1.15.4             | 3.2.12           |
-| 6.0.10        | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
+| 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
 | 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
-| 5.5.25        | Yes | October 17th, 2019   | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
+| 5.5.26        | Yes | October 17th, 2019   | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 | 5.4.10*       | No  | March 26th, 2019     | -                    | 1.13.5             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7            |
 | 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
@@ -365,12 +365,13 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 ## 5.x Releases
 
-### 5.5.25 (October 17th, 2019)
+### 5.5.26 (October 17th, 2019)
 
 #### Bugfixes
 
 * Upgrade Kubernetes to `v1.13.12` (CVE-2019-11253) ([#811](https://github.com/gravitational/gravity/pull/811)).
 * Fixes an issue with timeouts while validating agent connections ([#777](https://github.com/gravitational/gravity/pull/777)).
+* Fixes an issue where upgrade could fail with `latest package not found` error in gravity-site ([#813](https://github.com/gravitational/gravity/pull/813)).
 
 !!! warning
     This release fixes a security vulnerability in kubernetes. Please see


### PR DESCRIPTION
Note: I marked 5.6.x as obsolete as I think it's far past our support for a non LTS release.