### PR TITLE
[5.5.x] update nightly robotest script to test intermediate upgrades

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ properties([
     string(name: 'ROBOTEST_VERSION',
            defaultValue: 'stable-gce',
            description: 'Robotest tag to use.'),
-    choice(choices: ["true", "false"].join("\n"),
+    choice(choices: ["false", "true"].join("\n"),
            defaultValue: 'false',
            description: 'Whether to use preemptible VMs.',
            name: 'GCE_PREEMPTIBLE'),

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -118,7 +118,7 @@ timestamps {
           passwordVariable: 'AWS_SECRET_ACCESS_KEY',
         ],
         ]) {
-          sh 'make -C e production telekube opscenter'
+          sh 'make -C e production telekube-intermediate-upgrade opscenter'
         }
       }
     }

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -7,7 +7,8 @@ DOCKER_STORAGE_DRIVERS="overlay2"
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to test upgrades on
-UPGRADE_MAP[5.2.3]="centos:7 ubuntu:16"
+UPGRADE_MAP[5.2.15]="centos:7 ubuntu:16"
+UPGRADE_MAP[5.0.35]="debian:9 ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}


### PR DESCRIPTION
Update nightly script to test intermediate upgrades.
I'll be adding the individual branches to the nightly pipeline.