### PR TITLE
Update test plan.

### DIFF
--- a/docs/6.x/testplan.md
+++ b/docs/6.x/testplan.md
@@ -122,11 +122,11 @@ spec:
 - [ ] Install a Hub of the previous LTS version.
   - [ ] Push Telekube app of the previous LTS version into it.
   - [ ] Install a single-node Telekube cluster and connect it to the Hub.
-- [ ] Upgrade the Hub to the current version.
-  - [ ] Verify the cluster stays connected & online.
-  - [ ] Verify remote support can be toggled off/on.
 - [ ] Push Telekube app of the current version to the Hub.
 - [ ] Upgrade the cluster to the current version.
+  - [ ] Verify the cluster stays connected & online.
+  - [ ] Verify remote support can be toggled off/on.
+- [ ] Upgrade the Hub to the current version.
   - [ ] Verify the cluster stays connected & online.
   - [ ] Verify remote support can be toggled off/on.
 


### PR DESCRIPTION
When upgrading from 5.5 (teleport 3.0) to 6.1 (teleport 3.2), the expected upgrade order is that remote clusters are upgraded first and then the main cluster (the hub) last, otherwise the hub gets x509 error when trying to access the cluster.

Reflect that in the test plan.