### PR TITLE
pod access to etcd

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -662,6 +662,10 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 			req.Hosts = append(req.Hosts,
 				constants.APIServerDomainNameGravity,
 				constants.APIServerDomainName)
+		case constants.ETCDKeyPair:
+			// Give etcd certs on master nodes a SAN that can be used from within a pod to access etcd directly
+			// this configuration is discouraged, but currently stolon is using the cluster etcd instance.
+			req.Hosts = append(req.Hosts, constants.KubernetesServiceDomainNames...)
 		}
 		keyPair, err := authority.GenerateCertificate(req, caKeyPair, baseKeyPair.KeyPEM, defaults.CertificateExpiry)
 		if err != nil {


### PR DESCRIPTION
add kubernetes service SANs to etcd certs so that etcd is reachable from pods inside the cluster

Requires: forward-port


This is a result of the change in etcd 3 to using the etcd gateway. The etcd gateway acts as a L4 proxy to a master, which means the master cert needs SANs for the gateway nodes, which we don't currently support. As an alternative, have clients within pods access etcd via the kubernetes svc, and contact the master etcd servers directly.

I would discourage this mode of operation for most services, which should instead should deploy an etcd cluster within kubernetes, but in the stolon case it historically uses the cluster etcd.