### PR TITLE
[6.1.x] pod access to etcd

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -670,6 +670,10 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 			req.Hosts = append(req.Hosts, utils.KubeServiceNames(
 				defaults.LograngeAggregatorServiceName,
 				defaults.KubeSystemNamespace)...)
+		case constants.ETCDKeyPair:
+			// Give etcd certs on master nodes a SAN that can be used from within a pod to access etcd directly
+			// this configuration is discouraged, but currently stolon is using the cluster etcd instance.
+			req.Hosts = append(req.Hosts, constants.KubernetesServiceDomainNames...)
 		}
 		keyPair, err := authority.GenerateCertificate(req, caKeyPair, baseKeyPair.KeyPEM, defaults.CertificateExpiry)
 		if err != nil {


### PR DESCRIPTION
add kubernetes service SANs to etcd certs so that etcd is reachable from pods inside the cluster (#824)

Forward Port #824