### PR TITLE
Fixes 404s in the Docs

### DIFF
--- a/docs/6.x/catalog.md
+++ b/docs/6.x/catalog.md
@@ -67,16 +67,16 @@ chart and the Alpine image layers.
 ### Publish an Application Image
 
 !!! note:
-    Publishing applications requires an [Ops Center](/opscenter) and is
+    Publishing applications requires a [Gravity Hub](/docs/hub/) and is
     available only in the Enterprise edition of Gravity.
 
-A built application image can be published to an Ops Center. This allows the
-Ops Center to perform the role of a distribution endpoint for application images.
+A built application image can be published to an Gravity Hub. This allows the
+Gravity Hub to perform the role of a distribution endpoint for application images.
 
-To upload an application image to an Ops Center, first log into it:
+To upload an application image to an Gravity Hub, first log into it:
 
 ```bsh
-$ tele login -o ops.example.com
+$ tele login -o hub.example.com
 ```
 
 Then push the application image tarball:
@@ -96,33 +96,33 @@ App image   alpine:0.1.0    01/16/19 23:31
 
 #### Interacting with Docker Registry and Helm Chart Repository
 
-A Gravity Ops Center (and any Gravity cluster for that matter) acts as a Docker
+A Gravity Hub (and any Gravity cluster for that matter) acts as a Docker
 registry and a Helm chart repository so it is possible to pull Docker images
-and fetch Helm charts for published applications directly from the Ops Center.
-Note that you have to be logged into the Ops Center with `tele login` for this
+and fetch Helm charts for published applications directly from the Gravity Hub.
+Note that you have to be logged into the Gravity Hub with `tele login` for this
 to work.
 
 First let's try to pull a Docker image for the alpine application:
 
 ```bsh
-$ docker pull ops.example.com/alpine:3.3
+$ docker pull hub.example.com/alpine:3.3
 3.3: Pulling from alpine
 da1f53af4030: Pull complete
 Digest: sha256:014c089bd8b453b6870d2994eb4240ee69555fc5d760ffe515ef3079f5bcdad8
-Status: Downloaded newer image for ops.example.com/alpine:3.3
+Status: Downloaded newer image for hub.example.com/alpine:3.3
 ```
 
 !!! note:
-    Pushing Docker images directly to the Ops Center registry with `docker push`
+    Pushing Docker images directly to the Gravity Hub registry with `docker push`
     is not supported. Use `tele push` to publish application image along with
-    its charts and layers to the Ops Center.
+    its charts and layers to the Gravity Hub.
 
-Next make sure that the Ops Center was configured as a Helm charts repository:
+Next make sure that the Gravity Hub was configured as a Helm charts repository:
 
 ```bsh
 $ helm repo list
 NAME                URL
-ops.example.com     https://ops.example.com:443/charts
+hub.example.com     https://hub.example.com:443/charts
 ```
 
 To search for a particular chart the standard Helm command can be used:
@@ -130,17 +130,17 @@ To search for a particular chart the standard Helm command can be used:
 ```bsh
 $ helm search alpine
 NAME                        CHART VERSION   APP VERSION DESCRIPTION
-ops.example.com/alpine      0.1.0           3.3         Deploy a basic Alpine Linux pod
+hub.example.com/alpine      0.1.0           3.3         Deploy a basic Alpine Linux pod
 ```
 
 Helm can also be used to retrieve a Helm chart package archive, in the standard
 Helm format:
 
 ```bsh
-$ helm fetch ops.example.com/alpine --version 0.1.0  # will produce alpine-0.1.0.tgz
+$ helm fetch hub.example.com/alpine --version 0.1.0  # will produce alpine-0.1.0.tgz
 ```
 
-Execute `tele logout` to clear login information for the Ops Center, including
+Execute `tele logout` to clear login information for the Gravity Hub, including
 Docker registry and Helm chart repository credentials.
 
 ### Search Application Images
@@ -161,21 +161,21 @@ between the Open-Source and Enterprise versions of Gravity:
 
 * For the Open-Source clusters, it is the Gravitational default
 distribution portal (`get.gravitational.io`).
-* For the Enterprise clusters, it is the Ops Center a cluster
+* For the Enterprise clusters, it is the Gravity Hub a cluster
 is connected to. See [Configuring Trusted Clusters](/config/#trusted-clusters-enterprise)
-for details on how to connect a cluster to an Ops Center.
+for details on how to connect a cluster to an Gravity Hub.
 
 The `-a` flag makes the command to display both local and remote applications.
 
 Here's an example search result in a cluster that is connected to the Ops
-Center `ops.example.com`:
+Center `hub.example.com`:
 
 ```bsh
 $ gravity app search -r
 Name                    Version Description                      Created
 ----                    ------- -----------                      -------
-ops.example.com/alpine  0.1.0   Deploy a basic Alpine Linux pod  Wed Jan 16 23:31 UTC
-ops.example.com/nginx   0.1.0   A basic NGINX HTTP server        Tue Jan 15 20:58 UTC
+hub.example.com/alpine  0.1.0   Deploy a basic Alpine Linux pod  Wed Jan 16 23:31 UTC
+hub.example.com/nginx   0.1.0   A basic NGINX HTTP server        Tue Jan 15 20:58 UTC
 ```
 
 The search command also accepts an optional application name pattern:
@@ -184,7 +184,7 @@ The search command also accepts an optional application name pattern:
 $ gravity app search -r alpine
 Name                    Version Description                      Created
 ----                    ------- -----------                      -------
-ops.example.com/alpine  0.1.0   Deploy a basic Alpine Linux pod  Wed Jan 16 23:31 UTC
+hub.example.com/alpine  0.1.0   Deploy a basic Alpine Linux pod  Wed Jan 16 23:31 UTC
 ```
 
 ### Install a Release
@@ -198,10 +198,10 @@ $ gravity app install alpine-0.1.0.tar
 
 The install command can also download the specified application from a remote
 application catalog. Following up on the search example above, the alpine
-application can be installed directly from the remote Ops Center:
+application can be installed directly from the remote Gravity Hub:
 
 ```bsh
-$ gravity app install ops.example.com/alpine:0.1.0
+$ gravity app install hub.example.com/alpine:0.1.0
 ```
 
 When executed inside a Gravity cluster, it will automatically push the
@@ -248,10 +248,10 @@ $ gravity app upgrade test-release alpine-0.2.0.tar \
 ```
 
 Or, download and install the upgrade application image from the connected
-Ops Center:
+Gravity Hub:
 
 ```bsh
-$ gravity app upgrade test-release ops.example.com/alpine:0.2.0
+$ gravity app upgrade test-release hub.example.com/alpine:0.2.0
 ```
 
 Similar to app install, registry flags need to be provided only when installing

--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -2045,7 +2045,7 @@ transient error
 #### Improvements
 
 * Add support for TLS keypair configuration via resources. Read more [here](/config/#tls-key-pair).
-* Simplify Ops Center [post install configuration](/opscenter/#post-provisioning).
+* Simplify Ops Center [post install configuration](/hub/#post-provisioning).
 
 #### Bugfixes
 

--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -839,7 +839,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 #### Improvements
 
-* Introduce `ClusterConfiguration` resource, see [Configuring Cluster](/config/general-cluster-configuration) for details.
+* Introduce `ClusterConfiguration` resource, see [Configuring Cluster](/config/#general-cluster-configuration) for details.
 * Introduce `RuntimeEnvironment` resource, see [Configuring Runtime Environment Variables](/config/#runtime-environment-variables) for details.
 * Update 'gravity plan' to support all cluster operations.
 
@@ -1321,7 +1321,7 @@ for details.
 #### Improvements
 
 * Automatically load kernel modules and set kernel parameters required for
-installation. See [Verifying Node Requirements](/manage/#verifying-node-requirements)
+installation. See [Verifying Node Requirements](/requirements/#kernel-modules)
 for more info.
 
 #### Bugfixes

--- a/docs/6.x/config.md
+++ b/docs/6.x/config.md
@@ -609,7 +609,7 @@ $ gravity resource create auth.yaml
 ```
 
 !!! note:
-    Make sure to configure a proper [OIDC connector](/Cluster/#configuring-openid-connect)
+    Make sure to configure a proper [OIDC connector](/config/#configuring-openid-connect)
     when using "oidc" authentication type.
 
 To view the currently configured authentication preference:


### PR DESCRIPTION
This fixes 404s in the docs, I've also update 6.x docs to refer to Ops Center to be Gravity Hub