### PR TITLE
(5.5) Join prechecks.

### DIFF
--- a/lib/checks/remote.go
+++ b/lib/checks/remote.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checks
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/gravitational/gravity/lib/network/validation/proto"
+	"github.com/gravitational/gravity/lib/rpc"
+	"github.com/gravitational/gravity/lib/rpc/client"
+	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/satellite/agent/proto/agentpb"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// Remote defines an interface for validating remote nodes.
+type Remote interface {
+	// Exec executes the command remotely on the specified node.
+	Exec(ctx context.Context, addr string, command []string, out io.Writer) error
+	// CheckPorts executes network test to test port availability.
+	CheckPorts(context.Context, PingPongGame) (PingPongGameResults, error)
+	// CheckBandwidth executes network bandwidth test.
+	CheckBandwidth(context.Context, PingPongGame) (PingPongGameResults, error)
+	// Validate performs local checks on the specified node.
+	Validate(ctx context.Context, addr string, config ValidateConfig) ([]*agentpb.Probe, error)
+}
+
+// ValidateConfig specifies validation data to validate node against.
+type ValidateConfig struct {
+	// Manifest is the manifest to validate against.
+	Manifest schema.Manifest
+	// Profile is the node profile name to validate against.
+	Profile string
+	// Docker is the Docker configuration to validate.
+	Docker storage.DockerConfig
+}
+
+// NewRemote creates a remote node validator from the provided agents repository.
+func NewRemote(agents rpc.AgentRepository) *remote {
+	return &remote{
+		AgentRepository: agents,
+		FieldLogger: logrus.WithField(trace.Component,
+			"checks:remote"),
+	}
+}
+
+// remote allows to execute remote commands and validate remote nodes.
+//
+// Implements Remote.
+type remote struct {
+	// AgentRepository provides access to running RPC agents.
+	rpc.AgentRepository
+	// FieldLogger is used for logging.
+	logrus.FieldLogger
+}
+
+// Exec executes the command remotely on the specified node.
+//
+// The command's output is written to the provided writer.
+func (r *remote) Exec(ctx context.Context, addr string, command []string, out io.Writer) error {
+	clt, err := r.GetClient(ctx, addr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = clt.Command(ctx, r.FieldLogger, out, command...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// CheckPorts executes network test to test port availability.
+func (r *remote) CheckPorts(ctx context.Context, req PingPongGame) (PingPongGameResults, error) {
+	resp, err := pingPong(ctx, r, req, ports)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// CheckBandwidth executes network bandwidth test.
+func (r *remote) CheckBandwidth(ctx context.Context, req PingPongGame) (PingPongGameResults, error) {
+	resp, err := pingPong(ctx, r, req, bandwidth)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+// Validate performs local checks on the specified node.
+//
+// Returns a list of failed test results.
+func (r *remote) Validate(ctx context.Context, addr string, config ValidateConfig) ([]*agentpb.Probe, error) {
+	clt, err := r.GetClient(ctx, addr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	bytes, err := json.Marshal(config.Manifest)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req := proto.ValidateRequest{
+		Manifest: bytes,
+		Profile:  config.Profile,
+		Docker: &proto.Docker{
+			StorageDriver: config.Docker.StorageDriver,
+		},
+	}
+	failed, err := clt.Validate(ctx, &req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return failed, nil
+}
+
+func pingPong(ctx context.Context, remote rpc.AgentRepository, game PingPongGame, fn pingpongHandler) (PingPongGameResults, error) {
+	resultsCh := make(chan pingpongResult)
+	for addr, req := range game {
+		clt, err := remote.GetClient(ctx, addr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		go fn(ctx, rpc.AgentAddr(addr), clt, req, resultsCh)
+	}
+	results := make(PingPongGameResults, len(game))
+	for _, req := range game {
+		select {
+		case result := <-resultsCh:
+			if result.err != nil {
+				return nil, trace.Wrap(result.err)
+			}
+			results[result.addr] = *result.resp
+		case <-time.After(2 * req.Duration):
+			return nil, trace.LimitExceeded("timeout waiting for servers")
+		}
+	}
+	return results, nil
+}
+
+func ports(ctx context.Context, addr string, clt client.Client, req PingPongRequest, resultsCh chan<- pingpongResult) {
+	resp, err := clt.CheckPorts(ctx, req.PortsProto())
+	if err != nil {
+		resultsCh <- pingpongResult{addr: addr, err: err}
+		return
+	}
+	resultsCh <- pingpongResult{addr: addr, resp: ResultFromPortsProto(resp, nil)}
+}
+
+func bandwidth(ctx context.Context, addr string, clt client.Client, req PingPongRequest, resultsCh chan<- pingpongResult) {
+	resp, err := clt.CheckBandwidth(ctx, req.BandwidthProto())
+	if err != nil {
+		resultsCh <- pingpongResult{addr: addr, err: err}
+		return
+	}
+	resultsCh <- pingpongResult{addr: addr, resp: ResultFromBandwidthProto(resp, nil)}
+}
+
+type pingpongHandler func(ctx context.Context, addr string, clt client.Client,
+	req PingPongRequest, resultsCh chan<- pingpongResult)
+
+type pingpongResult struct {
+	addr string
+	resp *PingPongResult
+	err  error
+}

--- a/lib/checks/requirements.go
+++ b/lib/checks/requirements.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checks
+
+import (
+	"github.com/gravitational/gravity/lib/schema"
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// Requirements defines a set of requirements for a node profile.
+type Requirements struct {
+	// CPU describes CPU requirements.
+	CPU *schema.CPU
+	// RAM describes RAM requirements.
+	RAM *schema.RAM
+	// OS describes OS requirements
+	OS []schema.OS
+	// Network describes network requirements.
+	Network Network
+	// Volumes describes volumes requirements.
+	Volumes []schema.Volume
+	// Docker describes Docker requirements.
+	Docker storage.DockerConfig
+}
+
+// Network describes network requirements.
+type Network struct {
+	// MinTransferRate is minimum required transfer rate.
+	MinTransferRate utils.TransferRate
+	// Ports specifies requirements for ports to be available on server.
+	Ports Ports
+}
+
+// Ports describes port requirements for a specific profile.
+type Ports struct {
+	// TCP lists a range of TCP ports.
+	TCP []int
+	// UDP lists a range of UDP ports.
+	UDP []int
+}
+
+// RequirementsFromManifest returns check requirements for each node profile
+// in the provided manifest.
+func RequirementsFromManifest(manifest schema.Manifest) (map[string]Requirements, error) {
+	result := make(map[string]Requirements)
+	for i, profile := range manifest.NodeProfiles {
+		tcp, udp, err := profile.Ports()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		req := Requirements{
+			CPU:     &manifest.NodeProfiles[i].Requirements.CPU,
+			RAM:     &manifest.NodeProfiles[i].Requirements.RAM,
+			OS:      profile.Requirements.OS,
+			Volumes: profile.Requirements.Volumes,
+			Network: Network{
+				MinTransferRate: profile.Requirements.Network.MinTransferRate,
+				Ports:           Ports{TCP: tcp, UDP: udp},
+			},
+		}
+		result[profile.Name] = req
+	}
+	return result, nil
+}
+
+// RequirementsFromManifests generates check requirements as a difference
+// between two manifests - old and new.
+func RequirementsFromManifests(old, new schema.Manifest, profiles map[string]string, docker storage.DockerConfig) (map[string]Requirements, error) {
+	result := make(map[string]Requirements)
+	for _, profileName := range profiles {
+		oldProfile, err := old.NodeProfiles.ByName(profileName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		newProfile, err := new.NodeProfiles.ByName(profileName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Compute port requirements for this profile
+		tcp, udp, err := schema.DiffPorts(old, new, profileName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		req := Requirements{
+			OS:      newProfile.Requirements.OS,
+			Volumes: schema.DiffVolumes(oldProfile.Requirements.Volumes, newProfile.Requirements.Volumes),
+			Network: Network{
+				Ports: Ports{TCP: tcp, UDP: udp},
+			},
+			Docker: docker,
+		}
+		result[profileName] = req
+	}
+	return result, nil
+}

--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,6 +60,19 @@ type planBuilder struct {
 	DNSConfig storage.DNSConfig
 }
 
+// AddChecksPhase appends preflight checks phase to the plan.
+func (b *planBuilder) AddChecksPhase(plan *storage.OperationPlan) {
+	plan.Phases = append(plan.Phases, storage.OperationPhase{
+		ID:          ChecksPhase,
+		Description: "Execute preflight checks on the joining node",
+		Data: &storage.OperationPhaseData{
+			Server: &b.JoiningNode,
+			Master: &b.Master,
+		},
+		Requires: []string{StartAgentPhase},
+	})
+}
+
 // AddConfigurePhase appends package configuration phase to the plan
 func (b *planBuilder) AddConfigurePhase(plan *storage.OperationPlan) {
 	plan.Phases = append(plan.Phases, storage.OperationPhase{
@@ -68,6 +81,7 @@ func (b *planBuilder) AddConfigurePhase(plan *storage.OperationPlan) {
 		Data: &storage.OperationPhaseData{
 			ExecServer: &b.JoiningNode,
 		},
+		Requires: []string{ChecksPhase},
 	})
 }
 
@@ -167,7 +181,6 @@ func (b *planBuilder) AddStartAgentPhase(plan *storage.OperationPlan) {
 				OpsCenterURL: fmt.Sprintf("https://%v", b.Peer),
 			},
 		},
-		Requires: []string{SystemPhase},
 	})
 }
 

--- a/lib/expand/fsm.go
+++ b/lib/expand/fsm.go
@@ -60,7 +60,7 @@ type FSMConfig struct {
 	// Credentials is the credentials for gRPC agents
 	Credentials credentials.TransportCredentials
 	// Runner is optional runner to use when running remote commands
-	Runner fsm.AgentRepository
+	Runner rpc.AgentRepository
 	// DebugMode turns on FSM debug mode
 	DebugMode bool
 	// Insecure turns on FSM insecure mode
@@ -184,7 +184,7 @@ func (e *fsmEngine) GetPlan() (*storage.OperationPlan, error) {
 
 // RunCommand executes the phase specified by params on the specified
 // server using the provided runner
-func (e *fsmEngine) RunCommand(ctx context.Context, runner fsm.RemoteRunner, node storage.Server, p fsm.Params) error {
+func (e *fsmEngine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, node storage.Server, p fsm.Params) error {
 	args := []string{"join", "--phase", p.PhaseID, fmt.Sprintf("--force=%v", p.Force)}
 	if e.DebugMode {
 		args = append([]string{"--debug"}, args...)

--- a/lib/expand/fsmspec.go
+++ b/lib/expand/fsmspec.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,6 +31,11 @@ import (
 func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 	return func(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
 		switch {
+		case strings.HasPrefix(p.Phase.ID, ChecksPhase):
+			return phases.NewChecks(p,
+				config.Operator,
+				config.Runner)
+
 		case strings.HasPrefix(p.Phase.ID, installphases.ConfigurePhase):
 			return installphases.NewConfigure(p,
 				config.Operator)
@@ -106,6 +111,8 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 }
 
 const (
+	// ChecksPhase runs preflight checks on the joining node
+	ChecksPhase = "/checks"
 	// PreHookPhase runs pre-expand application hook
 	PreHookPhase = "/preHook"
 	// EtcdBackupPhase backs up etcd data on a master node

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -146,7 +146,7 @@ type agentStopExecutor struct {
 	// FieldLogger is used for logging
 	logrus.FieldLogger
 	// AgentClient is the RPC agent client
-	AgentClient fsm.AgentRepository
+	AgentClient rpc.AgentRepository
 	// Master is the master node where the agent is deployed
 	Master storage.Server
 	// ExecutorParams is common executor params

--- a/lib/expand/phases/checks.go
+++ b/lib/expand/phases/checks.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/checks"
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// NewChecks returns executor that executes preflight checks on the joining node.
+func NewChecks(p fsm.ExecutorParams, operator ops.Operator, runner rpc.AgentRepository) (*checksExecutor, error) {
+	logger := &fsm.Logger{
+		FieldLogger: logrus.WithFields(logrus.Fields{
+			constants.FieldPhase: p.Phase.ID,
+		}),
+		Key:      opKey(p.Plan),
+		Operator: operator,
+	}
+	return &checksExecutor{
+		FieldLogger:    logger,
+		Runner:         runner,
+		Operator:       operator,
+		ExecutorParams: p,
+	}, nil
+}
+
+type checksExecutor struct {
+	// FieldLogger is used for logging.
+	logrus.FieldLogger
+	// Runner is used to run remote commands.
+	Runner rpc.AgentRepository
+	// Operator is the cluster operator service.
+	Operator ops.Operator
+	// ExecutorParams is common executor params.
+	fsm.ExecutorParams
+}
+
+// Execute executes preflight checks on the joining node.
+func (p *checksExecutor) Execute(ctx context.Context) error {
+	master, err := checks.GetServer(ctx, p.Runner, *p.Phase.Data.Master)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	node, err := checks.GetServer(ctx, p.Runner, *p.Phase.Data.Server)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cluster, err := p.Operator.GetLocalSite()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	reqs, err := checks.RequirementsFromManifest(cluster.App.Manifest)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	checker, err := checks.New(checks.Config{
+		Remote:       checks.NewRemote(p.Runner),
+		Servers:      []checks.Server{*master, *node},
+		Manifest:     cluster.App.Manifest,
+		Requirements: reqs,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// For multi-node checks, use one of master nodes as an "anchor" so
+	// the joining node will be compared against that master (e.g. for
+	// the OS check, time drift check, etc).
+	return trace.NewAggregate(
+		checker.CheckNode(ctx, *node),
+		checker.CheckNodes(ctx, []checks.Server{*master, *node}))
+}
+
+// Rollback is no-op for this phase.
+func (*checksExecutor) Rollback(context.Context) error { return nil }
+
+// PreCheck is no-op for this phase.
+func (*checksExecutor) PreCheck(context.Context) error { return nil }
+
+// PostCheck is no-op for this phase.
+func (*checksExecutor) PostCheck(context.Context) error { return nil }

--- a/lib/expand/phases/etcd.go
+++ b/lib/expand/phases/etcd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	rpcclient "github.com/gravitational/gravity/lib/rpc/client"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/state"
@@ -39,7 +40,7 @@ import (
 )
 
 // NewEtcd returns executor that adds a new etcd member to the cluster
-func NewEtcd(p fsm.ExecutorParams, operator ops.Operator, runner fsm.AgentRepository) (*etcdExecutor, error) {
+func NewEtcd(p fsm.ExecutorParams, operator ops.Operator, runner rpc.AgentRepository) (*etcdExecutor, error) {
 	// create etcd client that's talking to members running on master nodes
 	var masters []storage.Server
 	for _, node := range p.Plan.Servers {
@@ -86,7 +87,7 @@ type etcdExecutor struct {
 	// Etcd is client to the cluster's etcd members API
 	Etcd etcd.MembersAPI
 	// Runner is used to run remote commands
-	Runner fsm.AgentRepository
+	Runner rpc.AgentRepository
 	// Master is one of the master nodes
 	Master storage.Server
 	// ExecutorParams is common executor params
@@ -200,7 +201,7 @@ func (*etcdExecutor) PostCheck(ctx context.Context) error {
 }
 
 // NewEtcdBackup returns executor that backs up etcd data
-func NewEtcdBackup(p fsm.ExecutorParams, operator ops.Operator, runner fsm.AgentRepository) (*etcdBackupExecutor, error) {
+func NewEtcdBackup(p fsm.ExecutorParams, operator ops.Operator, runner rpc.AgentRepository) (*etcdBackupExecutor, error) {
 	logger := &fsm.Logger{
 		FieldLogger: logrus.WithFields(logrus.Fields{
 			constants.FieldPhase: p.Phase.ID,
@@ -223,7 +224,7 @@ type etcdBackupExecutor struct {
 	// Master is the master server where backup should be taken
 	Master storage.Server
 	// Runner is used to run remote commands
-	Runner fsm.AgentRepository
+	Runner rpc.AgentRepository
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
 }

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -201,12 +201,13 @@ func (s *PlanSuite) TestPlan(c *check.C) {
 		phaseID       string
 		phaseVerifier func(*check.C, storage.OperationPhase)
 	}{
+		{StartAgentPhase, s.verifyStartAgentPhase},
+		{ChecksPhase, s.verifyChecksPhase},
 		{installphases.ConfigurePhase, s.verifyConfigurePhase},
 		{installphases.BootstrapPhase, s.verifyBootstrapPhase},
 		{installphases.PullPhase, s.verifyPullPhase},
 		{PreHookPhase, s.verifyPreHookPhase},
 		{SystemPhase, s.verifySystemPhase},
-		{StartAgentPhase, s.verifyStartAgentPhase},
 		{EtcdBackupPhase, s.verifyEtcdBackupPhase},
 		{EtcdPhase, s.verifyEtcdPhase},
 		{installphases.WaitPhase, s.verifyWaitPhase},
@@ -224,12 +225,24 @@ func (s *PlanSuite) TestPlan(c *check.C) {
 	}
 }
 
+func (s *PlanSuite) verifyChecksPhase(c *check.C, phase storage.OperationPhase) {
+	storage.DeepComparePhases(c, storage.OperationPhase{
+		ID: ChecksPhase,
+		Data: &storage.OperationPhaseData{
+			Server: &s.joiningNode,
+			Master: &s.masterNode,
+		},
+		Requires: []string{StartAgentPhase},
+	}, phase)
+}
+
 func (s *PlanSuite) verifyConfigurePhase(c *check.C, phase storage.OperationPhase) {
 	storage.DeepComparePhases(c, storage.OperationPhase{
 		ID: installphases.ConfigurePhase,
 		Data: &storage.OperationPhaseData{
 			ExecServer: &s.joiningNode,
 		},
+		Requires: []string{ChecksPhase},
 	}, phase)
 }
 
@@ -310,7 +323,6 @@ func (s *PlanSuite) verifyStartAgentPhase(c *check.C, phase storage.OperationPha
 				OpsCenterURL: fmt.Sprintf("https://%v:%v", s.masterNode.AdvertiseIP, defaults.GravitySiteNodePort),
 			},
 		},
-		Requires: []string{SystemPhase},
 	}, phase)
 }
 

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -39,7 +40,7 @@ type Engine interface {
 	GetPlan() (*storage.OperationPlan, error)
 	// RunCommand executes the phase specified by params on the specified
 	// server using the provided runner
-	RunCommand(context.Context, RemoteRunner, storage.Server, Params) error
+	RunCommand(context.Context, rpc.RemoteRunner, storage.Server, Params) error
 	// Complete transitions the operation to a completed state.
 	// Completed state is either successful or failed depending on the state of
 	// the operation plan.
@@ -115,7 +116,7 @@ type Config struct {
 	// Engine is the specific FSM engine
 	Engine
 	// Runner is used to run remote commands
-	Runner RemoteRunner
+	Runner rpc.RemoteRunner
 	// Insecure allows to turn off cert validation in dev mode
 	Insecure bool
 	// Logger allows to override default logger

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -18,7 +18,6 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
@@ -248,12 +247,10 @@ func (f *fsmEngine) GetExecutor(p fsm.ExecutorParams, remote fsm.Remote) (fsm.Ph
 
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
-func (f *fsmEngine) RunCommand(ctx context.Context, runner fsm.RemoteRunner, server storage.Server, p fsm.Params) error {
-	args := []string{"install", "--phase", p.PhaseID, fmt.Sprintf("--force=%v", p.Force)}
-	if f.RemoteOpsURL != "" && f.RemoteOpsToken != "" {
-		args = append(args,
-			fmt.Sprintf("--ops-url=%v", f.RemoteOpsURL),
-			fmt.Sprintf("--ops-token=%v", f.RemoteOpsToken))
+func (f *fsmEngine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, p fsm.Params) error {
+	args := []string{"plan", "execute", "--phase", p.PhaseID}
+	if p.Force {
+		args = append(args, "--force")
 	}
 	if f.Insecure {
 		args = append([]string{"--debug", "--insecure"}, args...)

--- a/lib/ops/checks.go
+++ b/lib/ops/checks.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,24 +35,35 @@ import (
 // agentService is the access point to the agent cluster for running remote
 // commands.
 // manifest specifies the application manifest with requirements.
-func CheckServers(ctx context.Context, opKey SiteOperationKey,
-	infos checks.ServerInfos, servers []storage.Server, agentService AgentService,
-	manifest schema.Manifest) error {
+func CheckServers(ctx context.Context,
+	opKey SiteOperationKey,
+	infos checks.ServerInfos,
+	servers []storage.Server,
+	agentService AgentService,
+	manifest schema.Manifest,
+) error {
 	nodes, err := mergeServers(infos, servers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	remote := &remoteCommands{key: opKey, AgentService: agentService}
-	requirements, err := requirementsFromManifest(manifest)
+	requirements, err := checks.RequirementsFromManifest(manifest)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	c, err := checks.New(remote, nodes, manifest, requirements)
-	if err != nil && !trace.IsNotFound(err) {
+	c, err := checks.New(checks.Config{
+		Remote:       &remoteCommands{key: opKey, AgentService: agentService},
+		Manifest:     manifest,
+		Servers:      nodes,
+		Requirements: requirements,
+		Features: checks.Features{
+			TestBandwidth:    true,
+			TestPorts:        true,
+			TestDockerDevice: true,
+		},
+	})
+	if err != nil {
 		return trace.Wrap(err)
 	}
-	c.TestBandwidth = true
-	c.TestDockerDevice = true
 	return trace.Wrap(c.Run(ctx))
 }
 
@@ -95,9 +106,8 @@ func (r *remoteCommands) CheckBandwidth(ctx context.Context, req checks.PingPong
 
 // Validate validates the node given with addr against the specified manifest.
 // Returns the list of failed test results.
-func (r *remoteCommands) Validate(ctx context.Context, addr string,
-	manifest schema.Manifest, profileName string) ([]*agentpb.Probe, error) {
-	failed, err := r.AgentService.Validate(ctx, r.key, addr, manifest, profileName)
+func (r *remoteCommands) Validate(ctx context.Context, addr string, config checks.ValidateConfig) ([]*agentpb.Probe, error) {
+	failed, err := r.AgentService.Validate(ctx, r.key, addr, config.Manifest, config.Profile)
 	return failed, trace.Wrap(err)
 }
 
@@ -106,28 +116,6 @@ func (r *remoteCommands) Validate(ctx context.Context, addr string,
 type remoteCommands struct {
 	AgentService
 	key SiteOperationKey
-}
-
-func requirementsFromManifest(manifest schema.Manifest) (map[string]checks.Requirements, error) {
-	result := make(map[string]checks.Requirements)
-	for i, profile := range manifest.NodeProfiles {
-		tcp, udp, err := checks.PortsForProfile(profile)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		req := checks.Requirements{
-			CPU:     &manifest.NodeProfiles[i].Requirements.CPU,
-			RAM:     &manifest.NodeProfiles[i].Requirements.RAM,
-			OS:      profile.Requirements.OS,
-			Volumes: profile.Requirements.Volumes,
-			Network: checks.Network{
-				MinTransferRate: profile.Requirements.Network.MinTransferRate,
-				Ports:           checks.Ports{TCP: tcp, UDP: udp},
-			},
-		}
-		result[profile.Name] = req
-	}
-	return result, nil
 }
 
 func mergeServers(infos checks.ServerInfos, servers []storage.Server) (result []checks.Server, err error) {

--- a/lib/rpc/shutdown.go
+++ b/lib/rpc/shutdown.go
@@ -18,9 +18,11 @@ package rpc
 
 import (
 	"context"
+	"io"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	rpcclient "github.com/gravitational/gravity/lib/rpc/client"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -58,8 +60,21 @@ func shutdownAgent(ctx context.Context, addr string, rpc AgentRepository) error 
 	return trace.Wrap(clt.Shutdown(ctx))
 }
 
-// AgentRepository manages RPC connections to remote servers
+// AgentRepository provides an interface for creating clients for remote RPC
+// agents and executing commands on them.
 type AgentRepository interface {
-	// GetClient returns a client to the remote server specified with addr
+	// RemoteRunner provides an interface for executing remote commands.
+	RemoteRunner
+	// GetClient returns a client to the remote server specified with addr.
 	GetClient(ctx context.Context, addr string) (rpcclient.Client, error)
+}
+
+// RemoteRunner provides an interface for executing remote commands.
+type RemoteRunner interface {
+	io.Closer
+	// Run executes a command on a remote node.
+	Run(ctx context.Context, server storage.Server, command ...string) error
+	// CanExecute determines whether the runner can execute a command
+	// on the specified remote node.
+	CanExecute(context.Context, storage.Server) error
 }

--- a/lib/schema/diff.go
+++ b/lib/schema/diff.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"sort"
+
+	"github.com/gravitational/trace"
+	"github.com/xtgo/set"
+)
+
+// DiffPorts returns a difference of port requirements between old and new
+// for the specified profile.
+func DiffPorts(old, new Manifest, profileName string) (tcp, udp []int, err error) {
+	profile, err := old.NodeProfiles.ByName(profileName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	oldTCP, oldUDP, err := profile.Ports()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	newProfile, err := new.NodeProfiles.ByName(profileName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tcp, udp, err = newProfile.Ports()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	commonTCP := append(oldTCP, tcp...)
+	commonUDP := append(oldUDP, udp...)
+
+	// Do not take ports that are only present in the old
+	// manifest into account
+	sizeTCP := set.Inter(sort.IntSlice(commonTCP), len(oldTCP))
+	sizeUDP := set.Inter(sort.IntSlice(commonUDP), len(oldUDP))
+	commonTCP = commonTCP[:sizeTCP]
+	commonUDP = commonUDP[:sizeUDP]
+
+	// Compute the difference
+	tcp = append(commonTCP, tcp...)
+	udp = append(commonUDP, udp...)
+	sizeTCP = set.SymDiff(sort.IntSlice(tcp), len(commonTCP))
+	sizeUDP = set.SymDiff(sort.IntSlice(udp), len(commonUDP))
+	return tcp[:sizeTCP], udp[:sizeUDP], nil
+}
+
+// DiffVolumes returns a difference between old and new volume requirements.
+func DiffVolumes(old, new []Volume) []Volume {
+	volumes := append(old, new...)
+	size := set.Inter(volumesByPath(volumes), len(old))
+	// Compute common volumes
+	common := volumes[:size]
+	// Compute volumes only present in new
+	volumes = append(common, new...)
+	size = set.SymDiff(volumesByPath(volumes), len(common))
+	return volumes[:size]
+}
+
+type volumesByPath []Volume
+
+func (r volumesByPath) Len() int           { return len(r) }
+func (r volumesByPath) Less(i, j int) bool { return r[i].Path < r[j].Path }
+func (r volumesByPath) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }

--- a/lib/schema/diff_test.go
+++ b/lib/schema/diff_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,34 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package phases
+package schema
 
 import (
-	"github.com/gravitational/gravity/lib/schema"
-
 	. "gopkg.in/check.v1"
 )
 
-type UpdateSuite struct {
-}
+type DiffSuite struct{}
 
-var _ = Suite(&UpdateSuite{})
+var _ = Suite(&DiffSuite{})
 
-func (_ *UpdateSuite) TestDiffsPorts(c *C) {
+func (_ *DiffSuite) TestDiffsPorts(c *C) {
 	var testCases = []struct {
-		old, new schema.Requirements
+		old, new Requirements
 		tcp      []int
 		udp      []int
 		comment  string
 	}{
 		{
-			old: schema.Requirements{
-				Network: schema.Network{Ports: []schema.Port{
+			old: Requirements{
+				Network: Network{Ports: []Port{
 					{Protocol: "tcp", Ranges: []string{"3000-3099"}},
 					{Protocol: "udp", Ranges: []string{"3200"}},
 				}}},
-			new: schema.Requirements{
-				Network: schema.Network{Ports: []schema.Port{
+			new: Requirements{
+				Network: Network{Ports: []Port{
 					{Protocol: "tcp", Ranges: []string{"3000-3199"}},
 					{Protocol: "udp", Ranges: []string{"3200", "3202"}},
 				}}},
@@ -50,13 +47,13 @@ func (_ *UpdateSuite) TestDiffsPorts(c *C) {
 			comment: "compute difference",
 		},
 		{
-			old: schema.Requirements{
-				Network: schema.Network{Ports: []schema.Port{
+			old: Requirements{
+				Network: Network{Ports: []Port{
 					{Protocol: "tcp", Ranges: []string{"3000-3009", "2099"}},
 					{Protocol: "udp", Ranges: []string{"3200", "1099"}},
 				}}},
-			new: schema.Requirements{
-				Network: schema.Network{Ports: []schema.Port{
+			new: Requirements{
+				Network: Network{Ports: []Port{
 					{Protocol: "tcp", Ranges: []string{"3000-3009", "3199"}},
 					{Protocol: "udp", Ranges: []string{"3200", "3201"}},
 				}}},
@@ -67,66 +64,66 @@ func (_ *UpdateSuite) TestDiffsPorts(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		old := schema.Manifest{
-			NodeProfiles: schema.NodeProfiles{{Name: "test", Requirements: testCase.old}},
+		old := Manifest{
+			NodeProfiles: NodeProfiles{{Name: "test", Requirements: testCase.old}},
 		}
-		new := schema.Manifest{
-			NodeProfiles: schema.NodeProfiles{{Name: "test", Requirements: testCase.new}},
+		new := Manifest{
+			NodeProfiles: NodeProfiles{{Name: "test", Requirements: testCase.new}},
 		}
 
-		tcp, udp, err := diffPorts(old, new, "test")
+		tcp, udp, err := DiffPorts(old, new, "test")
 		c.Assert(err, IsNil)
 		c.Assert(tcp, DeepEquals, testCase.tcp, Commentf(testCase.comment))
 		c.Assert(udp, DeepEquals, testCase.udp, Commentf(testCase.comment))
 	}
 }
 
-func (_ *UpdateSuite) TestDiffsVolumes(c *C) {
+func (_ *DiffSuite) TestDiffsVolumes(c *C) {
 	var testCases = []struct {
-		old, new []schema.Volume
-		diff     []schema.Volume
+		old, new []Volume
+		diff     []Volume
 		comment  string
 	}{
 		{
-			old: []schema.Volume{
-				schema.Volume{Name: "foo", Path: "/foo"},
+			old: []Volume{
+				Volume{Name: "foo", Path: "/foo"},
 			},
-			new: []schema.Volume{
-				schema.Volume{Name: "foo", Path: "/foo"},
+			new: []Volume{
+				Volume{Name: "foo", Path: "/foo"},
 			},
-			diff:    []schema.Volume{},
+			diff:    []Volume{},
 			comment: "no difference",
 		},
 		{
-			old: []schema.Volume{
-				schema.Volume{Path: "/foo"},
-				schema.Volume{Path: "/bar"},
+			old: []Volume{
+				Volume{Path: "/foo"},
+				Volume{Path: "/bar"},
 			},
-			new: []schema.Volume{
-				schema.Volume{Path: "/foo"},
-				schema.Volume{Path: "/bar"},
+			new: []Volume{
+				Volume{Path: "/foo"},
+				Volume{Path: "/bar"},
 			},
-			diff:    []schema.Volume{},
+			diff:    []Volume{},
 			comment: "no difference based on path",
 		},
 		{
-			old: []schema.Volume{
-				schema.Volume{Name: "foo", Path: "/foo"},
-				schema.Volume{Name: "qux", Path: "/qux"},
+			old: []Volume{
+				Volume{Name: "foo", Path: "/foo"},
+				Volume{Name: "qux", Path: "/qux"},
 			},
-			new: []schema.Volume{
-				schema.Volume{Name: "foo", Path: "/foo"},
-				schema.Volume{Name: "bar", Path: "/bar"},
+			new: []Volume{
+				Volume{Name: "foo", Path: "/foo"},
+				Volume{Name: "bar", Path: "/bar"},
 			},
-			diff: []schema.Volume{
-				schema.Volume{Name: "bar", Path: "/bar"},
+			diff: []Volume{
+				Volume{Name: "bar", Path: "/bar"},
 			},
 			comment: "do not account for volumes found only in old",
 		},
 	}
 
 	for _, testCase := range testCases {
-		diff := diffVolumes(testCase.old, testCase.new)
+		diff := DiffVolumes(testCase.old, testCase.new)
 		c.Assert(diff, DeepEquals, testCase.diff, Commentf(testCase.comment))
 	}
 }

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -643,6 +643,27 @@ func (p NodeProfile) TaintValues() []string {
 	return taints
 }
 
+// Ports parses ports ranges from the node profile.
+func (p NodeProfile) Ports() (tcp, udp []int, err error) {
+	for _, ports := range p.Requirements.Network.Ports {
+		for _, portRange := range ports.Ranges {
+			parsed, err := utils.ParsePorts(portRange)
+			if err != nil {
+				return nil, nil, trace.Wrap(err)
+			}
+			switch ports.Protocol {
+			case "tcp":
+				tcp = append(tcp, parsed...)
+			case "udp":
+				udp = append(udp, parsed...)
+			default:
+				return nil, nil, trace.BadParameter("unknown protocol for port: %q", ports.Protocol)
+			}
+		}
+	}
+	return tcp, udp, nil
+}
+
 // Requirements defines a set of requirements for a node profile
 type Requirements struct {
 	// CPU describes CPU requirements

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1934,6 +1934,15 @@ var DefaultSubnets = Subnets{
 // Servers is a list of servers
 type Servers []Server
 
+// Profiles returns a map of node profiles for these servers.
+func (r Servers) Profiles() map[string]string {
+	result := make(map[string]string, len(r))
+	for _, server := range r {
+		result[server.AdvertiseIP] = server.Role
+	}
+	return result
+}
+
 // FindByIP returns a server with the specified IP
 func (r Servers) FindByIP(ip string) *Server {
 	for _, server := range r {

--- a/lib/update/cluster/engine.go
+++ b/lib/update/cluster/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/update"
 	"github.com/gravitational/gravity/lib/users"
@@ -158,7 +159,7 @@ func (f *engine) GetExecutor(p fsm.ExecutorParams, remote fsm.Remote) (fsm.Phase
 
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
-func (f *engine) RunCommand(ctx context.Context, runner fsm.RemoteRunner, server storage.Server, p fsm.Params) error {
+func (f *engine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, p fsm.Params) error {
 	args := []string{"plan", "execute",
 		"--phase", p.PhaseID,
 		"--operation-id", f.plan.OperationID,

--- a/lib/update/cluster/phases/checks.go
+++ b/lib/update/cluster/phases/checks.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 
 	"github.com/gravitational/trace"
@@ -42,7 +43,7 @@ type updatePhaseChecks struct {
 	// installedPackage specifies the installed application package
 	installedPackage loc.Locator
 	// remote allows remote control of servers
-	remote         fsm.AgentRepository
+	remote         rpc.AgentRepository
 	existingDocker storage.DockerConfig
 }
 
@@ -51,7 +52,7 @@ func NewUpdatePhaseChecks(
 	p fsm.ExecutorParams,
 	operator ops.Operator,
 	apps app.Applications,
-	remote fsm.AgentRepository,
+	remote rpc.AgentRepository,
 	logger log.FieldLogger,
 ) (*updatePhaseChecks, error) {
 	if p.Phase.Data.Package == nil {

--- a/lib/update/cluster/phases/validate.go
+++ b/lib/update/cluster/phases/validate.go
@@ -18,266 +18,40 @@ package phases
 
 import (
 	"context"
-	"encoding/json"
-	"io"
-	"sort"
-	"time"
 
 	"github.com/gravitational/gravity/lib/checks"
-	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/fsm"
-	validationpb "github.com/gravitational/gravity/lib/network/validation/proto"
 	"github.com/gravitational/gravity/lib/rpc"
-	rpcclient "github.com/gravitational/gravity/lib/rpc/client"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 
-	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
-	"github.com/xtgo/set"
 )
 
-func validate(ctx context.Context, remote fsm.AgentRepository, servers []storage.Server, old, new schema.Manifest,
-	docker storage.DockerConfig) error {
-	profiles := make(map[string]string, len(servers))
-	nodes := make([]checks.Server, 0, len(servers))
-	for _, server := range servers {
-		connectCtx, cancel := context.WithTimeout(ctx, defaults.AgentConnectTimeout)
-		clt, err := remote.GetClient(connectCtx, server.AdvertiseIP)
-		cancel()
-		if err != nil {
-			return trace.Wrap(err, "failed to connect to agent.\n"+
-				"Make sure the node has an agent running by "+
-				"issuing `gravity agent deploy` from the upgrade node")
-		}
-
-		info, err := checks.GetServerInfo(ctx, clt)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		nodes = append(nodes, checks.Server{server, *info})
-		profiles[server.AdvertiseIP] = server.Role
-	}
-
-	requirements, err := requirementsFromManifests(old, new, profiles)
+func validate(ctx context.Context,
+	remote rpc.AgentRepository,
+	servers storage.Servers,
+	old, new schema.Manifest,
+	docker storage.DockerConfig,
+) error {
+	nodes, err := checks.GetServers(ctx, remote, servers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	remoteExec := &remoteCommands{
-		remote:   remote,
-		profiles: profiles,
-		docker:   docker,
+	requirements, err := checks.RequirementsFromManifests(old, new, servers.Profiles(), docker)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	c, err := checks.New(remoteExec, nodes, new, requirements)
-	if err != nil && !trace.IsNotFound(err) {
+	c, err := checks.New(checks.Config{
+		Remote:       checks.NewRemote(remote),
+		Manifest:     new,
+		Servers:      nodes,
+		Requirements: requirements,
+		Features: checks.Features{
+			TestPorts: true,
+		},
+	})
+	if err != nil {
 		return trace.Wrap(err)
 	}
 	return trace.Wrap(c.Run(ctx))
 }
-
-// Exec executes an arbitrary command on the remote node specified with addr.
-// The output is written into out
-func (r *remoteCommands) Exec(ctx context.Context, addr string, command []string, out io.Writer) error {
-	clt, err := r.remote.GetClient(ctx, addr)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return trace.Wrap(clt.Command(ctx, log.StandardLogger(), out, command...))
-}
-
-// CheckPorts validates the cluster port availability
-func (r *remoteCommands) CheckPorts(ctx context.Context, req checks.PingPongGame) (checks.PingPongGameResults, error) {
-	resp, err := pingPong(ctx, r.remote, req, ports)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// CheckBandwidth validates the cluster network bandwidth
-func (r *remoteCommands) CheckBandwidth(ctx context.Context, req checks.PingPongGame) (checks.PingPongGameResults, error) {
-	resp, err := pingPong(ctx, r.remote, req, bandwidth)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resp, nil
-}
-
-// Validate validates the node given with addr against the specified manifest.
-// Returns the list of failed test results.
-func (r *remoteCommands) Validate(ctx context.Context, addr string, manifest schema.Manifest, profileName string) ([]*agentpb.Probe, error) {
-	clt, err := r.remote.GetClient(ctx, addr)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	bytes, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	req := validationpb.ValidateRequest{
-		Manifest: bytes,
-		Profile:  profileName,
-		Docker:   &validationpb.Docker{StorageDriver: r.docker.StorageDriver},
-	}
-	failed, err := clt.Validate(ctx, &req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return failed, nil
-}
-
-// remoteCommands allows to execute remote commands and validate remote nodes.
-// Implements checks.Remote
-type remoteCommands struct {
-	remote fsm.AgentRepository
-	// profiles maps server address to its profile
-	profiles map[string]string
-	docker   storage.DockerConfig
-}
-
-func pingPong(ctx context.Context, remote fsm.AgentRepository, game checks.PingPongGame, fn pingpongHandler) (checks.PingPongGameResults, error) {
-	resultsCh := make(chan pingpongResult)
-	for addr, req := range game {
-		clt, err := remote.GetClient(ctx, addr)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		go fn(ctx, rpc.AgentAddr(addr), clt, req, resultsCh)
-	}
-
-	results := make(checks.PingPongGameResults, len(game))
-	for _, req := range game {
-		select {
-		case result := <-resultsCh:
-			if result.err != nil {
-				return nil, trace.Wrap(result.err)
-			}
-			results[result.addr] = *result.resp
-		case <-time.After(2 * req.Duration):
-			return nil, trace.LimitExceeded("timeout waiting for servers")
-		}
-	}
-	return results, nil
-}
-
-func ports(ctx context.Context, addr string, clt rpcclient.Client, req checks.PingPongRequest, resultsCh chan<- pingpongResult) {
-	resp, err := clt.CheckPorts(ctx, req.PortsProto())
-	if err != nil {
-		resultsCh <- pingpongResult{addr: addr, err: err}
-		return
-	}
-	resultsCh <- pingpongResult{addr: addr, resp: checks.ResultFromPortsProto(resp, nil)}
-}
-
-func bandwidth(ctx context.Context, addr string, clt rpcclient.Client, req checks.PingPongRequest, resultsCh chan<- pingpongResult) {
-	resp, err := clt.CheckBandwidth(ctx, req.BandwidthProto())
-	if err != nil {
-		resultsCh <- pingpongResult{addr: addr, err: err}
-		return
-	}
-	resultsCh <- pingpongResult{addr: addr, resp: checks.ResultFromBandwidthProto(resp, nil)}
-}
-
-type pingpongHandler func(ctx context.Context, addr string, clt rpcclient.Client,
-	req checks.PingPongRequest, resultsCh chan<- pingpongResult)
-
-type pingpongResult struct {
-	addr string
-	resp *checks.PingPongResult
-	err  error
-}
-
-// requirementsFromManifests generates check requirements as a difference between
-// two manifests - old and new.
-func requirementsFromManifests(old, new schema.Manifest, profiles map[string]string) (map[string]checks.Requirements, error) {
-	result := make(map[string]checks.Requirements)
-	for _, profileName := range profiles {
-		oldProfile, err := old.NodeProfiles.ByName(profileName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		newProfile, err := new.NodeProfiles.ByName(profileName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		// Compute port requirements for this profile
-		tcp, udp, err := diffPorts(old, new, profileName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		req := checks.Requirements{
-			OS:      newProfile.Requirements.OS,
-			Volumes: diffVolumes(oldProfile.Requirements.Volumes, newProfile.Requirements.Volumes),
-			Network: checks.Network{
-				Ports: checks.Ports{TCP: tcp, UDP: udp},
-			},
-		}
-		result[profileName] = req
-	}
-
-	log.Debugf("Update requirements: %+v.", result)
-
-	return result, nil
-}
-
-// diffPorts returns a difference of port requirements between old and new
-// for the specified profile
-func diffPorts(old, new schema.Manifest, profileName string) (tcp, udp []int, err error) {
-	profile, err := old.NodeProfiles.ByName(profileName)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	oldTCP, oldUDP, err := checks.PortsForProfile(*profile)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	newProfile, err := new.NodeProfiles.ByName(profileName)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	tcp, udp, err = checks.PortsForProfile(*newProfile)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	commonTCP := append(oldTCP, tcp...)
-	commonUDP := append(oldUDP, udp...)
-
-	// Do not take ports that are only present in the old
-	// manifest into account
-	sizeTCP := set.Inter(sort.IntSlice(commonTCP), len(oldTCP))
-	sizeUDP := set.Inter(sort.IntSlice(commonUDP), len(oldUDP))
-	commonTCP = commonTCP[:sizeTCP]
-	commonUDP = commonUDP[:sizeUDP]
-
-	// Compute the difference
-	tcp = append(commonTCP, tcp...)
-	udp = append(commonUDP, udp...)
-	sizeTCP = set.SymDiff(sort.IntSlice(tcp), len(commonTCP))
-	sizeUDP = set.SymDiff(sort.IntSlice(udp), len(commonUDP))
-	return tcp[:sizeTCP], udp[:sizeUDP], nil
-}
-
-func diffVolumes(old, new []schema.Volume) []schema.Volume {
-	volumes := append(old, new...)
-	size := set.Inter(volumesByPath(volumes), len(old))
-	// Compute common volumes
-	common := volumes[:size]
-	// Compute volumes only present in new
-	volumes = append(common, new...)
-	size = set.SymDiff(volumesByPath(volumes), len(common))
-	return volumes[:size]
-}
-
-type volumesByPath []schema.Volume
-
-func (r volumesByPath) Len() int           { return len(r) }
-func (r volumesByPath) Less(i, j int) bool { return r[i].Path < r[j].Path }
-func (r volumesByPath) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -155,7 +156,7 @@ func (r *Engine) ChangePhaseState(ctx context.Context, change fsm.StateChange) e
 
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
-func (r *Engine) RunCommand(ctx context.Context, runner fsm.RemoteRunner, server storage.Server, params fsm.Params) error {
+func (r *Engine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, params fsm.Params) error {
 	args := []string{"plan", "execute",
 		"--phase", params.PhaseID,
 		"--operation-id", r.Operation.ID,

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -208,7 +208,7 @@ type Config struct {
 	// LocalBackend specifies the authoritative source for operation state
 	LocalBackend storage.Backend
 	// Runner specifies the runner for remote commands
-	Runner fsm.AgentRepository
+	Runner rpc.AgentRepository
 	// FieldLogger is the logger to use
 	log.FieldLogger
 	// Silent controls whether the process outputs messages to stdout

--- a/lib/vacuum/internal/fsm/engine.go
+++ b/lib/vacuum/internal/fsm/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
 	libpack "github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 	libphase "github.com/gravitational/gravity/lib/vacuum/internal/phases"
@@ -111,7 +112,7 @@ type Config struct {
 	// Spec specifies the function that resolves to an executor
 	Spec libfsm.FSMSpecFunc
 	// Runner specifies the remote command runner
-	Runner libfsm.RemoteRunner
+	Runner rpc.RemoteRunner
 	// Silent controls whether the process outputs messages to stdout
 	localenv.Silent
 }
@@ -199,7 +200,7 @@ func (r *engine) GetExecutor(params libfsm.ExecutorParams, remote libfsm.Remote)
 
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
-func (r *engine) RunCommand(ctx context.Context, runner libfsm.RemoteRunner, server storage.Server, params libfsm.Params) error {
+func (r *engine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, params libfsm.Params) error {
 	args := []string{"plan", "execute", "--phase", params.PhaseID}
 	if params.Force {
 		args = append(args, "--force")

--- a/lib/vacuum/vacuum.go
+++ b/lib/vacuum/vacuum.go
@@ -225,7 +225,7 @@ type Config struct {
 	// Servers is the list of cluster servers
 	Servers []storage.Server
 	// Runner specifies the runner for remote commands
-	Runner libfsm.AgentRepository
+	Runner rpc.AgentRepository
 	// RuntimePath is the path to the runtime container's rootfs
 	RuntimePath string
 	// FieldLogger is the logger to use

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -19,10 +19,10 @@ package cli
 import (
 	"context"
 
-	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	libclusterconfig "github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/update"
@@ -192,7 +192,7 @@ func (configInitializer) newUpdater(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
-	runner fsm.AgentRepository,
+	runner rpc.AgentRepository,
 ) (*update.Updater, error) {
 	config := clusterconfig.Config{
 		Config: update.Config{

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -22,13 +22,13 @@ import (
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/update"
@@ -213,7 +213,7 @@ func (clusterInitializer) newUpdater(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
-	runner fsm.AgentRepository,
+	runner rpc.AgentRepository,
 ) (*update.Updater, error) {
 	config := clusterupdate.Config{
 		Config: update.Config{

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -19,10 +19,10 @@ package cli
 import (
 	"context"
 
-	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/update"
 	"github.com/gravitational/gravity/lib/update/environ"
@@ -182,7 +182,7 @@ func (environInitializer) newUpdater(
 	operation ops.SiteOperation,
 	localEnv, updateEnv *localenv.LocalEnvironment,
 	clusterEnv *localenv.ClusterEnvironment,
-	runner fsm.AgentRepository,
+	runner rpc.AgentRepository,
 ) (*update.Updater, error) {
 	config := environ.Config{
 		Config: update.Config{

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/update"
 
@@ -151,7 +151,7 @@ type updateInitializer interface {
 		operation ops.SiteOperation,
 		localEnv, updateEnv *localenv.LocalEnvironment,
 		clusterEnv *localenv.ClusterEnvironment,
-		runner fsm.AgentRepository,
+		runner rpc.AgentRepository,
 	) (*update.Updater, error)
 	updateDeployRequest(deployAgentsRequest) deployAgentsRequest
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/gravity/pull/530 to 5.5.

I've started looking into https://github.com/gravitational/gravity/issues/840 and remembered that when adding join prechecks a few months ago I did some refactoring in the checks-related code which would be good to have before working on making `gravity check` command works for upgrades. Hence, this backport. Will need to port to 6.1/6.2 as well.