### PR TITLE
[6.1.x] remove explicit calls to ActivateSite

### DIFF
--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -126,13 +126,6 @@ func (r *Engine) Complete(fsmErr error) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = r.operator.ActivateSite(ops.ActivateSiteRequest{
-		AccountID:  r.Operation.AccountID,
-		SiteDomain: r.Operation.SiteDomain,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	r.WithField("operation", r.Operation).Debug("Marked operation complete.")
 	return nil
 }
@@ -205,5 +198,4 @@ type Dispatcher interface {
 type operator interface {
 	CreateProgressEntry(ops.SiteOperationKey, ops.ProgressEntry) error
 	SetOperationState(ops.SiteOperationKey, ops.SetOperationStateRequest) error
-	ActivateSite(ops.ActivateSiteRequest) error
 }

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -134,10 +134,7 @@ func (r *Updater) Complete(fsmErr error) error {
 	if err := r.emitAuditEvent(context.TODO()); err != nil {
 		log.WithError(err).Warn("Failed to emit audit event.")
 	}
-	return r.Operator.ActivateSite(ops.ActivateSiteRequest{
-		AccountID:  r.Operation.ClusterKey().AccountID,
-		SiteDomain: r.Operation.ClusterKey().SiteDomain,
-	})
+	return nil
 }
 
 func (r *Updater) emitAuditEvent(ctx context.Context) error {


### PR DESCRIPTION
Remove explicit calls to `ActivateSite` - these are handled implicitly by cluster state transitions in `CompleteOperation` / `FailOperation`.