### PR TITLE
[6.1.x] reset cluster when completing update plan 

### DIFF
--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -59,26 +59,6 @@ func MarkCompleted(plan *storage.OperationPlan) {
 	}
 }
 
-// HasFailed returns true if the provided plan has at least one failed phase
-func HasFailed(plan *storage.OperationPlan) bool {
-	for _, phase := range FlattenPlan(plan) {
-		if phase.IsFailed() {
-			return true
-		}
-	}
-	return false
-}
-
-// IsFailed returns true if all phases of the provided plan are either rolled back or unstarted
-func IsFailed(plan *storage.OperationPlan) bool {
-	for _, phase := range FlattenPlan(plan) {
-		if !phase.IsFailed() && !phase.IsRolledBack() && !phase.IsUnstarted() {
-			return false
-		}
-	}
-	return true
-}
-
 // FindPhase finds a phase with the specified id in the provided plan
 func FindPhase(plan *storage.OperationPlan, phaseID string) (*storage.OperationPhase, error) {
 	allPhases := FlattenPlan(plan)

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -131,17 +131,18 @@ func (r *Updater) Complete(fsmErr error) error {
 	if err := r.machine.Complete(fsmErr); err != nil {
 		return trace.Wrap(err)
 	}
-	req := ops.ActivateSiteRequest{
-		AccountID:  r.Operation.AccountID,
-		SiteDomain: r.Operation.SiteDomain,
-	}
-	if err := r.Operator.ActivateSite(req); err != nil {
-		return trace.Wrap(err)
-	}
 	if err := r.emitAuditEvent(context.TODO()); err != nil {
 		log.WithError(err).Warn("Failed to emit audit event.")
 	}
 	return nil
+}
+
+// Activate activates the cluster.
+func (r *Updater) Activate() error {
+	return r.Operator.ActivateSite(ops.ActivateSiteRequest{
+		AccountID:  r.Operation.AccountID,
+		SiteDomain: r.Operation.SiteDomain,
+	})
 }
 
 func (r *Updater) emitAuditEvent(ctx context.Context) error {

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -131,6 +131,13 @@ func (r *Updater) Complete(fsmErr error) error {
 	if err := r.machine.Complete(fsmErr); err != nil {
 		return trace.Wrap(err)
 	}
+	req := ops.ActivateSiteRequest{
+		AccountID:  r.Operation.AccountID,
+		SiteDomain: r.Operation.SiteDomain,
+	}
+	if err := r.Operator.ActivateSite(req); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := r.emitAuditEvent(context.TODO()); err != nil {
 		log.WithError(err).Warn("Failed to emit audit event.")
 	}

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -137,7 +137,13 @@ func completeConfigPlan(env *localenv.LocalEnvironment, environ LocalEnvironment
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getConfigUpdater(localEnv, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) (*update.Updater, error) {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -151,7 +151,13 @@ func completeUpdatePlan(env *localenv.LocalEnvironment, environ LocalEnvironment
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getClusterUpdater(localEnv, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation, noValidateVersion bool) (*update.Updater, error) {

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -127,7 +127,13 @@ func completeEnvironPlan(env *localenv.LocalEnvironment, environ LocalEnvironmen
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getEnvironUpdater(env, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) (*update.Updater, error) {


### PR DESCRIPTION
Activate cluster in `Updater.Complete` which is used to explicitly finalize the operation.