### PR TITLE
Accept DOCKER_HOST env var in tele build

### DIFF
--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -121,7 +121,12 @@ func checkBuildEnv() error {
 		return trace.BadParameter("tele build is not supported on %v, only "+
 			"Linux is supported", runtime.GOOS)
 	}
-	client, err := docker.NewClient(constants.DockerEngineURL)
+
+	endpoint, docker_host_defined := os.LookupEnv("DOCKER_HOST")
+	if !docker_host_defined {
+		endpoint = constants.DockerEngineURL
+	}
+	client, err := docker.NewClient(endpoint)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -318,8 +318,12 @@ func (b *Builder) Vendor(ctx context.Context, dir string) (io.ReadCloser, error)
 			return nil, trace.Wrap(err)
 		}
 	}
+	endpoint, docker_host_defined := os.LookupEnv("DOCKER_HOST")
+	if !docker_host_defined {
+		endpoint = constants.DockerEngineURL
+	}
 	vendorer, err := service.NewVendorer(service.VendorerConfig{
-		DockerURL:   constants.DockerEngineURL,
+		DockerURL:   endpoint,
 		RegistryURL: constants.DockerRegistry,
 		Packages:    b.Packages,
 	})


### PR DESCRIPTION
Hi, concerning #884 I think it would be nice tele build read DOCKER_HOST variable to allow tcp mode in order to use dind in a CI environment and do not mess up with a lot of images the ci agents/runners. I don't write code in go usually but just in case would be helpful I start this pull request....

P.S: Sorry if this is not the way you guys usually use to contribute or something...

Thanks in advance