### PR TITLE
Add ability to provide additional images to vendor.

### DIFF
--- a/lib/app/resources/resourcefiles.go
+++ b/lib/app/resources/resourcefiles.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -203,6 +203,9 @@ func (r *ResourceFiles) RewriteImages(rewriteFunc func(string) string) error {
 						}
 					}
 				}
+				for i, image := range resource.Dependencies.AdditionalImages {
+					resource.Dependencies.AdditionalImages[i] = rewriteFunc(image)
+				}
 			case *corev1.Pod:
 				log.Infof("Rewriting images in Pod %q.", resource.Name)
 				rewrite(&resource.Spec)
@@ -311,6 +314,9 @@ func extractImages(objects []runtime.Object) (*ExtractedImages, error) {
 					containers = append(containers, job.Spec.Template.Spec.Containers...)
 					containers = append(containers, job.Spec.Template.Spec.InitContainers...)
 				}
+			}
+			for _, image := range resource.Dependencies.AdditionalImages {
+				imagesMap[image] = struct{}{}
 			}
 		case *corev1.Pod:
 			containers = append(resource.Spec.Containers, resource.Spec.InitContainers...)

--- a/lib/app/resources/resourcefiles_test.go
+++ b/lib/app/resources/resourcefiles_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,24 +41,30 @@ func (s *ResourceFilesSuite) TestResourceFiles(c *C) {
 		rFiles = append(rFiles, *rFile)
 	}
 	sourceImages := sorted([]string{
+		"another:3.2.1",
 		"cronjobimage:1.0.0",
 		"dns-install-hook:0.0.1",
+		"extraimage:1.2.3",
 		"image1:1.0.0",
 		"image2:2.0.0",
 		"image3:3.0.0",
 		"image4",
 		"image5",
 		"k8s-install-hook:0.0.1",
+		"systemimage:0.0.1",
 	})
 	rewrittenImages := sorted([]string{
+		"apiserver:5000/another:3.2.1",
 		"apiserver:5000/cronjobimage:1.0.0",
 		"apiserver:5000/dns-install-hook:0.0.1",
+		"apiserver:5000/extraimage:1.2.3",
 		"apiserver:5000/image1:1.0.0",
 		"apiserver:5000/image2:2.0.0",
 		"apiserver:5000/image3:3.0.0",
 		"apiserver:5000/image4",
 		"apiserver:5000/image5",
 		"apiserver:5000/k8s-install-hook:0.0.1",
+		"apiserver:5000/systemimage:0.0.1",
 	})
 
 	images, err := rFiles.Images()
@@ -390,6 +396,10 @@ metadata:
   namespace: kube-system
   name: k8s-aws
   resourceVersion: "1.2.3-1"
+dependencies:
+  additionalImages:
+  - extraimage:1.2.3
+  - another:3.2.1
 hooks:
   install:
     job: |
@@ -415,6 +425,9 @@ metadata:
   namespace: kube-system
   name: dns-app
   resourceVersion: "0.0.1"
+dependencies:
+  additionalImages:
+  - systemimage:0.0.1
 hooks:
   install:
     job: |

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -452,6 +452,9 @@ type Dependencies struct {
 	Packages []Dependency `json:"packages,omitempty"`
 	// Apps is a list of dependencies-apps
 	Apps []Dependency `json:"apps,omitempty"`
+	// AdditionalImages is a list of Docker images to vendor in addition to
+	// those discovered among application resource files
+	AdditionalImages []string `json:"additionalImages,omitempty"`
 }
 
 // ByName returns a dependency package locator by its name

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -101,6 +101,10 @@ const manifestSchema = `
             "apps": {
               "type": "array",
               "items": {"type": "string"}
+            },
+            "additionalImages": {
+              "type": "array",
+              "items": {"type": "string"}
             }
           }
         },


### PR DESCRIPTION
@a-palchikov @knisbet Take a look guys. I've added ability to provide additional images to vendor via manifest so you don't have to have fake pod spec anymore. I've extended the existing "dependencies" field as it seemed most fitting. This is how it looks like:

```yaml
dependencies:
  additionalImages:
  - nginx:1.17.5
  - quay.io/bitnami/redis:5.0
```

Also, added some docs on vendoring and this feature.

This can also be backported to 6.x.

Closes https://github.com/gravitational/gravity/issues/676, closes #https://github.com/gravitational/gravity/issues/680.