### PR TITLE
Couple gravity cli tweaks.

### DIFF
--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -182,6 +182,8 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.InstallCmd.FullCommand(),
 		g.JoinCmd.FullCommand(),
 		g.AutoJoinCmd.FullCommand(),
+		g.LeaveCmd.FullCommand(),
+		g.RemoveCmd.FullCommand(),
 		g.SystemDevicemapperMountCmd.FullCommand(),
 		g.SystemDevicemapperUnmountCmd.FullCommand(),
 		g.BackupCmd.FullCommand(),

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -266,6 +266,7 @@ func printStatusText(cluster clusterStatus) {
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
 	if cluster.Cluster != nil {
+		fmt.Fprintf(w, "Cluster name:\t%v\n", unknownFallback(cluster.Cluster.Domain))
 		if cluster.Status.IsDegraded() {
 			fmt.Fprintf(w, "Cluster status:\t%v\n", color.RedString("degraded"))
 		} else {
@@ -275,11 +276,7 @@ func printStatusText(cluster clusterStatus) {
 	}
 
 	if cluster.Agent != nil {
-		var domain string
-		if cluster.Cluster != nil {
-			domain = cluster.Cluster.Domain
-		}
-		fmt.Fprintf(w, "Cluster nodes:\t%v\n", unknownFallback(domain))
+		fmt.Fprintf(w, "Cluster nodes:\n")
 		printAgentStatus(*cluster.Agent, w)
 	}
 


### PR DESCRIPTION
A couple of minor cli tweaks:

* Print cluster name on a separate line in gravity status. Before, it was sort of hidden in the middle of the "cluster nodes" line and people couldn't find it.
* Add root check for "leave" and "remove" command. I actually think it fixes https://github.com/gravitational/gravity/issues/614 as the behavior before was that if you run leave command without sudo but with --force, it would suppress the "root required" error and proceed to system uninstall which would fail some steps that require root leading to this weird systemd unit state.

Should be easy enough to backport to 6.x/5.5 as well.

Closes https://github.com/gravitational/gravity/issues/666 😈 