### PR TITLE
tele build UX updates.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1090,12 +1090,12 @@
   revision = "6280a8f001681cc2321397be09c5894e569e479a"
 
 [[projects]]
-  branch = "roman/usermessage"
   digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9ff464e0a50a5bede13b5a9cbebbce58c7a3dee7"
+  revision = "42a8fffe760db82cf94b0c3e0112f91c3526a604"
+  version = "1.1.9"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1090,11 +1090,12 @@
   revision = "6280a8f001681cc2321397be09c5894e569e479a"
 
 [[projects]]
-  digest = "1:9aea6c85145b6ff99ad423d35c6026e098a12cd7f19cce9775cc7eb73aa78d47"
+  branch = "roman/usermessage"
+  digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3822600263648f166b2b2a14bc693e92947af68b"
+  revision = "9ff464e0a50a5bede13b5a9cbebbce58c7a3dee7"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"
@@ -3076,6 +3077,7 @@
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/check.v1",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/apps/v1beta2",
@@ -3125,7 +3127,6 @@
     "k8s.io/helm/pkg/helm/helmpath",
     "k8s.io/helm/pkg/helm/portforwarder",
     "k8s.io/helm/pkg/kube",
-    "k8s.io/helm/pkg/manifest",
     "k8s.io/helm/pkg/proto/hapi/chart",
     "k8s.io/helm/pkg/proto/hapi/release",
     "k8s.io/helm/pkg/provenance",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,8 @@ ignored = [
 [[override]]
   name = "github.com/gravitational/trace"
   #version = "1.1.8"
-  revision = "3822600263648f166b2b2a14bc693e92947af68b"
+  #revision = "3822600263648f166b2b2a14bc693e92947af68b"
+  branch = "roman/usermessage"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,9 +32,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  #version = "1.1.8"
-  #revision = "3822600263648f166b2b2a14bc693e92947af68b"
-  branch = "roman/usermessage"
+  version = "=1.1.9"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/lib/app/resources/decode.go
+++ b/lib/app/resources/decode.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -46,7 +47,7 @@ L:
 				log.Warn(err)
 				continue L
 			}
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "decode failure: %v", err)
 		}
 		objects = append(objects, object)
 	}
@@ -134,6 +135,9 @@ func (r *universalDecoder) Decode() (runtime.Object, error) {
 	if err := r.streamDecoder.Decode(&unk); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if len(unk.Raw) == 0 {
+		return nil, utils.Continue("skip empty object")
+	}
 	if unk.Kind == "" {
 		// Return unparsed for resources that are pass-through
 		return &unk, nil
@@ -190,12 +194,30 @@ func Encode(objects []runtime.Object, encoding encoding, w io.Writer) error {
 	return nil
 }
 
-// Unknown represents an unparsed kubernetes resource with an interpreted TypeMeta
-// field which is used for type recognition
+// ToUnknown attempts to convert the provided generic object to an unknown resource.
+func ToUnknown(object runtime.Object) (*Unknown, error) {
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var unk Unknown
+	if err := json.Unmarshal(bytes, &unk); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &unk, nil
+}
+
+// Unknown represents an unparsed Kubernetes resource with an interpreted
+// TypeMeta and ObjectMeta fields which are used for type recognition.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Unknown struct {
-	runtime.TypeMeta
+	unknown
 	Raw json.RawMessage `json:",inline"`
+}
+
+type unknown struct {
+	runtime.TypeMeta
+	Metadata metav1.ObjectMeta `json:"metadata"`
 }
 
 // GetObjectKind returns the ObjectKind for this Unknown.
@@ -205,11 +227,11 @@ func (r *Unknown) GetObjectKind() schema.ObjectKind {
 }
 
 // UnmarshalJSON consumes the specified data as a binary blob w/o interpreting it
-func (r *Unknown) UnmarshalJSON(data []byte) (err error) {
-	if err = json.Unmarshal(data, &r.TypeMeta); err != nil {
+func (r *Unknown) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &r.unknown); err != nil {
 		return trace.Wrap(err)
 	}
-	if err = r.Raw.UnmarshalJSON(data); err != nil {
+	if err := r.Raw.UnmarshalJSON(data); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/app/resources/resourcefiles.go
+++ b/lib/app/resources/resourcefiles.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
@@ -42,6 +43,7 @@ import (
 	settingsv1alpha1 "k8s.io/api/settings/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -368,7 +370,6 @@ func extractImages(objects []runtime.Object) (*ExtractedImages, error) {
 			containers = append(resource.Spec.JobTemplate.Spec.Template.Spec.Containers,
 				resource.Spec.JobTemplate.Spec.Template.Spec.InitContainers...)
 		default:
-			log.Debugf("Skipping object: %v.", obj.GetObjectKind().GroupVersionKind().String())
 			if !isKnownNonPodObject(obj) {
 				unrecognizedObjects = append(unrecognizedObjects, obj)
 			}
@@ -430,7 +431,10 @@ func isKnownNonPodObject(object runtime.Object) bool {
 		*corev1.ServiceAccount,
 		*corev1.Service,
 		*storagev1.StorageClass,
-		*storagev1beta1.StorageClass:
+		*storagev1beta1.StorageClass,
+		*v1beta1.CustomResourceDefinition,
+		*admissionv1beta1.ValidatingWebhookConfiguration,
+		*admissionv1beta1.MutatingWebhookConfiguration:
 		return true
 	}
 	return false

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -340,7 +340,6 @@ func analyzeResources(resourceFiles, chartFiles resources.ResourceFiles, req Ven
 //    has been detected
 func printResourceStatus(resourceFile resources.ResourceFile, req VendorRequest) error {
 	relPath := utils.TrimPathPrefix(resourceFile.Path(), filepath.Dir(req.ManifestPath))
-	//req.ProgressReporter.PrintSubDebug("Detected %v %v", resourceFile.Kind(), relPath)
 	extractedImages, err := resourceFile.Images()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gravitational/gravity/lib/docker"
 	"github.com/gravitational/gravity/lib/schema"
-	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -49,11 +48,11 @@ func Build(ctx context.Context, builder *Builder) error {
 
 	switch builder.Manifest.Kind {
 	case schema.KindBundle, schema.KindCluster:
-		builder.Config.Progress = utils.NewProgress(ctx, "Build",
-			clusterBuildSteps, builder.Config.Silent)
+		builder.NextStep("Building cluster image %v %v",
+			locator.Name, locator.Version)
 	case schema.KindApplication:
-		builder.Config.Progress = utils.NewProgress(ctx, "Build",
-			appBuildSteps, builder.Config.Silent)
+		builder.NextStep("Building application image %v %v",
+			locator.Name, locator.Version)
 	default:
 		return trace.BadParameter("unknown manifest kind %q",
 			builder.Manifest.Kind)
@@ -134,10 +133,3 @@ func checkBuildEnv() error {
 	}
 	return nil
 }
-
-const (
-	// clusterBuildSteps is a number of steps when building a cluster image.
-	clusterBuildSteps = 6
-	// appBuildSteps is a number of steps when building an app image.
-	appBuildSteps = 4
-)

--- a/lib/system/fs_test.go
+++ b/lib/system/fs_test.go
@@ -62,7 +62,7 @@ xfs
 		},
 		{
 			lsblk: failingRunner{trace.Errorf("error")},
-			err:   `error, failed to determine filesystem type on /dev/foo`,
+			err:   "failed to determine filesystem type on /dev/foo\n\terror",
 		},
 	}
 	for _, testCase := range testCases {

--- a/lib/utils/progress.go
+++ b/lib/utils/progress.go
@@ -101,6 +101,8 @@ type Progress interface {
 	PrintCurrentStep(message string, args ...interface{})
 	// PrintSubStep outputs the message as a sub-step of the current step
 	PrintSubStep(message string, args ...interface{})
+	// PrintSubWarn outputs the warning as a sub-step of the current step
+	PrintSubWarn(message string, args ...interface{})
 	// Print outputs the specified message in regular color
 	Print(message string, args ...interface{})
 	// PrintInfo outputs the specified info message in color
@@ -192,6 +194,11 @@ func (p *progressPrinter) PrintCurrentStep(message string, args ...interface{}) 
 func (p *progressPrinter) PrintSubStep(message string, args ...interface{}) {
 	entry := p.updateCurrentEntry(message, args...)
 	fmt.Fprintf(p.w, "\t%v\n", entry.message)
+}
+
+// PrintSubWarn outputs the warning as a sub-step of the current step
+func (p *progressPrinter) PrintSubWarn(message string, args ...interface{}) {
+	p.PrintSubStep(color.YellowString(message, args...))
 }
 
 func (p *progressPrinter) updateCurrentEntry(message string, args ...interface{}) *entry {
@@ -324,7 +331,8 @@ func printStep(out io.Writer, current, target int, message string) {
 	if target > 0 {
 		fmt.Fprintf(out, "* [%v/%v] %v\n", current, target, message)
 	} else {
-		fmt.Fprintf(out, "%v\n", message)
+		ts := color.New(color.Bold).Sprintf("%v", time.Now().UTC().Format(constants.HumanDateFormatSeconds))
+		fmt.Fprintf(out, "%v\t%v\n", ts, message)
 	}
 }
 
@@ -349,6 +357,9 @@ func (*nopProgress) PrintCurrentStep(message string, args ...interface{}) {}
 
 // PrintSubStep outputs the message as a sub-step of the current step
 func (*nopProgress) PrintSubStep(message string, args ...interface{}) {}
+
+// PrintSubWarn outputs warning as a sub-step of the current step
+func (*nopProgress) PrintSubWarn(message string, args ...interface{}) {}
 
 // Print outputs the specified message in regular color
 func (*nopProgress) Print(message string, args ...interface{}) {}

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -55,7 +55,7 @@ func build(ctx context.Context, params BuildParameters, req service.VendorReques
 		Overwrite:        params.Overwrite,
 		SkipVersionCheck: params.SkipVersionCheck,
 		VendorReq:        req,
-		Progress:         utils.NewProgress(ctx, "Build", 6, params.Silent),
+		Progress:         utils.NewProgress(ctx, "Build", 0, params.Silent),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -40,6 +40,8 @@ type BuildParameters struct {
 	SkipVersionCheck bool
 	// Silent is whether builder should report progress to the console
 	Silent bool
+	// Verbose turns on more details progress output.
+	Verbose bool
 	// Insecure turns on insecure verify mode
 	Insecure bool
 }
@@ -55,7 +57,10 @@ func build(ctx context.Context, params BuildParameters, req service.VendorReques
 		Overwrite:        params.Overwrite,
 		SkipVersionCheck: params.SkipVersionCheck,
 		VendorReq:        req,
-		Progress:         utils.NewProgress(ctx, "Build", 0, params.Silent),
+		Progress: utils.NewProgressWithConfig(ctx, "Build", utils.ProgressConfig{
+			Silent:  params.Silent,
+			Verbose: params.Verbose,
+		}),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -77,6 +77,8 @@ type BuildCmd struct {
 	Parallel *int
 	// Quiet allows to suppress console output
 	Quiet *bool
+	// Verbose enables more detailed build output.
+	Verbose *bool
 }
 
 type ListCmd struct {

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -53,6 +53,7 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.SkipVersionCheck = tele.BuildCmd.Flag("skip-version-check", "Skip version compatibility check.").Hidden().Bool()
 	tele.BuildCmd.Parallel = tele.BuildCmd.Flag("parallel", "Specifies the number of concurrent tasks. If < 0, the number of tasks is not restricted, if unspecified, then tasks are capped at the number of logical CPU cores.").Int()
 	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any output to stdout.").Short('q').Bool()
+	tele.BuildCmd.Verbose = tele.BuildCmd.Flag("verbose", "Produce more detailed build output, can be useful for troubleshooting.").Short('v').Bool()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "List cluster and application images published to Gravity Hub.")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes.").Short('r').Hidden().Bool()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -57,6 +57,7 @@ func Run(tele Application) error {
 			Overwrite:        *tele.BuildCmd.Overwrite,
 			SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
 			Silent:           *tele.BuildCmd.Quiet,
+			Verbose:          *tele.BuildCmd.Verbose,
 			Insecure:         *tele.Insecure,
 		}, service.VendorRequest{
 			PackageName:            *tele.BuildCmd.Name,

--- a/vendor/github.com/gravitational/trace/httplib.go
+++ b/vendor/github.com/gravitational/trace/httplib.go
@@ -74,7 +74,7 @@ func ReadError(statusCode int, re []byte) error {
 	case http.StatusGatewayTimeout:
 		e = &ConnectionProblemError{Message: string(re)}
 	default:
-		if statusCode < 200 || statusCode > 299 {
+		if statusCode < 200 || statusCode >= 400 {
 			return Errorf(string(re))
 		}
 		return nil


### PR DESCRIPTION
A few UX improvements to tele build:

* Fix the confusing `unrecognized object: apiVersion=/, kind=` error which was due to empty resource files which our decoder didn't ignore and returned empty resources instead.
* Do not print "unrecognized resource" warning for each resource in tele build output, they can accumulate, pollute the output and confuse the user. Instead, log them and print a single warning to tell them to look in the logs if needed.
* Get rid of the steps in the tele build output which always got out of sync. Instead, use our standard progress output with timestamps.
* Add more context to resource parsing errors. Previously, it would just print a generic "json parse error" with no way of telling which resource file it's for. Now it prints the name of the file with the error, and the actual error.
* Improve how errors with multiple user messages are displayed. See https://github.com/gravitational/trace/pull/53 for details (which this PR requires).

Closes https://github.com/gravitational/gravity/issues/679, closes https://github.com/gravitational/gravity/issues/852.