### PR TITLE
Add ability to provide helm values to tele build.

### DIFF
--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -79,6 +79,10 @@ type BuildCmd struct {
 	Quiet *bool
 	// Verbose enables more detailed build output.
 	Verbose *bool
+	// Set is a list of Helm chart values set on the CLI.
+	Set *[]string
+	// Values is a list of YAML files with Helm chart values.
+	Values *[]string
 }
 
 type ListCmd struct {

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -54,6 +54,8 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.Parallel = tele.BuildCmd.Flag("parallel", "Specifies the number of concurrent tasks. If < 0, the number of tasks is not restricted, if unspecified, then tasks are capped at the number of logical CPU cores.").Int()
 	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any output to stdout.").Short('q').Bool()
 	tele.BuildCmd.Verbose = tele.BuildCmd.Flag("verbose", "Produce more detailed build output, can be useful for troubleshooting.").Short('v').Bool()
+	tele.BuildCmd.Set = tele.BuildCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
+	tele.BuildCmd.Values = tele.BuildCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "List cluster and application images published to Gravity Hub.")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes.").Short('r').Hidden().Bool()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/helm"
 	"github.com/gravitational/gravity/lib/localenv"
 
 	teleutils "github.com/gravitational/teleport/lib/utils"
@@ -68,6 +69,10 @@ func Run(tele Application) error {
 			SetDeps:                *tele.BuildCmd.SetDeps,
 			Parallel:               *tele.BuildCmd.Parallel,
 			VendorRuntime:          true,
+			Helm: helm.RenderParameters{
+				Values: *tele.BuildCmd.Values,
+				Set:    *tele.BuildCmd.Set,
+			},
 		})
 	}
 


### PR DESCRIPTION
Add ability to override Helm values during tele build via `--set` and `--values` flags - flag names are the same as in helm commands and gravity app commands. Closes https://github.com/gravitational/gravity/issues/903.

Should be pretty easy to backport to 6.x as well.