### PR TITLE
(6.1) Export kubeproxy port.

### DIFF
--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -181,6 +181,8 @@ spec:
             containerPort: 3023
           - name: sshtunnel
             containerPort: 3024
+          - name: kubeproxy
+            containerPort: 3026
           - name: teleport
             containerPort: 3080
           - name: profile

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -637,6 +637,9 @@ const (
 	// AWSLBIdleTimeoutAnnotation is the kubernetes annotation that specifies
 	// idle timeout for an AWS load balancer
 	AWSLBIdleTimeoutAnnotation = "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"
+	// ExternalDNSHostnameAnnotation is the service annotation that is understood
+	// by external DNS controllers.
+	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 
 	// FinalStep is the number of the final install operation step in UI
 	FinalStep = 9

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -19,6 +19,7 @@ limitations under the License.
 package constants
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -769,6 +770,12 @@ var (
 	// HubImageName is the name of the Hub cluster image.
 	HubImageName = "hub"
 )
+
+// ExternalDNS formats the provided hostname as a wildcard A record for use
+// with external DNS provisioners.
+func ExternalDNS(hostname string) string {
+	return fmt.Sprintf("%[1]v,*.%[1]v", hostname)
+}
 
 // Format is the type for supported output formats
 type Format string


### PR DESCRIPTION
Expose `3026` in gravity-site. Requires https://github.com/gravitational/gravity.e/pull/4258. Refs https://github.com/gravitational/gravity/issues/908.