### PR TITLE
lib/blob/suite: fix dropped error

### DIFF
--- a/lib/blob/suite/suite.go
+++ b/lib/blob/suite/suite.go
@@ -120,6 +120,7 @@ func (s *BLOBSuite) BLOBWriteTwice(c *C) {
 	c.Assert(err, IsNil)
 
 	r, err := s.Objects.OpenBLOB(e.SHA512)
+	c.Assert(err, IsNil)
 	defer r.Close()
 
 	out, err := ioutil.ReadAll(r)


### PR DESCRIPTION
This picks up a a dropped error variable in `lib/blob/suite`.