### PR TITLE
Add CONTRIBUTING.md & CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at info@gravitational.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Gravity is an open source project.
 
-It is the work of tens of contributors. We appricate your help!
+It is the work of tens of contributors. We appreciate your help!
 
 We follow a [code of conduct](./CODE_OF_CONDUCT.md).
 
@@ -24,7 +24,7 @@ Gravity contributors will triage the issue shortly.
 ## Contributing A Patch
 
 If you're working on an existing issue, respond to the issue and express
-interest in working on it.  This helps other people know that the issue is
+interest in working on it. This helps other people know that the issue is
 active, and hopefully prevents duplicated efforts.
 
 If you want to work on a new idea of relatively small scope:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,4 @@ If your patch depends on new packages, the dependencies must:
 
 - be licensed via Apache2 license
 - be approved by core Gravity contributors ahead of time
-- be vendored via [`godep`](https://github.com/tools/godep)
+- be vendored via [`dep`](https://github.com/golang/dep)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Gravity is an open source project.
+
+It is the work of tens of contributors. We appricate your help!
+
+We follow a [code of conduct](./CODE_OF_CONDUCT.md).
+
+
+## Filing an Issue
+
+Security issues should be reported directly to security@gravitational.com.
+
+If you are unsure if you've found a bug, consider searching
+[current issues](https://github.com/gravitational/gravity/issues) or
+asking in the [community forum](https://community.gravitational.com/) first.
+
+Once you know you have a issue, make sure to fill out all sections of the
+one of the templates at https://github.com/gravitational/gravity/issues/new/choose.
+
+Gravity contributors will triage the issue shortly.
+
+
+## Contributing A Patch
+
+If you're working on an existing issue, respond to the issue and express
+interest in working on it.  This helps other people know that the issue is
+active, and hopefully prevents duplicated efforts.
+
+If you want to work on a new idea of relatively small scope:
+
+1. Submit an issue describing the proposed change and the implementation.
+2. The repo owners will respond to your issue promptly.
+3. Write your code, test your changes and _communicate_ with us as you're
+moving forward.
+4. Submit a pull request from your fork.
+
+### Adding dependencies
+
+If your patch depends on new packages, the dependencies must:
+
+- be licensed via Apache2 license
+- be approved by core Gravity contributors ahead of time
+- be vendored via [`godep`](https://github.com/tools/godep)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ documentation to reflect the differences between the proprietary and
 community/OSS editions of the software. We are also working on providing open
 source users with pre-built binaries on a regular basis.
 
+## Contributing
+
+To contribute, please read the [contribution guidelines](./CONTRIBUTING.md).
+
 ## Talk to us
 
 * Want to join our team to hack on Gravity? [We are always hiring!](https://gravitational.com/careers/systems-engineer/)


### PR DESCRIPTION
Resolves #923 by adding the code of conduct, and takes a stab at contribution guidelines. CONTRIBUTING felt appropriate to give discoverability to this info from the README.

Testing Done:
```
View these three files in my branch:

https://github.com/wadells/gravity/tree/code-of-conduct#contributing
https://github.com/wadells/gravity/blob/code-of-conduct/CONTRIBUTING.md
https://github.com/wadells/gravity/blob/code-of-conduct/CODE_OF_CONDUCT.md

Double checked that the links work.
```