### PR TITLE
Consider 'leader changed' a transient error

### DIFF
--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -122,8 +122,6 @@ cat %v 2> /dev/null || true`
 // planetLogs fetches planet syslog messages as well as the fresh journal entries
 func planetLogs() Collectors {
 	return Collectors{
-		// Fetch planet syslog messages as a tarball
-		Script("planet-logs.tar.gz", tarball(defaults.InGravity("planet/log/messages*"))),
 		// Fetch planet journal entries for the last two days
 		// The log can be imported as a journal with systemd-journal-remote:
 		//

--- a/lib/storage/keyval/etcd.go
+++ b/lib/storage/keyval/etcd.go
@@ -572,7 +572,7 @@ func (r retryApi) retry(ctx context.Context, fn apiCall) (resp *client.Response,
 	err = backoff.Retry(func() (err error) {
 		resp, err = fn()
 		if utils.IsTransientClusterError(err) {
-			log.Debugf("retrying on transient etcd error: %v", err)
+			log.WithError(err).Debug("Retry on transient etcd error.")
 			return trace.Wrap(err)
 		}
 		if err != nil {

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -208,7 +208,8 @@ func isEtcdClusterError(err error) bool {
 }
 
 func isEtcdClusterErrorMessage(message string) bool {
-	return isEtcdClusterMisconfigured(message) || isEtcdClusterHasNoLeader(message)
+	return isEtcdClusterMisconfigured(message) || isEtcdClusterHasNoLeader(message) ||
+		isEtcdClusterLeaderChanged(message)
 }
 
 func isEtcdClusterMisconfigured(message string) bool {
@@ -218,6 +219,10 @@ func isEtcdClusterMisconfigured(message string) bool {
 func isEtcdClusterHasNoLeader(message string) bool {
 	return strings.Contains(message, "etcd member") &&
 		strings.Contains(message, "has no leader")
+}
+
+func isEtcdClusterLeaderChanged(message string) bool {
+	return strings.Contains(message, "etcdserver: leader changed")
 }
 
 // MarshalJSON marshals this message as JSON.


### PR DESCRIPTION
 * Consider 'leader changed' a transient error and retry accordingly.
 * Remove the message collector as it is not working as expected (comes up empty while the logs are no longer stored where it expects them to be).

Fixes https://github.com/gravitational/gravity/issues/947.