### PR TITLE
(6.1) More efficient app endpoints retrieval.

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -475,6 +475,8 @@ const (
 
 	// KubeSystemNamespace is a k8s namespace
 	KubeSystemNamespace = "kube-system"
+	// AllNamespaces is the filter to search across all namespaces
+	AllNamespaces = ""
 
 	// GrafanaContextCookie hold the name of the cluster used in
 	// certain web handlers to determine the currently selected domain without including it

--- a/lib/ops/opsservice/endpoints.go
+++ b/lib/ops/opsservice/endpoints.go
@@ -75,10 +75,6 @@ func (o *Operator) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, err
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	namespaceList, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	var endpoints []ops.Endpoint
 	for _, e := range site.app.Manifest.Endpoints {
@@ -86,19 +82,11 @@ func (o *Operator) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, err
 			continue
 		}
 
-		var serviceList *v1.ServiceList
-		for _, ns := range namespaceList.Items {
-			services, err := client.CoreV1().Services(ns.Name).List(metav1.ListOptions{
-				LabelSelector: utils.MakeSelector(e.Selector).String(),
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if serviceList == nil {
-				serviceList = services
-			} else {
-				serviceList.Items = append(serviceList.Items, services.Items...)
-			}
+		serviceList, err := client.CoreV1().Services(constants.AllNamespaces).List(metav1.ListOptions{
+			LabelSelector: utils.MakeSelector(e.Selector).String(),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		if serviceList == nil {

--- a/lib/ops/opsservice/endpoints.go
+++ b/lib/ops/opsservice/endpoints.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/utils"
 
+	"github.com/gravitational/rigging"
 	"github.com/gravitational/trace"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,7 +87,7 @@ func (o *Operator) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, err
 			LabelSelector: utils.MakeSelector(e.Selector).String(),
 		})
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, rigging.ConvertError(err)
 		}
 
 		if serviceList == nil {


### PR DESCRIPTION
When retrieving endpoints, make a single API call to get services across all namespaces rather than iterating over namespaces.

Closes https://github.com/gravitational/gravity/issues/944. Needs port to 6.2 and master.