### PR TITLE
Add support for Helm values to install/upgrade

### DIFF
--- a/docs/6.x/faq.md
+++ b/docs/6.x/faq.md
@@ -147,3 +147,12 @@ systemOptions:
 ```
 
 See [Securing a Cluster](/cluster/#securing-a-cluster) for more details.
+
+## Customizing Helm Values
+
+When using Helm charts, it is possible to customize Helm values at
+build/install/upgrade time by providing `--values` and `--set` flags to
+the respective `tele build`, `gravity install` and `gravity upgrade`
+commands.
+
+See [Helm Integration](/pack/#helm-integration) for more details.

--- a/docs/6.x/pack.md
+++ b/docs/6.x/pack.md
@@ -733,9 +733,8 @@ To see more examples of specific hooks, please refer to the following documentat
 
 ## Helm Integration
 
-It is possible to use [Helm](https://docs.helm.sh/) charts as a way to package
-and install applications as every Gravity Cluster comes with a preconfigured
-Tiller server and its client, Helm.
+Gravity has a first-class [Helm](https://docs.helm.sh/) support and lets you use Helm
+charts as a way to package and install applications.
 
 Suppose you have the application resources directory with the following layout:
 
@@ -752,16 +751,25 @@ example/
 
 When building the Cluster Image, the `tele build` command will find
 directories with Helm charts (determined by the presence of `Chart.yaml` file)
-and vendor all Docker images they reference into the resulting installer
-tarball.
+and vendor all Docker images they reference into the resulting image tarball.
 
-!!! note:
-    The machine running `tele build` must have Helm binary [installed](https://docs.helm.sh/using_helm/#installing-helm)
-    and available in PATH as well as its [template plugin](https://docs.helm.sh/using_helm/#installing-a-plugin).
+The `tele build` command also allows to override Helm chart values at build time
+via `--values` and `--set` flags. These values will be taken into account when
+rendering Helm templates which is useful if you need to vendor a specific version
+of a certain Docker image or pull it from a specific registry.
+
+The flags have the same meaning and syntax as the Helm flags of the same names:
+`--values` specifies a YAML file with custom values and `--set` sets values directly
+on the command-line. Both can be provided multiple times:
+
+```bash
+$ tele build example/app.yaml --values=custom-values.yaml --set=nginx.image=1.9.1 --set=postgres.registry=internal.registry.io
+```
 
 During the installation, the vendored images will be pushed to the Cluster's local
-Docker registry which is available inside the Cluster at `leader.telekube.local:5000`.
+Docker registry which is available inside the Cluster at `registry.local:5000`.
 Helm templating engine can be used to tag images with an appropriate registry.
+
 For example, `example.yaml` may contain the following image reference:
 
 ```yaml
@@ -771,11 +779,9 @@ image: {{.Values.registry}}postgres:9.4.4
 And `values.yaml` may define the `registry` templating variable that can be set
 during application installation:
 
-
 ```
 registry: ""
 ```
-
 
 An install hook can then use the `helm` binary (which gets mounted into every hook
 container under `/usr/local/bin`) to install these resources:
@@ -804,6 +810,33 @@ correct image references.
 !!! tip:
     There is a sample application available on [GitHub](https://github.com/gravitational/quickstart/tree/master/mattermost)
     that demonstrates this workflow.
+
+### Customizing Helm values
+
+It is possible to customize values of your Helm charts when installing or
+upgrading the application. To provide custom Helm values at install time,
+pass them via `--values` and `--set` flags to `gravity install` command:
+
+```bash
+unpacked-image$ ./gravity install --values=custom-values.yaml --set=nginx.image=1.9.1 --set=postgres.registry=internal.registry.io
+```
+
+The provided values are merged into a single values file that is mounted
+into install and post-install hooks under `/var/lib/gravity/helm/values.yaml`
+so the install hook can use it in the `helm install` command:
+
+```yaml
+...
+command: ["/usr/local/bin/helm", "install", "/var/lib/gravity/resources/charts/example", "--values", "/var/lib/gravity/helm/values.yaml"]
+```
+
+The same is true for upgrades: both the `./upgrade` script included with the cluster
+image and `gravity upgrade` commands support providing custom Helm values which
+will get mounted at the same location in the upgrade/post-upgrade hooks:
+
+```bash
+unpacked-image$ ./upgrade --values=custom-values.yaml --set=nginx.image=1.11.0
+```
 
 ## Custom Installation Screen
 

--- a/docs/6.x/pack.md
+++ b/docs/6.x/pack.md
@@ -736,6 +736,9 @@ To see more examples of specific hooks, please refer to the following documentat
 Gravity has a first-class [Helm](https://docs.helm.sh/) support and lets you use Helm
 charts as a way to package and install applications.
 
+!!! note "Helm version":
+    Gravity 6 works with Helm 2. We are currently working on Helm 3 integration.
+
 Suppose you have the application resources directory with the following layout:
 
 ```

--- a/lib/app/app.go
+++ b/lib/app/app.go
@@ -216,6 +216,8 @@ type HookRunRequest struct {
 	NodeSelector map[string]string `json:"node_selector"`
 	// Env defines additional environment variables to pass to the hook job
 	Env map[string]string `json:"env"`
+	// Values are helm values in a marshaled yaml format
+	Values []byte `json:"values,omitempty"`
 	// SkipInitContainers skips injection of init containers
 	SkipInitContainers bool `json:"skip_init_containers"`
 	// HostNetwork specifies whether the hook job runs in host network namespace

--- a/lib/app/hooks/constants.go
+++ b/lib/app/hooks/constants.go
@@ -35,6 +35,9 @@ const (
 	// ResourcesDir is where the app's resources directory is mounted inside a hook container
 	ResourcesDir = "/var/lib/gravity/resources"
 
+	// HelmDir is the directory inside hooks where helm values files is mounted
+	HelmDir = "/var/lib/gravity/helm"
+
 	// GravityDir is the root directory with gravity state
 	GravityDir = "/var/lib/gravity"
 
@@ -51,13 +54,19 @@ const (
 	// Helm is where helm binary gets mounted inside hook containers
 	HelmPath = "/usr/local/bin/helm"
 
+	// HelmValuesFile is the name of the file with helm values
+	HelmValuesFile = "values.yaml"
+
 	// VolumeBin is the name of the volume with host's /usr/bin dir
 	VolumeBin = "bin"
 
 	// VolumeKubectl is the name of the volume with kubectl
-	VolumeKubectl = "kubectl"
+	VolumeKubectlBin = "kubectl-bin"
 
-	// VolumeHelm is the name of the volume with helm binary
+	// VolumeHelmBin is the name of the volume with helm binary
+	VolumeHelmBin = "helm-bin"
+
+	// VolumeHelmValues is the name of the volume with helm values file
 	VolumeHelm = "helm"
 
 	// VolumeBackup is the name of the volume that stores results of the backup hook

--- a/lib/app/hooks/hooks.go
+++ b/lib/app/hooks/hooks.go
@@ -83,6 +83,8 @@ type Params struct {
 	// ServiceUser specifies the service user which overrides the default
 	// security context for the job's Pod
 	ServiceUser storage.OSUser
+	// Values are helm values in a marshaled yaml format
+	Values []byte
 }
 
 // JobRef is a reference to a hook job

--- a/lib/app/service/app.go
+++ b/lib/app/service/app.go
@@ -319,6 +319,7 @@ func (r *applications) StartAppHook(ctx context.Context, req appservice.HookRunR
 		AgentPassword:      creds.Password,
 		GravityPackage:     req.GravityPackage,
 		ServiceUser:        req.ServiceUser,
+		Values:             req.Values,
 	}
 
 	ref, err := runner.Start(ctx, params)

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -406,7 +406,7 @@ fi
 
 scriptdir=$(dirname $(realpath $0))
 app=$("$scriptdir/gravity" app-package --state-dir="$scriptdir")
-"$scriptdir/upload" && "$scriptdir/gravity" --insecure update trigger $app
+"$scriptdir/upload" && "$scriptdir/gravity" --insecure upgrade $app
 `
 
 	checkScript = `#!/bin/bash

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -406,7 +406,7 @@ fi
 
 scriptdir=$(dirname $(realpath $0))
 app=$("$scriptdir/gravity" app-package --state-dir="$scriptdir")
-"$scriptdir/upload" && "$scriptdir/gravity" --insecure upgrade $app
+"$scriptdir/upload" && "$scriptdir/gravity" --insecure upgrade $app "$@"
 `
 
 	checkScript = `#!/bin/bash

--- a/lib/install/config.go
+++ b/lib/install/config.go
@@ -158,6 +158,8 @@ type Config struct {
 	Packages pack.PackageService
 	// LocalAgent specifies whether the installer will also run an agent
 	LocalAgent bool
+	// Values are helm values in marshaled yaml format
+	Values []byte
 }
 
 // checkAndSetDefaults checks the parameters and autodetects some defaults

--- a/lib/install/engine/cli/cli.go
+++ b/lib/install/engine/cli/cli.go
@@ -182,6 +182,7 @@ func (r *executor) createOperation() (*ops.SiteOperation, error) {
 				ServiceCIDR: r.config.ServiceCIDR,
 				VxlanPort:   r.config.VxlanPort,
 			},
+			Values: r.config.Values,
 		},
 		Profiles: install.ServerRequirements(*r.config.Flavor),
 	})

--- a/lib/install/phases/app.go
+++ b/lib/install/phases/app.go
@@ -99,6 +99,7 @@ func (p *hookExecutor) runHooks(ctx context.Context, hooks ...schema.HookType) e
 		req := app.HookRunRequest{
 			Application: locator,
 			Hook:        hook,
+			Values:      p.Phase.Data.Values,
 			ServiceUser: storage.OSUser{
 				Name: p.ServiceUser.Name,
 				UID:  strconv.Itoa(p.ServiceUser.UID),

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -43,6 +43,8 @@ import (
 type PlanBuilder struct {
 	// Cluster is the cluster being installed
 	Cluster storage.Site
+	// Operation is the operation the builder is for
+	Operation ops.SiteOperation
 	// Application is the app being installed
 	Application app.Application
 	// Runtime is the Runtime of the app being installed
@@ -577,6 +579,7 @@ func (b *PlanBuilder) AddApplicationPhase(plan *storage.OperationPlan) error {
 				Server:      &b.Master,
 				Package:     &applicationLocators[i],
 				ServiceUser: &b.ServiceUser,
+				Values:      b.Operation.GetVars().Values,
 			},
 			Requires: []string{phases.RuntimePhase},
 			Step:     6,
@@ -698,7 +701,8 @@ func (c *Config) GetPlanBuilder(operator ops.Operator, cluster ops.Site, op ops.
 		return nil, trace.Wrap(err)
 	}
 	builder := &PlanBuilder{
-		Cluster: ops.ConvertOpsSite(cluster),
+		Cluster:   ops.ConvertOpsSite(cluster),
+		Operation: op,
 		Application: app.Application{
 			Package:         cluster.App.Package,
 			PackageEnvelope: cluster.App.PackageEnvelope,

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1352,6 +1352,8 @@ type CreateSiteAppUpdateOperationRequest struct {
 	App string `json:"package"`
 	// StartAgents specifies whether the operation will automatically start the update agents
 	StartAgents bool `json:"start_agents"`
+	// Vars are variables specific to this operation
+	Vars storage.OperationVariables `json:"vars"`
 }
 
 // Check validates this request

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -364,6 +364,7 @@ func (s *site) createUpdateOperation(context context.Context, req ops.CreateSite
 		Provisioner: installOperation.Provisioner,
 		Update: &storage.UpdateOperationState{
 			UpdatePackage: req.App,
+			Vars:          req.Vars,
 		},
 	}
 

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -116,6 +116,8 @@ type OperationPhaseData struct {
 	TrustedCluster []byte `json:"trusted_cluster_resource,omitempty" yaml:"trusted_cluster_resource,omitempty"`
 	// Storage is the persistent storage resource configuration.
 	Storage []byte `json:"storage_resource,omitempty" yaml:"storage_resource,omitempty"`
+	// Values are helm values in a marshaled yaml format
+	Values []byte `json:"values,omitempty" yaml:"values,omitempty"`
 	// ServiceUser specifies the optional service user to use as a context
 	// for file operations
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -463,6 +463,9 @@ func (s *SiteOperation) Vars() OperationVariables {
 	if s.Uninstall != nil {
 		return s.Uninstall.Vars
 	}
+	if s.Update != nil {
+		return s.Update.Vars
+	}
 	return OperationVariables{}
 }
 

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1812,6 +1812,8 @@ type OperationVariables struct {
 	OnPrem OnPremVariables `json:"onprem"`
 	// AWS is a set of AWS-specific variables
 	AWS AWSVariables `json:"aws"`
+	// Values are helm values in a marshaled yaml format
+	Values []byte `json:"values,omitempty"`
 }
 
 // ToMap converts operation variables into a JSON object for easier use in templates

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -2065,6 +2065,8 @@ type UpdateOperationState struct {
 	ServerUpdates []ServerUpdate `json:"server_updates,omitempty"`
 	// Manual specifies whether this update operation was created in manual mode
 	Manual bool `json:"manual"`
+	// Vars are variables specific to this operation
+	Vars OperationVariables `json:"vars"`
 }
 
 // UpdateEnvarsOperationState describes the state of the operation to update cluster environment variables.

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -130,6 +130,7 @@ func (r phaseBuilder) app(updates []loc.Locator) *update.Phase {
 			Description: fmt.Sprintf("Update application %q to %v", loc.Name, loc.Version),
 			Data: &storage.OperationPhaseData{
 				Package: &updates[i],
+				Values:  r.operation.Vars().Values,
 			},
 		})
 	}

--- a/lib/update/cluster/phases/app.go
+++ b/lib/update/cluster/phases/app.go
@@ -63,6 +63,7 @@ func NewUpdatePhaseApp(
 	return &updatePhaseApp{
 		phaseApp: phaseApp{
 			FieldLogger:    logger,
+			ExecutorParams: p,
 			Apps:           apps,
 			Client:         client,
 			GravityPackage: p.Plan.GravityPackage,
@@ -135,6 +136,7 @@ func NewUpdatePhaseBeforeApp(
 	return &updatePhaseBeforeApp{
 		phaseApp: phaseApp{
 			FieldLogger:    logger,
+			ExecutorParams: p,
 			Apps:           apps,
 			Client:         client,
 			GravityPackage: p.Plan.GravityPackage,
@@ -170,7 +172,10 @@ type phaseApp struct {
 	Servers []storage.Server
 	// ServiceUser is the user used for services and system storage
 	ServiceUser storage.OSUser
+	// FieldLogger is used for logging
 	log.FieldLogger
+	// ExecutorParams is the common phase parameters
+	fsm.ExecutorParams
 }
 
 // PreCheck makes sure this phase is being executed on a master node
@@ -189,6 +194,7 @@ func (p *phaseApp) runHooks(ctx context.Context, hooks ...schema.HookType) error
 			Application:    p.Package,
 			GravityPackage: p.GravityPackage,
 			Hook:           hook,
+			Values:         p.Phase.Data.Values,
 			Env: map[string]string{
 				// TODO(r0mant) see if we can get rid of this flag
 				constants.ManualUpdateEnvVar: "true",

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -394,6 +394,10 @@ type InstallCmd struct {
 	// the client will simply connect to the service and stream its output and errors
 	// and control whether it should stop
 	FromService *bool
+	// Set is a list of Helm chart values set on the CLI.
+	Set *[]string
+	// Values is a list of YAML files with Helm chart values.
+	Values *[]string
 }
 
 // JoinCmd joins to the installer or existing cluster

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -650,6 +650,10 @@ type UpgradeCmd struct {
 	Resume *bool
 	// SkipVersionCheck suppresses version mismatch errors
 	SkipVersionCheck *bool
+	// Set is a list of Helm chart values set on the CLI.
+	Set *[]string
+	// Values is a list of YAML files with Helm chart values.
+	Values *[]string
 }
 
 // StatusCmd displays cluster status
@@ -979,6 +983,10 @@ type WizardCmd struct {
 	// the client will simply connect to the service and stream its output and errors
 	// and control whether it should stop
 	FromService *bool
+	// Set is a list of Helm chart values set on the CLI.
+	Set *[]string
+	// Values is a list of YAML files with Helm chart values.
+	Values *[]string
 }
 
 // AppPackageCmd displays the name of app in installer tarball

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -617,7 +617,7 @@ func (i *InstallConfig) validateCloudConfig(manifest schema.Manifest) (err error
 
 // NewWizardConfig returns new configuration for the interactive installer
 func NewWizardConfig(env *localenv.LocalEnvironment, g *Application) (*InstallConfig, error) {
-	values, err := helm.Vals(*g.InstallCmd.Values, *g.InstallCmd.Set, nil, nil, "", "", "")
+	values, err := helm.Vals(*g.WizardCmd.Values, *g.WizardCmd.Set, nil, nil, "", "", "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/helm"
 
 	"github.com/cenkalti/backoff"
 	"github.com/docker/docker/pkg/namesgenerator"
@@ -161,17 +162,23 @@ type InstallConfig struct {
 	// writeStateDir is the directory where installer stores state for the duration
 	// of the operation
 	writeStateDir string
+	// Values are helm values in marshaled yaml format
+	Values []byte
 }
 
 // NewInstallConfig creates install config from the passed CLI args and flags
-func NewInstallConfig(env *localenv.LocalEnvironment, g *Application) InstallConfig {
+func NewInstallConfig(env *localenv.LocalEnvironment, g *Application) (*InstallConfig, error) {
 	mode := *g.InstallCmd.Mode
 	if *g.InstallCmd.Wizard {
 		// this is obsolete parameter but take it into account in
 		// case somebody is still using it
 		mode = constants.InstallModeInteractive
 	}
-	return InstallConfig{
+	values, err := helm.Vals(*g.InstallCmd.Values, *g.InstallCmd.Set, nil, nil, "", "", "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InstallConfig{
 		Insecure:      *g.Insecure,
 		StateDir:      *g.InstallCmd.Path,
 		UserLogFile:   *g.UserLogFile,
@@ -207,8 +214,9 @@ func NewInstallConfig(env *localenv.LocalEnvironment, g *Application) InstallCon
 		Flavor:             *g.InstallCmd.Flavor,
 		Remote:             *g.InstallCmd.Remote,
 		FromService:        *g.InstallCmd.FromService,
+		Values:             values,
 		Printer:            env,
-	}
+	}, nil
 }
 
 // CheckAndSetDefaults validates the configuration object and populates default values
@@ -404,6 +412,7 @@ func (i *InstallConfig) NewInstallerConfig(
 		Packages:           wizard.Packages,
 		Operator:           wizard.Operator,
 		LocalAgent:         !i.Remote,
+		Values:             i.Values,
 	}, nil
 
 }

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -616,8 +616,12 @@ func (i *InstallConfig) validateCloudConfig(manifest schema.Manifest) (err error
 }
 
 // NewWizardConfig returns new configuration for the interactive installer
-func NewWizardConfig(env *localenv.LocalEnvironment, g *Application) InstallConfig {
-	return InstallConfig{
+func NewWizardConfig(env *localenv.LocalEnvironment, g *Application) (*InstallConfig, error) {
+	values, err := helm.Vals(*g.InstallCmd.Values, *g.InstallCmd.Set, nil, nil, "", "", "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InstallConfig{
 		Mode:               constants.InstallModeInteractive,
 		Insecure:           *g.Insecure,
 		UserLogFile:        *g.UserLogFile,
@@ -634,7 +638,8 @@ func NewWizardConfig(env *localenv.LocalEnvironment, g *Application) InstallConf
 		LocalApps:          env.Apps,
 		LocalBackend:       env.Backend,
 		LocalClusterClient: env.SiteOperator,
-	}
+		Values:             values,
+	}, nil
 }
 
 // JoinConfig describes command line configuration of the join command

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -188,6 +188,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpgradeCmd.Force = g.UpgradeCmd.Flag("force", "Force phase execution even if pre-conditions are not satisfied.").Bool()
 	g.UpgradeCmd.Resume = g.UpgradeCmd.Flag("resume", "Resume upgrade from the last failed step.").Bool()
 	g.UpgradeCmd.SkipVersionCheck = g.UpgradeCmd.Flag("skip-version-check", "Bypass version compatibility check.").Hidden().Bool()
+	g.UpgradeCmd.Set = g.UpgradeCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
+	g.UpgradeCmd.Values = g.UpgradeCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 
 	g.UpdateUploadCmd.CmdClause = g.UpdateCmd.Command("upload", "Upload update package to locally running site").Hidden()
 	g.UpdateUploadCmd.OpsCenterURL = g.UpdateUploadCmd.Flag("ops-url", "Optional Gravity Hub URL to upload new packages to (defaults to local gravity site)").Default(defaults.GravityServiceURL).String()
@@ -366,6 +368,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.WizardCmd.AdvertiseAddr = g.WizardCmd.Flag("advertise-addr", "The IP address to advertise. Will be selected automatically if unspecified").String()
 	g.WizardCmd.Token = g.WizardCmd.Flag("token", "Unique install token to authorize other nodes to join the cluster. Generated automatically if unspecified").String()
 	g.WizardCmd.FromService = g.WizardCmd.Flag("from-service", "Run in service mode").Hidden().Bool()
+	g.WizardCmd.Set = g.WizardCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
+	g.WizardCmd.Values = g.WizardCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 
 	g.AppPackageCmd.CmdClause = g.Command("app-package", "Display the name of application package from installer tarball").Hidden()
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -96,6 +96,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.InstallCmd.DNSZones = g.InstallCmd.Flag("dns-zone", "Specify an upstream server for the given zone within the cluster. Accepts <zone>/<nameserver> format where <nameserver> can be either <ip> or <ip>:<port>. Can be specified multiple times.").Strings()
 	g.InstallCmd.Remote = g.InstallCmd.Flag("remote", "Do not use this node in the cluster.").Bool()
 	g.InstallCmd.FromService = g.InstallCmd.Flag("from-service", "Run in service mode.").Hidden().Bool()
+	g.InstallCmd.Set = g.InstallCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
+	g.InstallCmd.Values = g.InstallCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 
 	g.JoinCmd.CmdClause = g.Command("join", "Join the existing cluster or an on-going install operation.")
 	g.JoinCmd.PeerAddr = g.JoinCmd.Arg("peer-addrs", "One or several IP addresses of cluster nodes to join, as comma-separated values.").String()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -324,11 +324,11 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			return trace.Wrap(err)
 		}
 		defer updateEnv.Close()
-		config, err := newUpgradeConfig(g)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return updateTrigger(localEnv, updateEnv, *config)
+		return updateTrigger(localEnv, updateEnv, upgradeConfig{
+			UpgradePackage:   *g.UpdateTriggerCmd.App,
+			Manual:           *g.UpdateTriggerCmd.Manual,
+			SkipVersionCheck: *g.UpdateTriggerCmd.SkipVersionCheck,
+		})
 	case g.UpdatePlanInitCmd.FullCommand():
 		updateEnv, err := g.NewUpdateEnv()
 		if err != nil {
@@ -354,11 +354,11 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 					SkipVersionCheck: *g.UpgradeCmd.SkipVersionCheck,
 				})
 		}
-		return updateTrigger(localEnv, updateEnv, upgradeConfig{
-			UpgradePackage:   *g.UpdateTriggerCmd.App,
-			Manual:           *g.UpdateTriggerCmd.Manual,
-			SkipVersionCheck: *g.UpdateTriggerCmd.SkipVersionCheck,
-		})
+		config, err := newUpgradeConfig(g)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return updateTrigger(localEnv, updateEnv, *config)
 	case g.ResumeCmd.FullCommand():
 		return resumeOperation(localEnv, g,
 			PhaseParams{

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -291,7 +291,11 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.WizardCmd.FullCommand():
 		return startInstall(localEnv, NewWizardConfig(localEnv, g))
 	case g.InstallCmd.FullCommand():
-		return startInstall(localEnv, NewInstallConfig(localEnv, g))
+		config, err := NewInstallConfig(localEnv, g)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return startInstall(localEnv, *config)
 	case g.JoinCmd.FullCommand():
 		return join(localEnv, g, NewJoinConfig(g))
 	case g.AutoJoinCmd.FullCommand():


### PR DESCRIPTION
Add `--values` and `--set` flags to the install/upgrade commands so users can pass Helm values at install/upgrade time. The provided values are merged into a single values file and mounted into hooks under `/var/lib/gravity/helm/values.yaml` (chose directory other than "resources" to avoid collisions with people's resources) where hooks can use it from. See included docs for more info.

Closes https://github.com/gravitational/gravity/issues/660 (the CLI part, anyway).