### PR TITLE
lib/users/usersservice: pick up dropped error in SetUpTest()

### DIFF
--- a/lib/users/usersservice/usersservice_test.go
+++ b/lib/users/usersservice/usersservice_test.go
@@ -64,6 +64,7 @@ func (s *UsersSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{
 		Path: filepath.Join(s.dir, "bolt.db"),
 	})
+	c.Assert(err, IsNil)
 
 	s.suite.Users, err = New(Config{
 		Backend: s.backend,


### PR DESCRIPTION
This picks off a dropped test error in `lib/users/usersservice`.