### PR TITLE
generate separate keys for each certificate

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -524,6 +524,8 @@ func (s *site) configurePlanetCertAuthority(ctx *operationContext) error {
 	// we have to share the same private key for various apiservers
 	// due to this issue:
 	// https://github.com/kubernetes/kubernetes/issues/11000#issuecomment-232469678
+	// TODO(security) separate this out to a separate secret for serviceaccounttokens
+	// For reference: https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/248
 	apiServer, err := authority.GenerateCertificate(csr.CertificateRequest{
 		CN:    constants.APIServerKeyPair,
 		Hosts: []string{"127.0.0.1"},
@@ -599,7 +601,9 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 		return nil, trace.Wrap(err)
 	}
 
-	baseKeyPair, err := archive.GetKeyPair(constants.APIServerKeyPair)
+	// Don't rotate apiserver secrets, as this secret is currently used to authenticate service account tokens
+	// TODO(securty) support rotation of apiserver / serviceaccount secrets
+	apiserverKeyPair, err := archive.GetKeyPair(constants.APIServerKeyPair)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -648,6 +652,8 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 		if config.group != "" {
 			req.Names = []csr.Name{{O: config.group}}
 		}
+
+		var privateKeyPEM []byte
 		switch name {
 		case constants.APIServerKeyPair:
 			req.Hosts = append(req.Hosts,
@@ -673,6 +679,10 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 						s.domainName, host}, "."))
 				}
 			}
+
+			// Don't rotate the APIServer key, the secret is currently used for validating serviceaccounttokens
+			// TODO(security) enable rotation of secret for apiserver/serviceaccounttokens
+			privateKeyPEM = apiserverKeyPair.KeyPEM
 		case constants.ProxyKeyPair:
 			req.Hosts = append(req.Hosts,
 				constants.APIServerDomainNameGravity,
@@ -682,7 +692,8 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 				defaults.LograngeAggregatorServiceName,
 				defaults.KubeSystemNamespace)...)
 		}
-		keyPair, err := authority.GenerateCertificate(req, caKeyPair, baseKeyPair.KeyPEM, defaults.CertificateExpiry)
+
+		keyPair, err := authority.GenerateCertificate(req, caKeyPair, privateKeyPEM, defaults.CertificateExpiry)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -749,7 +760,6 @@ func (s *site) getPlanetNodeSecretsPackage(ctx *operationContext, node *Provisio
 		constants.LograngeCollectorKeyPair: {},
 	}
 
-	var privateKeyPEM []byte
 	for keyName, config := range keyPairTypes {
 		req := csr.CertificateRequest{
 			Hosts: []string{constants.LoopbackIP, node.AdvertiseIP, node.Hostname},
@@ -770,14 +780,9 @@ func (s *site) getPlanetNodeSecretsPackage(ctx *operationContext, node *Provisio
 		if config.group != "" {
 			req.Names = []csr.Name{{O: config.group}}
 		}
-		keyPair, err := authority.GenerateCertificate(req, caKeyPair, privateKeyPEM, defaults.CertificateExpiry)
+		keyPair, err := authority.GenerateCertificate(req, caKeyPair, nil, defaults.CertificateExpiry)
 		if err != nil {
 			return nil, trace.Wrap(err)
-		}
-		// Store the private key from the first generated key pair and re-use
-		// it on subsequent requests to speed up certificate generation
-		if len(privateKeyPEM) == 0 {
-			privateKeyPEM = keyPair.KeyPEM
 		}
 		if err := newArchive.AddKeyPair(keyName, *keyPair); err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
Fixes a security issue where:
- master nodes re-use the same secret for a majority of certificates. Now only private keys that are required to be the same are maintained.
- Each certificate assigned to a particular node reuses the same private key. Now a private key is generated for each issued certificate.
- Rotation did not rotate private keys. Note: rotation of the root key or apiserver key is not yet supported.