### PR TITLE
Add gravity registry list command.

### DIFF
--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -46,7 +46,8 @@ way:
 
 * `gravity` runs its own local Docker registry which is used as a Cluster-level
   cache for container images. This makes application upgrades and restarts
-  faster and more reliable.
+  faster and more reliable. See [Interacting with Cluster Registry](#interacting-with-cluster-registry)
+  for details.
 
 * `gravity` provides the ability to perform Cluster state snapshots as part of
   Cluster upgrades or to be used independently.

--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -1437,6 +1437,32 @@ The CoreDNS configuration can be edited after installation, by updating the `kub
 [RBAC]: https://kubernetes.io/docs/admin/authorization/rbac/
 [promiscuous-mode]: https://en.wikipedia.org/wiki/Promiscuous_mode
 
+## Interacting with Cluster Registry
+
+Gravity clusters run private Docker registries on the master nodes. These registries are maintained
+in-sync by Gravity and contain Docker images for Gravity cluster and application images.
+
+To view a list of Docker images currently published in the cluster registry, Gravity provides
+a convenience command:
+
+```bash
+$ gravity registry list
+```
+
+By default the command will contact the registry server running at `registry.local:5000` address
+which resolves to the registry running on the currently active master node. To list images in a
+specific registry, provide a `--registry` flag to the command:
+
+```bash
+$ gravity registry list --registry=192.168.1.1:5000
+```
+
+The command can also output the images in the json or yaml format which can come handy in scripting:
+
+```bash
+$ gravity registry list --format=json
+```
+
 ## Troubleshooting
 
 To collect diagnostic information about a Cluster (e.g. to submit a bug report or get assistance in troubleshooting Cluster problems),

--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -1455,7 +1455,7 @@ which resolves to the registry running on the currently active master node. To l
 specific registry, provide a `--registry` flag to the command:
 
 ```bash
-$ gravity registry list --registry=192.168.1.1:5000
+$ gravity registry list --registry=192.168.1.1
 ```
 
 The command can also output the images in the json or yaml format which can come handy in scripting:

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1032,6 +1032,13 @@ const (
 
 	// PreflightChecksTimeout is the timeout for preflight checks.
 	PreflightChecksTimeout = 5 * time.Minute
+
+	// RegistryCAFilename is filename of cluster Docker registry CA certificate
+	RegistryCAFilename = RootCertFilename
+	// RegistryCertFilename is filename of cluster Docker registry certificate
+	RegistryCertFilename = KubeletCertFilename
+	// RegistryKeyFilename is filename of cluster Docker registry private key
+	RegistryKeyFilename = KubeletKeyFilename
 )
 
 var (

--- a/lib/docker/api.go
+++ b/lib/docker/api.go
@@ -57,6 +57,17 @@ type ImageService interface {
 	// Unwrap translates the specified image name to point to the original repository
 	// if it's prefixed with this registry address - functional inverse of Wrap
 	Unwrap(image string) string
+
+	// List fetches a list of all images from the registry
+	List(context.Context) ([]Image, error)
+}
+
+// Image represents a single Docker image.
+type Image struct {
+	// Repository is the image name.
+	Repository string `json:"repository" yaml:"repository"`
+	// Tags is the image tags.
+	Tags []string `json:"tags" yaml:"tags"`
 }
 
 // DockerPuller defines an interface to pull images

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -102,6 +102,10 @@ type Application struct {
 	StatusCmd StatusCmd
 	// StatusResetCmd resets the cluster to active state
 	StatusResetCmd StatusResetCmd
+	// RegistryCmd allows to interact with the cluster private registry
+	RegistryCmd RegistryCmd
+	// RegistryListCmd displays images from the registry
+	RegistryListCmd RegistryListCmd
 	// BackupCmd launches app backup hook
 	BackupCmd BackupCmd
 	// RestoreCmd launches app restore hook
@@ -666,6 +670,26 @@ type StatusCmd struct {
 // StatusResetCmd resets cluster to active state
 type StatusResetCmd struct {
 	*kingpin.CmdClause
+}
+
+// RegistryCmd allows to interact with the cluster private registry
+type RegistryCmd struct {
+	*kingpin.CmdClause
+}
+
+// RegistryListCmd lists images in the registry
+type RegistryListCmd struct {
+	*kingpin.CmdClause
+	// Registry is the address of registry to list contents in
+	Registry *string
+	// CAPath is path to registry CA certificate
+	CAPath *string
+	// CertPath is path to registry client certificate
+	CertPath *string
+	// KeyPath is path to registry client private key
+	KeyPath *string
+	// Format is the output format
+	Format *constants.Format
 }
 
 // BackupCmd launches app backup hook

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -211,6 +211,15 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// reset cluster state, for debugging/emergencies
 	g.StatusResetCmd.CmdClause = g.Command("status-reset", "Reset the cluster state to 'active'").Hidden()
 
+	// interacting with in-cluster registry
+	g.RegistryCmd.CmdClause = g.Command("registry", "Interact with the cluster private Docker registry.")
+	g.RegistryListCmd.CmdClause = g.RegistryCmd.Command("list", "List images in the registry.")
+	g.RegistryListCmd.Registry = g.RegistryListCmd.Flag("registry", "Address of the registry to list the contents of. Defaults to the currently active private cluster registry.").String()
+	g.RegistryListCmd.CAPath = g.RegistryListCmd.Flag("ca-path", "Optional registry CA certificate path.").String()
+	g.RegistryListCmd.CertPath = g.RegistryListCmd.Flag("cert-path", "Optional registry client certificate path.").String()
+	g.RegistryListCmd.KeyPath = g.RegistryListCmd.Flag("key-path", "Optional registry client private key path.").String()
+	g.RegistryListCmd.Format = common.Format(g.RegistryListCmd.Flag("format", fmt.Sprintf("Output format: %v.", constants.OutputFormats)).Default(string(constants.EncodingText)))
+
 	// backup
 	g.BackupCmd.CmdClause = g.Command("backup", "Launch the cluster's backup hook.")
 	g.BackupCmd.Tarball = g.BackupCmd.Arg("to", "Tarball to create with results of the backup hook.").Required().String()

--- a/tool/gravity/cli/registry.go
+++ b/tool/gravity/cli/registry.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/docker"
+	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/tool/common"
+
+	"github.com/buger/goterm"
+	"github.com/ghodss/yaml"
+	"github.com/gravitational/trace"
+)
+
+type registryConnectionRequest struct {
+	address  string
+	caPath   string
+	certPath string
+	keyPath  string
+}
+
+func (r *registryConnectionRequest) checkAndSetDefaults(env *localenv.LocalEnvironment) (err error) {
+	if r.address == "" {
+		r.address, err = utils.ResolveAddr(env.DNS.Addr(), constants.DockerRegistry)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	stateDir, err := state.GetStateDir()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if r.caPath == "" {
+		r.caPath = state.Secret(stateDir, defaults.RegistryCAFilename)
+	}
+	if r.certPath == "" {
+		r.certPath = state.Secret(stateDir, defaults.RegistryCertFilename)
+	}
+	if r.keyPath == "" {
+		r.keyPath = state.Secret(stateDir, defaults.RegistryKeyFilename)
+	}
+	return nil
+}
+
+// listRegistryContents displays images from the specified Docker registry.
+func listRegistryContents(ctx context.Context, env *localenv.LocalEnvironment, req registryConnectionRequest, format constants.Format) error {
+	if err := req.checkAndSetDefaults(env); err != nil {
+		return trace.Wrap(err)
+	}
+	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
+		RegistryAddress: req.address,
+		CACertPath:      req.caPath,
+		ClientCertPath:  req.certPath,
+		ClientKeyPath:   req.keyPath,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	images, err := imageService.List(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	switch format {
+	case constants.EncodingText:
+		t := goterm.NewTable(0, 10, 5, ' ', 0)
+		common.PrintTableHeader(t, []string{"Image", "Tags"})
+		for _, image := range images {
+			fmt.Fprintf(t, "%v\t%v\n", image.Repository, strings.Join(image.Tags, ", "))
+		}
+		fmt.Println(t.String())
+	case constants.EncodingJSON:
+		bytes, err := json.Marshal(images)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(string(bytes))
+	case constants.EncodingYAML:
+		bytes, err := yaml.Marshal(images)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Println(string(bytes))
+	default:
+		return trace.BadParameter("unsupported output format %q, supported are %v",
+			format, constants.OutputFormats)
+	}
+	return nil
+}

--- a/tool/gravity/cli/registry.go
+++ b/tool/gravity/cli/registry.go
@@ -48,6 +48,8 @@ func (r *registryConnectionRequest) checkAndSetDefaults(env *localenv.LocalEnvir
 		if err != nil {
 			return trace.Wrap(err)
 		}
+	} else {
+		r.address = utils.EnsurePort(r.address, constants.DockerRegistryPort)
 	}
 	stateDir, err := state.GetStateDir()
 	if err != nil {

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -685,6 +685,13 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		return resetPassword(localEnv)
 	case g.StatusResetCmd.FullCommand():
 		return resetClusterState(localEnv)
+	case g.RegistryListCmd.FullCommand():
+		return listRegistryContents(context.Background(), localEnv, registryConnectionRequest{
+			address:  *g.RegistryListCmd.Registry,
+			caPath:   *g.RegistryListCmd.CAPath,
+			certPath: *g.RegistryListCmd.CertPath,
+			keyPath:  *g.RegistryListCmd.KeyPath,
+		}, *g.RegistryListCmd.Format)
 	case g.LocalSiteCmd.FullCommand():
 		return getLocalSite(localEnv)
 	// system service commands


### PR DESCRIPTION
Add a convenience `gravity registry list` command that displays images published in the cluster registry. Closes https://github.com/gravitational/gravity/issues/696.