### PR TITLE
lib/expand: fix dropped test error

### DIFF
--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -118,6 +118,7 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 		ClusterName: s.cluster.Domain,
 		Admin:       true,
 	})
+	c.Assert(err, check.IsNil)
 	s.regularAgent, err = s.services.Operator.GetClusterAgent(ops.ClusterAgentRequest{
 		AccountID:   account.ID,
 		ClusterName: s.cluster.Domain,


### PR DESCRIPTION
This fixes a dropped test error in `lib/expand`.