### PR TITLE
tool/gravity/cli: fix dropped error

### DIFF
--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -71,6 +71,9 @@ func startInstall(env *localenv.LocalEnvironment, config InstallConfig) error {
 	strategy, err := NewInstallerConnectStrategy(env, config, cli.CommandArgs{
 		Parser: cli.ArgsParserFunc(parseArgs),
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	err = InstallerClient(env, installerclient.Config{
 		ConnectStrategy: strategy,
 		Lifecycle: &installerclient.AutomaticLifecycle{


### PR DESCRIPTION
This picks up a dropped error in `tool/gravity/cli`.