### PR TITLE
(6.3) Explicitly create teleport log dir during bootstrap phase.

### DIFF
--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -199,7 +199,7 @@ func (p *bootstrapExecutor) configureSystemDirectories() error {
 		filepath.Join(stateDir, "planet", "docker"),
 		filepath.Join(stateDir, "planet", "share", "hooks"),
 		filepath.Join(stateDir, "planet", "log", "journal"),
-		filepath.Join(stateDir, "site", "teleport"),
+		filepath.Join(stateDir, "site", "teleport", "log"),
 		filepath.Join(stateDir, "site", "packages", "unpacked"),
 		filepath.Join(stateDir, "site", "packages", "blobs"),
 		filepath.Join(stateDir, "site", "packages", "tmp"),


### PR DESCRIPTION
This is an attempt to fix the bad teleport log directory permissions issue (https://github.com/gravitational/gravity/issues/1009) which prevents gravity-site from starting up. This happens inconsistently when a customer rotates master nodes.

Full disclosure: I wasn't able to figure out exactly what and when creates `/var/lib/gravity/site/teleport/log` as root but looking at the system where this happened, it is not gravity-site itself b/c when gravity-site initializes it, it does it with correct permissions.

This fix explicitly creates the directory during the bootstrap phase with proper permissions which should alleviate the issue. Closes https://github.com/gravitational/gravity/issues/1009.