### PR TITLE
lib/terraform/provider: fix dropped error

### DIFF
--- a/lib/terraform/provider/resource_gravity_cluster_auth_preference.go
+++ b/lib/terraform/provider/resource_gravity_cluster_auth_preference.go
@@ -75,6 +75,9 @@ func resourceGravityClusterAuthPreferenceCreate(d *schema.ResourceData, m interf
 			Facets: ExpandStringList(u2fFacets),
 		},
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	err = client.UpsertClusterAuthPreference(context.TODO(), clusterKey, authPreference)
 	if err != nil {


### PR DESCRIPTION
This picks up a dropped error in `lib/terraform/provider`.