### PR TITLE
lib/process: fix dropped error

### DIFF
--- a/lib/process/proxy.go
+++ b/lib/process/proxy.go
@@ -404,6 +404,9 @@ func (t *teleportProxyService) ExecuteCommand(ctx context.Context, siteName, nod
 			defaults.PathEnv: defaults.PathEnvVal,
 		},
 	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return trace.Wrap(proxyClient.SSH(ctx, strings.Split(command, " "), false))
 }
 


### PR DESCRIPTION
This picks up a dropped error in `lib/process`.