### PR TITLE
(5.5) Do not unmount devices during system uninstall.

### DIFF
--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -1074,10 +1074,6 @@ func systemUninstall(env *localenv.LocalEnvironment, confirmed bool) error {
 		return trace.Wrap(err)
 	}
 
-	if err := removeMounts(env, svm, stateDir); err != nil {
-		log.WithError(err).Warnf("Failed to remove mounts: %v.", err)
-	}
-
 	env.PrintStep("Deleting all local data at %v", stateDir)
 	if err = os.RemoveAll(stateDir); err != nil {
 		// do not fail if the state directory cannot be removed, probably


### PR DESCRIPTION
I think I added this piece of logic when working on the "reusing devicemapper devices for overlay" feature a few months back but I can't recall what my motivation behind that was exactly, but as it turns out it makes it for a very annoying uninstall/install cycle b/c all devices mounted under system directory (state dir, etcd data dir) always get unmounted and their data does not get cleaned up.