### PR TITLE
Use retry when quering resources during possible fail-over

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1090,12 +1090,12 @@
   revision = "f4445fa6001335437357b4300010f97979af7789"
 
 [[projects]]
-  digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"
+  branch = "master"
+  digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "42a8fffe760db82cf94b0c3e0112f91c3526a604"
-  version = "1.1.9"
+  revision = "dd5b2e8eae86d31f6273ff3ac46d5b15edd6d6be"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,8 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  version = "=1.1.9"
+  #version = "=1.1.10"
+  branch = "master"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1023,6 +1023,9 @@ const (
 	// on a master node
 	ElectionWaitTimeout = 1 * time.Minute
 
+	// APIWaitTimeout specifies the maximum amount of time to wait for API call to succeed
+	APIWaitTimeout = 1 * time.Minute
+
 	// ImageRegistryVar is a local cluster registry variable that gets
 	// substituted in Helm templates.
 	ImageRegistryVar = "image.registry"

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -206,11 +206,11 @@ func (s *site) configureExpandPackages(ctx context.Context, opCtx *operationCont
 	}
 	secretsPackage := s.planetSecretsPackage(provisionedServer, planetPackage.Version)
 	configPackage := s.planetConfigPackage(provisionedServer, planetPackage.Version)
-	env, err := s.service.GetClusterEnvironmentVariables(s.key)
+	env, err := s.getClusterEnvironmentVariables()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	config, err := s.service.GetClusterConfiguration(s.key)
+	config, err := s.getClusterConfiguration()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/resources/gravity/gravity_test.go
+++ b/lib/ops/resources/gravity/gravity_test.go
@@ -106,7 +106,9 @@ func (s *GravityResourcesSuite) TestUser(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	collectionI, err = s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "user", Name: "test"})
-	c.Assert(err, check.FitsTypeOf, trace.NotFound(""))
+	if !trace.IsNotFound(err) {
+		c.Errorf("Expected err of type NotFound but got %T", err)
+	}
 }
 
 func (s *GravityResourcesSuite) TestToken(c *check.C) {
@@ -123,7 +125,9 @@ func (s *GravityResourcesSuite) TestToken(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	collection, err = s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: "token", Name: "test", User: s.s.Creds.Email})
-	c.Assert(err, check.FitsTypeOf, trace.NotFound(""))
+	if !trace.IsNotFound(err) {
+		c.Errorf("Expected err of type NotFound but got %T", err)
+	}
 }
 
 func toUnknown(c *check.C, resource teleservices.Resource) teleservices.UnknownResource {

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"syscall"
@@ -208,8 +209,10 @@ func isEtcdClusterError(err error) bool {
 }
 
 func isEtcdClusterErrorMessage(message string) bool {
-	return isEtcdClusterMisconfigured(message) || isEtcdClusterHasNoLeader(message) ||
-		isEtcdClusterLeaderChanged(message)
+	return isEtcdClusterMisconfigured(message) ||
+		isEtcdClusterHasNoLeader(message) ||
+		isEtcdClusterLeaderChanged(message) ||
+		isEtcdClusterRequestTimedOut(message)
 }
 
 func isEtcdClusterMisconfigured(message string) bool {
@@ -223,6 +226,10 @@ func isEtcdClusterHasNoLeader(message string) bool {
 
 func isEtcdClusterLeaderChanged(message string) bool {
 	return strings.Contains(message, "etcdserver: leader changed")
+}
+
+func isEtcdClusterRequestTimedOut(message string) bool {
+	return strings.Contains(message, "etcdserver: request timed out")
 }
 
 // MarshalJSON marshals this message as JSON.
@@ -342,6 +349,12 @@ func IsConnectionResetError(err error) bool {
 // 'connection refused' error.
 // err is expected to be non-nil
 func IsConnectionRefusedError(err error) bool {
+	if urlError, ok := trace.Unwrap(err).(*url.Error); ok {
+		if opError, ok := urlError.Err.(*net.OpError); ok {
+			errno, ok := opError.Err.(syscall.Errno)
+			return ok && errno == syscall.ECONNREFUSED
+		}
+	}
 	return strings.Contains(trace.Unwrap(err).Error(),
 		"connection refused")
 }

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -56,16 +56,15 @@ func (e *NotFoundError) OrigError() error {
 }
 
 // IsNotFound returns whether this error is of NotFoundError type
-func IsNotFound(e error) bool {
-	type nf interface {
+func IsNotFound(err error) bool {
+	err = Unwrap(err)
+	_, ok := err.(interface {
 		IsNotFoundError() bool
-	}
-	err := Unwrap(e)
-	_, ok := err.(nf)
+	})
 	if !ok {
 		return os.IsNotExist(err)
 	}
-	return ok
+	return true
 }
 
 // AlreadyExists returns a new instance of AlreadyExists error
@@ -252,11 +251,10 @@ func (e *AccessDeniedError) OrigError() error {
 }
 
 // IsAccessDenied detects if this error is of AccessDeniedError type
-func IsAccessDenied(e error) bool {
-	type ad interface {
+func IsAccessDenied(err error) bool {
+	_, ok := Unwrap(err).(interface {
 		IsAccessDeniedError() bool
-	}
-	_, ok := Unwrap(e).(ad)
+	})
 	return ok
 }
 
@@ -285,7 +283,7 @@ func ConvertSystemError(err error) error {
 			Message: message,
 		}, message)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return wrapWithDepth(&TrustError{Err: innerError}, 2)
+		return newTrace(&TrustError{Err: innerError}, 2)
 	}
 	if _, ok := innerError.(net.Error); ok {
 		return WrapWithMessage(&ConnectionProblemError{

--- a/vendor/github.com/gravitational/trace/httplib.go
+++ b/vendor/github.com/gravitational/trace/httplib.go
@@ -8,19 +8,21 @@ import (
 
 // WriteError sets up HTTP error response and writes it to writer w
 func WriteError(w http.ResponseWriter, err error) {
-	if IsAggregate(err) {
-		for i := 0; i < maxHops; i++ {
-			var aggErr Aggregate
-			var ok bool
-			if aggErr, ok = Unwrap(err).(Aggregate); !ok {
-				break
-			}
-			errors := aggErr.Errors()
-			if len(errors) == 0 {
-				break
-			}
-			err = errors[0]
+	if !IsAggregate(err) {
+		replyJSON(w, ErrorToCode(err), err)
+		return
+	}
+	for i := 0; i < maxHops; i++ {
+		var aggErr Aggregate
+		var ok bool
+		if aggErr, ok = Unwrap(err).(Aggregate); !ok {
+			break
 		}
+		errors := aggErr.Errors()
+		if len(errors) == 0 {
+			break
+		}
+		err = errors[0]
 	}
 	replyJSON(w, ErrorToCode(err), err)
 }
@@ -54,61 +56,58 @@ func ErrorToCode(err error) int {
 // ReadError converts http error to internal error type
 // based on HTTP response code and HTTP body contents
 // if status code does not indicate error, it will return nil
-func ReadError(statusCode int, re []byte) error {
-	var e error
-	switch statusCode {
-	case http.StatusNotFound:
-		e = &NotFoundError{Message: string(re)}
-	case http.StatusBadRequest:
-		e = &BadParameterError{Message: string(re)}
-	case http.StatusNotImplemented:
-		e = &NotImplementedError{Message: string(re)}
-	case http.StatusPreconditionFailed:
-		e = &CompareFailedError{Message: string(re)}
-	case http.StatusForbidden:
-		e = &AccessDeniedError{Message: string(re)}
-	case http.StatusConflict:
-		e = &AlreadyExistsError{Message: string(re)}
-	case http.StatusTooManyRequests:
-		e = &LimitExceededError{Message: string(re)}
-	case http.StatusGatewayTimeout:
-		e = &ConnectionProblemError{Message: string(re)}
-	default:
-		if statusCode < 200 || statusCode >= 400 {
-			return Errorf(string(re))
-		}
+func ReadError(statusCode int, respBytes []byte) error {
+	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
 		return nil
 	}
-	return unmarshalError(e, re)
+	var err error
+	switch statusCode {
+	case http.StatusNotFound:
+		err = &NotFoundError{}
+	case http.StatusBadRequest:
+		err = &BadParameterError{}
+	case http.StatusNotImplemented:
+		err = &NotImplementedError{}
+	case http.StatusPreconditionFailed:
+		err = &CompareFailedError{}
+	case http.StatusForbidden:
+		err = &AccessDeniedError{}
+	case http.StatusConflict:
+		err = &AlreadyExistsError{}
+	case http.StatusTooManyRequests:
+		err = &LimitExceededError{}
+	case http.StatusGatewayTimeout:
+		err = &ConnectionProblemError{}
+	default:
+		err = &externalError{}
+	}
+	return wrapProxy(unmarshalError(err, respBytes))
 }
 
 func replyJSON(w http.ResponseWriter, code int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-
 	var out []byte
-	if IsDebug() {
-		// trace error can marshal itself,
-		// otherwise capture error message and marshal it explicitly
-		var obj interface{} = err
-		if _, ok := err.(*TraceErr); !ok {
-			obj = message{Message: err.Error()}
-		}
-		out, err = json.MarshalIndent(obj, "", "    ")
-		if err != nil {
-			out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
-		}
-	} else {
-		innerError := err
-		if terr, ok := err.(Error); ok {
-			innerError = terr.OrigError()
-		}
-		out, err = json.Marshal(message{Message: innerError.Error()})
+	// trace error can marshal itself,
+	// otherwise capture error message and marshal it explicitly
+	var obj interface{} = err
+	if _, ok := err.(*TraceErr); !ok {
+		obj = externalError{Message: err.Error()}
+	}
+	out, err = json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
 	}
 	w.Write(out)
 }
 
-type message struct {
+// Error returns the underlying message
+func (r *externalError) Error() string {
+	return r.Message
+}
+
+type externalError struct {
+	// Message specifies the error message
 	Message string `json:"message"`
 }
 


### PR DESCRIPTION
Query `RuntimeEnvironment` and `ClusterConfiguration` resources in a loop with a circuit breaker to retry on transient errors.
Fix tests due to changes to gravitational/trace.
Update gravitational/trace for changes to how remote errors are marshaled.

Requires https://github.com/gravitational/gravity.e/pull/4272.
Updates https://github.com/gravitational/gravity/issues/1054.