### PR TITLE
Run gravity remove before instance is terminated in AWS

### DIFF
--- a/lib/autoscale/aws/events.go
+++ b/lib/autoscale/aws/events.go
@@ -107,10 +107,10 @@ func (a *Autoscaler) processEvent(ctx context.Context, operator Operator, event 
 			return trace.Wrap(err)
 		}
 	case InstanceTerminating:
-		if err := a.ensureInstanceTerminated(ctx, event); err != nil {
+		if err := a.removeInstance(ctx, operator, event); err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
-		if err := a.removeInstance(ctx, operator, event); err != nil && !trace.IsNotFound(err) {
+		if err := a.ensureInstanceTerminated(ctx, event); err != nil {
 			return trace.Wrap(err)
 		}
 		if err := a.DeleteEvent(ctx, event); err != nil {


### PR DESCRIPTION
AWS can take a while to terminate an instance, doing the remove first will trigger the shrink operation and let the cluster generally settle itself while AWS does its business. I have a feeling it will help resolve https://github.com/gravitational/gravity/issues/943 to some small extent

In internal asg roller I have doing `gravity remove` before AWS terminated (codified) has helped a lot with stability. When I had the roller only depend on the AWS lifecycle hook (this functionality) I would have `failed` nodes in `serf` frequently or other funky behaviours.