### PR TITLE
Better support for external registries auth in app catalog.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -18,6 +18,7 @@ package defaults
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/teleport/lib/utils"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -1304,4 +1306,13 @@ func InstallerAddr(installerIP string) (addr string) {
 // `kubectl get nodes`
 func FormatKubernetesNodeRoleLabel(role string) string {
 	return fmt.Sprintf("node-role.kubernetes.io/%v", role)
+}
+
+// TLSConfig returns default TLS configuration.
+func TLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CipherSuites:             utils.DefaultCipherSuites(),
+		PreferServerCipherSuites: true,
+	}
 }

--- a/lib/docker/imageservice.go
+++ b/lib/docker/imageservice.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,9 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	registryclient "github.com/docker/distribution/registry/client"
+	registryauth "github.com/docker/distribution/registry/client/auth"
+	registryauthchallenge "github.com/docker/distribution/registry/client/auth/challenge"
+	registrytransport "github.com/docker/distribution/registry/client/transport"
 	registrystorage "github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver/filesystem"
@@ -62,6 +66,19 @@ type RegistryConnectionRequest struct {
 	ClientCertPath string
 	// ClientKeyPath is the full path to the client private key
 	ClientKeyPath string
+	// Username specifies optional registry username for basic auth
+	Username string
+	// Password specifies optional registry password for basic auth
+	Password string
+	// Domain specifies optional registry prefix when pushing images
+	Domain string
+	// Insecure indicates a plain http registry
+	Insecure bool
+}
+
+// HasBasicAuth returns true if the request contains basic auth credentials.
+func (r *RegistryConnectionRequest) HasBasicAuth() bool {
+	return r.Username != "" && r.Password != ""
 }
 
 // CheckAndSetDefaults makes sure the request is valid and sets some defaults
@@ -192,7 +209,19 @@ func (r *imageService) Sync(ctx context.Context, dir string, progress utils.Prin
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		remoteRepo, err := r.remoteStore.Repository(ctx, localRepoName)
+		remoteRepoName := localRepoName
+		// If the registry prefix was specified, rewrite all images to point
+		// to that domain - some registries (such as OpenShift) require a
+		// specific namespace where images should be pushed so an image like
+		// gravitational/debian-tall would become <namespace>/debian-tall.
+		if r.Domain != "" {
+			named, err := parseNamed(localRepoName)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			remoteRepoName = fmt.Sprintf("%v/%v", r.Domain, Path(named))
+		}
+		remoteRepo, err := r.remoteStore.Repository(ctx, remoteRepoName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -240,7 +269,7 @@ func (r *imageService) Sync(ctx context.Context, dir string, progress utils.Prin
 			if remoteManifest == nil || !compareManifests(localManifest, remoteManifest) {
 				progress.PrintStep("Pushing image %s", tagSpec)
 				if err = r.remoteStore.updateRepo(ctx, remoteRepo, localRepo, localManifest, tag); err != nil {
-					return nil, trace.Wrap(err, "failed to update remote for tag %q", tagSpec)
+					return nil, trace.Wrap(err, "failed to update remote for tag %q: %v", tagSpec, err)
 				}
 			} else {
 				progress.PrintStep("Image %s is up-to-date", tagSpec)
@@ -282,7 +311,7 @@ func (r *imageService) connect(ctx context.Context) (err error) {
 // remoteStore defines a remote distribution registry
 type remoteStore struct {
 	log.FieldLogger
-	transport *http.Transport
+	transport http.RoundTripper
 	registry  registryclient.Registry
 	addr      string
 }
@@ -320,7 +349,7 @@ func newCertPool(CAFiles []string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-func initTransport(req RegistryConnectionRequest) (*http.Transport, string) {
+func initTransport(req RegistryConnectionRequest) (http.RoundTripper, string, error) {
 	const connectTimeout = 30 * time.Second
 	const keepAlivePeriod = 30 * time.Second
 	const handshakeTimeout = 30 * time.Second
@@ -336,29 +365,75 @@ func initTransport(req RegistryConnectionRequest) (*http.Transport, string) {
 		DisableKeepAlives:   true,
 	}
 
+	// Figure out the registry address scheme (http or https). If the scheme
+	// was specified explicitly, keep it as-is. Otherwise, default to https
+	// unless the insecure flag was provided.
+	registryAddress, err := url.Parse(req.RegistryAddress)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	if registryAddress.Scheme == "" {
+		if req.Insecure {
+			registryAddress.Scheme = "http"
+		} else {
+			registryAddress.Scheme = "https"
+		}
+	}
+
 	cert, err := tls.LoadX509KeyPair(req.ClientCertPath, req.ClientKeyPath)
 	if err == nil {
 		roots, err := newCertPool([]string{req.CACertPath})
 		if err == nil {
-			log.Debugf("Found TLS trust for %s.", req)
 			transport.TLSClientConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				MinVersion:   tls.VersionTLS10,
 				RootCAs:      roots,
 			}
-			return transport, fmt.Sprintf("https://%v", req.RegistryAddress)
 		}
 	}
 
-	log.Debugf("No TLS trust for %s.", req)
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	return transport, fmt.Sprintf("http://%v", req.RegistryAddress)
+	if transport.TLSClientConfig != nil {
+		log.Debugf("Found TLS trust for %s.", req)
+	} else {
+		log.WithError(err).Debugf("No TLS trust for %s.", req)
+	}
+
+	// If the scheme was set explicitly to https, along with the insecure
+	// flag, ignore the certificate error (this is what Docker does too).
+	if req.Insecure && registryAddress.Scheme == "https" {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	challengeManager, err := ping(transport, registryAddress.String())
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	if !req.HasBasicAuth() {
+		return transport, registryAddress.String(), nil
+	}
+
+	// If basic auth credentials were provided, set up the authorizer
+	// middleware for the transport.
+	credentials := &credentials{
+		username: req.Username,
+		password: req.Password,
+		tokens:   make(map[string]string),
+	}
+	basicHandler := registryauth.NewBasicHandler(credentials)
+	tokenHandler := registryauth.NewTokenHandlerWithOptions(
+		registryauth.TokenHandlerOptions{
+			Transport:   transport,
+			Credentials: credentials,
+		})
+	authorizer := registryauth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)
+	return registrytransport.NewTransport(transport, authorizer), registryAddress.String(), nil
 }
 
 // ConnectRegistry connects to the registry with the specified address
 func ConnectRegistry(ctx context.Context, request RegistryConnectionRequest) (*remoteStore, error) {
-	transport, registryAddr := initTransport(request)
-	if err := ping(transport, registryAddr); err != nil {
+	transport, registryAddr, err := initTransport(request)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -375,7 +450,26 @@ func ConnectRegistry(ctx context.Context, request RegistryConnectionRequest) (*r
 	}, nil
 }
 
-func ping(transport *http.Transport, registryAddr string) error {
+// credentials implements docker/distribution/registry/client/auth.CredentialsStore.
+type credentials struct {
+	username string
+	password string
+	tokens   map[string]string
+}
+
+func (c credentials) Basic(u *url.URL) (string, string) {
+	return c.username, c.password
+}
+
+func (c credentials) RefreshToken(u *url.URL, service string) string {
+	return c.tokens[service]
+}
+
+func (c credentials) SetRefreshToken(u *url.URL, service, token string) {
+	c.tokens[service] = token
+}
+
+func ping(transport http.RoundTripper, registryAddr string) (registryauthchallenge.Manager, error) {
 	const pingClientTimeout = 30 * time.Second
 	pingClient := &http.Client{
 		Transport: transport,
@@ -384,19 +478,23 @@ func ping(transport *http.Transport, registryAddr string) error {
 	endpoint := registryAddr + "/v2/"
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	resp, err := pingClient.Do(req)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	log.WithField("registry", registryAddr).Debugf("Repository response: %s.", data)
-	return nil
+	chManager := registryauthchallenge.NewSimpleManager()
+	if err := chManager.AddResponse(resp); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	log.WithField("registry", registryAddr).Debugf("Repository response: %s %v.", data, resp.Header)
+	return chManager, nil
 }
 
 // openLocal creates a distribution registry in the local directory given with dir

--- a/lib/helm/client.go
+++ b/lib/helm/client.go
@@ -72,6 +72,8 @@ type client struct {
 type ClientConfig struct {
 	// DNSAddress is an optional in-cluster DNS address.
 	DNSAddress string
+	// TillerNamespace is an optional namespace where Tiller server is running.
+	TillerNamespace string
 	// TODO Add Helm TLS flags.
 }
 
@@ -81,7 +83,7 @@ func NewClient(conf ClientConfig) (Client, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tunnel, err := portforwarder.New("kube-system", kubeClient, kubeConfig)
+	tunnel, err := portforwarder.New(conf.TillerNamespace, kubeClient, kubeConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -111,6 +111,15 @@ func EnsurePort(address, defaultPort string) string {
 	return net.JoinHostPort(address, defaultPort)
 }
 
+// EnsureScheme makes sure the provided URL contains http or https scheme and
+// adds the specified default one if it does not.
+func EnsureScheme(url, defaultScheme string) string {
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return url
+	}
+	return fmt.Sprintf("%v://%v", defaultScheme, url)
+}
+
 // EnsurePortURL is like EnsurePort but for URLs.
 func EnsurePortURL(url, defaultPort string) string {
 	return ParseOpsCenterAddress(url, defaultPort)

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -740,6 +740,8 @@ type CheckCmd struct {
 // AppCmd combines subcommands for app service
 type AppCmd struct {
 	*kingpin.CmdClause
+	// TillerNamespace specifies namespace where Tiller server is running.
+	TillerNamespace *string
 }
 
 // AppInstallCmd installs an application from an application image.
@@ -763,6 +765,12 @@ type AppInstallCmd struct {
 	RegistryCert *string
 	// RegistryKey is a registry client private key path.
 	RegistryKey *string
+	// RegistryUsername is registry username for basic auth.
+	RegistryUsername *string
+	// RegistryPassword is registry password for basic auth.
+	RegistryPassword *string
+	// RegistryDomain is registry prefix when pushing images.
+	RegistryDomain *string
 }
 
 // AppListCmd shows all application releases.
@@ -791,6 +799,12 @@ type AppUpgradeCmd struct {
 	RegistryCert *string
 	// RegistryKey is a registry client private key path.
 	RegistryKey *string
+	// RegistryUsername is registry username for basic auth.
+	RegistryUsername *string
+	// RegistryPassword is registry password for basic auth.
+	RegistryPassword *string
+	// RegistryDomain is registry prefix when pushing images.
+	RegistryDomain *string
 }
 
 // AppRollbackCmd rolls back a release.
@@ -829,6 +843,12 @@ type AppSyncCmd struct {
 	RegistryCert *string
 	// RegistryKey is a registry client private key path.
 	RegistryKey *string
+	// RegistryUsername is registry username for basic auth.
+	RegistryUsername *string
+	// RegistryPassword is registry password for basic auth.
+	RegistryPassword *string
+	// RegistryDomain is registry prefix when pushing images.
+	RegistryDomain *string
 }
 
 // AppSearchCmd searches for applications.

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -769,8 +769,8 @@ type AppInstallCmd struct {
 	RegistryUsername *string
 	// RegistryPassword is registry password for basic auth.
 	RegistryPassword *string
-	// RegistryDomain is registry prefix when pushing images.
-	RegistryDomain *string
+	// RegistryPrefix is registry prefix when pushing images.
+	RegistryPrefix *string
 }
 
 // AppListCmd shows all application releases.
@@ -803,8 +803,8 @@ type AppUpgradeCmd struct {
 	RegistryUsername *string
 	// RegistryPassword is registry password for basic auth.
 	RegistryPassword *string
-	// RegistryDomain is registry prefix when pushing images.
-	RegistryDomain *string
+	// RegistryPrefix is registry prefix when pushing images.
+	RegistryPrefix *string
 }
 
 // AppRollbackCmd rolls back a release.
@@ -847,8 +847,8 @@ type AppSyncCmd struct {
 	RegistryUsername *string
 	// RegistryPassword is registry password for basic auth.
 	RegistryPassword *string
-	// RegistryDomain is registry prefix when pushing images.
-	RegistryDomain *string
+	// RegistryPrefix is registry prefix when pushing images.
+	RegistryPrefix *string
 }
 
 // AppSearchCmd searches for applications.

--- a/tool/gravity/cli/helm.go
+++ b/tool/gravity/cli/helm.go
@@ -49,6 +49,8 @@ type releaseInstallConfig struct {
 	Name string
 	// Namespace is a namespace to install release into.
 	Namespace string
+	// helmConfig combines Helm configuration parameters.
+	helmConfig
 	// valuesConfig combines values set on the CLI.
 	valuesConfig
 	// registryConfig is registry configuration.
@@ -68,6 +70,8 @@ type releaseUpgradeConfig struct {
 	Release string
 	// Image is an application image to upgrade to, can be path or locator.
 	Image string
+	// helmConfig combines Helm configuration parameters.
+	helmConfig
 	// valuesConfig combines values set on the CLI.
 	valuesConfig
 	// registryConfig is registry configuration.
@@ -87,16 +91,27 @@ type releaseRollbackConfig struct {
 	Release string
 	// Revision is a version number to rollback to.
 	Revision int
+	// helmConfig combines Helm configuration parameters.
+	helmConfig
 }
 
 type releaseUninstallConfig struct {
 	// Release is a release name to uninstall.
 	Release string
+	// helmConfig combines Helm configuration parameters.
+	helmConfig
 }
 
 type releaseHistoryConfig struct {
 	// Release is a release name to display revisions for.
 	Release string
+	// helmConfig combines Helm configuration parameters.
+	helmConfig
+}
+
+type helmConfig struct {
+	// TillerNamespace is the namespace where Tiller server is running.
+	TillerNamespace string
 }
 
 type valuesConfig struct {
@@ -166,7 +181,8 @@ func releaseInstall(env *localenv.LocalEnvironment, conf releaseInstallConfig) e
 		return trace.Wrap(err)
 	}
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: conf.TillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -187,9 +203,10 @@ func releaseInstall(env *localenv.LocalEnvironment, conf releaseInstallConfig) e
 	return nil
 }
 
-func releaseList(env *localenv.LocalEnvironment, all bool) error {
+func releaseList(env *localenv.LocalEnvironment, all bool, tillerNamespace string) error {
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: tillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -236,7 +253,8 @@ func releaseUpgrade(env *localenv.LocalEnvironment, conf releaseUpgradeConfig) e
 		defer result.Close() // Remove downloaded tarball after upgrade.
 	}
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: conf.TillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -286,7 +304,8 @@ func releaseUpgrade(env *localenv.LocalEnvironment, conf releaseUpgradeConfig) e
 
 func releaseRollback(env *localenv.LocalEnvironment, conf releaseRollbackConfig) error {
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: conf.TillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -306,7 +325,8 @@ func releaseRollback(env *localenv.LocalEnvironment, conf releaseRollbackConfig)
 
 func releaseUninstall(env *localenv.LocalEnvironment, conf releaseUninstallConfig) error {
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: conf.TillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -323,7 +343,8 @@ func releaseUninstall(env *localenv.LocalEnvironment, conf releaseUninstallConfi
 
 func releaseHistory(env *localenv.LocalEnvironment, conf releaseHistoryConfig) error {
 	helmClient, err := helm.NewClient(helm.ClientConfig{
-		DNSAddress: env.DNS.Addr(),
+		DNSAddress:      env.DNS.Addr(),
+		TillerNamespace: conf.TillerNamespace,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -245,6 +245,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	// operations on gravity applications
 	g.AppCmd.CmdClause = g.Command("app", "Operations with application images and releases.")
+	g.AppCmd.TillerNamespace = g.AppCmd.Flag("tiller-namespace", "Namespace where Tiller is running").String()
 
 	// helm-specific flags
 	g.AppInstallCmd.CmdClause = g.AppCmd.Command("install", "Install an application from the specified application image.")
@@ -257,6 +258,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppInstallCmd.RegistryCA = g.AppInstallCmd.Flag("registry-ca", "Docker registry CA certificate path.").String()
 	g.AppInstallCmd.RegistryCert = g.AppInstallCmd.Flag("registry-cert", "Docker registry client certificate path.").String()
 	g.AppInstallCmd.RegistryKey = g.AppInstallCmd.Flag("registry-key", "Docker registry client private key path.").String()
+	g.AppInstallCmd.RegistryUsername = g.AppInstallCmd.Flag("registry-username", "Docker registry username.").String()
+	g.AppInstallCmd.RegistryPassword = g.AppInstallCmd.Flag("registry-password", "Docker registry password.").String()
+	g.AppInstallCmd.RegistryDomain = g.AppInstallCmd.Flag("registry-domain", "Repository prefix.").String()
 
 	g.AppListCmd.CmdClause = g.AppCmd.Command("ls", "Show all application releases.").Alias("list")
 	g.AppListCmd.All = g.AppListCmd.Flag("all", "Do not filter releases by status.").Short('a').Bool()
@@ -270,6 +274,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppUpgradeCmd.RegistryCA = g.AppUpgradeCmd.Flag("registry-ca", "Docker registry CA certificate path.").String()
 	g.AppUpgradeCmd.RegistryCert = g.AppUpgradeCmd.Flag("registry-cert", "Docker registry client certificate path.").String()
 	g.AppUpgradeCmd.RegistryKey = g.AppUpgradeCmd.Flag("registry-key", "Docker registry client private key path.").String()
+	g.AppUpgradeCmd.RegistryUsername = g.AppUpgradeCmd.Flag("registry-username", "Docker registry username.").String()
+	g.AppUpgradeCmd.RegistryPassword = g.AppUpgradeCmd.Flag("registry-password", "Docker registry password.").String()
+	g.AppUpgradeCmd.RegistryDomain = g.AppUpgradeCmd.Flag("registry-domain", "Repository prefix.").String()
 
 	g.AppRollbackCmd.CmdClause = g.AppCmd.Command("rollback", "Rollback a release.")
 	g.AppRollbackCmd.Release = g.AppRollbackCmd.Arg("release", "Release name to rollback.").Required().String()
@@ -287,6 +294,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppSyncCmd.RegistryCA = g.AppSyncCmd.Flag("registry-ca", "Docker registry CA certificate path.").String()
 	g.AppSyncCmd.RegistryCert = g.AppSyncCmd.Flag("registry-cert", "Docker registry client certificate path.").String()
 	g.AppSyncCmd.RegistryKey = g.AppSyncCmd.Flag("registry-key", "Docker registry client private key path.").String()
+	g.AppSyncCmd.RegistryUsername = g.AppSyncCmd.Flag("registry-username", "Docker registry username.").String()
+	g.AppSyncCmd.RegistryPassword = g.AppSyncCmd.Flag("registry-password", "Docker registry password.").String()
+	g.AppSyncCmd.RegistryDomain = g.AppSyncCmd.Flag("registry-domain", "Repository prefix.").String()
 
 	g.AppSearchCmd.CmdClause = g.AppCmd.Command("search", "Search for applications.")
 	g.AppSearchCmd.Pattern = g.AppSearchCmd.Arg("pattern", "Application name pattern, treated as a substring.").String()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -260,7 +260,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppInstallCmd.RegistryKey = g.AppInstallCmd.Flag("registry-key", "Docker registry client private key path.").String()
 	g.AppInstallCmd.RegistryUsername = g.AppInstallCmd.Flag("registry-username", "Docker registry username.").String()
 	g.AppInstallCmd.RegistryPassword = g.AppInstallCmd.Flag("registry-password", "Docker registry password.").String()
-	g.AppInstallCmd.RegistryDomain = g.AppInstallCmd.Flag("registry-domain", "Repository prefix.").String()
+	g.AppInstallCmd.RegistryPrefix = g.AppInstallCmd.Flag("registry-prefix", "Docker registry prefix.").String()
 
 	g.AppListCmd.CmdClause = g.AppCmd.Command("ls", "Show all application releases.").Alias("list")
 	g.AppListCmd.All = g.AppListCmd.Flag("all", "Do not filter releases by status.").Short('a').Bool()
@@ -276,7 +276,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppUpgradeCmd.RegistryKey = g.AppUpgradeCmd.Flag("registry-key", "Docker registry client private key path.").String()
 	g.AppUpgradeCmd.RegistryUsername = g.AppUpgradeCmd.Flag("registry-username", "Docker registry username.").String()
 	g.AppUpgradeCmd.RegistryPassword = g.AppUpgradeCmd.Flag("registry-password", "Docker registry password.").String()
-	g.AppUpgradeCmd.RegistryDomain = g.AppUpgradeCmd.Flag("registry-domain", "Repository prefix.").String()
+	g.AppUpgradeCmd.RegistryPrefix = g.AppUpgradeCmd.Flag("registry-prefix", "Docker registry prefix.").String()
 
 	g.AppRollbackCmd.CmdClause = g.AppCmd.Command("rollback", "Rollback a release.")
 	g.AppRollbackCmd.Release = g.AppRollbackCmd.Arg("release", "Release name to rollback.").Required().String()
@@ -296,7 +296,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AppSyncCmd.RegistryKey = g.AppSyncCmd.Flag("registry-key", "Docker registry client private key path.").String()
 	g.AppSyncCmd.RegistryUsername = g.AppSyncCmd.Flag("registry-username", "Docker registry username.").String()
 	g.AppSyncCmd.RegistryPassword = g.AppSyncCmd.Flag("registry-password", "Docker registry password.").String()
-	g.AppSyncCmd.RegistryDomain = g.AppSyncCmd.Flag("registry-domain", "Repository prefix.").String()
+	g.AppSyncCmd.RegistryPrefix = g.AppSyncCmd.Flag("registry-prefix", "Docker registry prefix.").String()
 
 	g.AppSearchCmd.CmdClause = g.AppCmd.Command("search", "Search for applications.")
 	g.AppSearchCmd.Pattern = g.AppSearchCmd.Arg("pattern", "Application name pattern, treated as a substring.").String()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -444,6 +444,9 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			Image:     *g.AppInstallCmd.Image,
 			Name:      *g.AppInstallCmd.Name,
 			Namespace: *g.AppInstallCmd.Namespace,
+			helmConfig: helmConfig{
+				TillerNamespace: *g.AppCmd.TillerNamespace,
+			},
 			valuesConfig: valuesConfig{
 				Values: *g.AppInstallCmd.Set,
 				Files:  *g.AppInstallCmd.Values,
@@ -453,15 +456,23 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				CAPath:   *g.AppInstallCmd.RegistryCA,
 				CertPath: *g.AppInstallCmd.RegistryCert,
 				KeyPath:  *g.AppInstallCmd.RegistryKey,
+				Username: *g.AppInstallCmd.RegistryUsername,
+				Password: *g.AppInstallCmd.RegistryPassword,
+				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Insecure: *g.Insecure,
 			},
 		})
 	case g.AppListCmd.FullCommand():
 		return releaseList(localEnv,
-			*g.AppListCmd.All)
+			*g.AppListCmd.All,
+			*g.AppCmd.TillerNamespace)
 	case g.AppUpgradeCmd.FullCommand():
 		return releaseUpgrade(localEnv, releaseUpgradeConfig{
 			Release: *g.AppUpgradeCmd.Release,
 			Image:   *g.AppUpgradeCmd.Image,
+			helmConfig: helmConfig{
+				TillerNamespace: *g.AppCmd.TillerNamespace,
+			},
 			valuesConfig: valuesConfig{
 				Values: *g.AppUpgradeCmd.Set,
 				Files:  *g.AppUpgradeCmd.Values,
@@ -471,20 +482,33 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				CAPath:   *g.AppUpgradeCmd.RegistryCA,
 				CertPath: *g.AppUpgradeCmd.RegistryCert,
 				KeyPath:  *g.AppUpgradeCmd.RegistryKey,
+				Username: *g.AppInstallCmd.RegistryUsername,
+				Password: *g.AppInstallCmd.RegistryPassword,
+				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Insecure: *g.Insecure,
 			},
 		})
 	case g.AppRollbackCmd.FullCommand():
 		return releaseRollback(localEnv, releaseRollbackConfig{
 			Release:  *g.AppRollbackCmd.Release,
 			Revision: *g.AppRollbackCmd.Revision,
+			helmConfig: helmConfig{
+				TillerNamespace: *g.AppCmd.TillerNamespace,
+			},
 		})
 	case g.AppUninstallCmd.FullCommand():
 		return releaseUninstall(localEnv, releaseUninstallConfig{
 			Release: *g.AppUninstallCmd.Release,
+			helmConfig: helmConfig{
+				TillerNamespace: *g.AppCmd.TillerNamespace,
+			},
 		})
 	case g.AppHistoryCmd.FullCommand():
 		return releaseHistory(localEnv, releaseHistoryConfig{
 			Release: *g.AppHistoryCmd.Release,
+			helmConfig: helmConfig{
+				TillerNamespace: *g.AppCmd.TillerNamespace,
+			},
 		})
 	case g.AppSyncCmd.FullCommand():
 		return appSync(localEnv, appSyncConfig{
@@ -494,6 +518,10 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				CAPath:   *g.AppSyncCmd.RegistryCA,
 				CertPath: *g.AppSyncCmd.RegistryCert,
 				KeyPath:  *g.AppSyncCmd.RegistryKey,
+				Username: *g.AppInstallCmd.RegistryUsername,
+				Password: *g.AppInstallCmd.RegistryPassword,
+				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Insecure: *g.Insecure,
 			},
 		})
 	case g.AppSearchCmd.FullCommand():

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -458,7 +458,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				KeyPath:  *g.AppInstallCmd.RegistryKey,
 				Username: *g.AppInstallCmd.RegistryUsername,
 				Password: *g.AppInstallCmd.RegistryPassword,
-				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Prefix:   *g.AppInstallCmd.RegistryPrefix,
 				Insecure: *g.Insecure,
 			},
 		})
@@ -484,7 +484,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				KeyPath:  *g.AppUpgradeCmd.RegistryKey,
 				Username: *g.AppInstallCmd.RegistryUsername,
 				Password: *g.AppInstallCmd.RegistryPassword,
-				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Prefix:   *g.AppInstallCmd.RegistryPrefix,
 				Insecure: *g.Insecure,
 			},
 		})
@@ -520,7 +520,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				KeyPath:  *g.AppSyncCmd.RegistryKey,
 				Username: *g.AppInstallCmd.RegistryUsername,
 				Password: *g.AppInstallCmd.RegistryPassword,
-				Domain:   *g.AppInstallCmd.RegistryDomain,
+				Prefix:   *g.AppInstallCmd.RegistryPrefix,
 				Insecure: *g.Insecure,
 			},
 		})

--- a/tool/gravity/cli/sync.go
+++ b/tool/gravity/cli/sync.go
@@ -48,8 +48,8 @@ type registryConfig struct {
 	Username string
 	// Password is optional password for basic auth.
 	Password string
-	// Domain is optional registry prefix when pushing images.
-	Domain string
+	// Prefix is optional registry prefix when pushing images.
+	Prefix string
 	// Insecure indicates insecure registry.
 	Insecure bool
 }
@@ -63,7 +63,7 @@ func (c registryConfig) imageService() (docker.ImageService, error) {
 		ClientKeyPath:   c.KeyPath,
 		Username:        c.Username,
 		Password:        c.Password,
-		Domain:          c.Domain,
+		Prefix:          c.Prefix,
 		Insecure:        c.Insecure,
 	})
 }

--- a/tool/gravity/cli/sync.go
+++ b/tool/gravity/cli/sync.go
@@ -44,6 +44,14 @@ type registryConfig struct {
 	CertPath string
 	// KeyPath is a client key path for a registry.
 	KeyPath string
+	// Username is optional username for basic auth.
+	Username string
+	// Password is optional password for basic auth.
+	Password string
+	// Domain is optional registry prefix when pushing images.
+	Domain string
+	// Insecure indicates insecure registry.
+	Insecure bool
 }
 
 // imageService returns a new registry client for this config.
@@ -53,6 +61,10 @@ func (c registryConfig) imageService() (docker.ImageService, error) {
 		CACertPath:      c.CAPath,
 		ClientCertPath:  c.CertPath,
 		ClientKeyPath:   c.KeyPath,
+		Username:        c.Username,
+		Password:        c.Password,
+		Domain:          c.Domain,
+		Insecure:        c.Insecure,
 	})
 }
 


### PR DESCRIPTION
This PR implements a few improvements for the "gravity app" set of commands so they play better with external registries. Before, our registry connection code was pretty much tailored to working with registries inside Gravity clusters.

* Add support for basic auth with registries. I used registry provided with OpenShift online to test this.
* Add support for registry prefixes/namespaces, which is also required by OpenShift for example so the images have to be pushed like `<namespace>/debian-tall`.
* More straightforward connection logic - always try to connect to the registry in a secure way, unless `--insecure` flag (or respective configuration parameter) was specified (which is what Docker does as well). I don't think the "insecure" path was actually before so hopefully nothing will break.
* Add ability to override tiller namespace (used to be hardcoded to system ns).
