### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# https://github.blog/2017-07-06-introducing-code-owners/
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Global Owners
+*  @r0mant @a-palchikov @knisbet
+
+# Web UI
+/web/ @alex-kovoy


### PR DESCRIPTION
What does the team think about using code-owners to automatically assign code reviewers?

The owners can be pointed at github teams, but for the short term it's probably just as easy to assign individual reviewers.

https://github.blog/2017-07-06-introducing-code-owners/
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
