### PR TITLE
[6.1.x] convenience commands for gravity-specific services

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -321,7 +321,7 @@ const (
 	SerfBin = "/usr/bin/serf"
 
 	// JournalctlBin is the default location of the journalctl inside planet
-	JournalctlBin = "/usr/bin/journalctl"
+	JournalctlBin = "/bin/journalctl"
 
 	// SystemctlBin is systemctl executable inside planet
 	SystemctlBin = "/bin/systemctl"

--- a/lib/system/environ/uninstall.go
+++ b/lib/system/environ/uninstall.go
@@ -119,7 +119,7 @@ func DisableAgentServices(logger log.FieldLogger) error {
 }
 
 func uninstallPackageServices(svm systemservice.ServiceManager, printer utils.Printer, logger log.FieldLogger) error {
-	services, err := svm.ListPackageServices()
+	services, err := svm.ListPackageServices(systemservice.DefaultListServiceOptions)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/systemservice/service.go
+++ b/lib/systemservice/service.go
@@ -231,6 +231,25 @@ type PackageServiceStatus struct {
 	Status string
 }
 
+// ListServiceOptions describes additional configuration for listing
+// services.
+// An empty value of this type is usable
+type ListServiceOptions struct {
+	// All optionally indicates whether to query all units (and not only those in memory)
+	All bool
+	// Type optionally specifies the unit type
+	Type string
+	// State optionally specifies the unit state
+	State string
+	// Pattern optionally specifies the unit pattern
+	Pattern string
+}
+
+const (
+	// UnitTypeService defines the service type of the unit file
+	UnitTypeService = "service"
+)
+
 // ServiceManager is an interface for collaborating with system
 // service managers, e.g. systemd for host packages
 type ServiceManager interface {
@@ -247,7 +266,7 @@ type ServiceManager interface {
 	DisablePackageService(pkg loc.Locator) error
 
 	// ListPackageServices lists installed package services
-	ListPackageServices() ([]PackageServiceStatus, error)
+	ListPackageServices(ListServiceOptions) ([]PackageServiceStatus, error)
 
 	// StartPackageService starts package service
 	StartPackageService(pkg loc.Locator, noBlock bool) error

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -231,7 +231,7 @@ func (s *systemdManager) DisablePackageService(pkg loc.Locator) error {
 
 // IsPackageServiceInstalled checks if the package service is installed
 func (s *systemdManager) IsPackageServiceInstalled(pkg loc.Locator) (bool, error) {
-	units, err := s.ListPackageServices()
+	units, err := s.ListPackageServices(DefaultListServiceOptions)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -244,10 +244,23 @@ func (s *systemdManager) IsPackageServiceInstalled(pkg loc.Locator) (bool, error
 }
 
 // ListPackageServices lists installed package services
-func (s *systemdManager) ListPackageServices() ([]PackageServiceStatus, error) {
+func (s *systemdManager) ListPackageServices(opts ListServiceOptions) ([]PackageServiceStatus, error) {
 	var services []PackageServiceStatus
 
-	out, err := invokeSystemctl("list-units", "--plain", "--no-legend")
+	args := []string{"list-units", "--plain", "--no-legend"}
+	if opts.All {
+		args = append(args, "--all")
+	}
+	if opts.Type != "" {
+		args = append(args, "--type", opts.Type)
+	}
+	if opts.State != "" {
+		args = append(args, "--state", opts.State)
+	}
+	if opts.Pattern != "" {
+		args = append(args, opts.Pattern)
+	}
+	out, err := invokeSystemctl(args...)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to list-units: %v", out)
 	}
@@ -344,7 +357,7 @@ func (s *systemdManager) UninstallService(req UninstallServiceRequest) error {
 	status := strings.TrimSpace(out)
 
 	unitPath := unitPath(req.Name)
-	if errDelete := os.Remove(unitPath); errDelete != nil && !os.IsNotExist(err) {
+	if errDelete := os.Remove(unitPath); errDelete != nil && !os.IsNotExist(errDelete) {
 		logger.WithError(errDelete).Warn("Failed to delete service unit file.")
 	}
 
@@ -460,9 +473,21 @@ func unitPath(name string) (path string) {
 	return DefaultUnitPath(name)
 }
 
+// PackageServiceName returns the name of the package service
+// for the specified package locator
+func PackageServiceName(loc loc.Locator) string {
+	return newSystemdUnit(loc).serviceName()
+}
+
 // DefaultUnitPath returns the default path for the specified systemd unit
 func DefaultUnitPath(name string) (path string) {
 	return filepath.Join(defaults.SystemUnitDir, SystemdNameEscape(name))
+}
+
+// DefaultListServiceOptions specifies the default configuration to list package services
+var DefaultListServiceOptions = ListServiceOptions{
+	All:  true,
+	Type: UnitTypeService,
 }
 
 // serviceName returns just the name portion of the unit path.

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -262,7 +262,7 @@ type Application struct {
 	SystemServiceInstallCmd SystemServiceInstallCmd
 	// SystemServiceUninstallCmd uninstalls systemd service
 	SystemServiceUninstallCmd SystemServiceUninstallCmd
-	// SystemServiceStatusCmd displays status of systemd service
+	// SystemServiceStatusCmd queries the runtime status of a package service
 	SystemServiceStatusCmd SystemServiceStatusCmd
 	// SystemServiceListCmd lists systemd services
 	SystemServiceListCmd SystemServiceListCmd
@@ -1472,13 +1472,12 @@ type SystemServiceUninstallCmd struct {
 	Name *string
 }
 
-// SystemServiceStatusCmd displays status of systemd service
+// SystemServiceStatusCmd queries the runtime status of a package service
 type SystemServiceStatusCmd struct {
 	*kingpin.CmdClause
-	// Package is system service package locator
-	Package *loc.Locator
-	// Name is service name
-	Name *string
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
 }
 
 // SystemServiceListCmd lists systemd services

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -266,6 +266,12 @@ type Application struct {
 	SystemServiceStatusCmd SystemServiceStatusCmd
 	// SystemServiceListCmd lists systemd services
 	SystemServiceListCmd SystemServiceListCmd
+	// SystemServiceStopCmd stops a package service
+	SystemServiceStopCmd SystemServiceStopCmd
+	// SystemServiceStartCmd stops or restarts a package service
+	SystemServiceStartCmd SystemServiceStartCmd
+	// SystemServiceJournalCmd queries the system journal of a package service
+	SystemServiceJournalCmd SystemServiceJournalCmd
 	// SystemReportCmd generates tarball with system diagnostics information
 	SystemReportCmd SystemReportCmd
 	// SystemStateDirCmd shows local state directory
@@ -1478,6 +1484,32 @@ type SystemServiceStatusCmd struct {
 // SystemServiceListCmd lists systemd services
 type SystemServiceListCmd struct {
 	*kingpin.CmdClause
+}
+
+// SystemServiceStartCmd starts or restart a package service
+type SystemServiceStartCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+}
+
+// SystemServiceStopCmd stops a running package service
+type SystemServiceStopCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+}
+
+// SystemServiceJournalCmd queries the system journal of a package service
+type SystemServiceJournalCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+	// Args optionally lists additional arguments to journalctl
+	Args *[]string
 }
 
 // SystemReportCmd generates tarball with system diagnostics information

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -630,11 +630,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemServiceUninstallCmd.Package = Locator(g.SystemServiceUninstallCmd.Flag("package", "the package related to this service"))
 	g.SystemServiceUninstallCmd.Name = g.SystemServiceUninstallCmd.Flag("name", "the service name").String()
 
-	// check status of a service
-	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "status of a package service, supply either package or service name ").Hidden()
-	g.SystemServiceStatusCmd.Package = Locator(g.SystemServiceStatusCmd.Flag("package", "the package related to this service"))
-	g.SystemServiceStatusCmd.Name = g.SystemServiceStatusCmd.Flag("name", "service name to check").String()
-
 	// list running services
 	g.SystemServiceListCmd.CmdClause = g.SystemServiceCmd.Command("list", "list running services").Hidden()
 
@@ -643,6 +638,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.SystemServiceStartCmd.CmdClause = g.SystemServiceCmd.Command("start", "start a service").Hidden()
 	g.SystemServiceStartCmd.Package = g.SystemServiceStartCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	// query runtime status of a package service
+	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "query runtime status information of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceStatusCmd.Package = g.SystemServiceStatusCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
 
 	g.SystemServiceJournalCmd.CmdClause = g.SystemServiceCmd.Command("journal", "query system journal of the specified service").Interspersed(false).Hidden()
 	g.SystemServiceJournalCmd.Package = g.SystemServiceJournalCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -638,6 +638,16 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// list running services
 	g.SystemServiceListCmd.CmdClause = g.SystemServiceCmd.Command("list", "list running services").Hidden()
 
+	g.SystemServiceStopCmd.CmdClause = g.SystemServiceCmd.Command("stop", "stop a running service").Hidden()
+	g.SystemServiceStopCmd.Package = g.SystemServiceStopCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	g.SystemServiceStartCmd.CmdClause = g.SystemServiceCmd.Command("start", "start a service").Hidden()
+	g.SystemServiceStartCmd.Package = g.SystemServiceStartCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	g.SystemServiceJournalCmd.CmdClause = g.SystemServiceCmd.Command("journal", "query system journal of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceJournalCmd.Package = g.SystemServiceJournalCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+	g.SystemServiceJournalCmd.Args = g.SystemServiceJournalCmd.Arg("arg", "optional arguments to the journalctl").Strings()
+
 	g.SystemReportCmd.CmdClause = g.SystemCmd.Command("report", "collect system diagnostics and output as gzipped tarball to terminal").Hidden()
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -774,6 +774,14 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.SystemServiceUninstallCmd.Name)
 	case g.SystemServiceListCmd.FullCommand():
 		return systemServiceList(localEnv)
+	case g.SystemServiceStartCmd.FullCommand():
+		return systemServiceStart(localEnv, *g.SystemServiceStartCmd.Package)
+	case g.SystemServiceStopCmd.FullCommand():
+		return systemServiceStop(localEnv, *g.SystemServiceStopCmd.Package)
+	case g.SystemServiceJournalCmd.FullCommand():
+		return systemServiceJournal(localEnv,
+			*g.SystemServiceJournalCmd.Package,
+			*g.SystemServiceJournalCmd.Args)
 	case g.SystemServiceStatusCmd.FullCommand():
 		return systemServiceStatus(localEnv,
 			*g.SystemServiceStatusCmd.Package,

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -784,8 +784,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.SystemServiceJournalCmd.Args)
 	case g.SystemServiceStatusCmd.FullCommand():
 		return systemServiceStatus(localEnv,
-			*g.SystemServiceStatusCmd.Package,
-			*g.SystemServiceStatusCmd.Name)
+			*g.SystemServiceStatusCmd.Package)
 	case g.SystemUninstallCmd.FullCommand():
 		return systemUninstall(localEnv, *g.SystemUninstallCmd.Confirmed)
 	case g.SystemReportCmd.FullCommand():


### PR DESCRIPTION
Add low-level convenience commands to work with gravity-specific systemd services:

```sh
$ gravity system service stop planet
$ gravity system service start teleport
$ gravity system service journal planet -r
```
Note, that `planet` / `teleport` in the examples above is a pattern - not a service name. It is matched against a list of (possibly active - depending on the action) package services. It ensures that the pattern is unique - otherwise an error is given.

`system service journal` also accepts an arbitrary list of `journalctl` options (`-r` in this example).

A full package locator (albeit less convenient) is also accepted:
```sh
gravity system service stop gravity__gravitational.io__planet__6.1.14-11505-30-g9d0ccde.service
```

Needs forward port to master.