### PR TITLE
Fix helm chart link

### DIFF
--- a/docs/6.x/catalog.md
+++ b/docs/6.x/catalog.md
@@ -33,7 +33,7 @@ Helm Version: v2.12
 
 ### Build an Application Image
 
-For this example we will be using a [sample Helm chart](https://github.com/helm/helm/tree/master/docs/examples/alpine).
+For this example we will be using a [sample Helm chart](https://github.com/helm/helm/tree/release-2.0/cmd/helm/testdata/testcharts/alpine).
 This chart spins up a single pod of Alpine Linux:
 
 ```bsh


### PR DESCRIPTION
The helm chart link referenced no longer exists.  Tele is also only compatible with the 2.X version of the provided helm chart for alpine, not the 3.X.  The link is set to the release-2.0 of alpine that works with Tele.