### PR TITLE
update code owners to point to team assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Global Owners
-*  @r0mant @a-palchikov @knisbet
+*  @gravitational/code-owners-gravity
 
 # Web UI
-/web/ @alex-kovoy
+/web/ @gravitational/code-owners-web


### PR DESCRIPTION
Instead of hardcoding individual users, create team assignments within github teams, and have the code-owners point to the teams that can be updated.