### PR TITLE
Export fio binary in peer.

### DIFF
--- a/lib/install/phases/init.go
+++ b/lib/install/phases/init.go
@@ -18,16 +18,13 @@ package phases
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
-	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/state"
-	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -84,21 +81,15 @@ func (p *initExecutor) downloadFio() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, reader, err := p.Packages.ReadPackage(*locator)
+	path, err := state.InStateDir(constants.FioBin)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer reader.Close()
-	stateDir, err := state.GetStateDir()
+	err = pack.ExportExecutable(p.Packages, *locator, path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	path := filepath.Join(stateDir, constants.FioBin)
-	err = utils.CopyReaderWithPerms(path, reader, defaults.SharedExecutableMask)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	p.Infof("Downloaded fio v%v to %v.", locator.Version, path)
+	p.Infof("Exported fio v%v to %v.", locator.Version, path)
 	return nil
 }
 

--- a/lib/pack/utils.go
+++ b/lib/pack/utils.go
@@ -696,6 +696,21 @@ func FindSecretsPackage(packages PackageService) (*loc.Locator, error) {
 	return &env.Locator, nil
 }
 
+// ExportExecutable downloads the specified package from the package service
+// into the provided path as an executable.
+func ExportExecutable(packages PackageService, locator loc.Locator, path string) error {
+	_, reader, err := packages.ReadPackage(locator)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer reader.Close()
+	err = utils.CopyReaderWithPerms(path, reader, defaults.SharedExecutableMask)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // IsSecretsPackage returns true if the specified package is a runtime secrets package
 func IsSecretsPackage(loc loc.Locator, labels map[string]string) bool {
 	if Labels(labels).HasPurpose(PurposePlanetSecrets) {

--- a/lib/state/state.go
+++ b/lib/state/state.go
@@ -74,6 +74,15 @@ type stateLocator struct {
 	StateDir string `json:"stateDir,omitempty"`
 }
 
+// InStateDir returns the provided path elements joined with the state dir.
+func InStateDir(elems ...string) (string, error) {
+	stateDir, err := GetStateDir()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return filepath.Join(append([]string{stateDir}, elems...)...), nil
+}
+
 // Secret returns a full path to a secret
 func Secret(baseDir, secretName string) string {
 	return filepath.Join(baseDir, defaults.SecretsDir, secretName)


### PR DESCRIPTION
The fio binary is downloaded during the install operation "init" phase which breaks wizard installer because it runs prechecks before the operation starts and as such there's no fio binary yet.

This PR updates join peer bootstrap to export fio beforehand.