### PR TITLE
Make sure key store directory is not created unless necessary.

### DIFF
--- a/lib/users/usersservice/local.go
+++ b/lib/users/usersservice/local.go
@@ -29,11 +29,13 @@ import (
 
 // NewLocalKeyStore returns new user-local key storage
 func NewLocalKeyStore(path string) (*users.KeyStore, error) {
-	path, err := utils.EnsureLocalPath(path, defaults.LocalConfigDir, defaults.LocalConfigFile)
+	path, err := utils.GetLocalPath(path, defaults.LocalConfigDir, defaults.LocalConfigFile)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return users.NewCredsService(users.CredsConfig{Backend: &LocalLogins{path: path, Clock: clockwork.NewRealClock()}})
+	return users.NewCredsService(users.CredsConfig{
+		Backend: &LocalLogins{path: path, Clock: clockwork.NewRealClock()},
+	})
 }
 
 // LocalLogins store local logins with remote ops centers

--- a/lib/utils/fileutils.go
+++ b/lib/utils/fileutils.go
@@ -246,7 +246,7 @@ func EnsureLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (stri
 	return path, nil
 }
 
-// GetLocalPath constructs path to the local gravity config file like decsribed
+// GetLocalPath constructs path to the local gravity config file like described
 // in the EnsureLocalPath above.
 func GetLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (string, error) {
 	if customPath != "" {
@@ -254,7 +254,7 @@ func GetLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (string,
 	}
 	homeDir := os.Getenv(constants.EnvHome)
 	if homeDir == "" {
-		return "", trace.BadParameter("no path provided and environment variable %v is not not set", constants.EnvHome)
+		return "", trace.BadParameter("no path provided and environment variable %v is not set", constants.EnvHome)
 	}
 	return filepath.Join(homeDir, defaultLocalDir, defaultLocalPath), nil
 }

--- a/lib/utils/fileutils.go
+++ b/lib/utils/fileutils.go
@@ -227,16 +227,13 @@ func CopyDirContents(fromDir, toDir string) error {
 // EnsureLocalPath("", ".gravity", "config") -> ${HOME}/.gravity/config
 //
 // It also makes sure that base dir exists
-func EnsureLocalPath(customPath string, defaultLocalDir, defaultLocalPath string) (string, error) {
-	if customPath == "" {
-		homeDir := os.Getenv(constants.EnvHome)
-		if homeDir == "" {
-			return "", trace.BadParameter("no path provided and environment variable %v is not not set", constants.EnvHome)
-		}
-		customPath = filepath.Join(homeDir, defaultLocalDir, defaultLocalPath)
+func EnsureLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (string, error) {
+	path, err := GetLocalPath(customPath, defaultLocalDir, defaultLocalPath)
+	if err != nil {
+		return "", trace.Wrap(err)
 	}
-	baseDir := filepath.Dir(customPath)
-	_, err := StatDir(baseDir)
+	baseDir := filepath.Dir(path)
+	_, err = StatDir(baseDir)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			if err := MkdirAll(baseDir, defaults.PrivateDirMask); err != nil {
@@ -246,7 +243,20 @@ func EnsureLocalPath(customPath string, defaultLocalDir, defaultLocalPath string
 			return "", trace.Wrap(err)
 		}
 	}
-	return customPath, nil
+	return path, nil
+}
+
+// GetLocalPath constructs path to the local gravity config file like decsribed
+// in the EnsureLocalPath above.
+func GetLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (string, error) {
+	if customPath != "" {
+		return customPath, nil
+	}
+	homeDir := os.Getenv(constants.EnvHome)
+	if homeDir == "" {
+		return "", trace.BadParameter("no path provided and environment variable %v is not not set", constants.EnvHome)
+	}
+	return filepath.Join(homeDir, defaultLocalDir, defaultLocalPath), nil
 }
 
 // CopyFile copies contents of src to dst atomically


### PR DESCRIPTION
There was an annoying side effect of initializing a local key store (where now-obsolete gravity config file is) which would attempt to create ~/.gravity directory even for read operations, such as when determining whether a user is logged into a cluster or not. This not just created unnecessary dirs/files, but would also lead to the commands failing if user, say, doesn't have permissions to create that directory (e.g. bandwagon when creating a user - that's how I discovered this).

Now the keystore doesn't attempt to create this directory unless necessary. The LocalLogins backend implementation takes care of this on its own.