### PR TITLE
[5.5] Add RHEL8 to base image manifest.

### DIFF
--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -77,7 +77,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
         - name: ubuntu-core
@@ -113,7 +113,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
         - name: ubuntu-core
@@ -154,7 +154,7 @@ nodeProfiles:
         - name: centos
           versions: ["7"]
         - name: rhel
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
         - name: ubuntu-core


### PR DESCRIPTION
I've tested it on RHEL8.1. Also, update the e-ref. Closes https://github.com/gravitational/gravity/issues/1143.