### PR TITLE
Do not encrypt fio package.

### DIFF
--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -247,6 +247,14 @@ var (
 	Teleport = MustParseLocator(
 		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, constants.TeleportPackage, ZeroVersion))
 
+	// Gravity is the gravity binary package locator
+	Gravity = MustParseLocator(
+		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, constants.GravityPackage, ZeroVersion))
+
+	// Fio is the fio binary package locator
+	Fio = MustParseLocator(
+		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, constants.FioPackage, ZeroVersion))
+
 	// TrustedCluster is the trusted-cluster package locator
 	TrustedCluster = MustParseLocator(
 		fmt.Sprintf("%v/%v:0.0.1", defaults.SystemAccountOrg, constants.TrustedClusterPackage))

--- a/lib/pack/encryptedpack/encryptedpack.go
+++ b/lib/pack/encryptedpack/encryptedpack.go
@@ -133,8 +133,11 @@ func isSystemPackage(locator loc.Locator) bool {
 	return false
 }
 
-// systemPackages are packages that are not encrypted
+// systemPackages is a list of packages that are not encrypted because they
+// are required for bootstrapping the installer when license has not yet
+// been provided by the user.
 var systemPackages = []loc.Locator{
-	loc.MustParseLocator("gravitational.io/web-assets:0.0.0"),
-	loc.MustParseLocator("gravitational.io/gravity:0.0.0"),
+	loc.Gravity,
+	loc.Fio,
+	loc.WebAssetsPackageLocator,
 }


### PR DESCRIPTION
Add `fio` to a list of packages required for bootstrapping the installer and as such not being encrypted, otherwise the UI installer is not able to run the disk check when the app requires a license.