### PR TITLE
Fix tests and forward-port service management sub-commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1106,12 +1106,12 @@
   revision = "f4445fa6001335437357b4300010f97979af7789"
 
 [[projects]]
-  branch = "master"
-  digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"
+  branch = "dmitri/proxy-error"
+  digest = "1:4e3d7e080383752f45ac35da815876e8aa3c5b44296b3626dc8ac88beac689fc"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "dd5b2e8eae86d31f6273ff3ac46d5b15edd6d6be"
+  revision = "d7a539a4496ed3dcd4c56adf636485f5ce9a4971"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"
@@ -3203,6 +3203,7 @@
     "github.com/julienschmidt/httprouter",
     "github.com/kardianos/osext",
     "github.com/kylelemons/godebug/diff",
+    "github.com/mailgun/lemma/secret",
     "github.com/mailgun/timetools",
     "github.com/miekg/dns",
     "github.com/mitchellh/go-ps",
@@ -3270,6 +3271,7 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",
@@ -3292,7 +3294,10 @@
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/code-generator",
     "k8s.io/helm/pkg/chartutil",
+    "k8s.io/helm/pkg/getter",
     "k8s.io/helm/pkg/helm",
+    "k8s.io/helm/pkg/helm/environment",
+    "k8s.io/helm/pkg/helm/helmpath",
     "k8s.io/helm/pkg/helm/portforwarder",
     "k8s.io/helm/pkg/kube",
     "k8s.io/helm/pkg/proto/hapi/chart",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1106,12 +1106,11 @@
   revision = "f4445fa6001335437357b4300010f97979af7789"
 
 [[projects]]
-  branch = "dmitri/proxy-error"
-  digest = "1:4e3d7e080383752f45ac35da815876e8aa3c5b44296b3626dc8ac88beac689fc"
+  digest = "1:7b65e71a43314399db406911332bd338da7021b11e8f9ca9b02e5ab7eb750135"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d7a539a4496ed3dcd4c56adf636485f5ce9a4971"
+  revision = "f1826cb7433410e4bc7990258a62b0b4468341e0"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  #version = "=1.1.10"
-  branch = "master"
+  #version = "=1.1.11"
+  branch = "dmitri/proxy-error"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@ ignored = [
 [[override]]
   name = "github.com/gravitational/trace"
   #version = "=1.1.11"
-  branch = "dmitri/proxy-error"
+  revision = "f1826cb7433410e4bc7990258a62b0b4468341e0"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -530,15 +529,6 @@ func (h *WebHandler) exportApp(w http.ResponseWriter, req *http.Request,
 	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		return trace.Wrap(err)
 	}
-	_, _, err = net.SplitHostPort(config.RegistryHostPort)
-	if config.RegistryHostPort == "" || err != nil {
-		message := "invalid host:port value"
-		if err != nil {
-			message = err.Error()
-		}
-		return trace.BadParameter("registryHostPort: %v", message)
-	}
-
 	if err = context.applications.ExportApp(app.ExportAppRequest{
 		Package:         *locator,
 		RegistryAddress: config.RegistryHostPort,

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -58,7 +58,7 @@ type VendorerConfig struct {
 	DockerClient docker.DockerInterface
 	// ImageService is the docker registry service
 	docker.ImageService
-	// RegistryURL is the URL of the active docker registry to use to
+	// RegistryURL is the URL of the active docker registry to use
 	RegistryURL string
 	// Packages is the pack service
 	Packages pack.PackageService
@@ -241,7 +241,6 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 		}
 		image := image // create new variable for go routine below
 		group.Go(groupCtx, func() error {
-
 			// pull all missing images (this will correctly fail for images without a remote
 			// registry that do not exist i.e. due to failed image build)
 			if err := pullMissingRemoteImage(image, v.dockerPuller, log, req.ProgressReporter); err != nil {

--- a/lib/app/suite/suite.go
+++ b/lib/app/suite/suite.go
@@ -206,7 +206,7 @@ spec:
 	c.Assert(err, IsNil)
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf("%v:5000", constants.APIServerDomainName),
+		RegistryAddress: constants.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -266,7 +266,7 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf(constants.DockerRegistry),
+		RegistryAddress: constants.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 	apps := r.NewService(c, dockerClient, imageService)
@@ -280,14 +280,15 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	c.Assert(err, IsNil)
 	application := r.importApplication(apps, vendorer, c)
 
+	registryAddr := registryAddr(registry.Addr())
 	c.Assert(apps.ExportApp(app.ExportAppRequest{
 		Package:         application.Package,
-		RegistryAddress: registry.Addr(),
+		RegistryAddress: registryAddr,
 	}), IsNil)
 
 	remoteRegistry, err := docker.ConnectRegistry(context.TODO(),
 		docker.RegistryConnectionRequest{
-			RegistryAddress: registry.Addr(),
+			RegistryAddress: registryAddr,
 		})
 	c.Assert(err, IsNil)
 	repos := make([]string, 3)
@@ -624,7 +625,7 @@ func (r *AppsSuite) Charts(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf(constants.DockerRegistry),
+		RegistryAddress: constants.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -694,19 +695,19 @@ registry:
 	c.Assert(files["resources/charts/mattermost/values.yaml"], Equals, valuesBytes)
 	c.Assert(files["resources/charts/mattermost/templates/pod.yaml"], Equals, templateBytes)
 
+	registryAddr := registryAddr(registry.Addr())
 	// alpine was referenced as a part of helm template,
 	// but make sure helm template has captured it
 	// and added to the list of vendored apps
 	c.Assert(apps.ExportApp(app.ExportAppRequest{
 		Package:         application.Package,
-		RegistryAddress: registry.Addr(),
+		RegistryAddress: registryAddr,
 	}), IsNil)
 
 	ctx := context.Background()
 	remoteRegistry, err := docker.ConnectRegistry(
-		ctx,
-		docker.RegistryConnectionRequest{
-			RegistryAddress: registry.Addr(),
+		ctx, docker.RegistryConnectionRequest{
+			RegistryAddress: registryAddr,
 		})
 	c.Assert(err, IsNil)
 	repos := make([]string, 2)
@@ -893,4 +894,8 @@ spec:
 	defer reader.Close()
 	archive.AssertArchiveHasFiles(c, reader, []string{"registry"}, "resources", "resources/resource-0.yaml", "resources/app.yaml")
 	return importedApplication
+}
+
+func registryAddr(addr string) string {
+	return fmt.Sprintf("http://%v", addr)
 }

--- a/lib/docker/imageservice.go
+++ b/lib/docker/imageservice.go
@@ -55,7 +55,7 @@ import (
 
 // RegistryConnectionRequest represents connection information for a Docker registry
 type RegistryConnectionRequest struct {
-	// RegistryAddress is host:port of a Docker registry
+	// RegistryAddress is either a host:port or a complete URL of a Docker registry
 	RegistryAddress string
 	// CertName allows to override directory where to look for certs
 	// which normally equals to the registry address
@@ -403,7 +403,7 @@ func initTransport(req RegistryConnectionRequest) (http.RoundTripper, string, er
 
 	challengeManager, err := ping(transport, registryAddress)
 	if err != nil {
-		return nil, "", trace.Wrap(err, "failed to ping Docker registry").AddField("req", req)
+		return nil, "", trace.Wrap(err, "failed to ping Docker registry: %s", err).AddField("req", req)
 	}
 
 	if !req.HasBasicAuth() {

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -42,6 +42,8 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	netcontext "golang.org/x/net/context" // TODO: remove in go1.9
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type agentServer storage.Server
@@ -357,12 +359,12 @@ func (r *AgentPeerStore) NewPeer(ctx netcontext.Context, req pb.PeerJoinRequest,
 
 	token, user, err := r.authenticatePeer(req.Config.Token)
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	info, err := storage.UnmarshalSystemInfo(req.SystemInfo)
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	group, err := r.getOrCreateGroup(ops.SiteOperationKey{
@@ -371,13 +373,13 @@ func (r *AgentPeerStore) NewPeer(ctx netcontext.Context, req pb.PeerJoinRequest,
 		OperationID: token.OperationID,
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	if req.Config.KeyValues[ops.AgentMode] != ops.AgentModeShrink {
 		errCheck := r.validatePeer(ctx, group, info, req, token.SiteDomain)
 		if errCheck != nil {
-			return trace.Wrap(errCheck)
+			return errCheck
 		}
 	}
 
@@ -396,12 +398,12 @@ func (r *AgentPeerStore) RemovePeer(ctx netcontext.Context, req pb.PeerLeaveRequ
 
 	token, user, err := r.authenticatePeer(req.Config.Token)
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	info, err := storage.UnmarshalSystemInfo(req.SystemInfo)
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	group, err := r.getOrCreateGroup(ops.SiteOperationKey{
@@ -410,7 +412,7 @@ func (r *AgentPeerStore) RemovePeer(ctx netcontext.Context, req pb.PeerLeaveRequ
 		OperationID: token.OperationID,
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return err
 	}
 
 	group.remove(ctx, peer, info.GetHostname())
@@ -421,8 +423,8 @@ func (r *AgentPeerStore) RemovePeer(ctx netcontext.Context, req pb.PeerLeaveRequ
 func (r *AgentPeerStore) authenticatePeer(token string) (*storage.ProvisioningToken, storage.User, error) {
 	provToken, err := r.users.GetProvisioningToken(token)
 	if err != nil {
-		r.Warnf("Invalid peer auth token %q: %v.", token, trace.DebugReport(err))
-		return nil, nil, trace.AccessDenied("peer auth failed: %v",
+		r.WithError(err).Warn("Invalid peer auth token.")
+		return nil, nil, status.Errorf(codes.PermissionDenied, "peer auth failed: %v",
 			trace.UserMessage(err))
 	}
 	user, _, err := r.users.AuthenticateUser(httplib.AuthCreds{
@@ -430,8 +432,8 @@ func (r *AgentPeerStore) authenticatePeer(token string) (*storage.ProvisioningTo
 		Type:     httplib.AuthBearer,
 	})
 	if err != nil {
-		r.Warnf("Peer auth failed: %v.", trace.DebugReport(err))
-		return nil, nil, trace.AccessDenied("user auth failed: %v",
+		r.WithError(err).Warn("Peer auth failed.")
+		return nil, nil, status.Errorf(codes.PermissionDenied, "peer auth failed: %v",
 			trace.UserMessage(err))
 	}
 	return provToken, user, nil

--- a/lib/rpc/server/agent.go
+++ b/lib/rpc/server/agent.go
@@ -55,7 +55,7 @@ func (srv *agentServer) Command(req *pb.CommandArgs, stream pb.Agent_CommandServ
 
 // PeerJoin accepts a new peer
 func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (*types.Empty, error) {
-	srv.WithField("req", req.Describe()).Debug("PeerJoin.")
+	srv.WithField("req", req.String()).Debug("PeerJoin.")
 	err := srv.PeerStore.NewPeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,
@@ -69,7 +69,7 @@ func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (
 
 // PeerLeave receives a "leave" request from a peer and initiates its shutdown
 func (srv *agentServer) PeerLeave(ctx context.Context, req *pb.PeerLeaveRequest) (*types.Empty, error) {
-	srv.WithField("req", req.Describe()).Debug("PeerLeave.")
+	srv.WithField("req", req.String()).Debug("PeerLeave.")
 	err := srv.PeerStore.RemovePeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,

--- a/lib/rpc/server/agent.go
+++ b/lib/rpc/server/agent.go
@@ -39,7 +39,7 @@ func (srv *agentServer) Command(req *pb.CommandArgs, stream pb.Agent_CommandServ
 	log := srv.WithFields(log.Fields{
 		"request": "Command",
 		"args":    req.Args})
-	log.Debug("request received")
+	log.Debug("Request received.")
 
 	if req.SelfCommand {
 		gravityPath, err := os.Executable()
@@ -55,7 +55,7 @@ func (srv *agentServer) Command(req *pb.CommandArgs, stream pb.Agent_CommandServ
 
 // PeerJoin accepts a new peer
 func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (*types.Empty, error) {
-	srv.WithField("req", req).Debug("PeerJoin.")
+	srv.WithField("req", req.Describe()).Debug("PeerJoin.")
 	err := srv.PeerStore.NewPeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,
@@ -69,14 +69,14 @@ func (srv *agentServer) PeerJoin(ctx context.Context, req *pb.PeerJoinRequest) (
 
 // PeerLeave receives a "leave" request from a peer and initiates its shutdown
 func (srv *agentServer) PeerLeave(ctx context.Context, req *pb.PeerLeaveRequest) (*types.Empty, error) {
-	srv.WithField("req", req).Debug("PeerLeave.")
+	srv.WithField("req", req.Describe()).Debug("PeerLeave.")
 	err := srv.PeerStore.RemovePeer(ctx, *req, &remotePeer{
 		addr:             req.Addr,
 		creds:            srv.Config.Client,
 		reconnectTimeout: srv.Config.ReconnectTimeout,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, err
 	}
 	return &types.Empty{}, nil
 }
@@ -91,14 +91,14 @@ func (srv *agentServer) GetRuntimeConfig(ctx context.Context, _ *types.Empty) (*
 			return nil, trace.Wrap(err)
 		}
 	}
+	tempDir := os.TempDir()
 	config := &pb.RuntimeConfig{
 		Role:          srv.Role,
 		AdvertiseAddr: srv.Config.Listener.Addr().String(),
-		DockerDevice:  srv.DockerDevice,
 		SystemDevice:  srv.SystemDevice,
 		Mounts:        srv.Mounts,
 		StateDir:      stateDir,
-		TempDir:       srv.TempDir,
+		TempDir:       tempDir,
 		KeyValues:     srv.KeyValues,
 		CloudMetadata: srv.CloudMetadata,
 	}

--- a/lib/rpc/server/agent.go
+++ b/lib/rpc/server/agent.go
@@ -91,14 +91,13 @@ func (srv *agentServer) GetRuntimeConfig(ctx context.Context, _ *types.Empty) (*
 			return nil, trace.Wrap(err)
 		}
 	}
-	tempDir := os.TempDir()
 	config := &pb.RuntimeConfig{
 		Role:          srv.Role,
 		AdvertiseAddr: srv.Config.Listener.Addr().String(),
 		SystemDevice:  srv.SystemDevice,
 		Mounts:        srv.Mounts,
 		StateDir:      stateDir,
-		TempDir:       tempDir,
+		TempDir:       os.TempDir(),
 		KeyValues:     srv.KeyValues,
 		CloudMetadata: srv.CloudMetadata,
 	}

--- a/lib/system/environ/uninstall.go
+++ b/lib/system/environ/uninstall.go
@@ -132,7 +132,7 @@ func DisableAgentServices(logger log.FieldLogger) error {
 }
 
 func uninstallPackageServices(svm systemservice.ServiceManager, printer utils.Printer, logger log.FieldLogger) error {
-	services, err := svm.ListPackageServices()
+	services, err := svm.ListPackageServices(systemservice.DefaultListServiceOptions)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/systemservice/service.go
+++ b/lib/systemservice/service.go
@@ -231,6 +231,25 @@ type PackageServiceStatus struct {
 	Status string
 }
 
+// ListServiceOptions describes additional configuration for listing
+// services.
+// An empty value of this type is usable
+type ListServiceOptions struct {
+	// All optionally indicates whether to query all units (and not only those in memory)
+	All bool
+	// Type optionally specifies the unit type
+	Type string
+	// State optionally specifies the unit state
+	State string
+	// Pattern optionally specifies the unit pattern
+	Pattern string
+}
+
+const (
+	// UnitTypeService defines the service type of the unit file
+	UnitTypeService = "service"
+)
+
 // ServiceManager is an interface for collaborating with system
 // service managers, e.g. systemd for host packages
 type ServiceManager interface {
@@ -250,7 +269,7 @@ type ServiceManager interface {
 	EnablePackageService(pkg loc.Locator) error
 
 	// ListPackageServices lists installed package services
-	ListPackageServices() ([]PackageServiceStatus, error)
+	ListPackageServices(ListServiceOptions) ([]PackageServiceStatus, error)
 
 	// StartPackageService starts package service
 	StartPackageService(pkg loc.Locator, noBlock bool) error

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/utils"
@@ -74,9 +73,6 @@ ExecStartPre={{.}}{{end}}
 WantedBy={{.WantedBy}}
 {{end}}
 `
-
-	// Should we make the target configurable too?
-	systemdUnitFileDir = "/etc/systemd/system/"
 
 	systemdUnitFileSuffix = ".service"
 
@@ -127,6 +123,10 @@ func (u *systemdUnit) serviceName() string {
 		systemdServiceDelimiter) + systemdUnitFileSuffix
 }
 
+func (u *systemdUnit) servicePath() string {
+	return unitPath(u.serviceName())
+}
+
 func (s *systemdManager) installService(service serviceTemplate, req NewServiceRequest) error {
 	if service.Environment == nil {
 		service.Environment = make(map[string]string)
@@ -156,7 +156,7 @@ func (s *systemdManager) installService(service serviceTemplate, req NewServiceR
 }
 
 func (s *systemdManager) installMountService(service mountServiceTemplate, noBlock bool) error {
-	servicePath := filepath.Join(systemdUnitFileDir, SystemdNameEscape(service.Name))
+	servicePath := filepath.Join(defaults.SystemUnitDir, SystemdNameEscape(service.Name))
 	f, err := os.Create(servicePath)
 	if err != nil {
 		return trace.Wrap(trace.ConvertSystemError(err),
@@ -231,7 +231,7 @@ func (s *systemdManager) DisablePackageService(pkg loc.Locator) error {
 
 // IsPackageServiceInstalled checks if the package service is installed
 func (s *systemdManager) IsPackageServiceInstalled(pkg loc.Locator) (bool, error) {
-	units, err := s.ListPackageServices()
+	units, err := s.ListPackageServices(DefaultListServiceOptions)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -244,10 +244,23 @@ func (s *systemdManager) IsPackageServiceInstalled(pkg loc.Locator) (bool, error
 }
 
 // ListPackageServices lists installed package services
-func (s *systemdManager) ListPackageServices() ([]PackageServiceStatus, error) {
+func (s *systemdManager) ListPackageServices(opts ListServiceOptions) ([]PackageServiceStatus, error) {
 	var services []PackageServiceStatus
 
-	out, err := invokeSystemctl("list-units", "--plain", "--no-legend", "--all")
+	args := []string{"list-units", "--plain", "--no-legend"}
+	if opts.All {
+		args = append(args, "--all")
+	}
+	if opts.Type != "" {
+		args = append(args, "--type", opts.Type)
+	}
+	if opts.State != "" {
+		args = append(args, "--state", opts.State)
+	}
+	if opts.Pattern != "" {
+		args = append(args, opts.Pattern)
+	}
+	out, err := invokeSystemctl(args...)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to list-units: %v", out)
 	}
@@ -332,19 +345,19 @@ func (s *systemdManager) UninstallService(req UninstallServiceRequest) error {
 	serviceName := serviceName(req.Name)
 	out, err := invokeSystemctl("stop", serviceName)
 	if err != nil && !IsUnknownServiceError(err) {
-		return trace.Wrap(err, out)
+		return trace.Wrap(err)
 	}
 
 	out, err = invokeSystemctl("disable", serviceName)
 	if err != nil && !IsUnknownServiceError(err) {
-		return trace.Wrap(err, out)
+		return trace.Wrap(err)
 	}
 
 	out, err = invokeSystemctl("is-failed", serviceName)
 	status := strings.TrimSpace(out)
 
 	unitPath := unitPath(req.Name)
-	if errDelete := os.Remove(unitPath); errDelete != nil && !os.IsNotExist(err) {
+	if errDelete := os.Remove(unitPath); errDelete != nil && !os.IsNotExist(errDelete) {
 		logger.WithError(errDelete).Warn("Failed to delete service unit file.")
 	}
 
@@ -445,9 +458,9 @@ func (s *systemdManager) supportsTasksAccounting() bool {
 }
 
 func invokeSystemctl(args ...string) (string, error) {
+	var out bytes.Buffer
 	cmd := exec.Command("systemctl", append(args, "--no-pager")...)
-	out := &bytes.Buffer{}
-	err := utils.ExecL(cmd, out, log.WithField(trace.Component, constants.ComponentSystem))
+	err := utils.Exec(cmd, &out)
 	return out.String(), trace.Wrap(err)
 }
 
@@ -460,9 +473,21 @@ func unitPath(name string) (path string) {
 	return DefaultUnitPath(name)
 }
 
+// PackageServiceName returns the name of the package service
+// for the specified package locator
+func PackageServiceName(loc loc.Locator) string {
+	return newSystemdUnit(loc).serviceName()
+}
+
 // DefaultUnitPath returns the default path for the specified systemd unit
 func DefaultUnitPath(name string) (path string) {
-	return filepath.Join(systemdUnitFileDir, SystemdNameEscape(name))
+	return filepath.Join(defaults.SystemUnitDir, SystemdNameEscape(name))
+}
+
+// DefaultListServiceOptions specifies the default configuration to list package services
+var DefaultListServiceOptions = ListServiceOptions{
+	All:  true,
+	Type: UnitTypeService,
 }
 
 // serviceName returns just the name portion of the unit path.

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -36,6 +36,8 @@ import (
 	"github.com/cenkalti/backoff"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -364,7 +366,8 @@ func IsConnectionRefusedError(err error) bool {
 // It detects unrecoverable errors and aborts the reconnect attempts
 func ShouldReconnectPeer(err error) error {
 	switch {
-	case isPeerDeniedError(err.Error()),
+	case trace.IsAccessDenied(err),
+		isPeerDeniedError(err),
 		isLicenseError(err.Error()),
 		isHostAlreadyRegisteredError(err.Error()):
 		return &backoff.PermanentError{Err: err}
@@ -381,6 +384,7 @@ func NewFailedPreconditionError(err error) error {
 // ExitCodeError defines an interface for exit code errors
 type ExitCodeError interface {
 	error
+	// ExitCode returns the numeric error code to exit with
 	ExitCode() int
 	// OrigError returns the original error this error wraps.
 	OrigError() error
@@ -454,8 +458,14 @@ type exitCodeError struct {
 	err error
 }
 
-func isPeerDeniedError(message string) bool {
-	return strings.Contains(message, "peer not authorized")
+func isPeerDeniedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if statusErr, ok := status.FromError(trace.Unwrap(err)); ok {
+		return statusErr.Code() == codes.PermissionDenied
+	}
+	return strings.Contains(err.Error(), "peer auth failed")
 }
 
 func isLicenseError(message string) bool {

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -366,8 +366,7 @@ func IsConnectionRefusedError(err error) bool {
 // It detects unrecoverable errors and aborts the reconnect attempts
 func ShouldReconnectPeer(err error) error {
 	switch {
-	case trace.IsAccessDenied(err),
-		isPeerDeniedError(err),
+	case isPermissionDeniedError(err),
 		isLicenseError(err.Error()),
 		isHostAlreadyRegisteredError(err.Error()):
 		return &backoff.PermanentError{Err: err}
@@ -458,14 +457,14 @@ type exitCodeError struct {
 	err error
 }
 
-func isPeerDeniedError(err error) bool {
+func isPermissionDeniedError(err error) bool {
 	if err == nil {
 		return false
 	}
 	if statusErr, ok := status.FromError(trace.Unwrap(err)); ok {
 		return statusErr.Code() == codes.PermissionDenied
 	}
-	return strings.Contains(err.Error(), "peer auth failed")
+	return trace.IsAccessDenied(err)
 }
 
 func isLicenseError(message string) bool {

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -274,10 +274,16 @@ type Application struct {
 	SystemServiceInstallCmd SystemServiceInstallCmd
 	// SystemServiceUninstallCmd uninstalls systemd service
 	SystemServiceUninstallCmd SystemServiceUninstallCmd
-	// SystemServiceStatusCmd displays status of systemd service
+	// SystemServiceStatusCmd queries the runtime status of a package service
 	SystemServiceStatusCmd SystemServiceStatusCmd
 	// SystemServiceListCmd lists systemd services
 	SystemServiceListCmd SystemServiceListCmd
+	// SystemServiceStopCmd stops a package service
+	SystemServiceStopCmd SystemServiceStopCmd
+	// SystemServiceStartCmd stops or restarts a package service
+	SystemServiceStartCmd SystemServiceStartCmd
+	// SystemServiceJournalCmd queries the system journal of a package service
+	SystemServiceJournalCmd SystemServiceJournalCmd
 	// SystemReportCmd generates tarball with system diagnostics information
 	SystemReportCmd SystemReportCmd
 	// SystemStateDirCmd shows local state directory
@@ -1566,18 +1572,43 @@ type SystemServiceUninstallCmd struct {
 	Name *string
 }
 
-// SystemServiceStatusCmd displays status of systemd service
+// SystemServiceStatusCmd queries the runtime status of a package service
 type SystemServiceStatusCmd struct {
 	*kingpin.CmdClause
-	// Package is system service package locator
-	Package *loc.Locator
-	// Name is service name
-	Name *string
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
 }
 
 // SystemServiceListCmd lists systemd services
 type SystemServiceListCmd struct {
 	*kingpin.CmdClause
+}
+
+// SystemServiceStartCmd starts or restart a package service
+type SystemServiceStartCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+}
+
+// SystemServiceStopCmd stops a running package service
+type SystemServiceStopCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+}
+
+// SystemServiceJournalCmd queries the system journal of a package service
+type SystemServiceJournalCmd struct {
+	*kingpin.CmdClause
+	// Package specifies the service either a package locator
+	// or a partial unique pattern (i.e. 'planet')
+	Package *string
+	// Args optionally lists additional arguments to journalctl
+	Args *[]string
 }
 
 // SystemReportCmd generates tarball with system diagnostics information

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -670,13 +670,22 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemServiceUninstallCmd.Package = Locator(g.SystemServiceUninstallCmd.Flag("package", "the package related to this service"))
 	g.SystemServiceUninstallCmd.Name = g.SystemServiceUninstallCmd.Flag("name", "the service name").String()
 
-	// check status of a service
-	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "status of a package service, supply either package or service name ").Hidden()
-	g.SystemServiceStatusCmd.Package = Locator(g.SystemServiceStatusCmd.Flag("package", "the package related to this service"))
-	g.SystemServiceStatusCmd.Name = g.SystemServiceStatusCmd.Flag("name", "service name to check").String()
-
 	// list running services
 	g.SystemServiceListCmd.CmdClause = g.SystemServiceCmd.Command("list", "list running services").Hidden()
+
+	g.SystemServiceStopCmd.CmdClause = g.SystemServiceCmd.Command("stop", "stop a running service").Hidden()
+	g.SystemServiceStopCmd.Package = g.SystemServiceStopCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	g.SystemServiceStartCmd.CmdClause = g.SystemServiceCmd.Command("start", "start a service").Hidden()
+	g.SystemServiceStartCmd.Package = g.SystemServiceStartCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	// query runtime status of a package service
+	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "query runtime status information of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceStatusCmd.Package = g.SystemServiceStatusCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+
+	g.SystemServiceJournalCmd.CmdClause = g.SystemServiceCmd.Command("journal", "query system journal of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceJournalCmd.Package = g.SystemServiceJournalCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
+	g.SystemServiceJournalCmd.Args = g.SystemServiceJournalCmd.Arg("arg", "optional arguments to the journalctl").Strings()
 
 	g.SystemReportCmd.CmdClause = g.SystemCmd.Command("report", "collect system diagnostics and output as gzipped tarball to terminal").Hidden()
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -651,7 +651,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemServiceCmd.CmdClause = g.SystemCmd.Command("service", "operations on system services")
 
 	// install a new system service
-	g.SystemServiceInstallCmd.CmdClause = g.SystemServiceCmd.Command("install", "install a new service").Hidden()
+	g.SystemServiceInstallCmd.CmdClause = g.SystemServiceCmd.Command("install", "install a new service")
 	g.SystemServiceInstallCmd.Package = Locator(g.SystemServiceInstallCmd.Arg("pkg", "the package to generate unit file for").Required())
 	g.SystemServiceInstallCmd.ConfigPackage = Locator(g.SystemServiceInstallCmd.Arg("conf-pkg", "the configuration package used to launch the service with").Required())
 	g.SystemServiceInstallCmd.StartCommand = g.SystemServiceInstallCmd.Flag("start-command", "the command used to start the service").Required().String()
@@ -671,19 +671,19 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemServiceUninstallCmd.Name = g.SystemServiceUninstallCmd.Flag("name", "the service name").String()
 
 	// list running services
-	g.SystemServiceListCmd.CmdClause = g.SystemServiceCmd.Command("list", "list running services").Hidden()
+	g.SystemServiceListCmd.CmdClause = g.SystemServiceCmd.Command("list", "list running services")
 
-	g.SystemServiceStopCmd.CmdClause = g.SystemServiceCmd.Command("stop", "stop a running service").Hidden()
+	g.SystemServiceStopCmd.CmdClause = g.SystemServiceCmd.Command("stop", "stop a running service")
 	g.SystemServiceStopCmd.Package = g.SystemServiceStopCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
 
-	g.SystemServiceStartCmd.CmdClause = g.SystemServiceCmd.Command("start", "start a service").Hidden()
+	g.SystemServiceStartCmd.CmdClause = g.SystemServiceCmd.Command("start", "start a service")
 	g.SystemServiceStartCmd.Package = g.SystemServiceStartCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
 
 	// query runtime status of a package service
-	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "query runtime status information of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceStatusCmd.CmdClause = g.SystemServiceCmd.Command("status", "query runtime status information of the specified service")
 	g.SystemServiceStatusCmd.Package = g.SystemServiceStatusCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
 
-	g.SystemServiceJournalCmd.CmdClause = g.SystemServiceCmd.Command("journal", "query system journal of the specified service").Interspersed(false).Hidden()
+	g.SystemServiceJournalCmd.CmdClause = g.SystemServiceCmd.Command("journal", "query system journal of the specified service").Interspersed(false)
 	g.SystemServiceJournalCmd.Package = g.SystemServiceJournalCmd.Arg("package", "package for the service. Can be specified either as a partial match - i.e. planet or complete package locator").Required().String()
 	g.SystemServiceJournalCmd.Args = g.SystemServiceJournalCmd.Arg("arg", "optional arguments to the journalctl").Strings()
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -831,10 +831,17 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.SystemServiceUninstallCmd.Name)
 	case g.SystemServiceListCmd.FullCommand():
 		return systemServiceList(localEnv)
+	case g.SystemServiceStartCmd.FullCommand():
+		return systemServiceStart(localEnv, *g.SystemServiceStartCmd.Package)
+	case g.SystemServiceStopCmd.FullCommand():
+		return systemServiceStop(localEnv, *g.SystemServiceStopCmd.Package)
+	case g.SystemServiceJournalCmd.FullCommand():
+		return systemServiceJournal(localEnv,
+			*g.SystemServiceJournalCmd.Package,
+			*g.SystemServiceJournalCmd.Args)
 	case g.SystemServiceStatusCmd.FullCommand():
 		return systemServiceStatus(localEnv,
-			*g.SystemServiceStatusCmd.Package,
-			*g.SystemServiceStatusCmd.Name)
+			*g.SystemServiceStatusCmd.Package)
 	case g.SystemUninstallCmd.FullCommand():
 		return systemUninstall(localEnv, *g.SystemUninstallCmd.Confirmed)
 	case g.SystemReportCmd.FullCommand():

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -537,7 +537,7 @@ func systemServiceList(env *localenv.LocalEnvironment) error {
 	return nil
 }
 
-// systemServiceStart starts or restarts the package service specified with packagePattern
+// systemServiceStart starts the package service specified with packagePattern
 func systemServiceStart(env *localenv.LocalEnvironment, packagePattern string) error {
 	services, err := systemservice.New()
 	if err != nil {

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -317,6 +317,8 @@ type TraceErr struct {
 // Fields maps arbitrary keys to values inside an error
 type Fields map[string]interface{}
 
+// Error returns the error message this trace describes.
+// Implements error
 func (r *RawTrace) Error() string {
 	return r.Message
 }


### PR DESCRIPTION
 * Fix chart tests broken with the https://github.com/gravitational/gravity/pull/1072 commit.
 * Forward port low-level system management commands for starting/stopping
gravity-specific services as well as viewing system journal.

Requires https://github.com/gravitational/trace/pull/55.