### PR TITLE
Add client/server version information to gravity status.

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -1092,6 +1092,11 @@ func (o *OperatorACL) EmitAuditEvent(ctx context.Context, req AuditEventRequest)
 	return o.operator.EmitAuditEvent(ctx, req)
 }
 
+// GetVersion returns the server version information.
+func (o *OperatorACL) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return o.operator.GetVersion(ctx)
+}
+
 // CreateUserInvite creates a new invite token for a user.
 func (o *OperatorACL) CreateUserInvite(ctx context.Context, req CreateUserInviteRequest) (*storage.UserToken, error) {
 	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/network/validation/proto"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/pack"
@@ -700,6 +701,8 @@ type Status interface {
 	CheckSiteStatus(ctx context.Context, key SiteKey) error
 	// GetClusterNodes returns a real-time information about cluster nodes
 	GetClusterNodes(SiteKey) ([]Node, error)
+	// GetVersion returns the gravity binary version information.
+	GetVersion(context.Context) (*modules.Version, error)
 }
 
 // Node represents a cluster node information based on Teleport node

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/storage"
@@ -1609,6 +1610,19 @@ func (c *Client) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) 
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// GetVersion returns the server version information.
+func (c *Client) GetVersion(ctx context.Context) (*modules.Version, error) {
+	out, err := c.Get(ctx, c.Endpoint("version"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var version modules.Version
+	if err := json.Unmarshal(out.Bytes(), &version); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &version, nil
 }
 
 // PostJSON issues HTTP POST request to the server with the provided JSON data

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -124,6 +124,9 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 	// Report portal status
 	h.GET("/portal/v1/status", h.getStatus)
 
+	// Return server version
+	h.GET("/portal/v1/version", h.needsAuth(h.getVersion))
+
 	// Applications API
 	h.GET("/portal/v1/apps", h.needsAuth(h.getApps))
 	h.GET("/portal/v1/gravity", h.needsAuth(h.getGravityBinary))
@@ -376,6 +379,20 @@ func (h *WebHandler) getSiteInstructions(w http.ResponseWriter, r *http.Request,
 */
 func (h *WebHandler) getStatus(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{"status": "healthy"})
+}
+
+/*
+   getVersion returns the server version information.
+
+   GET /portal/v1/version
+*/
+func (h *WebHandler) getVersion(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
+	version, err := context.Operator.GetVersion(r.Context())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, version)
+	return nil
 }
 
 /* getApps returns information about apps available for installation

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/storage"
@@ -912,6 +913,11 @@ func (r *Router) ListReleases(req ops.ListReleasesRequest) ([]storage.Release, e
 // EmitAuditEvent saves the provided event in the audit log.
 func (r *Router) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) error {
 	return r.Local.EmitAuditEvent(ctx, req)
+}
+
+// GetVersion returns the gravity binary version information.
+func (r *Router) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return r.Local.GetVersion(ctx)
 }
 
 // CreateUserInvite creates a new invite token for a user.

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/gravity/lib/helm"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/events"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
@@ -1402,6 +1403,12 @@ func (o *Operator) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// GetVersion returns the gravity binary version information.
+func (o *Operator) GetVersion(ctx context.Context) (*modules.Version, error) {
+	version := modules.Get().Version()
+	return &version, nil
 }
 
 func (o *Operator) openSite(key ops.SiteKey) (*site, error) {

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/storage"
@@ -61,6 +62,11 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 	if token != nil {
 		status.Token = *token
+	}
+
+	status.Cluster.Version, err = operator.GetVersion(ctx)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to query server version information.")
 	}
 
 	// Collect application endpoints.
@@ -208,6 +214,8 @@ type Cluster struct {
 	Endpoints Endpoints `json:"endpoints"`
 	// Extension is a cluster status extension
 	Extension `json:",inline,omitempty"`
+	// Version is the server version information.
+	Version *modules.Version `json:"version"`
 }
 
 // Endpoints contains information about cluster and application endpoints.

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -49,10 +49,11 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		Cluster: &Cluster{
 			Domain: cluster.Domain,
 			// Default to degraded - reset on successful query
-			State:     ops.SiteStateDegraded,
-			Reason:    cluster.Reason,
-			App:       cluster.App.Package,
-			Extension: newExtension(),
+			State:         ops.SiteStateDegraded,
+			Reason:        cluster.Reason,
+			App:           cluster.App.Package,
+			ClientVersion: modules.Get().Version(),
+			Extension:     newExtension(),
 		},
 	}
 
@@ -64,7 +65,7 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		status.Token = *token
 	}
 
-	status.Cluster.Version, err = operator.GetVersion(ctx)
+	status.Cluster.ServerVersion, err = operator.GetVersion(ctx)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to query server version information.")
 	}
@@ -214,8 +215,10 @@ type Cluster struct {
 	Endpoints Endpoints `json:"endpoints"`
 	// Extension is a cluster status extension
 	Extension `json:",inline,omitempty"`
-	// Version is the server version information.
-	Version *modules.Version `json:"version"`
+	// ServerVersion is version of the server the operator is talking to.
+	ServerVersion *modules.Version `json:"server_version,omitempty"`
+	// ClientVersion is version of the binary collecting the status.
+	ClientVersion modules.Version `json:"client_version"`
 }
 
 // Endpoints contains information about cluster and application endpoints.

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	statusapi "github.com/gravitational/gravity/lib/status"
@@ -286,11 +287,20 @@ func printStatusText(out io.Writer, cluster clusterStatus) error {
 	return clusterStatusError(cluster)
 }
 
+func formatVersion(version *modules.Version) string {
+	if version != nil {
+		return version.Version
+	}
+	return "n/a"
+}
+
 func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 	if cluster.App.Name != "" {
 		fmt.Fprintf(w, "Cluster image:\t%v, version %v\n", cluster.App.Name,
 			cluster.App.Version)
 	}
+	fmt.Fprintf(w, "Gravity version:\t%v (client) / %v (server)\n",
+		modules.Get().Version().Version, formatVersion(cluster.Version))
 	if cluster.Token.Token != "" {
 		fmt.Fprintf(w, "Join token:\t%v\n", cluster.Token.Token)
 	}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -300,7 +300,7 @@ func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 			cluster.App.Version)
 	}
 	fmt.Fprintf(w, "Gravity version:\t%v (client) / %v (server)\n",
-		modules.Get().Version().Version, formatVersion(cluster.Version))
+		cluster.ClientVersion.Version, formatVersion(cluster.ServerVersion))
 	if cluster.Token.Token != "" {
 		fmt.Fprintf(w, "Join token:\t%v\n", cluster.Token.Token)
 	}


### PR DESCRIPTION
A small improvement to add client/server version information to gravity status output - I oftentimes find myself missing it from customer reports and otherwise, and also helpful to know which version gravity-site is running as well. Adds the following line to gravity status output:

```
ubuntu@node-1:~/installer$ sudo gravity status
Cluster name:		heuristicliskov1018
Cluster status:		active
Cluster image:		telekube, version 7.0.0-alpha.2.13
Gravity version:	7.0.0-alpha.2.13 (client) / 7.0.0-alpha.2.13 (server)
...
```

Needs to be backported everywhere. Closes https://github.com/gravitational/gravity/issues/1149.