### PR TITLE
re-arrange coredns config generation (#1110)

### DIFF
--- a/lib/install/phases/coredns_test.go
+++ b/lib/install/phases/coredns_test.go
@@ -136,7 +136,7 @@ func (*StartSuite) TestCoreDNSConf(c *check.C) {
 	}
 
 	for _, tt := range configTable {
-		config, err := GenerateCorefile(tt.config)
+		config, err := generateCorefile(tt.config)
 
 		c.Assert(err, check.IsNil)
 		c.Assert(config, check.Equals, tt.expected)

--- a/lib/update/cluster/phases/coredns.go
+++ b/lib/update/cluster/phases/coredns.go
@@ -25,7 +25,6 @@ import (
 	libinstall "github.com/gravitational/gravity/lib/install/phases"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
-	"github.com/gravitational/gravity/lib/systeminfo"
 
 	"github.com/gravitational/rigging"
 	"github.com/gravitational/trace"
@@ -131,18 +130,10 @@ func (p *updatePhaseCoreDNS) Rollback(context.Context) error {
 // Corefile, as that may have been modified by a user.
 func (p *updatePhaseCoreDNS) generateCorefile(context.Context) error {
 	p.Info("Generating CoreDNS Corefile.")
-	// Read the resolv.conf from the host doing upgrade
-	// it will be used for configuring coredns upstream servers
-	resolvConf, err := systeminfo.ResolvFromFile("/etc/resolv.conf")
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
 	conf, err := libinstall.GenerateCorefile(libinstall.CorednsConfig{
-		UpstreamNameservers: resolvConf.Servers,
-		Rotate:              resolvConf.Rotate,
-		Hosts:               p.DNSOverrides.Hosts,
-		Zones:               p.DNSOverrides.Zones,
+		Hosts: p.DNSOverrides.Hosts,
+		Zones: p.DNSOverrides.Zones,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
* re-arrange coredns config generation to be consistent between install and upgrade

* separate testable / untestable corefile generation

* protect against nil resolv conf