### PR TITLE
[5.5] Add client/server version to gravity status.

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ops
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"io"
@@ -1036,4 +1037,9 @@ func (o *OperatorACL) GetAuthGateway(key SiteKey) (storage.AuthGateway, error) {
 		return nil, trace.Wrap(err)
 	}
 	return o.operator.GetAuthGateway(key)
+}
+
+// GetVersion returns the server version information.
+func (o *OperatorACL) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return o.operator.GetVersion(ctx)
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
@@ -571,6 +572,8 @@ type Status interface {
 	CheckSiteStatus(key SiteKey) error
 	// GetClusterNodes returns a real-time information about cluster nodes
 	GetClusterNodes(SiteKey) ([]Node, error)
+	// GetVersion returns the gravity binary version information.
+	GetVersion(context.Context) (*modules.Version, error)
 }
 
 // Node represents a cluster node information

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/pack"
@@ -1503,6 +1504,19 @@ func (c *Client) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
 		return nil, trace.Wrap(err)
 	}
 	return storage.UnmarshalAuthGateway(response.Bytes())
+}
+
+// GetVersion returns the server version information.
+func (c *Client) GetVersion(ctx context.Context) (*modules.Version, error) {
+	out, err := c.Get(c.Endpoint("version"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var version modules.Version
+	if err := json.Unmarshal(out.Bytes(), &version); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &version, nil
 }
 
 // PostJSON issues HTTP POST request to the server with the provided JSON data

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -100,6 +100,9 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 	// Report portal status
 	h.GET("/portal/v1/status", h.getStatus)
 
+	// Return server version
+	h.GET("/portal/v1/version", h.needsAuth(h.getVersion))
+
 	// Applications API
 	h.GET("/portal/v1/apps", h.needsAuth(h.getApps))
 
@@ -316,6 +319,19 @@ func (h *WebHandler) getSiteInstructions(w http.ResponseWriter, r *http.Request,
 */
 func (h *WebHandler) getStatus(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{"status": "healthy"})
+}
+
+/*
+   getVersion returns the server version information.
+   GET /portal/v1/version
+*/
+func (h *WebHandler) getVersion(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
+	version, err := context.Operator.GetVersion(r.Context())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, version)
+	return nil
 }
 
 /* getApps returns information about apps available for installation

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -17,12 +17,14 @@ limitations under the License.
 package opsroute
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
 
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
@@ -879,4 +881,9 @@ func (r *Router) UpsertAuthGateway(key ops.SiteKey, gw storage.AuthGateway) erro
 // GetAuthGateway returns auth gateway configuration.
 func (r *Router) GetAuthGateway(key ops.SiteKey) (storage.AuthGateway, error) {
 	return r.Local.GetAuthGateway(key)
+}
+
+// GetVersion returns the gravity binary version information.
+func (r *Router) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return r.Local.GetVersion(ctx)
 }

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/ops/opsclient"
@@ -1369,6 +1370,12 @@ func (o *Operator) GetClusterNodes(key ops.SiteKey) ([]ops.Node, error) {
 		})
 	}
 	return result, nil
+}
+
+// GetVersion returns the gravity binary version information.
+func (o *Operator) GetVersion(ctx context.Context) (*modules.Version, error) {
+	version := modules.Get().Version()
+	return &version, nil
 }
 
 func (o *Operator) openSite(key ops.SiteKey) (*site, error) {

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/storage"
@@ -47,10 +48,11 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		Cluster: &Cluster{
 			Domain: cluster.Domain,
 			// Default to degraded - reset on successful query
-			State:     ops.SiteStateDegraded,
-			Reason:    cluster.Reason,
-			App:       cluster.App.Package,
-			Extension: newExtension(),
+			State:         ops.SiteStateDegraded,
+			Reason:        cluster.Reason,
+			App:           cluster.App.Package,
+			ClientVersion: modules.Get().Version(),
+			Extension:     newExtension(),
 		},
 	}
 
@@ -60,6 +62,11 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 	if token != nil {
 		status.Token = *token
+	}
+
+	status.Cluster.ServerVersion, err = operator.GetVersion(ctx)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to query server version information.")
 	}
 
 	// Collect application endpoints.
@@ -197,6 +204,10 @@ type Cluster struct {
 	Endpoints Endpoints `json:"endpoints"`
 	// Extension is a cluster status extension
 	Extension `json:",inline,omitempty"`
+	// ServerVersion is version of the server the operator is talking to.
+	ServerVersion *modules.Version `json:"server_version,omitempty"`
+	// ClientVersion is version of the binary collecting the status.
+	ClientVersion modules.Version `json:"client_version"`
 }
 
 // Endpoints contains information about cluster and application endpoints.

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	statusapi "github.com/gravitational/gravity/lib/status"
@@ -286,11 +287,20 @@ func printStatusText(cluster clusterStatus) {
 	}
 }
 
+func formatVersion(version *modules.Version) string {
+	if version != nil {
+		return version.Version
+	}
+	return "n/a"
+}
+
 func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 	if cluster.App.Name != "" {
 		fmt.Fprintf(w, "Application:\t%v, version %v\n", cluster.App.Name,
 			cluster.App.Version)
 	}
+	fmt.Fprintf(w, "Gravity version:\t%v (client) / %v (server)\n",
+		cluster.ClientVersion.Version, formatVersion(cluster.ServerVersion))
 	if cluster.Token.Token != "" {
 		fmt.Fprintf(w, "Join token:\t%v\n", cluster.Token.Token)
 	}


### PR DESCRIPTION
https://github.com/gravitational/gravity/pull/1156 backport.