### PR TITLE
[6.1] Add client/server version to gravity status.

### DIFF
--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -1070,6 +1070,11 @@ func (o *OperatorACL) EmitAuditEvent(ctx context.Context, req AuditEventRequest)
 	return o.operator.EmitAuditEvent(ctx, req)
 }
 
+// GetVersion returns the server version information.
+func (o *OperatorACL) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return o.operator.GetVersion(ctx)
+}
+
 // CreateUserInvite creates a new invite token for a user.
 func (o *OperatorACL) CreateUserInvite(ctx context.Context, req CreateUserInviteRequest) (*storage.UserToken, error) {
 	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbUpdate); err != nil {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
@@ -682,6 +683,8 @@ type Status interface {
 	CheckSiteStatus(ctx context.Context, key SiteKey) error
 	// GetClusterNodes returns a real-time information about cluster nodes
 	GetClusterNodes(SiteKey) ([]Node, error)
+	// GetVersion returns the gravity binary version information.
+	GetVersion(context.Context) (*modules.Version, error)
 }
 
 // Node represents a cluster node information based on Teleport node

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/storage"
@@ -1556,6 +1557,19 @@ func (c *Client) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) 
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// GetVersion returns the server version information.
+func (c *Client) GetVersion(ctx context.Context) (*modules.Version, error) {
+	out, err := c.Get(ctx, c.Endpoint("version"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var version modules.Version
+	if err := json.Unmarshal(out.Bytes(), &version); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &version, nil
 }
 
 // PostJSON issues HTTP POST request to the server with the provided JSON data

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -1561,7 +1561,7 @@ func (c *Client) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) 
 
 // GetVersion returns the server version information.
 func (c *Client) GetVersion(ctx context.Context) (*modules.Version, error) {
-	out, err := c.Get(ctx, c.Endpoint("version"), url.Values{})
+	out, err := c.Get(c.Endpoint("version"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -101,6 +101,9 @@ func NewWebHandler(cfg WebHandlerConfig) (*WebHandler, error) {
 	// Report portal status
 	h.GET("/portal/v1/status", h.getStatus)
 
+	// Return server version
+	h.GET("/portal/v1/version", h.needsAuth(h.getVersion))
+
 	// Applications API
 	h.GET("/portal/v1/apps", h.needsAuth(h.getApps))
 	h.GET("/portal/v1/gravity", h.needsAuth(h.getGravityBinary))
@@ -338,6 +341,20 @@ func (h *WebHandler) getSiteInstructions(w http.ResponseWriter, r *http.Request,
 */
 func (h *WebHandler) getStatus(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{"status": "healthy"})
+}
+
+/*
+   getVersion returns the server version information.
+
+   GET /portal/v1/version
+*/
+func (h *WebHandler) getVersion(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
+	version, err := context.Operator.GetVersion(r.Context())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roundtrip.ReplyJSON(w, http.StatusOK, version)
+	return nil
 }
 
 /* getApps returns information about apps available for installation

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/storage"
@@ -889,6 +890,11 @@ func (r *Router) ListReleases(req ops.ListReleasesRequest) ([]storage.Release, e
 // EmitAuditEvent saves the provided event in the audit log.
 func (r *Router) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest) error {
 	return r.Local.EmitAuditEvent(ctx, req)
+}
+
+// GetVersion returns the gravity binary version information.
+func (r *Router) GetVersion(ctx context.Context) (*modules.Version, error) {
+	return r.Local.GetVersion(ctx)
 }
 
 // CreateUserInvite creates a new invite token for a user.

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/gravity/lib/helm"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/events"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
@@ -1439,6 +1440,12 @@ func (o *Operator) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// GetVersion returns the gravity binary version information.
+func (o *Operator) GetVersion(ctx context.Context) (*modules.Version, error) {
+	version := modules.Get().Version()
+	return &version, nil
 }
 
 func (o *Operator) openSite(key ops.SiteKey) (*site, error) {

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	statusapi "github.com/gravitational/gravity/lib/status"
@@ -286,11 +287,20 @@ func printStatusText(cluster clusterStatus) {
 	}
 }
 
+func formatVersion(version *modules.Version) string {
+	if version != nil {
+		return version.Version
+	}
+	return "n/a"
+}
+
 func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 	if cluster.App.Name != "" {
 		fmt.Fprintf(w, "Application:\t%v, version %v\n", cluster.App.Name,
 			cluster.App.Version)
 	}
+	fmt.Fprintf(w, "Gravity version:\t%v (client) / %v (server)\n",
+		cluster.ClientVersion.Version, formatVersion(cluster.ServerVersion))
 	if cluster.Token.Token != "" {
 		fmt.Fprintf(w, "Join token:\t%v\n", cluster.Token.Token)
 	}


### PR DESCRIPTION
https://github.com/gravitational/gravity/pull/1156 backport.