### PR TITLE
lib/systemservice: remove unused systemdUnit.servicePath()

### DIFF
--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -123,10 +123,6 @@ func (u *systemdUnit) serviceName() string {
 		systemdServiceDelimiter) + systemdUnitFileSuffix
 }
 
-func (u *systemdUnit) servicePath() string {
-	return unitPath(u.serviceName())
-}
-
 func (s *systemdManager) installService(service serviceTemplate, req NewServiceRequest) error {
 	if service.Environment == nil {
 		service.Environment = make(map[string]string)


### PR DESCRIPTION
This removes an unused function from `lib/systemservice`.