### PR TITLE
[5.5] Upgrade agents deployment improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -962,12 +962,12 @@
   revision = "cdbeea01bfdb0053a9defb1a1f0bfe5c89bc4c2f"
 
 [[projects]]
-  digest = "1:418247f700939c99867b42639d985686ba229fd9f8ee9e119c7cc3ffde6e0fe3"
+  digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a535a178675fb4a11ba74818491754a8c5575dd6"
-  version = "1.1.8"
+  revision = "42a8fffe760db82cf94b0c3e0112f91c3526a604"
+  version = "v1.1.9"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"
@@ -2654,6 +2654,7 @@
     "github.com/julienschmidt/httprouter",
     "github.com/kardianos/osext",
     "github.com/kylelemons/godebug/diff",
+    "github.com/mailgun/lemma/secret",
     "github.com/mailgun/timetools",
     "github.com/miekg/dns",
     "github.com/mitchellh/go-ps",
@@ -2713,6 +2714,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer/json",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",
@@ -2729,7 +2731,10 @@
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/helm/pkg/chartutil",
+    "k8s.io/helm/pkg/getter",
     "k8s.io/helm/pkg/helm",
+    "k8s.io/helm/pkg/helm/environment",
+    "k8s.io/helm/pkg/helm/helmpath",
     "k8s.io/helm/pkg/helm/portforwarder",
     "k8s.io/helm/pkg/kube",
     "k8s.io/helm/pkg/manifest",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  version = "=1.1.8"
+  version = "=1.1.9"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/lib/rpc/deploy.go
+++ b/lib/rpc/deploy.go
@@ -92,7 +92,7 @@ func (r *DeployAgentsRequest) CheckAndSetDefaults() error {
 		}
 	}
 	if r.Progress == nil {
-		r.Progress = utils.NewConsoleProgress(context.TODO(), "", 0)
+		r.Progress = utils.NewNopProgress()
 	}
 	return nil
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -44,6 +44,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 	"github.com/tstranex/u2f"
 	"k8s.io/helm/pkg/repo"
 )
@@ -1598,6 +1599,11 @@ func (s *Server) KubeNodeID() string {
 // IsMaster returns true if the server has a master role
 func (s *Server) IsMaster() bool {
 	return s.ClusterRole == string(schema.ServiceRoleMaster)
+}
+
+// Fields returns log fields describing the server.
+func (s *Server) Fields() logrus.Fields {
+	return logrus.Fields{"hostname": s.Hostname, "ip": s.AdvertiseIP}
 }
 
 // Strings formats this server as readable text

--- a/lib/system/fs_test.go
+++ b/lib/system/fs_test.go
@@ -63,7 +63,7 @@ xfs
 		},
 		{
 			lsblk:   failingRunner{trace.Errorf("error")},
-			err:     `error, failed to determine filesystem type on /dev/foo: error`,
+			err:     "failed to determine filesystem type on /dev/foo: error\n\terror",
 			comment: "lsblk fails",
 		},
 	}

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -174,7 +174,7 @@ func RetryOnNetworkError(period time.Duration, maxAttempts int, fn func() error)
 		case *net.OpError:
 			return Continue("network error: %v", err)
 		}
-		if trace.IsConnectionProblem(err) {
+		if trace.IsConnectionProblem(err) || trace.IsEOF(err) {
 			return Continue("network error: %v", err)
 		}
 		if err != nil {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -312,8 +312,8 @@ func checkForUpdate(
 		return nil, trace.Wrap(err)
 	}
 
-	env.Printf("updating %v from %v to %v\n",
-		updateApp.Package.Name, installedPackage.Version, updateApp.Package.Version)
+	env.PrintStep("Upgrading cluster from %v to %v", installedPackage.Version,
+		updateApp.Package.Version)
 
 	return updateApp, nil
 }

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -175,7 +175,7 @@ func newCollector(env *localenv.LocalEnvironment) (*vacuum.Collector, error) {
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
 	}
-	creds, err := deployAgents(ctx, req)
+	creds, err := deployAgents(ctx, env, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -293,6 +293,7 @@ func newDeployAgentsRequest(ctx context.Context, req deployAgentsRequest) (*rpc.
 		LeaderParams:   req.leaderParams,
 		Leader:         req.leader,
 		NodeParams:     req.nodeParams,
+		Progress:       utils.NewConsoleProgress(ctx, "", 0),
 	}, nil
 }
 

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -187,7 +187,7 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 
 	localCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)
 	defer cancel()
-	return deployAgents(localCtx, req)
+	return deployAgents(localCtx, localEnv, req)
 }
 
 func verifyCluster(ctx context.Context,
@@ -246,8 +246,8 @@ func upsertRPCCredentialsPackage(
 	return secretsPackage, nil
 }
 
-func deployAgents(ctx context.Context, req deployAgentsRequest) (credentials.TransportCredentials, error) {
-	deployReq, err := newDeployAgentsRequest(ctx, req)
+func deployAgents(ctx context.Context, env *localenv.LocalEnvironment, req deployAgentsRequest) (credentials.TransportCredentials, error) {
+	deployReq, err := newDeployAgentsRequest(ctx, env, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -266,7 +266,7 @@ func deployAgents(ctx context.Context, req deployAgentsRequest) (credentials.Tra
 }
 
 // newDeployAgentsRequest creates a new request to deploy agents on the local cluster
-func newDeployAgentsRequest(ctx context.Context, req deployAgentsRequest) (*rpc.DeployAgentsRequest, error) {
+func newDeployAgentsRequest(ctx context.Context, env *localenv.LocalEnvironment, req deployAgentsRequest) (*rpc.DeployAgentsRequest, error) {
 	servers, err := verifyCluster(ctx, req.clusterState, req.proxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -293,7 +293,7 @@ func newDeployAgentsRequest(ctx context.Context, req deployAgentsRequest) (*rpc.
 		LeaderParams:   req.leaderParams,
 		Leader:         req.leader,
 		NodeParams:     req.nodeParams,
-		Progress:       utils.NewConsoleProgress(ctx, "", 0),
+		Progress:       utils.NewProgress(ctx, "", 0, bool(env.Silent)),
 	}, nil
 }
 

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -254,7 +254,7 @@ func deployAgents(ctx context.Context, req deployAgentsRequest) (credentials.Tra
 
 	err = rpc.DeployAgents(ctx, *deployReq)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to deploy agents")
+		return nil, trace.Wrap(err)
 	}
 
 	clientCreds, err := getClientCredentials(ctx, req.clusterEnv.ClusterPackages, deployReq.SecretsPackage)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
@@ -81,6 +82,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 			// agents may have started so we need to shut them down. If they're
 			// not running, it will be no-op so there's no harm in running this
 			// even if we failed before deploying the agents.
+			localEnv.PrintStep(color.YellowString("Encountered error, will shutdown agents"))
 			if errShutdown := rpcAgentShutdown(localEnv); errShutdown != nil {
 				logger.WithError(errShutdown).Warn("Failed to shutdown upgrade agents.")
 			}
@@ -120,8 +122,8 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	})
 	deployCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)
 	defer cancel()
-	logger.WithField("request", req).Debug("Deploying agents on nodes.")
-	localEnv.Println("Deploying agents on nodes")
+	logger.WithField("request", req).Debug("Deploying agents on cluster nodes.")
+	localEnv.PrintStep("Deploying agents on cluster nodes")
 	creds, err := deployAgents(deployCtx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -124,7 +124,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	defer cancel()
 	logger.WithField("request", req).Debug("Deploying agents on cluster nodes.")
 	localEnv.PrintStep("Deploying agents on cluster nodes")
-	creds, err := deployAgents(deployCtx, req)
+	creds, err := deployAgents(deployCtx, localEnv, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR addresses a number of issues with upgrade agents deployment we discovered during a recent support call and adds a few improvements/niceties as well. So, in no particular order:

* Make sure the "main" upgrade agent that runs automatic operation does not commence the operation until all other agents are available.
* Make deployment of a single agent more resilient by retrying on networking errors. I've tested this by playing with iptables ability to randomly drop packets.
* Make sure that if the upgrade operation fails to initialize (e.g. to deploy one of agents), all agents are shut down. Previously they were kept lingering even though the operation was canceled.
* Various CLI and logging polish: make output more consistent and also a progress message is now printed when an agent is successfully deployed.
* Upgrade trace library to take advantage of improved output of wrapped errors I did a couple of months ago.

Needs forward-ports everywhere. Closes https://github.com/gravitational/gravity/issues/1065.