### PR TITLE
[5.5.x] fix version script to carefully consider commits since last tag

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
+set -Euo pipefail
 
-# this versioning algo:
-# keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+# versioning algorithm:
+# keep tag as is in case if this version is an equal match or number of commits are 0
+# otherwise add .<number of commits since last tag> or -<number of commits since last tag> (depending on the prerelease info)
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
-COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
+COMMITS_SINCE_LAST_TAG=`git rev-list ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
 if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+    echo "$SHORT_TAG"
+elif [[ "$COMMITS_SINCE_LAST_TAG" == "0" ]] ; then
     echo "$SHORT_TAG"
 elif [[ "$SHORT_TAG" != *-* ]] ; then
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"


### PR DESCRIPTION
Update the version script to avoid adding 0 commits since last tag to fix forming versions like '5.5.37-0'.
The last 5.5.x release is building to an invalid bucket because of this.

Needs forward ports.