### PR TITLE
[5.5.x] Adjust patch versioning strategy.

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -2,8 +2,12 @@
 
 # this versioning algo:
 #  - if on a tagged commit, use the tag
-#  - if last tag was a regular relase, bump the minor version, make a it pre-release, and append # of commits since tag
-#  - if last tag was a pre-release tag, append number of commits since the tag
+#    e.g. 6.2.18 (for the commit tagged 6.2.18)
+#  - if last tag was a regular release, bump the minor version, make a it a 'dev' pre-release, and append # of commits since tag
+#    e.g. 5.5.38-dev.5 (for 5 commits after 5.5.37)
+#  - if last tag was a pre-release tag (e.g. alpha, beta, rc), append number of commits since the tag
+#    e.g. 7.0.0-alpha.1.5 (for 5 commits after 7.0.0-alpha.1)
+
 
 increment_patch() {
     # increment_patch returns x.y.(z+1) given valid x.y.z semver.
@@ -26,7 +30,7 @@ if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then  # the current commit is tagged as a
     echo "$SHORT_TAG"
 elif [[ "$SHORT_TAG" != *-* ]] ; then  # the current ref is not a decendent of a pre-release version
     SHORT_TAG=$(increment_patch ${SHORT_TAG})
-    echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 else  # the current ref is a decendent of a pre-release version (e.g. already an rc, alpha, or beta)
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,18 +1,32 @@
 #!/bin/bash
 
 # this versioning algo:
-# keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+#  - if on a tagged commit, use the tag
+#  - if last tag was a regular relase, bump the minor version, make a it pre-release, and append # of commits since tag
+#  - if last tag was a pre-release tag, append number of commits since the tag
+
+increment_patch() {
+    # increment_patch returns x.y.(z+1) given valid x.y.z semver.
+    # If we need to robustly handle this, it is probably worth
+    # looking at https://github.com/davidaurelio/shell-semver/
+    # or moving this logic to a 'real' programming language -- 2020-03 walt
+    major=$(echo $1 | cut -d'.' -f1)
+    minor=$(echo $1 | cut -d'.' -f2)
+    patch=$(echo $1 | cut -d'.' -f3)
+    patch=$((patch + 1))
+    echo "${major}.${minor}.${patch}"
+}
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git rev-list -n1 ${SHORT_TAG}`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
-if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
-elif [[ "$SHORT_TAG" != *-* ]] ; then
+elif [[ "$SHORT_TAG" != *-* ]] ; then  # the current ref is not a decendent of a pre-release version
+    SHORT_TAG=$(increment_patch ${SHORT_TAG})
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
-else
+else  # the current ref is a decendent of a pre-release version (e.g. already an rc, alpha, or beta)
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -6,7 +6,7 @@
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
-COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
+COMMIT_WITH_LAST_TAG=`git rev-list -n1 ${SHORT_TAG}`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
 if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then


### PR DESCRIPTION
After discovering that upgrading from `5.5.37` to the latest build of `5.5.x` was not possible and discussing with @r0mant, I believe that our patch version should increment as soon as we're one commit past a tagged release.  As discussed at https://semver.org/#spec-item-9, the ordering would now be:

5.5.37 < 5.5.38-dev.10 < 5.5.38

As opposed to our previous

5.5.37-10 < 5.5.37 < 5.5.38

Where 5.5.37-10 is intended to denote 10 commits after 5.5.37.

If you're hesitant about the `dev` pre-release tag or the `+sha` build metadata (now removed from this PR), I specifically factored these out into ac0c996  and 4bf85f0, such that we can pick and choose.  The commit messages have context on why I chose to add each of these.

**Notes:** 

The first commit in this stack fixes a latent bug we had where we were incorrectly handling lightweight tags as opposed to annotated tags.  This bug was the root cause of #1176.

For the 5.5.37 -> 5.5.x-latest upgrade failures, see [this jenkins job](https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/8/console) or [these stackdriver logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-02-28T00:01:38.741089370Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22dee502ee-6ffd-4214-b322-ad6624ff2ec7%22%0Alabels.__suite__%3D%224e0bc64a-7bf2-4658-91d2-ff3f669999d7%22%0Aseverity%3E%3DINFO%0AjsonPayload.logs%3D%22https:%2F%2Fconsole.cloud.google.com%2Flogs%2Fviewer%3FadvancedFilter%3Dresource.type%253D%2522project%2522%250Alabels.__uuid__%253D%2522dee502ee-6ffd-4214-b322-ad6624ff2ec7%2522%250Alabels.__suite__%253D%25224e0bc64a-7bf2-4658-91d2-ff3f669999d7%2522%250Aseverity%253E%253DINFO%26authuser%3D1%26expandAll%3Dfalse%26project%3Dkubeadm-167321%22&dateRangeEnd=2020-03-02T18:55:13.487Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-02-28T00:01:38.740883669Z).

This PR likely supersedes the work in #1176.

Once I've got buy off on the right path forward, I'll port this change to all other active release branches.

**Testing:**

Build:
```
walt@work:~/git/gravity$ make                                                                                                                                                                 
make -C build.assets build                                                                                                                                                                    
make[1]: Entering directory '/home/walt/git/gravity/build.assets'                                                                                                                             
make[2]: Entering directory '/home/walt/git/gravity/build.assets'                                                                                                                             
# snip lots...
make: Leaving directory '/gopath/src/github.com/gravitational/gravity/build.assets'
make[2]: Leaving directory '/home/walt/git/gravity/build.assets'
make[1]: Leaving directory '/home/walt/git/gravity/build.assets'
walt@work:~/git/gravity$ ./build/5.5.38-dev.9+ac0c996e/tele version
Edition:        open-source
Version:        5.5.38-dev.9+ac0c996e
Git Commit:     ac0c996ee4ba7169a80117de263331912f5e06c6
Helm Version:   v2.12
walt@work:~/git/gravity$ ./build/5.5.38-dev.9+ac0c996e/gravity version
Edition:        open-source
Version:        5.5.38-dev.9+ac0c996e
Git Commit:     ac0c996ee4ba7169a80117de263331912f5e06c6
Helm Version:   v2.12

```

Various versions:
```
walt@work:~/git/gravity$ git checkout version-fix
Switched to branch 'version-fix'
walt@work:~/git/gravity$ ./version.sh
5.5.38-dev.10+4bf85f07

# master (at a tag)

walt@work:~/git/gravity$ cp version.sh version.sh.bak
walt@work:~/git/gravity$ git checkout master
M       e
Switched to branch 'master'
Your branch is up to date with 'grav/master'.
walt@work:~/git/gravity$ cp version.sh.bak version.sh
walt@work:~/git/gravity$ ./version.sh
7.0.0-beta.1


# master+1 (version after a tagged pre-release)

walt@work:~/git/gravity$ touch foo && git add foo && git commit -m throwaway
[master 7da73beb] throwaway
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 foo
walt@work:~/git/gravity$ ./version.sh                                       
7.0.0-beta.1.1+7da73beb
walt@work:~/git/gravity$ git reset --hard HEAD^                             
HEAD is now at 229a0f96 Update e ref. (#1171)


# 6.0.x

walt@work:~/git/gravity$ git checkout version/6.0.x 
M       e
Branch 'version/6.0.x' set up to track remote branch 'version/6.0.x' from 'grav'.
Switched to a new branch 'version/6.0.x'
walt@work:~/git/gravity$ cp version.sh.bak version.sh                       
walt@work:~/git/gravity$ ./version.sh
6.0.11-dev.1+30e85f11
```