### PR TITLE
Add gravity to release tarball.

### DIFF
--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -40,6 +40,8 @@ What are these binaries?
   Gravity clusters and installed applications.
 * `tsh` is a tool to remotely connect to clusters created from the images.
   tsh supports both SSH and Kubernetes API.
+* `terraform-provider-gravity` is a Terraform plugin used to support management
+  of open-source Gravity clusters.
 
 See the quick start to learn how to use these tools:
 https://gravitational.com/gravity/docs/quickstart/

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -16,10 +16,10 @@ Introduction
 ============
 Gravity is an open source toolkit for creating "images" of Kubernetes
 clusters and the applications running inside the clusters. The resulting
-images are called *application bundles* and they are just `.tar` files.
+images are called *cluster or application images* and they are just `.tar` files.
 
-An application bundle can be used to re-create full replicas of the original
-cluster in any environment where compliance and consistency matters, i.e. in 
+A cluster image can be used to re-create full replicas of the original
+cluster in any environment where compliance and consistency matters, i.e. in
 locked-down AWS/GCE/Azure environments or even in air-gapped server rooms. A
 bundle can run without human supervision, as a "kubernetes appliance".
 
@@ -30,13 +30,14 @@ fall of 2018.
 Installing
 ==========
 
-Execute `./install.sh` script as root. It will copy `tele` and `tsh` binaries
-into `/usr/local/bin`.
+Execute `./install.sh` script as root. It will copy `tele`, `gravity` and `tsh`
+binaries into `/usr/local/bin`.
 
 What are these binaries?
 
-* `tele` is a tool to build cluster images. These images will contain
-  a Kubernetes installer.
+* `tele` is a tool to build cluster and application images.
+* `gravity` is a tool to install cluster and application images and manage
+  Gravity clusters and installed applications.
 * `tsh` is a tool to remotely connect to clusters created from the images.
   tsh supports both SSH and Kubernetes API.
 

--- a/build.assets/install.sh
+++ b/build.assets/install.sh
@@ -2,8 +2,8 @@
 set -e
 
 #
-# the directory where Gravity binaries will be located
+# The directory where Gravity binaries will be located.
 #
 BINDIR=/usr/local/bin
 
-sudo cp -f tele tsh $BINDIR
+sudo cp -f tele tsh gravity $BINDIR

--- a/build.assets/release.sh
+++ b/build.assets/release.sh
@@ -9,9 +9,10 @@ trap "rm -rf ${TEMP_DIR}" exit
 # LICENSE
 # README.md
 # tele
+# gravity
 # tsh
 # VERSION
-cp ${TSH_OUT} ${TELE_OUT} install.sh README.md ../LICENSE ${TEMP_DIR}
+cp ${GRAVITY_OUT} ${TSH_OUT} ${TELE_OUT} install.sh README.md ../LICENSE ${TEMP_DIR}
 ../version.sh > ${TEMP_DIR}/VERSION
 
 tar -C ${TEMP_DIR} -zcvf ${RELEASE_OUT} .

--- a/build.assets/release.sh
+++ b/build.assets/release.sh
@@ -10,9 +10,10 @@ trap "rm -rf ${TEMP_DIR}" exit
 # README.md
 # tele
 # gravity
+# terraform-provider-gravity
 # tsh
 # VERSION
-cp ${GRAVITY_OUT} ${TSH_OUT} ${TELE_OUT} install.sh README.md ../LICENSE ${TEMP_DIR}
+cp ${GRAVITY_OUT} ${TSH_OUT} ${TELE_OUT} ${TF_PROVIDER_GRAVITY_OUT} install.sh README.md ../LICENSE ${TEMP_DIR}
 ../version.sh > ${TEMP_DIR}/VERSION
 
 tar -C ${TEMP_DIR} -zcvf ${RELEASE_OUT} .

--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -1109,7 +1109,7 @@ fi
 
 URL=https://get.gravitational.io/telekube/bin/{{.version}}/$OS/$ARCH
 
-for BINARY in tele tsh; do
+for BINARY in tele gravity tsh; do
     echo "Downloading $BINARY..."
     rm -f $BINARY
     curl -sOfL $URL/$BINARY


### PR DESCRIPTION
Add `gravity` binary to the release tarball users download from our Downloads page.

I also added it to the enterprise installer script - I realize this won't actually have effect until we somehow manage to upgrade our get.gravitational.io, but I figured I'd add it there anyway.

About https://github.com/gravitational/gravity/issues/1189.