### PR TITLE
[5.5] extend upgrade matrix

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -5,10 +5,21 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 DOCKER_STORAGE_DRIVERS="overlay2"
 
+# UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# gravity version -> list of OS releases to test upgrades on
+# latest patch release on compatible LTS, keep these up to date
+UPGRADE_MAP[5.5.37]="centos:7 ubuntu:16"
 UPGRADE_MAP[5.2.16]="centos:7 ubuntu:16"
+
+# via intermediate upgrade
 UPGRADE_MAP[5.0.35]="debian:9 ubuntu:16"
+
+# important versions in the field
+UPGRADE_MAP[5.2.12]="ubuntu:16"
+UPGRADE_MAP[5.5.19]="ubuntu:16"
+UPGRADE_MAP[5.5.20]="ubuntu:16"
+UPGRADE_MAP[5.5.28]="ubuntu:16"
+UPGRADE_MAP[5.5.36]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -7,7 +7,7 @@ DOCKER_STORAGE_DRIVERS="overlay2"
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to test upgrades on
-UPGRADE_MAP[5.2.15]="centos:7 ubuntu:16"
+UPGRADE_MAP[5.2.16]="centos:7 ubuntu:16"
 UPGRADE_MAP[5.0.35]="debian:9 ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -3,10 +3,21 @@ set -eu -o pipefail
 
 readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
+# UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# gravity version -> list of OS releases to exercise on
+# latest patch release on compatible LTS, keep these up to date
+UPGRADE_MAP[5.5.37]="ubuntu:16"
 UPGRADE_MAP[5.2.16]="ubuntu:16"
+
+# via intermediate upgrade
 UPGRADE_MAP[5.0.35]="ubuntu:16"
+
+# important versions in the field
+UPGRADE_MAP[5.2.12]="ubuntu:16"
+UPGRADE_MAP[5.5.19]="ubuntu:16"
+UPGRADE_MAP[5.5.20]="ubuntu:16"
+UPGRADE_MAP[5.5.28]="ubuntu:16"
+UPGRADE_MAP[5.5.36]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -5,7 +5,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to exercise on
-UPGRADE_MAP[5.2.15]="ubuntu:16"
+UPGRADE_MAP[5.2.16]="ubuntu:16"
 UPGRADE_MAP[5.0.35]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}


### PR DESCRIPTION
**Attention:** This work is dependent on #1179.  The `5.5.37` -> `5.5.x-latest` upgrade scenario is expected to fail without that work.  Please go review that first, if it isn't yet merged.

This PR adds several new upgrade scenarios to our 5.5.x branch, increasing our coverage for key gravity versions deployed in the field.  This gets us most of the value of https://github.com/gravitational/robotest/issues/155 without requiring any substantial development.

Testing done:

I successfully ran a version of this patch rebased on top of #1179 here:

https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/21/

Note: This work increases PR build time to almost 2 hours!  This sucks.  I'd like to keep PR builds under an hour, if possible.  We may look at bumping concurrency further:

https://github.com/gravitational/gravity/blob/20c2bc373ae33f0a401d5eed78ba9d9f8e1256be/Jenkinsfile#L33-L35

I haven't found the priority to look into that yet though.  I suspect 4 simultaneous tests may be tuned to the capacity of our GCE account.  Do you know where 4 comes from @a-palchikov (or anyone else)?