### PR TITLE
Default to tele version during tele pull.

### DIFF
--- a/lib/hub/hub.go
+++ b/lib/hub/hub.go
@@ -199,7 +199,7 @@ func (h *s3Hub) Download(f *os.File, locator loc.Locator) (err error) {
 	if err != nil {
 		err := utils.ConvertS3Error(err)
 		if trace.IsNotFound(err) {
-			return trace.NotFound("application %v:%v not found in %v, use 'tele ls' to see available applications",
+			return trace.NotFound("image %v:%v not found in %v, use 'tele ls' to see available images",
 				locator.Name, locator.Version, h.Bucket)
 		}
 		return trace.Wrap(err)

--- a/lib/hub/hub.go
+++ b/lib/hub/hub.go
@@ -199,7 +199,7 @@ func (h *s3Hub) Download(f *os.File, locator loc.Locator) (err error) {
 	if err != nil {
 		err := utils.ConvertS3Error(err)
 		if trace.IsNotFound(err) {
-			return trace.NotFound("image %v:%v not found in %v, use 'tele ls' to see available images",
+			return trace.NotFound("image %v:%v not found in %v, use 'tele ls -a' to see available images",
 				locator.Name, locator.Version, h.Bucket)
 		}
 		return trace.Wrap(err)

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -198,7 +198,9 @@ func (s *LocatorSuite) TestMakeLocator(c *C) {
 		var loc *Locator
 		var err error
 		if test.version != "" {
-			loc, err = MakeLocatorWithDefault(test.input, test.version)
+			loc, err = MakeLocatorWithDefault(test.input, func(name string) string {
+				return test.version
+			})
 		} else {
 			loc, err = MakeLocator(test.input)
 		}

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/compare"
 
+	"github.com/gravitational/trace"
 	. "gopkg.in/check.v1"
 )
 
@@ -75,8 +76,8 @@ func (s *LocatorSuite) TestLocatorFail(c *C) {
 		"example:0.0.1",                 // missing repository
 		"example.com/example:blabla",    // not a sem ver
 		"example.com/example com:0.0.2", // unallowed chars
-		"", //emtpy
-		"arffewfaef aefeafaesf e", //garbage
+		"",                              //emtpy
+		"arffewfaef aefeafaesf e",       //garbage
 		"-:.",
 	}
 	for i, tc := range tcs {
@@ -154,4 +155,58 @@ func (s *LocatorSuite) TestDeduplicate(c *C) {
 		MustParseLocator("test3/qux:1.0.0"),
 	}
 	c.Assert(uniq, compare.DeepEquals, expected)
+}
+
+func (s *LocatorSuite) TestMakeLocator(c *C) {
+	tests := []struct {
+		input   string
+		version string
+		error   error
+		output  string
+	}{
+		{
+			input:  "gravity",
+			output: "gravitational.io/gravity:0.0.0+latest",
+		},
+		{
+			input:  "gravity:0.0.1",
+			output: "gravitational.io/gravity:0.0.1",
+		},
+		{
+			input:  "gravitational.io/gravity:0.0.2",
+			output: "gravitational.io/gravity:0.0.2",
+		},
+		{
+			input:   "gravity",
+			version: "1.0.0",
+			output:  "gravitational.io/gravity:1.0.0",
+		},
+		{
+			input:  "gravity:latest",
+			output: "gravitational.io/gravity:0.0.0+latest",
+		},
+		{
+			input:  "gravity:stable",
+			output: "gravitational.io/gravity:0.0.0+stable",
+		},
+		{
+			input: "gravity:0.0.1:1.0.0",
+			error: trace.BadParameter(""),
+		},
+	}
+	for _, test := range tests {
+		var loc *Locator
+		var err error
+		if test.version != "" {
+			loc, err = MakeLocatorWithDefault(test.input, test.version)
+		} else {
+			loc, err = MakeLocator(test.input)
+		}
+		if test.error != nil {
+			c.Assert(err, FitsTypeOf, test.error)
+		} else {
+			c.Assert(err, IsNil)
+			c.Assert(loc.String(), Equals, test.output)
+		}
+	}
 }

--- a/lib/loc/make.go
+++ b/lib/loc/make.go
@@ -58,5 +58,5 @@ func MakeLocatorWithDefault(app, defaultVersion string) (*Locator, error) {
 		}
 		return NewLocator(defaults.SystemAccountOrg, parts[0], version)
 	}
-	return nil, trace.BadParameter("invalid app name format: %v, should be: 'repo/name:ver' or 'name:ver' or 'name'", app)
+	return nil, trace.BadParameter("invalid package name format %q, expected 'repository/name:version' or 'name:version' or 'name'", app)
 }

--- a/lib/loc/make.go
+++ b/lib/loc/make.go
@@ -30,13 +30,23 @@ import (
 //  - if it's in the 'name:ver' format, returns locator with system repo (systemrepo/name:ver)
 //  - if it's in the 'name' format, returns locator with system repo and latest meta-version (systemrepo/name:0.0.0+latest)
 func MakeLocator(app string) (*Locator, error) {
+	return MakeLocatorWithDefault(app, "")
+}
+
+// MakeLocatorWithDefault is like MakeLocator but uses the provided default
+// version if the one isn't specified explicitly, instead of defaulting to
+// the latest.
+func MakeLocatorWithDefault(app, defaultVersion string) (*Locator, error) {
 	locator, err := ParseLocator(app)
 	if err == nil {
 		return locator, nil
 	}
+	if defaultVersion == "" {
+		defaultVersion = LatestVersion
+	}
 	parts := strings.Split(app, ":")
 	if len(parts) == 1 {
-		return NewLocator(defaults.SystemAccountOrg, app, LatestVersion)
+		return NewLocator(defaults.SystemAccountOrg, app, defaultVersion)
 	}
 	if len(parts) == 2 {
 		version := parts[1]
@@ -48,6 +58,5 @@ func MakeLocator(app string) (*Locator, error) {
 		}
 		return NewLocator(defaults.SystemAccountOrg, parts[0], version)
 	}
-	return nil, trace.BadParameter(
-		"invalid app name format: %v, should be: 'repo/name:ver' or 'name:ver' or 'name'", app)
+	return nil, trace.BadParameter("invalid app name format: %v, should be: 'repo/name:ver' or 'name:ver' or 'name'", app)
 }

--- a/tool/tele/cli/pull.go
+++ b/tool/tele/cli/pull.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/hub"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -43,7 +44,7 @@ func NewProgress(ctx context.Context, title string, silent bool) utils.Progress 
 }
 
 func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool) error {
-	locator, err := loc.MakeLocator(app)
+	locator, err := loc.MakeLocatorWithDefault(app, modules.Get().Version().Version)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tele/cli/pull.go
+++ b/tool/tele/cli/pull.go
@@ -43,8 +43,22 @@ func NewProgress(ctx context.Context, title string, silent bool) utils.Progress 
 	})
 }
 
+// MakeLocator creates locator from the provided application package name.
+func MakeLocator(app string) (*loc.Locator, error) {
+	return loc.MakeLocatorWithDefault(app, func(name string) string {
+		switch name {
+		case constants.BaseImageName, constants.LegacyBaseImageName, constants.HubImageName, constants.LegacyHubImageName:
+			// For system images (base and hub) default to tele version for compatibility.
+			return modules.Get().Version().Version
+		default:
+			// For everything else (user images) default to the latest.
+			return loc.LatestVersion
+		}
+	})
+}
+
 func pull(env localenv.LocalEnvironment, app, outFile string, force, quiet bool) error {
-	locator, err := loc.MakeLocatorWithDefault(app, modules.Get().Version().Version)
+	locator, err := MakeLocator(app)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Make sure that when a user does `tele pull gravity`, it defaults to the version of tele itself, same behavior as with tele build. Otherwise it defaults to the latest version and pulls an alpha (it will still pull an alpha if tele itself is alpha, but if tele is, say, 7.0.0, it will pull that).

Closes https://github.com/gravitational/gravity/issues/1181.