### PR TITLE
Forward-port improvements in terraform-dev from version/5.5.x

### DIFF
--- a/terraform-dev/Makefile
+++ b/terraform-dev/Makefile
@@ -1,8 +1,9 @@
 IMAGEURL := https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img
 CPU_COUNT ?= 1
-GRAVITY_DIR_SIZE ?= 12000000000
+DISK_SIZE ?= 15000000000
 OS ?= ubuntu
 ANSIBLE_EXTRA_VARS ?=
+NODES_COUNT ?= 3
 
 ifeq ($(OS), centos)
 	IMAGEURL=https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1907.qcow2
@@ -10,7 +11,7 @@ endif
 
 IMAGENAME := $(shell basename $(IMAGEURL))
 TF_VARIABLES := TF_VAR_image_name=$(IMAGENAME) TF_VAR_cpu_count=$(CPU_COUNT)\
-	TF_VAR_gravity_dir_size=$(GRAVITY_DIR_SIZE) TF_VAR_username=$(OS)
+	TF_VAR_disk_size=$(DISK_SIZE) TF_VAR_username=$(OS) TF_VAR_nodes_count=$(NODES_COUNT)
 
 .PHONY: all
 all: apply install

--- a/terraform-dev/cloudinit.cfg
+++ b/terraform-dev/cloudinit.cfg
@@ -1,0 +1,44 @@
+#cloud-config
+packages: [python, curl, htop, iotop, lsof, ltrace, mc, net-tools, strace, tcpdump, telnet, vim, wget, ntp, traceroute, bash-completion]
+ssh_authorized_keys: ["${file("ssh/key.pub")}"]
+manage_resolv_conf: true
+resolv_conf:
+  nameservers: ['8.8.4.4', '8.8.8.8', '1.1.1.1']
+  options:
+    rotate: true
+bootcmd:
+- echo ${ip_address} ${hostname} >> /etc/hosts
+hostname: "${hostname}"
+write_files:
+- content: "br_netfilter"
+  path: /etc/modules-load.d/br_netfilter.conf
+- content: "ebtables"
+  path: /etc/modules-load.d/ebtables.conf
+- content: "overlay"
+  path: /etc/modules-load.d/overlay.conf
+- content: |
+    ip_tables
+    iptable_nat
+    iptable_filter
+  path: /etc/modules-load.d/iptables.conf
+- content: |
+    net.bridge.bridge-nf-call-arptables=1
+    net.bridge.bridge-nf-call-ip6tables=1
+    net.bridge.bridge-nf-call-iptables=1
+  path: /etc/sysctl.d/10-br-netfilter.conf
+- content: |
+    net.ipv4.ip_forward=1
+  path: /etc/sysctl.d/10-ipv4-forwarding-on.conf
+- content: |
+    fs.may_detach_mounts=1
+  path: /etc/sysctl.d/10-fs-may-detach-mounts.conf
+runcmd:
+- 'modprobe overlay'
+- 'modprobe br_netfilter'
+- 'modprobe ebtables'
+- 'modprobe ip_tables'
+- 'modprobe iptable_nat'
+- 'modprobe iptable_filter'
+- 'sysctl -p /etc/sysctl.d/10-br-netfilter.conf'
+- 'sysctl -p /etc/sysctl.d/10-ipv4-forwarding-on.conf'
+- 'if [ -f /proc/sys/fs/may_detach_mounts ]; then sysctl -p /etc/sysctl.d/10-fs-may-detach-mounts.conf; fi'

--- a/terraform-dev/cluster.tf
+++ b/terraform-dev/cluster.tf
@@ -1,11 +1,11 @@
 variable "image_name" {
   type = "string"
-  default = "ubuntu-16.04-server-cloudimg-amd64-disk1.img"
+  default = "ubuntu-18.04-server-cloudimg-amd64.img"
 }
 
-variable "gravity_dir_size" {
+variable "disk_size" {
   type = "string"
-  default = "12000000000"
+  default = "15000000000"
 }
 
 variable "memory_size" {
@@ -18,6 +18,11 @@ variable "cpu_count" {
   default = "1"
 }
 
+variable "nodes_count" {
+  type = "string"
+  default = "3"
+}
+
 # Initialize the provider
 provider "libvirt" {
   uri = "qemu:///system"
@@ -25,101 +30,39 @@ provider "libvirt" {
 
 # Use locally pre-fetched image
 resource "libvirt_volume" "os-qcow2" {
-  name = "os-${count.index}-qcow2"
+  name = "os-disk-${count.index}.qcow2"
   pool = "default"
   source = "/var/lib/libvirt/images/${var.image_name}"
-  format = "qcow2"
-  count = 3
+  format = "raw"
+  count = "${var.nodes_count}"
 }
 
 # Create a network for our VMs
 resource "libvirt_network" "vm_network" {
    name = "vm_network"
    addresses = ["172.28.128.0/24"]
+   dns {
+     enabled = true
+     local_only = false
+   }
 }
 
-# 12 GB volume for gravity install
-resource "libvirt_volume" "gravity" {
-  name = "gravity-disk-${count.index}.qcow2"
+resource "libvirt_volume" "root" {
+  name = "root-disk-${count.index}.qcow2"
+  base_volume_id = "${element(libvirt_volume.os-qcow2.*.id, count.index)}"
   pool = "default"
-  size = "${var.gravity_dir_size}"
-  count = 3
-}
-
-# 12 GB volume for tmp
-resource "libvirt_volume" "tmp" {
-  name = "gravity-tmp-disk-${count.index}.qcow2"
-  pool = "default"
-  size = 12000000000
-  count = 3
+  size = "${var.disk_size}"
+  count = "${var.nodes_count}"
 }
 
 # Use CloudInit to add our ssh-key to the instance
 resource "libvirt_cloudinit_disk" "commoninit" {
-  name           = "commoninit.iso"
-  user_data = <<EOF
-    #cloud-config
-    packages: [python, curl, htop, iotop, lsof, ltrace, mc, net-tools, strace, tcpdump, telnet, vim, wget, ntp, traceroute, bash-completion]
-    ssh_authorized_keys: ["${file("ssh/key.pub")}"]
-    write_files:
-    - content: "br_netfilter"
-      path: /etc/modules-load.d/br_netfilter.conf
-    - content: "ebtables"
-      path: /etc/modules-load.d/ebtables.conf
-    - content: "overlay"
-      path: /etc/modules-load.d/overlay.conf
-    - content: |
-        ip_tables
-        iptable_nat
-        iptable_filter
-      path: /etc/modules-load.d/iptables.conf
-    - content: |
-        net.bridge.bridge-nf-call-arptables=1
-        net.bridge.bridge-nf-call-ip6tables=1
-        net.bridge.bridge-nf-call-iptables=1
-      path: /etc/sysctl.d/10-br-netfilter.conf
-    - content: |
-        net.ipv4.ip_forward=1
-      path: /etc/sysctl.d/10-ipv4-forwarding-on.conf
-    - content: |
-        fs.may_detach_mounts=1
-      path: /etc/sysctl.d/10-fs-may-detach-mounts.conf
-    disk_setup:
-      /dev/vdb:
-        table_type: mbr
-        layout:
-          - 100
-        overwrite: true
-      /dev/vdc:
-        table_type: mbr
-        layout:
-          - 100
-        overwrite: true
-    fs_setup:
-      - device: /dev/vdb
-        partition: 1
-        filesystem: ext4
-      - device: /dev/vdc
-        partition: 1
-        filesystem: ext4
-    debug:
-      verbose: true
-    mounts:
-      - [ /dev/vdb1, /var/lib/gravity, ext4, "discard,noatime,nodiratime,nofail,x-systemd.requires=cloud-init.service", "0", "0"]
-    runcmd:
-    - 'modprobe overlay'
-    - 'modprobe br_netfilter'
-    - 'modprobe ebtables'
-    - 'modprobe ip_tables'
-    - 'modprobe iptable_nat'
-    - 'modprobe iptable_filter'
-    - 'sysctl -p /etc/sysctl.d/10-br-netfilter.conf'
-    - 'sysctl -p /etc/sysctl.d/10-ipv4-forwarding-on.conf'
-    - 'sysctl -p /etc/sysctl.d/10-fs-may-detach-mounts.conf'
-    - 'echo "/dev/vdc1 /tmp ext4 discard,noatime,nodiratime 0 0" >> /etc/fstab'
-    - 'mount -a'
-    - 'chmod 777 /tmp'
-    EOF
+  name      = "commoninit-${count.index}.iso"
+  user_data = templatefile("cloudinit.cfg", {
+            ip_address = "172.28.128.${count.index+3}",
+            hostname = "telekube${count.index}"
+            })
+  count     = "${var.nodes_count}"
 }
 
 # Create the machine
@@ -127,14 +70,15 @@ resource "libvirt_domain" "domain-gravity" {
   name = "telekube${count.index}"
   memory = "${var.memory_size}"
   vcpu = "${var.cpu_count}"
-  count = 3
-  cloudinit = "${libvirt_cloudinit_disk.commoninit.id}"
+  count = "${var.nodes_count}"
+  cloudinit = "${element(libvirt_cloudinit_disk.commoninit.*.id, count.index)}"
 
   network_interface {
     hostname = "telekube${count.index}"
     network_id = "${libvirt_network.vm_network.id}"
     addresses = ["172.28.128.${count.index+3}"]
     mac = "6E:02:C0:21:62:5${count.index+3}"
+    wait_for_lease = true
   }
 
   # IMPORTANT
@@ -153,14 +97,10 @@ resource "libvirt_domain" "domain-gravity" {
   }
 
   disk {
-    volume_id = "${element(libvirt_volume.os-qcow2.*.id, count.index)}"
+    volume_id = "${element(libvirt_volume.root.*.id, count.index)}"
   }
+}
 
-  disk {
-    volume_id = "${element(libvirt_volume.gravity.*.id, count.index)}"
-  }
-
-  disk {
-    volume_id = "${element(libvirt_volume.tmp.*.id, count.index)}"
-  }
+terraform {
+  required_version = ">= 0.12"
 }

--- a/terraform-dev/install.yaml
+++ b/terraform-dev/install.yaml
@@ -32,9 +32,9 @@
   - set_fact: gopath="{{ lookup('env','GOPATH') }}"
   - debug: msg="gopath {{gopath}}"
 
-  - name: Creating /tmp/installer
+  - name: Creating "{{ ansible_env.HOME }}/installer"
     file:
-      path: "/tmp/installer"
+      path: "{{ ansible_env.HOME }}/installer"
       state: directory
 
   - name: upload installer tarball to the first node
@@ -43,7 +43,7 @@
     unarchive:
       force: yes
       src: "{{tarball_path}}"
-      dest: "/tmp/installer"
+      dest: "{{ ansible_env.HOME }}/installer"
 
   - name: upload gravity binary
     when: inventory_hostname != groups['all'][0]
@@ -51,7 +51,7 @@
     copy:
       force: yes
       src: "{{gravity_bin_path}}"
-      dest: "/tmp/gravity"
+      dest: "{{ ansible_env.HOME }}/gravity"
       mode: 0755
 
 - hosts: all
@@ -65,14 +65,14 @@
     shell: |
       umask 0066
       {% if inventory_hostname == groups['all'][0] %}
-      cd /tmp/installer
+      cd {{ ansible_env.HOME }}/installer
       ./gravity install \
         --cluster=dev.test \
         --advertise-addr=172.28.128.3 \
         --flavor=three \
-        --token=token
+        --token=longtoken
       {% else %}
-      /tmp/gravity join \
+      {{ ansible_env.HOME }}/gravity join \
         {{hostvars[groups['all'][0]]['ansible_default_ipv4']['address']}} \
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
         --token=longtoken
@@ -80,8 +80,8 @@
   - name: Clean tmp
     file:
       state: absent
-      path: "/tmp/installer"
+      path: "{{ ansible_env.HOME }}/installer"
   - name: Clean tmp gravity
     file:
       state: absent
-      path: "/tmp/gravity"
+      path: "{{ ansible_env.HOME }}/gravity"

--- a/terraform-dev/install.yaml
+++ b/terraform-dev/install.yaml
@@ -77,11 +77,11 @@
         --advertise-addr={{hostvars[inventory_hostname]['ansible_default_ipv4']['address']}} \
         --token=longtoken
       {% endif %}
-  - name: Clean tmp
+  - name: Clean installer directory
     file:
       state: absent
       path: "{{ ansible_env.HOME }}/installer"
-  - name: Clean tmp gravity
+  - name: Delete gravity binary
     file:
       state: absent
       path: "{{ ansible_env.HOME }}/gravity"


### PR DESCRIPTION
### Purpose

- Fix the issue with resolving DNS requests inside VMs. With terraform-libvirt plugin [v0.5.2](https://github.com/dmacvicar/terraform-provider-libvirt/tree/v0.5.2) DNS enabled option was added and the default value is false.
- Move all cloud-init code from terraform file into dedicated to improve readability.
- Use one root disk to simplify setup. Usage of the dedicated disk for `/tmp` directory(which was used to unpack installer tarball) is deprecated.
- Set minimum requirements for terraform to `0.12.x`.
- Change default OS for VM to Ubuntu 18.04.