### PR TITLE
[master/7.0] port version & upgrade matrix changes

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -7,8 +7,8 @@ DOCKER_STORAGE_DRIVERS="overlay2"
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to test upgrades on
-UPGRADE_MAP[6.1.5]="centos:7 debian:9 ubuntu:18"
-UPGRADE_MAP[6.2.0]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[6.1.18]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[6.3.6]="centos:7 debian:9 ubuntu:18"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -5,10 +5,19 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 DOCKER_STORAGE_DRIVERS="overlay2"
 
+# UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# gravity version -> list of OS releases to test upgrades on
+
+# latest patch release on compatible LTS, keep this up to date
 UPGRADE_MAP[6.1.18]="centos:7 debian:9 ubuntu:18"
+
+# latest patch release on supported non-LTS version, keep this up to date
 UPGRADE_MAP[6.3.6]="centos:7 debian:9 ubuntu:18"
+
+# important versions in the field, these are static
+UPGRADE_MAP[6.1.0]="ubuntu:16"
+UPGRADE_MAP[6.2.5]="ubuntu:16"
+UPGRADE_MAP[6.3.0]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -17,7 +17,7 @@ UPGRADE_MAP[6.3.6]="centos:7 debian:9 ubuntu:18"
 # important versions in the field, these are static
 UPGRADE_MAP[6.1.0]="ubuntu:16"
 UPGRADE_MAP[6.2.5]="ubuntu:16"
-UPGRADE_MAP[6.3.0]="ubuntu:16"
+# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -3,10 +3,18 @@ set -eu -o pipefail
 
 readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
+# UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# gravity version -> list of OS releases to exercise on
+
+# latest patch release on compatible LTS, keep this up to date
 UPGRADE_MAP[6.1.18]="ubuntu:18"
+
+# latest patch release on supported non-LTS version, keep this up to date
 UPGRADE_MAP[6.3.6]="ubuntu:18"
+
+# important versions in the field, these are static
+UPGRADE_MAP[6.1.0]="ubuntu:16"
+UPGRADE_MAP[6.3.0]="ubuntu:16"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -5,8 +5,8 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 declare -A UPGRADE_MAP
 # gravity version -> list of OS releases to exercise on
-UPGRADE_MAP[6.1.6]="ubuntu:18"
-UPGRADE_MAP[6.2.0]="ubuntu:18"
+UPGRADE_MAP[6.1.18]="ubuntu:18"
+UPGRADE_MAP[6.3.6]="ubuntu:18"
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -14,7 +14,7 @@ UPGRADE_MAP[6.3.6]="ubuntu:18"
 
 # important versions in the field, these are static
 UPGRADE_MAP[6.1.0]="ubuntu:16"
-UPGRADE_MAP[6.3.0]="ubuntu:16"
+# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/version.sh
+++ b/version.sh
@@ -2,8 +2,12 @@
 
 # this versioning algo:
 #  - if on a tagged commit, use the tag
-#  - if last tag was a regular relase, bump the minor version, make a it pre-release, and append # of commits since tag
-#  - if last tag was a pre-release tag, append number of commits since the tag
+#    e.g. 6.2.18 (for the commit tagged 6.2.18)
+#  - if last tag was a regular release, bump the minor version, make a it a 'dev' pre-release, and append # of commits since tag
+#    e.g. 5.5.38-dev.5 (for 5 commits after 5.5.37)
+#  - if last tag was a pre-release tag (e.g. alpha, beta, rc), append number of commits since the tag
+#    e.g. 7.0.0-alpha.1.5 (for 5 commits after 7.0.0-alpha.1)
+
 
 increment_patch() {
     # increment_patch returns x.y.(z+1) given valid x.y.z semver.
@@ -26,7 +30,7 @@ if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then  # the current commit is tagged as a
     echo "$SHORT_TAG"
 elif [[ "$SHORT_TAG" != *-* ]] ; then  # the current ref is not a decendent of a pre-release version
     SHORT_TAG=$(increment_patch ${SHORT_TAG})
-    echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
+    echo "$SHORT_TAG-dev.${COMMITS_SINCE_LAST_TAG}"
 else  # the current ref is a decendent of a pre-release version (e.g. already an rc, alpha, or beta)
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,18 +1,32 @@
 #!/bin/bash
 
 # this versioning algo:
-# keeps tag as is in case if this version is an equal match
-# otherwise adds .<number of commits since last tag>
+#  - if on a tagged commit, use the tag
+#  - if last tag was a regular relase, bump the minor version, make a it pre-release, and append # of commits since tag
+#  - if last tag was a pre-release tag, append number of commits since the tag
+
+increment_patch() {
+    # increment_patch returns x.y.(z+1) given valid x.y.z semver.
+    # If we need to robustly handle this, it is probably worth
+    # looking at https://github.com/davidaurelio/shell-semver/
+    # or moving this logic to a 'real' programming language -- 2020-03 walt
+    major=$(echo $1 | cut -d'.' -f1)
+    minor=$(echo $1 | cut -d'.' -f2)
+    patch=$(echo $1 | cut -d'.' -f3)
+    patch=$((patch + 1))
+    echo "${major}.${minor}.${patch}"
+}
 
 SHORT_TAG=`git describe --abbrev=0 --tags`
 LONG_TAG=`git describe --tags`
 COMMIT_WITH_LAST_TAG=`git show-ref --tags --dereference | grep "refs/tags/${SHORT_TAG}^{}" | awk '{print $1}'`
 COMMITS_SINCE_LAST_TAG=`git rev-list  ${COMMIT_WITH_LAST_TAG}..HEAD --count`
 
-if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then
+if [[ "$LONG_TAG" == "$SHORT_TAG" ]] ; then  # the current commit is tagged as a release
     echo "$SHORT_TAG"
-elif [[ "$SHORT_TAG" != *-* ]] ; then
+elif [[ "$SHORT_TAG" != *-* ]] ; then  # the current ref is not a decendent of a pre-release version
+    SHORT_TAG=$(increment_patch ${SHORT_TAG})
     echo "$SHORT_TAG-${COMMITS_SINCE_LAST_TAG}"
-else
+else  # the current ref is a decendent of a pre-release version (e.g. already an rc, alpha, or beta)
     echo "$SHORT_TAG.${COMMITS_SINCE_LAST_TAG}"
 fi


### PR DESCRIPTION
This is a forward port of the work in #1179 and #1195 to master/7.0.0.  The main purpose of this is to improve our PR & nightly build coverage scenarios.  This contributes substantially to https://github.com/gravitational/robotest/issues/155.

**Testing Done:**
```
walt@work:~/git/gravity$ make get-version
7.0.0-beta.1.4
```

I have not tried to run this robotest config in a try build (for either nightly or the PR build) because I didn't believe it an effective use of time, based on the level of testing I did for #1179 and #1195.  If we see failures or significant feedback I'll come back and dig into this testing.