### PR TITLE
[5.5] robotest test .0 patch release parity with 6.1/master

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -14,6 +14,10 @@ UPGRADE_MAP[5.5.37]="centos:7 ubuntu:16"
 # latest patch release on previous compatible LTS, keep this up to date
 UPGRADE_MAP[5.2.16]="centos:7 ubuntu:16"
 
+# first release from this release & last LTS, these don't need to change until a new major/minor release
+UPGRADE_MAP[5.5.0]="ubuntu:16"
+UPGRADE_MAP[5.2.0]="ubuntu:16"
+
 # via intermediate upgrade
 UPGRADE_MAP[5.0.35]="debian:9 ubuntu:16"
 

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -7,14 +7,18 @@ DOCKER_STORAGE_DRIVERS="overlay2"
 
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# latest patch release on compatible LTS, keep these up to date
+
+# latest patch release on this release, keep this up to date
 UPGRADE_MAP[5.5.37]="centos:7 ubuntu:16"
+
+# latest patch release on previous compatible LTS, keep this up to date
 UPGRADE_MAP[5.2.16]="centos:7 ubuntu:16"
 
 # via intermediate upgrade
 UPGRADE_MAP[5.0.35]="debian:9 ubuntu:16"
 
-# important versions in the field
+# important versions in the field, per:
+# https://github.com/gravitational/robotest/issues/155#issuecomment-589743687
 UPGRADE_MAP[5.2.12]="ubuntu:16"
 UPGRADE_MAP[5.5.19]="ubuntu:16"
 UPGRADE_MAP[5.5.20]="ubuntu:16"

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -5,14 +5,18 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
-# latest patch release on compatible LTS, keep these up to date
+
+# latest patch release on this release, keep this up to date
 UPGRADE_MAP[5.5.37]="ubuntu:16"
+
+# latest patch release on previous compatible LTS, keep this up to date
 UPGRADE_MAP[5.2.16]="ubuntu:16"
 
 # via intermediate upgrade
 UPGRADE_MAP[5.0.35]="ubuntu:16"
 
-# important versions in the field
+# important versions in the field, per:
+# https://github.com/gravitational/robotest/issues/155#issuecomment-589743687
 UPGRADE_MAP[5.2.12]="ubuntu:16"
 UPGRADE_MAP[5.5.19]="ubuntu:16"
 UPGRADE_MAP[5.5.20]="ubuntu:16"

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -12,6 +12,10 @@ UPGRADE_MAP[5.5.37]="ubuntu:16"
 # latest patch release on previous compatible LTS, keep this up to date
 UPGRADE_MAP[5.2.16]="ubuntu:16"
 
+# first release from this release & last LTS, these don't need to change until a new major/minor release
+UPGRADE_MAP[5.5.0]="ubuntu:16"
+UPGRADE_MAP[5.2.0]="ubuntu:16"
+
 # via intermediate upgrade
 UPGRADE_MAP[5.0.35]="ubuntu:16"
 


### PR DESCRIPTION
This PR brings in further robotest upgrade testing diversification, building off of #1195.  Two key changes, and some better comments.  Key changes:


* Add upgrade testing from X.Y.0 for supported releases. I'm a little nervous about this based on my experience with #1202 and 9a640836.
* Diversify the range of OSes we test on.  Particularly: switching to redhat:7 for "important versions in the field" (NOW REMOVED due to https://github.com/gravitational/robotest/issues/182 and https://github.com/gravitational/robotest/issues/183)

**Testing Done**

None.  I need to improve the try build setup I've been tinkering with to make it easier for me to run these tests in a pre-PR environment.  Until then, its more effective to use the PR as my testing. 