### PR TITLE
(5.5) Fix teleport session upload issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -902,8 +902,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "roman/3.0-g/serverid"
-  digest = "1:b9ffcc78f18e3fd5d95fbedca43cae3a7468e403981a7b7069c321ad241cb624"
+  branch = "branch/3.0-g"
+  digest = "1:855cb45a1383f5334e5fd68e4e15703a349ad1acf202296c7ccf54c0cf8a58bb"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -959,7 +959,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "6b8ae6f18a2f54221b84806b749e93c78790b2c9"
+  revision = "dbbd5dc817b2c27e7c6f7efd768701e861cb0f5f"
 
 [[projects]]
   digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -902,8 +902,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "branch/3.0-g"
-  digest = "1:c6645b07439c305c52e0845ee979bbb9c5cb9a170a5a07bfc8e9b4cf5bcfbe7d"
+  branch = "roman/3.0-g/serverid"
+  digest = "1:b9ffcc78f18e3fd5d95fbedca43cae3a7468e403981a7b7069c321ad241cb624"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -959,7 +959,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "cdbeea01bfdb0053a9defb1a1f0bfe5c89bc4c2f"
+  revision = "6b8ae6f18a2f54221b84806b749e93c78790b2c9"
 
 [[projects]]
   digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,8 +203,7 @@ ignored = [
   # use gravity-specific 3.0 branch of teleport which includes
   # new Kubernetes because it can't be revendored in regular
   # 3.0 branch due to some compability issues
-#  branch = "branch/3.0-g"
-  branch = "roman/3.0-g/serverid"
+  branch = "branch/3.0-g"
 
 [[constraint]]
   version = "0.0.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,7 +203,8 @@ ignored = [
   # use gravity-specific 3.0 branch of teleport which includes
   # new Kubernetes because it can't be revendored in regular
   # 3.0 branch due to some compability issues
-  branch = "branch/3.0-g"
+#  branch = "branch/3.0-g"
+  branch = "roman/3.0-g/serverid"
 
 [[constraint]]
   version = "0.0.1"

--- a/vendor/github.com/gravitational/teleport/lib/auth/apiserver.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/apiserver.go
@@ -2379,6 +2379,14 @@ func (s *APIServer) getServerID(r *http.Request) (string, error) {
 		return "", trace.Wrap(err)
 	}
 
+	// The username extracted from the node's identity (x.509 certificate)
+	// is expected to consist of "<server-id>.<cluster-name>" so strip the
+	// cluster name suffix to get the server id.
+	//
+	// Note that as of right now Teleport expects server id to be a uuid4
+	// but older Gravity clusters used to override it with strings like
+	// "192_168_1_1.<cluster-name>" so this code can't rely on it being
+	// uuid4 to account for clusters upgraded from older versions.
 	return strings.TrimSuffix(role.Username, "."+clusterName), nil
 }
 


### PR DESCRIPTION
Revendor teleport with the fix https://github.com/gravitational/teleport/pull/3411 to fix the issue with teleport nodes failing to upload sessions on clusters upgraded from 5.2 or before. Closes https://github.com/gravitational/gravity/issues/1207.