### PR TITLE
Update installation.md

### DIFF
--- a/docs/6.x/installation.md
+++ b/docs/6.x/installation.md
@@ -132,8 +132,6 @@ Flag               | Description
 `--cloud-provider` | _(Optional)_ Cloud provider integration, `generic` or `aws`. Autodetected if not set.
 `--mounts`         | _(Optional)_ Comma-separated list of mount points as <name>:<path>.
 `--state-dir`      | _(Optional)_ Directory where all Gravity system data will be kept on this node. Defaults to `/var/lib/gravity`.
-`--service-uid`    | _(Optional)_ Service user ID (numeric). See [Service User](pack/#service-user) for details. A user named `planet` is created automatically if unspecified.
-`--service-gid`    | _(Optional)_ Service group ID (numeric). See [Service User](pack/#service-user) for details. A group named `planet` is created automatically if unspecified.
 
 ### Environment Variables
 


### PR DESCRIPTION
service-uid / service-gid are not actually options on the join command. https://github.com/gravitational/gravity/blob/352d3dc5c201d8efb701ff9ead5d87ce09f563d4/tool/gravity/cli/register.go#L103-L127