### PR TITLE
Correct kind in trusted cluster example

### DIFF
--- a/docs/6.x/config.md
+++ b/docs/6.x/config.md
@@ -789,7 +789,7 @@ a Gravity Hub. It brings the following advantages:
 To configure a Trusted Cluster create the following resource:
 
 ```yaml
-kind: TrustedCluster
+kind: trusted_cluster
 version: v2
 metadata:
   name: hub.example.com

--- a/docs/7.x/config.md
+++ b/docs/7.x/config.md
@@ -789,7 +789,7 @@ a Gravity Hub. It brings the following advantages:
 To configure a Trusted Cluster create the following resource:
 
 ```yaml
-kind: TrustedCluster
+kind: trusted_cluster
 version: v2
 metadata:
   name: hub.example.com


### PR DESCRIPTION
The kind was TrustedCluster, should be trusted_cluster for Trusted Cluster yamls.  With TrustedTluster you will get the error [ERROR]: invalid kind "TrustedCluster", expected "trusted_cluster"
