### PR TITLE
Relax fio test requirements a bit.

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -392,10 +392,13 @@ func (r *checker) CheckNode(ctx context.Context, server Server) (failed []*agent
 	if server.IsMaster() && r.TestEtcdDisk {
 		err = r.checkEtcdDisk(ctx, server)
 		if err != nil {
-			failed = append(failed, &agentpb.Probe{
-				Detail: err.Error(),
-				Error:  "failed to validate etcd disk requirements",
-			})
+			log.WithError(err).Warn("Failed to validate etcd disk requirements.")
+			if isFioTestError(err) {
+				failed = append(failed, &agentpb.Probe{
+					Detail: err.Error(),
+					Error:  "failed to validate etcd disk requirements",
+				})
+			}
 		}
 	}
 

--- a/lib/checks/disks.go
+++ b/lib/checks/disks.go
@@ -107,7 +107,7 @@ func (e *fioTestError) Error() string {
 
 // isFioTestError returns true if the provided error is the fio disk test error.
 func isFioTestError(err error) bool {
-	_, ok := err.(*fioTestError)
+	_, ok := trace.Unwrap(err).(*fioTestError)
 	return ok
 }
 


### PR DESCRIPTION
I think the fio test might be a little bit too strict right now and there's also some potential unknowns related to executing fio binary on people's machines so relax the test requirements a bit so this check doesn't get in the way too much:

* Bump allowed fsync latency to 50ms.
* Only consider the check failed if we got a successful test result back and its results are unsatisfactory. If fio binary failed to execute for some reason, log it and keep going (there's fallback to dd check anyway).