### PR TITLE
Backport upgrade-via to 5.x docs.

### DIFF
--- a/docs/5.x/cluster.md
+++ b/docs/5.x/cluster.md
@@ -484,6 +484,36 @@ root$ ./gravity plan resume
 root$ ./gravity agent shutdown
 ```
 
+## Direct Upgrades From Older LTS Versions
+
+Gravity LTS releases are at most 8 months apart and are based on Kubernetes releases which are no more than 2 minor versions apart.
+This requirement is partially necessitated by the Kubernetes version skew [support policy](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-version-skew).
+Gravity can thus only upgrade clusters from a previous LTS version. For example, an existing cluster based on Gravity `5.0.35` can be upgraded to one based on Gravity
+`5.2.14` but not to `5.5.20`.
+
+Since version `5.5.21` `tele` is capable of producing cluster image tarballs that can upgrade clusters based on older LTS versions (i.e. more than one version apart) directly.
+For this to work, it embeds the data from (a series) of previous LTS releases.
+
+As a result, the tarball will grow roughly by 1Gb per embedded release. Additionally, each embedded LTS release increases the upgrade time by a certain
+amount (which is cluster size-specific) - this should also be taken into account when planning for the upgrade.
+
+To embed an LTS release, specify its version as a parameter to `tele build`:
+
+```bash
+$ tele build ... --upgrade-via=5.2.15
+```
+
+The flag can be specified multiple times to add as many LTS versions as required.
+
+!!! note "Embedding intermediate LTS releases"
+    The version specified with the `--upgrade-via` flag must be an LTS version.
+    Check [Releases](changelog.md) page to see which LTS versions are available for embedding.
+    The upgrade path from the existing version must contain all intermediate LTS releases to reach the target version but
+    the target version does not have to be LTS.
+    For example, to upgrade a cluster based on Gravity `5.0.35` to the image based on Gravity `5.5.21`, the cluster
+    image must embed the LTS version `5.2.15`.
+
+
 ## Managing An Ongoing Operation
 
 Some operations in a Gravity cluster require cooperation from all cluster nodes.


### PR DESCRIPTION
The `tele build --upgrade-via` flag is only supported in 5.5.x
currently, so it makes sense to include it in the 5.x docs.

I'm mostly issuing this PR to test the setup our new gravity-pr-docs CI job, though the change is valid.  I expect two commit statuses to post, one from the regular build/robotest job and one from the new docs job.

### Testing Done
Eyeballed the change in with `make run`:

```
walt@work:~/git/gravity/docs$ make run RUN_CFG=5.x.yaml                                                                                                                                 [130] 
                                                                                                                                                                                              
                                                                                                                                                                                              
Open http://localhost:6601/ in your local browser                                                                                                                                             
                                                                                                                                                                                              
                                                                                                                                                                                              
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs -p 6601:6601 docs-buildbox:latest make BUILDROOT=../build container-run RUN_CFG=5.x.yaml                
Starting mkdocs server...                                                                                                                                                                     
mkdocs serve --strict --livereload --config-file 5.x.yaml --dev-addr=0.0.0.0:6601                                                                                                             
INFO    -  Building documentation...                                                                                                                                                          
INFO    -  Cleaning site directory                                                                                                                                                            
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:                                                                                  
  - testplan.md                                                                                                                                                                               
  - workshops.md                                                                                                                                                                              
[I 200319 17:23:45 server:296] Serving on http://0.0.0.0:6601                                                                                                                                 
[I 200319 17:23:45 handlers:62] Start watching changes                                                                                                                                        
[I 200319 17:23:45 handlers:64] Start detecting changes                                                                                                                                       
[W 200319 17:23:48 web:2246] 404 GET /gravitational/images/backgrounds/footer-bg.svg (172.17.0.1) 0.65ms                                                                                      
[I 200319 17:23:48 handlers:135] Browser Connected: http://localhost:6601/                                                                                                                    
[W 200319 17:23:56 web:2246] 404 GET /gravitational/images/backgrounds/footer-bg.svg (172.17.0.1) 0.47ms                                                                                      
[I 200319 17:23:56 handlers:135] Browser Connected: http://localhost:6601/cluster/                                                                                                            
^C[I 200319 17:24:41 server:318] Shutting down...     
```
It is a cut & paste job, so I didn't do any more than this.
