### PR TITLE
(5.5) Update teleport to fix UI terminal copy.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -903,7 +903,7 @@
 
 [[projects]]
   branch = "branch/3.0-g"
-  digest = "1:855cb45a1383f5334e5fd68e4e15703a349ad1acf202296c7ccf54c0cf8a58bb"
+  digest = "1:4844cc1b82b1d9500007be50c601675f791238baa63e7455010b1704cd98894e"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -959,7 +959,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "dbbd5dc817b2c27e7c6f7efd768701e861cb0f5f"
+  revision = "50a1f1cab731ca2d5096166e36f45c12ecb1cbe3"
 
 [[projects]]
   digest = "1:3afdc8c5bad39bda75ede9cd18bf590c385ff9a28c742f7330e3d3e19c685c47"

--- a/vendor/github.com/gravitational/teleport/lib/web/terminal.go
+++ b/vendor/github.com/gravitational/teleport/lib/web/terminal.go
@@ -161,6 +161,10 @@ type TerminalHandler struct {
 
 	// decoder is used to decode UTF-8 strings.
 	decoder *encoding.Decoder
+
+	// buffer is a buffer used to store the remaining payload data if it did not
+	// fit into the buffer provided by the callee to Read method
+	buffer []byte
 }
 
 // Serve builds a connect to the remote node and then pumps back two types of
@@ -459,6 +463,16 @@ func (t *TerminalHandler) write(data []byte, ws *websocket.Conn) (n int, err err
 // Read unwraps the envelope and either fills out the passed in bytes or
 // performs an action on the connection (sending window-change request).
 func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error) {
+	if len(t.buffer) > 0 {
+		n := copy(out, t.buffer)
+		if n == len(t.buffer) {
+			t.buffer = []byte{}
+		} else {
+			t.buffer = t.buffer[n:]
+		}
+		return n, nil
+	}
+
 	var bytes []byte
 	err = websocket.Message.Receive(ws, &bytes)
 	if err != nil {
@@ -486,10 +500,13 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 
 	switch string(envelope.GetType()) {
 	case defaults.WebsocketRaw:
-		if len(out) < len(data) {
-			t.log.Warnf("websocket failed to receive everything: %d vs %d", len(out), len(data))
+		n := copy(out, data)
+		// if payload size is greater than [out], store the remaining
+		// part in the buffer to be processed on the next Read call
+		if len(data) > n {
+			t.buffer = data[n:]
 		}
-		return copy(out, data), nil
+		return n, nil
 	case defaults.WebsocketResize:
 		var e events.EventFields
 		err := json.Unmarshal(data, &e)


### PR DESCRIPTION
Revendor teleport with https://github.com/gravitational/teleport/pull/3455 fix. Closes https://github.com/gravitational/gravity/issues/1145.