### PR TITLE
Revert back to explicit bootstrapping of SELinux configuration

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -31,8 +31,7 @@ STORAGE_APP_TAG ?= 0.0.1
 STORAGE_APP_BRANCH ?= $(STORAGE_APP_TAG)
 K8S_APP_TAG ?= 0.0.1
 TILLER_APP_TAG ?= 0.0.1
-#SELINUX_BRANCH ?= distro/centos_rhel/7
-SELINUX_BRANCH ?= dmitri/1262-upgrade
+SELINUX_BRANCH ?= distro/centos_rhel/7
 
 GOLFLAGS ?= -w -s
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -31,7 +31,8 @@ STORAGE_APP_TAG ?= 0.0.1
 STORAGE_APP_BRANCH ?= $(STORAGE_APP_TAG)
 K8S_APP_TAG ?= 0.0.1
 TILLER_APP_TAG ?= 0.0.1
-SELINUX_BRANCH ?= distro/centos_rhel/7
+#SELINUX_BRANCH ?= distro/centos_rhel/7
+SELINUX_BRANCH ?= dmitri/1262-upgrade
 
 GOLFLAGS ?= -w -s
 

--- a/lib/localenv/tarballenv.go
+++ b/lib/localenv/tarballenv.go
@@ -36,7 +36,8 @@ func NewTarballEnvironment(config TarballEnvironmentArgs) (*TarballEnvironment, 
 		return nil, trace.Wrap(err)
 	}
 	env, err := NewLocalEnvironment(LocalEnvironmentArgs{
-		StateDir: config.StateDir,
+		StateDir:        config.StateDir,
+		ReadonlyBackend: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/backup_restore.go
+++ b/tool/gravity/cli/backup_restore.go
@@ -128,17 +128,17 @@ func runBackupRestore(env *localenv.LocalEnvironment, operation string,
 		return trace.Wrap(err)
 	}
 
-	site, err := operator.GetLocalSite()
+	cluster, err := operator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	node, err := findLocalServer(*site)
+	node, err := findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	log.Infof("running %v for %v on %v", operation, site.App.Package, node.KubeNodeID())
+	log.Infof("running %v for %v on %v", operation, cluster.App.Package, node.KubeNodeID())
 
 	id, err := teleutils.CryptoRandomHex(3)
 	if err != nil {
@@ -146,7 +146,7 @@ func runBackupRestore(env *localenv.LocalEnvironment, operation string,
 	}
 
 	req := &app.HookRunRequest{
-		Application: site.App.Package,
+		Application: cluster.App.Package,
 		Volumes: []v1.Volume{{
 			Name: hooks.VolumeBackup,
 			VolumeSource: v1.VolumeSource{

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -58,12 +58,15 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/system/environ"
+	libselinux "github.com/gravitational/gravity/lib/system/selinux"
 	"github.com/gravitational/gravity/lib/system/signals"
 	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/utils/helm"
+	"github.com/gravitational/satellite/monitoring"
+	"github.com/opencontainers/selinux/go-selinux"
 
 	gcemeta "cloud.google.com/go/compute/metadata"
 	"github.com/cenkalti/backoff"
@@ -499,6 +502,28 @@ func (i *InstallConfig) RunLocalChecks() error {
 	}))
 }
 
+// BootstrapSELinux configures SELinux on a node prior to installation
+func (i *InstallConfig) BootstrapSELinux(ctx context.Context, printer utils.Printer) error {
+	if !i.SELinux || i.FromService || i.Mode == constants.InstallModeInteractive || i.Remote {
+		return nil
+	}
+	metadata, err := monitoring.GetOSRelease()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !selinux.GetEnabled() {
+		i.WithField(trace.Component, "selinux").Info("SELinux not enabled on host.")
+		i.SELinux = false
+	} else if !libselinux.IsSystemSupported(metadata.ID) {
+		i.WithField("id", metadata.ID).Info("Distribution not supported.")
+		i.SELinux = false
+	}
+	return BootstrapSELinuxAndRespawn(ctx, libselinux.BootstrapConfig{
+		StateDir: i.StateDir,
+		OS:       metadata,
+	}, printer)
+}
+
 func (i *InstallConfig) validateApplicationDir() error {
 	_, err := i.getApp()
 	return trace.Wrap(err)
@@ -829,6 +854,29 @@ func (j *JoinConfig) GetRuntimeConfig() proto.RuntimeConfig {
 	}
 }
 
+// bootstrapSELinux configures SELinux on a node prior to join
+func (j *JoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
+	if !j.SELinux || j.FromService {
+		return nil
+	}
+	metadata, err := monitoring.GetOSRelease()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	logger := log.WithField(trace.Component, "selinux")
+	if !selinux.GetEnabled() {
+		logger.Info("SELinux not enabled on host.")
+		j.SELinux = false
+	} else if !libselinux.IsSystemSupported(metadata.ID) {
+		logger.WithField("id", metadata.ID).Info("Distribution not supported.")
+		j.SELinux = false
+	}
+	return BootstrapSELinuxAndRespawn(ctx, libselinux.BootstrapConfig{
+		StateDir: j.SystemStateDir,
+		OS:       metadata,
+	}, printer)
+}
+
 func (r *removeConfig) checkAndSetDefaults() error {
 	if r.server == "" {
 		return trace.BadParameter("server flag is required")
@@ -842,17 +890,18 @@ type removeConfig struct {
 	confirmed bool
 }
 
-func (r *autojoinConfig) newJoinConfig() JoinConfig {
+func (j *autojoinConfig) newJoinConfig() JoinConfig {
 	return JoinConfig{
-		SystemLogFile: r.systemLogFile,
-		UserLogFile:   r.userLogFile,
-		Role:          r.role,
-		SystemDevice:  r.systemDevice,
-		Mounts:        r.mounts,
-		AdvertiseAddr: r.advertiseAddr,
-		PeerAddrs:     r.serviceURL,
-		Token:         r.token,
-		FromService:   r.fromService,
+		SystemLogFile: j.systemLogFile,
+		UserLogFile:   j.userLogFile,
+		Role:          j.role,
+		SystemDevice:  j.systemDevice,
+		Mounts:        j.mounts,
+		AdvertiseAddr: j.advertiseAddr,
+		PeerAddrs:     j.serviceURL,
+		Token:         j.token,
+		FromService:   j.fromService,
+		SELinux:       j.seLinux,
 		// Autojoin can only join an existing cluster, so skip attempts to use the wizard
 		SkipWizard: true,
 	}
@@ -874,6 +923,28 @@ func (r *autojoinConfig) checkAndSetDefaults() error {
 	return nil
 }
 
+// bootstrapSELinux configures SELinux on a node prior to join
+func (j *autojoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
+	if !j.seLinux || j.fromService {
+		return nil
+	}
+	metadata, err := monitoring.GetOSRelease()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	logger := log.WithField(trace.Component, "selinux")
+	if !selinux.GetEnabled() {
+		logger.Info("SELinux not enabled on host.")
+		j.seLinux = false
+	} else if !libselinux.IsSystemSupported(metadata.ID) {
+		logger.WithField("id", metadata.ID).Info("Distribution not supported.")
+		j.seLinux = false
+	}
+	return BootstrapSELinuxAndRespawn(ctx, libselinux.BootstrapConfig{
+		OS: metadata,
+	}, printer)
+}
+
 type autojoinConfig struct {
 	systemLogFile string
 	userLogFile   string
@@ -885,7 +956,7 @@ type autojoinConfig struct {
 	serviceURL    string
 	advertiseAddr string
 	token         string
-	selinux       bool
+	seLinux       bool
 }
 
 func (r *agentConfig) newServiceArgs(gravityPath string) (args []string) {

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -864,7 +864,7 @@ func (j *JoinConfig) GetRuntimeConfig() proto.RuntimeConfig {
 func (j *JoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
 	logger := log.WithField(trace.Component, "selinux")
 	if !j.shouldBootstrapSELinux() {
-		logger.Info("SELinux disable with configuration.")
+		logger.Info("SELinux disabled with configuration.")
 		return nil
 	}
 	metadata, err := monitoring.GetOSRelease()
@@ -938,7 +938,7 @@ func (r *autojoinConfig) checkAndSetDefaults() error {
 func (j *autojoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
 	logger := log.WithField(trace.Component, "selinux")
 	if !j.shouldBootstrapSELinux() {
-		logger.Info("SELinux disable with configuration.")
+		logger.Info("SELinux disabled with configuration.")
 		return nil
 	}
 	metadata, err := monitoring.GetOSRelease()

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -56,8 +56,10 @@ import (
 )
 
 func startInstall(env *localenv.LocalEnvironment, config InstallConfig) error {
+	if err := config.BootstrapSELinux(context.TODO(), env); err != nil {
+		return trace.Wrap(err)
+	}
 	env.PrintStep("Starting installer")
-
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -327,12 +329,12 @@ func tryLeave(env *localenv.LocalEnvironment, c leaveConfig) error {
 		return trace.Wrap(err)
 	}
 
-	site, err := operator.GetLocalSite()
+	cluster, err := operator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	server, err := findLocalServer(*site)
+	server, err := findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
 		return trace.NotFound(
 			"this server is not a part of the running cluster, please use --force flag to clean up the local state")
@@ -373,12 +375,12 @@ func remove(env *localenv.LocalEnvironment, c removeConfig) error {
 		return trace.Wrap(err)
 	}
 
-	site, err := operator.GetLocalSite()
+	cluster, err := operator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	server, err := findServer(*site, []string{c.server})
+	server, err := findServer(cluster.ClusterState.Servers, []string{c.server})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -393,8 +395,8 @@ func remove(env *localenv.LocalEnvironment, c removeConfig) error {
 
 	key, err := operator.CreateSiteShrinkOperation(context.TODO(),
 		ops.CreateSiteShrinkOperationRequest{
-			AccountID:  site.AccountID,
-			SiteDomain: site.Domain,
+			AccountID:  cluster.AccountID,
+			SiteDomain: cluster.Domain,
 			Servers:    []string{server.Hostname},
 			Force:      c.force,
 		})
@@ -406,23 +408,26 @@ func remove(env *localenv.LocalEnvironment, c removeConfig) error {
 	return nil
 }
 
-func autojoin(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, d autojoinConfig) (err error) {
-	if d.fromService {
-		return autojoinFromService(env, environ, d)
+func autojoin(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, config autojoinConfig) (err error) {
+	if err := config.bootstrapSELinux(context.TODO(), env); err != nil {
+		return trace.Wrap(err)
 	}
 
-	err = retryUpdateJoinConfigFromCloudMetadata(context.TODO(), &d)
+	if config.fromService {
+		return autojoinFromService(env, environ, config)
+	}
+
+	err = retryUpdateJoinConfigFromCloudMetadata(context.TODO(), &config)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := d.checkAndSetDefaults(); err != nil {
+	if err := config.checkAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 
-	env.PrintStep("Auto-joining cluster %q via %v\n", d.clusterName, d.serviceURL)
+	env.PrintStep("Auto-joining cluster %q via %v\n", config.clusterName, config.serviceURL)
 
-	config := d.newJoinConfig()
-	strategy, err := newAutoAgentConnectStrategy(env, config)
+	strategy, err := newAutoAgentConnectStrategy(env, config.newJoinConfig())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -676,8 +681,10 @@ func InstallerClient(env *localenv.LocalEnvironment, config installerclient.Conf
 
 // join executes the join command and runs either the client or the service depending on the configuration
 func join(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, config JoinConfig) error {
+	if err := config.bootstrapSELinux(context.TODO(), env); err != nil {
+		return trace.Wrap(err)
+	}
 	env.PrintStep("Starting agent")
-
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -53,7 +53,7 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	leader, err := findLocalServer(*cluster)
+	leader, err := findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -204,7 +204,7 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 	}
 
 	// Force this node to be the operation leader
-	req.leader, err = findLocalServer(*cluster)
+	req.leader, err = findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
 		log.WithError(err).Warn("Failed to determine local node.")
 		return nil, trace.Wrap(err, "failed to find local node in cluster state.\n"+

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -95,7 +95,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	leader, err := findLocalServer(*cluster)
+	leader, err := findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to find local node in cluster state.\n"+
 			"Make sure you start the operation from one of the cluster master nodes.")


### PR DESCRIPTION
Revert back to explicit bootstrapping of SELinux configuration per operation instead of early bootstrapping for install/join/upgrade.

The change does not matter much for installs/joins but in case of upgrades it allows to avoid unnecessary bootstrapping if the node does not have SELinux support turned on.
Additionally, it avoid the pitfall of having the labeled installer binary and SELinux support off - if that were the case, the binary running in confined context will fail to access resources it does not have access to (incl. access to the state directory which is labeled with a base type instead of the type expected by the installer SELinux domain).

A note on installer operation during upgrade: as previously implemented but discarded, the installer will attempt to determine the state of SELinux support by querying cluster state using the existing gravity binary which aims to avoid the risk of running into a permission denied at the early stage prior to configuring the SELinux configuration for the installer.

Requires https://github.com/gravitational/gravity.e/pull/4283.
Fixes https://github.com/gravitational/gravity/issues/1262.