### PR TITLE
[6.3.x] workaround initial install DNS config for hooks

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -964,10 +964,6 @@ const (
 	// DNSListenAddr is the default address coredns will be configured to listen on
 	DNSListenAddr = "127.0.0.2"
 
-	// LegacyDNSListenAddr is the address coredns was configured to listen on
-	// in older environments
-	LegacyDNSListenAddr = "127.0.0.1"
-
 	// DNSPort is the default DNS port coredns will be configured with
 	DNSPort = 53
 

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -182,7 +182,7 @@ func (env *LocalEnvironment) init() error {
 	}
 
 	if env.DNS.IsEmpty() {
-		dns, err := storage.GetDNSConfig(env.Backend, storage.LegacyDNSConfig)
+		dns, err := storage.GetDNSConfig(env.Backend, storage.DefaultDNSConfig)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1077,7 +1077,7 @@ var DefaultDNSConfig = DNSConfig{
 // LegacyDNSConfig defines the local DNS configuration on older clusters
 var LegacyDNSConfig = DNSConfig{
 	Port:  defaults.DNSPort,
-	Addrs: []string{defaults.LegacyDNSListenAddr},
+	Addrs: []string{"127.0.0.1"},
 }
 
 // String returns textual representation of this DNS configuration

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -72,8 +72,7 @@ type updatePhaseBootstrap struct {
 	log.FieldLogger
 	// ExecutorParams stores the phase parameters
 	fsm.ExecutorParams
-	remote           fsm.Remote
-	clusterDNSConfig storage.DNSConfig
+	remote fsm.Remote
 }
 
 // NewUpdatePhaseBootstrap creates a new bootstrap phase executor
@@ -119,7 +118,6 @@ func NewUpdatePhaseBootstrap(
 		FieldLogger:      logger,
 		ExecutorParams:   p,
 		remote:           remote,
-		clusterDNSConfig: cluster.DNSConfig,
 	}, nil
 }
 
@@ -200,13 +198,8 @@ func (p *updatePhaseBootstrap) exportGravity(ctx context.Context) error {
 
 // updateDNSConfig persists the DNS configuration in the local backend if it has not been set
 func (p *updatePhaseBootstrap) updateDNSConfig() error {
-	dnsConfig := storage.LegacyDNSConfig
-	if !p.clusterDNSConfig.IsEmpty() {
-		dnsConfig = p.clusterDNSConfig
-	}
-
-	err := p.HostLocalBackend.SetDNSConfig(dnsConfig)
-	p.Infof("Update cluster DNS configuration as %v.", dnsConfig)
+	p.Infof("Update cluster DNS configuration as %v.", p.Plan.DNSConfig)
+	err := p.HostLocalBackend.SetDNSConfig(p.Plan.DNSConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -76,7 +76,24 @@ func (g *Application) NewInstallEnv() (env *localenv.LocalEnvironment, err error
 	} else {
 		stateDir = filepath.Join(stateDir, defaults.LocalDir)
 	}
-	return g.getEnv(stateDir)
+	return g.getEnvWithArgs(localenv.LocalEnvironmentArgs{
+		StateDir:         stateDir,
+		Insecure:         *g.Insecure,
+		Silent:           localenv.Silent(*g.Silent),
+		Debug:            *g.Debug,
+		EtcdRetryTimeout: *g.EtcdRetryTimeout,
+		// Use DNS configuration from installer command line.
+		// TODO(dmitri): setting this will only be useful for the install operation
+		// as in this case the DNS coniguration will first be set in local state during
+		// boostrapping step and the application service that is created based on this
+		// setting would have otherwise pointed to the legacy DNS configuration which is
+		// incorrect.
+		// This is rather a workaround - proper solution will be more involved and will have
+		// the application service using the kubernetes client (and hence the DNS config
+		// to resolve the names) only for hooks.
+		DNS:      localenv.DNSConfig(g.InstallCmd.DNSConfig()),
+		Reporter: common.ProgressReporter(*g.Silent),
+	})
 }
 
 // NewUpdateEnv returns an instance of the local environment that is used


### PR DESCRIPTION
Use DNS configuration from command line for initial install operation environment so that the application service can use proper name resolution to execute and track application hooks.

Updates github.com/gravitational/gravity/issues/1265.