### PR TITLE
Add 5.5.38.

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -7,9 +7,10 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 6.3.7         | No  | February 12th, 2020  | -                    | 1.17.2             | 3.2.13           |
+| 7.0.0-rc.3    | No  | March 23rd, 2020     | -                    | 1.17.4             | 3.2.13           |
+| 6.3.8         | No  | March 23rd, 2020     | -                    | 1.17.4             | 3.2.13           |
 | 6.2.5*        | No  | December 3rd, 2019   | -                    | 1.16.3             | 3.2.13           |
-| 6.1.18        | Yes | February 4th, 2020   | November 10th, 2021  | 1.15.5             | 3.2.12           |
+| 6.1.19        | Yes | March 23rd, 2020     | November 10th, 2021  | 1.15.11             | 3.2.12           |
 | 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
 | 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
 | 5.5.38        | Yes | March 10th, 2020     | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
@@ -37,6 +38,56 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
 
 ## 6.x Releases
+
+### 6.3.9 (March 23rd, 2020)
+
+#### Bugfixes
+
+* Fix an issue with missing helm symlink on reinstall ([#1103](https://github.com/gravitational/gravity/pull/1103)).
+* Fix an issue with dns configuration during upgrade when host DNS has a localhost resolver ([#1161](https://github.com/gravitational/gravity/pull/1161)).
+* Fix an issue where the main upgrade agent could begin upgrade steps before all node agents are available ([#1205](https://github.com/gravitational/gravity/pull/1205)).
+* Agent deployment will now retry on transient network errors ([#1205](https://github.com/gravitational/gravity/pull/1205)).
+* If the upgrade fails to initialize, shut down all upgrade agents ([#1205](https://github.com/gravitational/gravity/pull/1205)).
+* Fix an issue with uploading teleport session logs ([#1225](https://github.com/gravitational/gravity/pull/1225)).
+* Prevent grafana from attempting to contact analytics servers ([#1250](https://github.com/gravitational/gravity/pull/1250)).
+* Fix an issue with serf members not leaving the cluster ([#1260](https://github.com/gravitational/gravity/pull/1260)).
+* Upgrade Kubernetes to `v1.17.04` (CVE-2020-8551, CVE-2020-8552) ([#1271](https://github.com/gravitational/gravity/pull/1271)).
+
+#### Improvements
+
+* Implement `gravity status history` command to show status changes ([#1119](https://github.com/gravitational/gravity/pull/1119)).
+* `gravity status` now shows both the client and server version in the status output ([#1166](https://github.com/gravitational/gravity/pull/1166)).
+* The runtime will now properly check and prevent upgrades on unsupported upgrade paths ([#1237](https://github.com/gravitational/gravity/pull/1237)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://groups.google.com/forum/#!topic/kubernetes-announce/jPiyJ1KL_FI) for more information.
+
+### 6.1.19 (March 23rd, 2020)
+
+#### Bugfixes
+
+* Fix an issue with serf members not leaving the cluster ([#1251](https://github.com/gravitational/gravity/pull/1251)).
+* Fix an issue with changing the pod CIDR on a running cluster ([#1045](https://github.com/gravitational/gravity/pull/1045)).
+* Prevent grafana from attempting to contact analytics servers ([#1250](https://github.com/gravitational/gravity/pull/1249)).
+* Fix an issue with uploading teleport session logs ([#1224](https://github.com/gravitational/gravity/pull/1224)).
+* Fix an issue where the main upgrade agent could begin upgrade steps before all node agents are available ([#1204](https://github.com/gravitational/gravity/pull/1204)).
+* Agent deployment will now retry on transient network errors ([#1204](https://github.com/gravitational/gravity/pull/1204)).
+* If the upgrade fails to initialize, shut down all upgrade agents ([#1204](https://github.com/gravitational/gravity/pull/1204)).
+* Fix an issue with dns configuration during upgrade when host DNS has a localhost resolver ([#1162](https://github.com/gravitational/gravity/pull/1162)).
+* Upgrade Kubernetes to `v1.15.11` (CVE-2020-8551, CVE-2020-8552) ([#1272](https://github.com/gravitational/gravity/pull/1272)).
+
+#### Improvements
+
+* Implement more extensive validations on ClusterConfiguration resource ([#1045](https://github.com/gravitational/gravity/pull/1045)).
+* The runtime will now properly check and prevent upgrades on unsupported upgrade paths ([#1236](https://github.com/gravitational/gravity/pull/1236)).
+* `gravity status` now shows both the client and server version in the status output ([#1165](https://github.com/gravitational/gravity/pull/1166)).
+* Implement `gravity status history` command to show status changes ([#1118](https://github.com/gravitational/gravity/pull/1118)).
+* Implement some low level convenience commands `gravity system service [stop/start/journal] ([1104](https://github.com/gravitational/gravity/pull/1104)).
+
+!!! warning
+    This release fixes a security vulnerability in kubernetes. Please see
+    [Kubernetes Announcement](https://groups.google.com/forum/#!topic/kubernetes-announce/jPiyJ1KL_FI) for more information.
 
 ### 6.3.7 (February 12th, 2020)
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -12,7 +12,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | 6.1.18        | Yes | February 4th, 2020   | November 10th, 2021  | 1.15.5             | 3.2.12           |
 | 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
 | 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
-| 5.5.37        | Yes | February 11th, 2020  | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
+| 5.5.38        | Yes | March 10th, 2020     | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 | 5.4.10*       | No  | March 26th, 2019     | -                    | 1.13.5             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7            |
 | 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
@@ -549,6 +549,25 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 * Add support for using `helm` directly from host.
 
 ## 5.x Releases
+
+### 5.5.38 LTS (March 10th, 2020)
+
+#### Improvements
+
+* Add ability to view [cluster status history](https://gravitational.com/gravity/docs/cluster/#cluster-status-history) using `gravity status history` command. ([#1116](https://github.com/gravitational/gravity/pull/1116))
+* Add RHEL 8 to the list of supported distros. ([#1144](https://github.com/gravitational/gravity/pull/1144))
+* Add client/server version information to `gravity status`. ([#1164](https://github.com/gravitational/gravity/pull/1164))
+* Make upgrade agents deployment more tolerant to networking issues. ([#1174](https://github.com/gravitational/gravity/pull/1174))
+* Update default Grafana dashboards to include data from medium and long retentions policies. ([monitoring-app#144](https://github.com/gravitational/monitoring-app/pull/144))
+* Update built-in Grafana configuration to disable update checks and analytics. ([monitoring-app#146](https://github.com/gravitational/monitoring-app/pull/146))
+
+#### Bugfixes
+
+* Fix an issue with CoreDNS config generation during upgrade. ([#1163](https://github.com/gravitational/gravity/pull/1163))
+* Fix an issue with upgrade operation starting even if some agents failed to deploy. ([#1174](https://github.com/gravitational/gravity/pull/1174))
+* Fix an issue with Teleport nodes failing to upload recorded sessions after upgrading from older clusters. ([#1216](https://github.com/gravitational/gravity/pull/1216))
+* Fix an issue with localhost resolution inside monitoring application containers. ([monitoring-app#145](https://github.com/gravitational/monitoring-app/pull/145))
+* Mitigate issues with launching buster-based Docker containers in some environments by rolling back to stretch. ([#1228](https://github.com/gravitational/gravity/pull/1228), [monitoring-app#149](https://github.com/gravitational/monitoring-app/pull/149))
 
 ### 5.5.37 LTS (February 11th, 2020)
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -7,10 +7,10 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 7.0.0-rc.3    | No  | March 23rd, 2020     | -                    | 1.17.4             | 3.2.13           |
-| 6.3.8         | No  | March 23rd, 2020     | -                    | 1.17.4             | 3.2.13           |
+| 7.0.0-rc.3    | No  | March 24th, 2020     | -                    | 1.17.4             | 3.2.13           |
+| 6.3.8         | No  | March 24th, 2020     | -                    | 1.17.4             | 3.2.13           |
 | 6.2.5*        | No  | December 3rd, 2019   | -                    | 1.16.3             | 3.2.13           |
-| 6.1.19        | Yes | March 23rd, 2020     | November 10th, 2021  | 1.15.11             | 3.2.12           |
+| 6.1.19        | Yes | March 24th, 2020     | November 10th, 2021  | 1.15.11            | 3.2.12           |
 | 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
 | 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
 | 5.5.38        | Yes | March 10th, 2020     | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
@@ -83,7 +83,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 * The runtime will now properly check and prevent upgrades on unsupported upgrade paths ([#1236](https://github.com/gravitational/gravity/pull/1236)).
 * `gravity status` now shows both the client and server version in the status output ([#1165](https://github.com/gravitational/gravity/pull/1166)).
 * Implement `gravity status history` command to show status changes ([#1118](https://github.com/gravitational/gravity/pull/1118)).
-* Implement some low level convenience commands `gravity system service [stop/start/journal] ([1104](https://github.com/gravitational/gravity/pull/1104)).
+* Implement some low level convenience commands `gravity system service [stop/start/journal]` ([1104](https://github.com/gravitational/gravity/pull/1104)).
 
 !!! warning
     This release fixes a security vulnerability in kubernetes. Please see

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -39,7 +39,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 ## 6.x Releases
 
-### 6.3.9 (March 23rd, 2020)
+### 6.3.8 (March 23rd, 2020)
 
 #### Bugfixes
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -7,7 +7,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 6.3.6         | No  | February 4th, 2020   | -                    | 1.17.0             | 3.2.13           |
+| 6.3.7         | No  | February 12th, 2020  | -                    | 1.17.2             | 3.2.13           |
 | 6.2.5*        | No  | December 3rd, 2019   | -                    | 1.16.3             | 3.2.13           |
 | 6.1.18        | Yes | February 4th, 2020   | November 10th, 2021  | 1.15.5             | 3.2.12           |
 | 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
@@ -37,6 +37,17 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
 
 ## 6.x Releases
+
+### 6.3.7 (February 12th, 2020)
+
+#### Improvements
+
+* Update Kubernetes to `v1.17.2` ([#1080](https://github.com/gravitational/gravity/pull/1080)).
+
+#### Bugfixes
+
+* Fix an issue with merging `ClusterConfiguration` resource and validation checks ([#1093](https://github.com/gravitational/gravity/pull/1093)).
+* Update kernel module checker to support 5.0/5.1 Linux kernels ([#1094](https://github.com/gravitational/gravity/pull/1094)).
 
 ### 6.3.6 (February 4th, 2020)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,8 +1,5 @@
 DOCBOX=docs-buildbox:latest
-# BUILDROOT needs to be relative so that it works inside & outside the docbox container
-# - build to the gravity version specific version directory if running under the uber-make
-# - build to ../build/docs if running in this directory
-BUILDROOT ?= $(if $(GRAVITY_VERSION),../build/$(GRAVITY_VERSION),../build)
+BUILDROOT:=../build
 BUILDDIR:=$(BUILDROOT)/docs
 DOCBOX_ID_FILE=$(BUILDROOT)/.docs-buildbox.id
 WORKDIR=/home
@@ -10,7 +7,7 @@ PORT=6601
 DOCKERPORTS = -p $(PORT):$(PORT)
 NOROOT=-u $$(id -u):$$(id -g)
 DOCKERFLAGS = --rm=true $(NOROOT) -v "$$(pwd)/../":$(WORKDIR) -w $(WORKDIR)/docs -h docs
-DOCKERMAKE=docker run $(DOCKERFLAGS) $(DOCBOX) make BUILDROOT=$(BUILDROOT)
+DOCKERMAKE=docker run $(DOCKERFLAGS) $(DOCBOX) make
 VERSIONS=4.x 5.x 6.x 7.x
 LATEST=$(lastword $(VERSIONS))
 CFGS=$(addsuffix .yaml, $(VERSIONS))

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ WORKDIR=/home
 PORT=6601
 DOCKERPORTS = -p $(PORT):$(PORT)
 NOROOT=-u $$(id -u):$$(id -g)
-DOCKERFLAGS = --rm=true $(NOROOT) -v "$$(pwd)/../":$(WORKDIR) -w $(WORKDIR)/docs -h docs $(DOCKERPORTS)
+DOCKERFLAGS = --rm=true $(NOROOT) -v "$$(pwd)/../":$(WORKDIR) -w $(WORKDIR)/docs -h docs
 DOCKERMAKE=docker run $(DOCKERFLAGS) $(DOCBOX) make BUILDROOT=$(BUILDROOT)
 VERSIONS=4.x 5.x 6.x 7.x
 LATEST=$(lastword $(VERSIONS))
@@ -28,10 +28,14 @@ lint: $(DOCBOX_ID_FILE)
 	$(DOCKERMAKE) container-lint
 
 # run the docs in development mode
+#
+# requires DOCKERPORTS, which should not be shared with other targets due to
+# port collision. E.g. If other targets use DOCKERPORTS, multiple `make docs`
+# cannot run at the same time on the same server, which CI doesn't like --2020-03 walt
 .PHONY:run
 run: $(DOCBOX_ID_FILE) $(RUN_CFG)
 	@echo "\n\nOpen http://localhost:$(PORT)/ in your local browser\n\n"
-	$(DOCKERMAKE) container-run RUN_CFG=$(RUN_CFG)
+	docker run $(DOCKERFLAGS) $(DOCKERPORTS) $(DOCBOX) make BUILDROOT=$(BUILDROOT) container-run RUN_CFG=$(RUN_CFG)
 
 # drops you into bash shell of mkdocs container
 .PHONY:shell


### PR DESCRIPTION
This PR re-introduces the 5.5.38 changelog entry, which was accidentally removed in #1210 

In addition, it fixes a bug (no issue filed) introduced by c2c2dba8bb393b2dc51c8b65d8b20e5f0b7bfd67, where only one of (`make docs`, `make run-docs`, and `make docs-lint`) could be running at the same time, because they all requested port 6601.  This is the cause of the failure here:

https://jenkins.gravitational.io/view/Publishing/job/Telekube-Deploy-Docs/323/console

```
+ make docs
// snip ...
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs -p 6601:6601 docs-buildbox:latest make BUILDROOT=../build/7.0.0-rc.2.7 container-compile-docs
docker: Error response from daemon: driver failed programming external connectivity on endpoint vigilant_franklin (ac87f51ad097fc13bb8204324da97e50231cf9b4282238d7da81719b81a7618f): Bind for 0.0.0.0:6601 failed: port is already allocated.
make[1]: *** [docs] Error 125
make[1]: Leaving directory `/var/lib/jenkins/workspace/Telekube-Deploy-Docs/gravity/docs'
make: *** [docs] Error 2
Build step 'Execute shell' marked build as failure
```
