### PR TITLE
Disable GCE preemptible instances on nightly runs.

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -83,7 +83,7 @@ properties([
            defaultValue: 'dima',
            description: 'Robotest tag to use.'),
     choice(choices: ["true", "false"].join("\n"),
-           defaultValue: 'true',
+           defaultValue: 'false',
            description: 'Whether to use preemptible VMs.',
            name: 'GCE_PREEMPTIBLE'),
     choice(choices: ["custom-4-8192", "custom-8-8192"].join("\n"),


### PR DESCRIPTION
I triaged the past week of nightly failures today, and 1/3 of
failures are directly attributable to nodes being preempted.

I have not run the financial analysis to determine if preemptible
instances are saving on our GCE bill.

### Testing Done
None!  I believe this is simple enough I don't need to test it.