### PR TITLE
[report] dump plain-text resources

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1043,7 +1043,7 @@ var (
 
 	// KubernetesReportResourceTypes lists the kubernetes resource types used in diagnostics report
 	KubernetesReportResourceTypes = []string{"pods", "jobs", "services", "daemonsets", "deployments",
-		"endpoints", "replicationcontrollers", "replicasets"}
+		"endpoints", "replicationcontrollers", "replicasets", "events"}
 
 	// LogServiceURL is the URL of logging app API running in the cluster
 	LogServiceURL = fmt.Sprintf("http://%v:%v",

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -63,8 +63,11 @@ func systemClusterInfo(env *localenv.LocalEnvironment) error {
 	defer os.RemoveAll(dir)
 
 	var buf bytes.Buffer
-	cmd := exec.Command("kubectl", "cluster-info", "dump", "--all-namespaces",
-		fmt.Sprintf("--output-directory=%v", dir))
+	cmd := exec.Command("kubectl", "cluster-info", "dump",
+		"--all-namespaces",
+		"--output-directory", dir,
+		"--output", "yaml",
+	)
 	cmd.Stderr = &buf
 	if err := cmd.Run(); err != nil {
 		return trace.Wrap(err, "failed to dump kubernetes cluster info: %s", buf.String())


### PR DESCRIPTION
Revert the changes in lib/report to dump plain-text resource descriptions for better observability.
Also change `cluster-info dump` to dump resources as YAML for better readability w/o the need for post-processing.

Fixes https://github.com/gravitational/gravity/issues/1264.