### PR TITLE
Wait for operator.

### DIFF
--- a/lib/install/process.go
+++ b/lib/install/process.go
@@ -50,11 +50,6 @@ func InitProcess(ctx context.Context, gravityConfig processconfig.Config, newPro
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = p.WaitForAPI(ctx)
-	if err != nil {
-		shutdown(p)
-		return nil, trace.Wrap(err)
-	}
 	return p, nil
 }
 

--- a/lib/localenv/remoteenv.go
+++ b/lib/localenv/remoteenv.go
@@ -17,11 +17,13 @@ limitations under the License.
 package localenv
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/app/client"
@@ -163,6 +165,22 @@ func (w *RemoteEnvironment) LoginWizard(addr, token string) (entry *storage.Logi
 		Password:     token,
 		OpsCenterURL: url,
 	})
+}
+
+// WaitForOperator blocks until the configured operator becomes available or timeout expires.
+func (w *RemoteEnvironment) WaitForOperator(ctx context.Context) error {
+	err := utils.RetryFor(ctx, time.Minute, func() error {
+		if err := w.Operator.Ping(ctx); err != nil {
+			w.Infof("Operator isn't available yet: %v.", err)
+			return trace.Wrap(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	w.Info("Operator is available.")
+	return nil
 }
 
 func (w *RemoteEnvironment) login(entry storage.LoginEntry) (*storage.LoginEntry, error) {

--- a/lib/localenv/remoteenv.go
+++ b/lib/localenv/remoteenv.go
@@ -167,7 +167,7 @@ func (w *RemoteEnvironment) LoginWizard(addr, token string) (entry *storage.Logi
 	})
 }
 
-// WaitForOperator blocks until the configured operator becomes available or timeout expires.
+// WaitForOperator blocks until the configured operator becomes available or context expires.
 func (w *RemoteEnvironment) WaitForOperator(ctx context.Context) error {
 	err := utils.RetryFor(ctx, time.Minute, func() error {
 		if err := w.Operator.Ping(ctx); err != nil {

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -52,7 +52,6 @@ import (
 	"github.com/gravitational/gravity/lib/modules"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/monitoring"
-	"github.com/gravitational/gravity/lib/ops/opsclient"
 	"github.com/gravitational/gravity/lib/ops/opshandler"
 	"github.com/gravitational/gravity/lib/ops/opsroute"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
@@ -1654,26 +1653,6 @@ func (p *Process) ServeHealth() error {
 		// TODO(dmitri): add a cancelation point for p.context
 		return trace.Wrap(p.healthServer.ListenAndServe())
 	})
-	return nil
-}
-
-// WaitForAPI blocks until the process API is available or retry attempts reached.
-func (p *Process) WaitForAPI(ctx context.Context) error {
-	client, err := opsclient.NewClient(p.packages.PortalURL(), opsclient.HTTPClient(httplib.GetClient(true)))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = utils.RetryFor(ctx, time.Minute, func() error {
-		if err := client.Ping(ctx); err != nil {
-			p.Infof("Process API isn't available yet: %v.", err)
-			return trace.Wrap(err)
-		}
-		return nil
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	p.Info("Process API is available.")
 	return nil
 }
 

--- a/lib/process/service.go
+++ b/lib/process/service.go
@@ -45,8 +45,6 @@ type GravityProcess interface {
 	UsersService() users.Identity
 	// Config returns the proces config
 	Config() *processconfig.Config
-	// WaitForAPI blocks until the process API is available or the context expires
-	WaitForAPI(context.Context) error
 	// Shutdown starts graceful shutdown of the process,
 	// blocks until all resources are freed and go-routines have shut down
 	Shutdown(context.Context)
@@ -79,10 +77,6 @@ func Run(ctx context.Context, configDir, importDir string, newProcess NewGravity
 		return trace.Wrap(err)
 	}
 	err = process.Start()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = process.WaitForAPI(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -145,6 +145,10 @@ func newInstallerConfig(ctx context.Context, env *localenv.LocalEnvironment, con
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	err = wizard.WaitForOperator(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	installerConfig, err := config.NewInstallerConfig(env, wizard, process, resources.ValidateFunc(gravity.Validate))
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
My previous attempt to fix the issue with waiting for process listeners to come up by embedding "wait" function into the process itself has some deficiencies as it turns out. In particular, process itself can't really reliably call it's own API in a general use-case b/c it doesn't know how clients are supposed to reach it: for example in installer use-case the advertise address is the IP address which works fine but when installing a hub, the "pack" address (which I used before) points to the public advertise hostname of the hub.

This PR instead moves the logic of checking the operator status to the caller - I integrated it into RemoteEnvironment instead which I think suits its purpose cause it knows the address of the installer it talks to, and the installer calls this method explicitly.