### PR TITLE
Bump e to remove redundant SELinux bootstrap calls

### DIFF
--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -506,7 +506,9 @@ func (i *InstallConfig) RunLocalChecks() error {
 func (i *InstallConfig) BootstrapSELinux(ctx context.Context, printer utils.Printer) error {
 	logger := log.WithField(trace.Component, "selinux")
 	if !i.shouldBootstrapSELinux() {
-		logger.Info("SELinux disabled with configuration.")
+		if !i.FromService {
+			logger.Info("SELinux disabled with configuration.")
+		}
 		return nil
 	}
 	metadata, err := monitoring.GetOSRelease()
@@ -864,7 +866,9 @@ func (j *JoinConfig) GetRuntimeConfig() proto.RuntimeConfig {
 func (j *JoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
 	logger := log.WithField(trace.Component, "selinux")
 	if !j.shouldBootstrapSELinux() {
-		logger.Info("SELinux disabled with configuration.")
+		if !j.FromService {
+			logger.Info("SELinux disabled with configuration.")
+		}
 		return nil
 	}
 	metadata, err := monitoring.GetOSRelease()
@@ -938,7 +942,9 @@ func (r *autojoinConfig) checkAndSetDefaults() error {
 func (j *autojoinConfig) bootstrapSELinux(ctx context.Context, printer utils.Printer) error {
 	logger := log.WithField(trace.Component, "selinux")
 	if !j.shouldBootstrapSELinux() {
-		logger.Info("SELinux disabled with configuration.")
+		if !j.fromService {
+			logger.Info("SELinux disabled with configuration.")
+		}
 		return nil
 	}
 	metadata, err := monitoring.GetOSRelease()


### PR DESCRIPTION
Requires https://github.com/gravitational/gravity.e/pull/4285.