### PR TITLE
Tweak top-level Makefile for targeted builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,9 +597,7 @@ tele-mac: flags
 # goinstall builds and installs gravity locally
 #
 .PHONY: goinstall
-goinstall: remove-temp-files compile
-	mkdir -p $(GRAVITY_BUILDDIR)
-	mkdir -p $(TF_PROVIDER_DIR)
+goinstall: remove-temp-files compile | $(TF_PROVIDER_DIR) $(GRAVITY_BUILDDIR)
 	for bin in ${BINARIES} ; do \
 		cp $(GOPATH)/bin/$${bin} $(GRAVITY_BUILDDIR)/$${bin} ; \
 	done
@@ -614,8 +612,14 @@ goinstall: remove-temp-files compile
 		$(GRAVITY) package import $(GRAVITY_OUT) $(GRAVITY_PKG)
 	$(MAKE) binary-packages
 
+$(GRAVITY_BUILDDIR):
+	mkdir -p $@
+
+$(TF_PROVIDER_DIR):
+	mkdir -p $@
+
 .PHONY: $(BINARIES)
-$(BINARIES):
+$(BINARIES): selinux
 	go install -ldflags $(GRAVITY_LINKFLAGS) -tags "$(GRAVITY_BUILDTAGS)" $(GRAVITY_PKG_PATH)/tool/$@
 
 .PHONY: wizard-publish
@@ -692,7 +696,7 @@ robotest-installer-ready:
 	mv $(GRAVITY_BUILDDIR)/telekube.tar $(GRAVITY_BUILDDIR)/telekube_ready.tar
 
 .PHONY: dev
-dev: selinux goinstall
+dev: goinstall
 
 # Clean up development environment:
 #  + remove development directories


### PR DESCRIPTION
Move selinux dependency closer to $(BINARIES) target in top-level makefile to enable targeted builds.