### PR TITLE
[5.5.x] expand improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -868,11 +868,12 @@
   version = "5.5.2"
 
 [[projects]]
-  digest = "1:27daf346b94c013dcec722a9e596d5bff92d7559ab37f787fd71b128bc31066a"
+  branch = "dmitri/optional-context"
+  digest = "1:283710d107ea5e719f4515eb3f0593ffc826332964a3e019dea168a2ecc02674"
   name = "github.com/gravitational/roundtrip"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6a87d116a90b9c4e73bedc19ebc9c17f1b43d826"
+  revision = "bb1c52b93c1831d2aad1cc403f172a9df9c17298"
 
 [[projects]]
   digest = "1:5fdac9094bb05fdf65f336bb375bd850a549af205739158f4a54301e17d86895"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -868,12 +868,12 @@
   version = "5.5.2"
 
 [[projects]]
-  branch = "dmitri/optional-context"
+  branch = "version/5.5.x"
   digest = "1:283710d107ea5e719f4515eb3f0593ffc826332964a3e019dea168a2ecc02674"
   name = "github.com/gravitational/roundtrip"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bb1c52b93c1831d2aad1cc403f172a9df9c17298"
+  revision = "2e451040dbe9def043beba737d92a6b773bbd3f2"
 
 [[projects]]
   digest = "1:5fdac9094bb05fdf65f336bb375bd850a549af205739158f4a54301e17d86895"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -970,12 +970,12 @@
   revision = "50a1f1cab731ca2d5096166e36f45c12ecb1cbe3"
 
 [[projects]]
-  digest = "1:dc84545f9f2a442b14864f2f7e54ae556cae53bd437a05a456572fea9e73cc87"
+  digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"
   name = "github.com/gravitational/trace"
   packages = ["."]
   pruneopts = "UT"
-  revision = "dd5b2e8eae86d31f6273ff3ac46d5b15edd6d6be"
-  version = "1.1.10"
+  revision = "2d27a078e25b4e8f656d1354fddf37d316d1e9bf"
+  version = "1.1.11"
 
 [[projects]]
   digest = "1:841d5835e94129658adabece66a4cc54d2cec9a40fa8b51743ea35d0519dd6c2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -196,7 +196,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/roundtrip"
-  revision = "6a87d116a90b9c4e73bedc19ebc9c17f1b43d826"
+  branch = "dmitri/optional-context"
 
 [[constraint]]
   name = "github.com/gravitational/teleport"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/trace"
-  version = "=1.1.10"
+  version = "=1.1.11"
 
 [[override]]
   name = "github.com/mitchellh/go-ps"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -196,7 +196,7 @@ ignored = [
 
 [[override]]
   name = "github.com/gravitational/roundtrip"
-  branch = "dmitri/optional-context"
+  branch = "version/5.5.x"
 
 [[constraint]]
   name = "github.com/gravitational/teleport"

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -213,6 +213,10 @@ const (
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 
+	// AgentGroupPeerReconnectTimeout is the maximum amount of time agent group will attempt
+	// to reconnect to the peer
+	AgentGroupPeerReconnectTimeout = 15 * time.Minute
+
 	// EnvPeerConnectTimeout is the environment variable that overrides the value of the
 	// agent timeout for the validating connect
 	EnvPeerConnectTimeout = "GRAVITY_PEER_CONNECT_TIMEOUT"

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -887,6 +887,10 @@ const (
 	// RPCAgentSecretsPackage specifies the name of the RPC credentials package
 	RPCAgentSecretsPackage = "rpcagent-secrets"
 
+	// ShutdownTimeout specifies the maximum amount of time to wait for completion
+	// when closing
+	ShutdownTimeout = 1 * time.Minute
+
 	// ArchiveUID specifies the user ID to use for tarball items that do not exist on disk
 	ArchiveUID = 1000
 

--- a/lib/expand/fsm.go
+++ b/lib/expand/fsm.go
@@ -198,16 +198,13 @@ func (e *fsmEngine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, nod
 // Complete is called to mark operation complete
 func (e *fsmEngine) Complete(fsmErr error) error {
 	plan, err := e.GetPlan()
-	if err != nil && !trace.IsNotFound(err) {
+	if err != nil {
 		return trace.Wrap(err)
 	}
 	if fsmErr == nil {
 		fsmErr = trace.Errorf("completed manually")
 	}
-	if err == nil {
-		return fsm.CompleteOperation(plan, e.Operator, fsmErr.Error())
-	}
-	return ops.FailOperation(fsm.OperationKey(*plan), e.Operator, fsmErr.Error())
+	return fsm.CompleteOrFailOperation(plan, e.Operator, fsmErr.Error())
 }
 
 // UpdateProgress reports operation progress to the cluster's operator

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -620,7 +620,7 @@ func (p *Peer) waitForAgents(ctx operationContext) error {
 			if tm.IsZero() {
 				return trace.ConnectionProblem(nil, "timed out waiting for agents to join")
 			}
-			report, err := ctx.Operator.GetSiteExpandOperationAgentReport(ctx.Operation.Key())
+			report, err := ctx.Operator.GetSiteExpandOperationAgentReport(p.Context, ctx.Operation.Key())
 			if err != nil {
 				log.WithField("err", err).Warn("Failed to query operation report.")
 				continue

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
@@ -144,6 +145,7 @@ type Peer struct {
 	agentDoneCh <-chan struct{}
 	// agent is this peer's RPC agent
 	agent *rpcserver.PeerServer
+	wg    sync.WaitGroup
 }
 
 // NewPeer returns new cluster peer client
@@ -167,7 +169,7 @@ func (p *Peer) Init() error {
 // formatClusterURL returns cluster API URL from the provided peer addr which
 // can be either IP address or a URL (in which case it is returned as-is)
 func formatClusterURL(addr string) string {
-	if strings.Contains(addr, "http") {
+	if strings.HasPrefix(addr, "http") {
 		return addr
 	}
 	return fmt.Sprintf("https://%v:%v", addr, defaults.GravitySiteNodePort)
@@ -180,7 +182,6 @@ func (p *Peer) dialSite(addr string) (*operationContext, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	packages, err := webpack.NewBearerClient(targetURL, p.Token, roundtrip.HTTPClient(httpClient))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -205,15 +206,6 @@ func (p *Peer) dialSite(addr string) (*operationContext, error) {
 	if err != nil {
 		return nil, utils.Abort(err) // stop retrying on failed checks
 	}
-	var operation *ops.SiteOperation
-	if p.OperationID == "" {
-		operation, err = p.createExpandOperation(operator, *cluster)
-	} else {
-		operation, err = p.getExpandOperation(operator, *cluster)
-	}
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	creds, err := install.LoadRPCCredentials(p.Context, packages, p.FieldLogger)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -222,15 +214,27 @@ func (p *Peer) dialSite(addr string) (*operationContext, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &operationContext{
-		Operator:  operator,
-		Packages:  packages,
-		Apps:      apps,
-		Peer:      peerURL.Host,
-		Operation: *operation,
-		Cluster:   *cluster,
-		Creds:     *creds,
-	}, nil
+	var operation *ops.SiteOperation
+	if p.OperationID == "" {
+		operation, err = p.createExpandOperation(operator, *cluster)
+	} else {
+		operation, err = p.getExpandOperation(operator, *cluster)
+	}
+	ctx := &operationContext{
+		Operator: operator,
+		Packages: packages,
+		Apps:     apps,
+		Peer:     peerURL.Host,
+		Cluster:  *cluster,
+		Creds:    *creds,
+	}
+	if operation != nil {
+		ctx.Operation = *operation
+	}
+	if err != nil {
+		return ctx, trace.Wrap(err)
+	}
+	return ctx, nil
 }
 
 // createExpandOperation creates a new expand operation
@@ -244,15 +248,15 @@ func (p *Peer) createExpandOperation(operator ops.Operator, cluster ops.Site) (*
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	operation, err := operator.GetSiteOperation(*key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	err = operator.SetOperationState(*key, ops.SetOperationStateRequest{
 		State: ops.OperationStateReady,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	operation, err := operator.GetSiteOperation(*key)
-	if err != nil {
-		return nil, trace.Wrap(err)
+		return operation, trace.Wrap(err)
 	}
 	return operation, nil
 }
@@ -384,10 +388,10 @@ func (p *Peer) connect() (*operationContext, error) {
 			if err != nil {
 				// join token is incorrect, fail immediately and report to user
 				if trace.IsAccessDenied(err) {
-					return nil, trace.AccessDenied("access denied: bad secret token")
+					return ctx, trace.AccessDenied("access denied: bad secret token")
 				}
 				if err, ok := trace.Unwrap(err).(*utils.AbortRetry); ok {
-					return nil, trace.BadParameter(err.OriginalError())
+					return ctx, trace.BadParameter(err.OriginalError())
 				}
 				// most of the time errors are expected, like another operation
 				// is in progress, so just retry until we connect (or timeout)
@@ -418,7 +422,6 @@ func (p *Peer) tryConnect() (op *operationContext, err error) {
 			p.sendMessage("Waiting for the install operation to finish")
 			return nil, trace.Wrap(err)
 		}
-
 		op, err = p.dialSite(addr)
 		if err == nil {
 			p.Debugf("Connected to cluster at %v.", op.Peer)
@@ -427,7 +430,7 @@ func (p *Peer) tryConnect() (op *operationContext, err error) {
 		}
 		p.Infof("Failed connecting to cluster: %v.", err)
 		if utils.IsAbortError(err) {
-			return nil, trace.Wrap(err)
+			return op, trace.Wrap(err)
 		}
 		if trace.IsCompareFailed(err) {
 			p.sendMessage("Waiting for another operation to finish at %v", addr)
@@ -504,6 +507,29 @@ func (p *Peer) getAgent(opCtx operationContext) (*rpcserver.PeerServer, error) {
 
 func (p *Peer) run() error {
 	ctx, err := p.connect()
+
+	// schedule a cleanup function to fail the operation if this exits
+	// with error
+	defer func() {
+		if err == nil {
+			return
+		}
+		p.WithError(err).Warn("Peer is exiting with error.")
+		stopCtx, cancel := context.WithTimeout(context.Background(), defaults.AgentStopTimeout)
+		defer cancel()
+		if p.agent != nil {
+			p.Info("Stopping peer.")
+			if err := p.agent.Stop(stopCtx); err != nil {
+				p.WithError(err).Error("Failed to stop peer.")
+			}
+		}
+		if ctx != nil && ctx.Operation.ID != "" {
+			if err2 := ops.FailOperation(ctx.Operation.Key(), ctx.Operator, err.Error()); err2 != nil {
+				p.WithError(err2).Error("Failed to mark the operation as failed.")
+			}
+		}
+	}()
+
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -517,35 +543,6 @@ func (p *Peer) run() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// schedule cleanup function in case anything goes wrong before
-	// the operation can start
-	defer func() {
-		if err == nil {
-			return
-		}
-		p.Warnf("Peer is exiting with error: %v.", trace.DebugReport(err))
-		stopCtx, cancel := context.WithTimeout(p.Context, defaults.AgentStopTimeout)
-		defer cancel()
-		p.Warn("Stopping peer.")
-		if err := p.Stop(stopCtx); err != nil {
-			p.Errorf("Failed to stop peer: %v.", trace.DebugReport(err))
-		}
-		// in case of join via CLI the operation has already been created
-		// above but the agent failed to connect so we're deleting the
-		// operation because from user's perspective it hasn't started
-		//
-		// in case of join via UI the peer is joining to the existing
-		// operation created via UI so we're not touching it and the
-		// user can cancel it in the UI
-		if p.OperationID == "" { // operation ID is given in UI usecase
-			p.Warnf("Cleaning up unstarted operation %v.", ctx.Operation)
-			if err := ctx.Operator.DeleteSiteOperation(ctx.Operation.Key()); err != nil {
-				p.Errorf("Failed to delete unstarted operation: %v.",
-					trace.DebugReport(err))
-			}
-		}
-	}()
 
 	p.agent, err = p.getAgent(*ctx)
 	if err != nil {
@@ -562,19 +559,20 @@ func (p *Peer) run() error {
 		}
 	}
 
-	install.PollProgress(p.Context, p.send, ctx.Operator, ctx.Operation.Key(), p.agent.Done())
-	return nil
+	err = install.PollProgress(p.Context, p.send, ctx.Operator, ctx.Operation.Key(), p.agent.Done())
+	return trace.Wrap(err)
 }
 
 // Stop shuts down RPC agent
 func (p *Peer) Stop(ctx context.Context) error {
-	if p.agent == nil {
-		return nil
+	if p.agent != nil {
+		err := p.agent.Stop(ctx)
+		if err != nil {
+			p.WithError(err).Warn("Failed to stop agent.")
+		}
 	}
-	err := p.agent.Stop(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	p.Cancel()
+	p.wg.Wait()
 	return nil
 }
 
@@ -624,7 +622,7 @@ func (p *Peer) waitForAgents(ctx operationContext) error {
 			}
 			report, err := ctx.Operator.GetSiteExpandOperationAgentReport(ctx.Operation.Key())
 			if err != nil {
-				log.Warningf("%v", err)
+				log.WithField("err", err).Warn("Failed to query operation report.")
 				continue
 			}
 			if len(report.Servers) == 0 {
@@ -633,12 +631,12 @@ func (p *Peer) waitForAgents(ctx operationContext) error {
 			}
 			op, err := ctx.Operator.GetSiteOperation(ctx.Operation.Key())
 			if err != nil {
-				log.Warningf("%v", err)
+				log.WithField("err", err).Warn("Failed to query cluster operation.")
 				continue
 			}
 			req, err := install.GetServers(*op, report.Servers)
 			if err != nil {
-				log.Warningf("%v", err)
+				log.WithField("err", err).Warn("Failed to query servers.")
 				continue
 			}
 			err = ctx.Operator.UpdateExpandOperationState(ctx.Operation.Key(), *req)
@@ -680,11 +678,13 @@ func (p *Peer) printf(format string, args ...interface{}) {
 
 // Start starts non-interactive join process
 func (p *Peer) Start() (err error) {
+	p.wg.Add(1)
 	go func() {
 		err := p.run()
 		if err != nil {
 			p.send(install.Event{Error: err})
 		}
+		p.wg.Done()
 	}()
 	return nil
 }
@@ -698,6 +698,10 @@ func (p *Peer) Done() <-chan struct{} {
 // Wait waits for the expand operation to complete
 func (p *Peer) Wait() error {
 	start := time.Now()
+	defer func() {
+		p.Cancel()
+		p.wg.Wait()
+	}()
 	for {
 		select {
 		case <-p.Done():
@@ -753,6 +757,7 @@ After all phases have completed successfully, complete the operation using "grav
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	p.wg.Add(1)
 	go func() {
 		fsmErr := fsm.ExecutePlan(p.Context, utils.NewNopProgress())
 		if err != nil {
@@ -762,6 +767,7 @@ After all phases have completed successfully, complete the operation using "grav
 		if err != nil {
 			p.WithError(err).Warn("Failed to complete operation.")
 		}
+		p.wg.Done()
 	}()
 	return nil
 }

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -17,11 +17,13 @@ limitations under the License.
 package fsm
 
 import (
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // CanRollback checks if specified phase can be rolled back
@@ -214,6 +216,25 @@ func ClusterKey(plan storage.OperationPlan) ops.SiteKey {
 		AccountID:  plan.AccountID,
 		SiteDomain: plan.ClusterName,
 	}
+}
+
+// CompleteOperation completes the operation given by the plan in the specified operator.
+// planErr optionally specifies the error to record in the failed message
+func CompleteOperation(plan *storage.OperationPlan, operator ops.Operator, planErr string) (err error) {
+	key := OperationKey(*plan)
+	if IsCompleted(plan) {
+		err = ops.CompleteOperation(key, operator)
+	} else {
+		err = ops.FailOperation(key, operator, planErr)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	logrus.WithFields(logrus.Fields{
+		constants.FieldSuccess: IsCompleted(plan),
+		constants.FieldError:   planErr,
+	}).Debug("Marked operation complete.")
+	return nil
 }
 
 func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -218,9 +218,9 @@ func ClusterKey(plan storage.OperationPlan) ops.SiteKey {
 	}
 }
 
-// CompleteOperation completes the operation given by the plan in the specified operator.
-// planErr optionally specifies the error to record in the failed message
-func CompleteOperation(plan *storage.OperationPlan, operator ops.Operator, planErr string) (err error) {
+// CompleteOrFailOperation completes or fails the operation given by the plan in the specified operator.
+// planErr optionally specifies the error to record in the failed message and record operation failure
+func CompleteOrFailOperation(plan *storage.OperationPlan, operator ops.Operator, planErr string) (err error) {
 	key := OperationKey(*plan)
 	if IsCompleted(plan) {
 		err = ops.CompleteOperation(key, operator)

--- a/lib/httplib/client.go
+++ b/lib/httplib/client.go
@@ -212,7 +212,11 @@ type Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 // using local resolver prior to dialing
 func DialFromEnviron(dnsAddr string) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
-		log.WithField("addr", addr).Debug("Dial.")
+		logger := log.WithFields(log.Fields{
+			"addr":    addr,
+			"network": network,
+		})
+		logger.Debug("Dial.")
 
 		if isInsidePod() {
 			return Dial(ctx, network, addr)
@@ -224,7 +228,7 @@ func DialFromEnviron(dnsAddr string) func(ctx context.Context, network, addr str
 		}
 
 		// Dial with a kubernetes service resolver
-		log.WithError(err).Warn("Failed to dial with local resolver.")
+		logger.WithError(err).Warn("Failed to dial with local resolver.")
 		return DialWithServiceResolver(ctx, network, addr)
 
 	}
@@ -250,7 +254,7 @@ func DialWithLocalResolver(ctx context.Context, dnsAddr, network, addr string) (
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to resolve %v", addr)
 	}
-	log.Debugf("Dialing %v", hostPort)
+	log.WithField("host-port", hostPort).Debug("Dial.")
 	var d net.Dialer
 	return d.DialContext(ctx, network, hostPort)
 }

--- a/lib/httplib/client.go
+++ b/lib/httplib/client.go
@@ -212,7 +212,7 @@ type Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 // using local resolver prior to dialing
 func DialFromEnviron(dnsAddr string) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
-		log.Debugf("dialing %v", addr)
+		log.WithField("addr", addr).Debug("Dial.")
 
 		if isInsidePod() {
 			return Dial(ctx, network, addr)
@@ -224,7 +224,7 @@ func DialFromEnviron(dnsAddr string) func(ctx context.Context, network, addr str
 		}
 
 		// Dial with a kubernetes service resolver
-		log.Warnf("Failed to dial with local resolver: %v.", trace.DebugReport(err))
+		log.WithError(err).Warn("Failed to dial with local resolver.")
 		return DialWithServiceResolver(ctx, network, addr)
 
 	}
@@ -250,7 +250,7 @@ func DialWithLocalResolver(ctx context.Context, dnsAddr, network, addr string) (
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to resolve %v", addr)
 	}
-	log.Debugf("dialing %v", hostPort)
+	log.Debugf("Dialing %v", hostPort)
 	var d net.Dialer
 	return d.DialContext(ctx, network, hostPort)
 }

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -536,11 +536,11 @@ func (o *OperatorACL) StreamOperationLogs(key SiteOperationKey, reader io.Reader
 	return o.operator.StreamOperationLogs(key, reader)
 }
 
-func (o *OperatorACL) GetSiteExpandOperationAgentReport(key SiteOperationKey) (*AgentReport, error) {
+func (o *OperatorACL) GetSiteExpandOperationAgentReport(ctx context.Context, key SiteOperationKey) (*AgentReport, error) {
 	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteExpandOperationAgentReport(key)
+	return o.operator.GetSiteExpandOperationAgentReport(ctx, key)
 }
 
 func (o *OperatorACL) SiteExpandOperationStart(key SiteOperationKey) error {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -672,7 +672,7 @@ type Operations interface {
 	//
 	// 2. This method is called as a second step to get information
 	// about servers participating in the operations
-	GetSiteExpandOperationAgentReport(SiteOperationKey) (*AgentReport, error)
+	GetSiteExpandOperationAgentReport(context.Context, SiteOperationKey) (*AgentReport, error)
 
 	// SiteExpandOperationStart begins actuall expand using
 	// the Operation plan configured as a previous step

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -500,8 +500,8 @@ func (c *Client) SiteInstallOperationStart(req ops.SiteOperationKey) error {
 	return nil
 }
 
-func (c *Client) GetSiteExpandOperationAgentReport(key ops.SiteOperationKey) (*ops.AgentReport, error) {
-	out, err := c.Get(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "operations", "expand", key.OperationID, "agent-report"), url.Values{})
+func (c *Client) GetSiteExpandOperationAgentReport(ctx context.Context, key ops.SiteOperationKey) (*ops.AgentReport, error) {
+	out, err := c.GetWithContext(ctx, c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "operations", "expand", key.OperationID, "agent-report"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1531,7 +1531,12 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*roundtrip.Response
 
 // Get issues HTTP GET request to the server
 func (c *Client) Get(endpoint string, params url.Values) (*roundtrip.Response, error) {
-	return telehttplib.ConvertResponse(c.Client.Get(endpoint, params))
+	return c.GetWithContext(context.TODO(), endpoint, params)
+}
+
+// GetWithContext issues HTTP GET request bound to the specified context to the server
+func (c *Client) GetWithContext(ctx context.Context, endpoint string, params url.Values) (*roundtrip.Response, error) {
+	return telehttplib.ConvertResponse(c.Client.Get(endpoint, params, roundtrip.WithContext(ctx)))
 }
 
 // GetFile issues HTTP GET request to the server to download a file

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1630,8 +1630,8 @@ Success response:
       "instructions": "download instructions to display to user"
    }
 */
-func (h *WebHandler) getSiteExpandOperationAgentReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	agentReport, err := context.Operator.GetSiteExpandOperationAgentReport(siteOperationKey(p))
+func (h *WebHandler) getSiteExpandOperationAgentReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, hcontext *HandlerContext) error {
+	agentReport, err := hcontext.Operator.GetSiteExpandOperationAgentReport(r.Context(), siteOperationKey(p))
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -377,12 +377,12 @@ func (r *Router) StreamOperationLogs(key ops.SiteOperationKey, reader io.Reader)
 	return client.StreamOperationLogs(key, reader)
 }
 
-func (r *Router) GetSiteExpandOperationAgentReport(key ops.SiteOperationKey) (*ops.AgentReport, error) {
+func (r *Router) GetSiteExpandOperationAgentReport(ctx context.Context, key ops.SiteOperationKey) (*ops.AgentReport, error) {
 	client, err := r.PickOperationClient(key.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteExpandOperationAgentReport(key)
+	return client.GetSiteExpandOperationAgentReport(ctx, key)
 }
 
 func (r *Router) SiteExpandOperationStart(key ops.SiteOperationKey) error {

--- a/lib/ops/opsservice/agents_test.go
+++ b/lib/ops/opsservice/agents_test.go
@@ -346,11 +346,11 @@ func (s *AgentSuite) token(tok string) string {
 	return fmt.Sprintf("%v.%v", tok, s.key.OperationID)
 }
 
-func newTestAgentGroup(c *C, addr, hostname string) agentGroup {
+func newTestAgentGroup(c *C, addr, hostname string) *agentGroup {
 	group, err := rpcserver.NewAgentGroup(rpcserver.AgentGroupConfig{}, []rpcserver.Peer{testPeer{addr: addr}})
 	c.Assert(err, IsNil)
 
-	return agentGroup{
+	return &agentGroup{
 		AgentGroup: *group,
 		hostnames:  map[string]string{addr: hostname},
 	}
@@ -380,19 +380,19 @@ func newSystemInfo(hostname string) rpcserver.TestSystemInfo {
 	sysinfo := storage.NewSystemInfo(storage.SystemSpecV2{
 		Hostname: hostname,
 		Filesystems: []storage.Filesystem{
-			storage.Filesystem{
+			{
 				DirName: "/foo/bar",
 				Type:    "tmpfs",
 			},
 		},
 		FilesystemStats: map[string]storage.FilesystemUsage{
-			"/foo/bar": storage.FilesystemUsage{
+			"/foo/bar": {
 				TotalKB: 512,
 				FreeKB:  0,
 			},
 		},
 		NetworkInterfaces: map[string]storage.NetworkInterface{
-			"device0": storage.NetworkInterface{
+			"device0": {
 				Name: "device0",
 				IPv4: "172.168.0.1",
 			},

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -128,11 +128,8 @@ func (s *site) createInstallExpandOperation(operationType, operationInitialState
 	}
 
 	tokenType := storage.ProvisioningTokenTypeInstall
-	expires := s.clock().UtcNow().Add(defaults.InstallTokenTTL)
 	if op.Type == ops.OperationExpand {
 		tokenType = storage.ProvisioningTokenTypeExpand
-		// Do not expire join tokens
-		expires = time.Time{}
 	}
 
 	_, err = s.users().CreateProvisioningToken(storage.ProvisioningToken{
@@ -140,7 +137,6 @@ func (s *site) createInstallExpandOperation(operationType, operationInitialState
 		AccountID:   s.key.AccountID,
 		SiteDomain:  s.key.SiteDomain,
 		Type:        storage.ProvisioningTokenType(tokenType),
-		Expires:     expires,
 		OperationID: op.ID,
 		UserEmail:   agentUser.GetName(),
 	})

--- a/lib/ops/opsservice/operationgroup.go
+++ b/lib/ops/opsservice/operationgroup.go
@@ -23,9 +23,11 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -263,15 +265,11 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	}
 
 	if operation.IsCompleted() {
-		token, err := cluster.users().GetOperationProvisioningToken(key.SiteDomain, key.OperationID)
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		if err == nil {
-			err = cluster.users().DeleteProvisioningToken(*token)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+		if err := deleteProvisioningTokenForOperation(cluster.users(), key); err != nil && !trace.IsNotFound(err) {
+			log.WithFields(logrus.Fields{
+				logrus.ErrorKey: err,
+				"operation":     operation.String(),
+			}).Warn("Failed to delete provisioning token.")
 		}
 	}
 
@@ -286,6 +284,14 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	}
 
 	return nil
+}
+
+func deleteProvisioningTokenForOperation(users users.Identity, key ops.SiteOperationKey) error {
+	token, err := users.GetOperationProvisioningToken(key.SiteDomain, key.OperationID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return users.DeleteProvisioningToken(*token)
 }
 
 // addClusterStateServers adds the provided servers to the cluster state

--- a/lib/ops/opsservice/operationgroup_test.go
+++ b/lib/ops/opsservice/operationgroup_test.go
@@ -113,7 +113,7 @@ func (s *OperationGroupSuite) TestExpandMaxConcurrency(c *check.C) {
 			State:      ops.OperationStateExpandInitiated,
 			InstallExpand: &storage.InstallExpandOperationState{
 				Profiles: map[string]storage.ServerProfile{
-					"node": storage.ServerProfile{
+					"node": {
 						ServiceRole: string(schema.ServiceRoleNode),
 					},
 				},
@@ -132,7 +132,7 @@ func (s *OperationGroupSuite) TestExpandMaxConcurrency(c *check.C) {
 		State:      ops.OperationStateExpandInitiated,
 		InstallExpand: &storage.InstallExpandOperationState{
 			Profiles: map[string]storage.ServerProfile{
-				"node": storage.ServerProfile{
+				"node": {
 					ServiceRole: string(schema.ServiceRoleNode),
 				},
 			},
@@ -228,7 +228,7 @@ func (s *OperationGroupSuite) TestMultiExpandClusterState(c *check.C) {
 			State:      ops.OperationStateExpandInitiated,
 			InstallExpand: &storage.InstallExpandOperationState{
 				Profiles: map[string]storage.ServerProfile{
-					"node": storage.ServerProfile{
+					"node": {
 						ServiceRole: string(schema.ServiceRoleNode),
 					},
 				},

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1022,7 +1022,7 @@ func (o *Operator) GetSiteInstallOperationAgentReport(key ops.SiteOperationKey) 
 	return o.getSiteOperationAgentReport(key)
 }
 
-func (o *Operator) GetSiteExpandOperationAgentReport(key ops.SiteOperationKey) (*ops.AgentReport, error) {
+func (o *Operator) GetSiteExpandOperationAgentReport(_ context.Context, key ops.SiteOperationKey) (*ops.AgentReport, error) {
 	return o.getSiteOperationAgentReport(key)
 }
 

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -38,13 +38,13 @@ import (
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
-	"github.com/gravitational/rigging"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/license"
+	"github.com/gravitational/rigging"
 	"github.com/gravitational/trace"
 	"github.com/mailgun/timetools"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // site is an internal helper object that implements operations

--- a/lib/ops/resources/gravity/gravity_test.go
+++ b/lib/ops/resources/gravity/gravity_test.go
@@ -101,7 +101,7 @@ func (s *GravityResourcesSuite) TestUser(c *check.C) {
 
 	collectionI, err = s.r.GetCollection(resources.ListRequest{Kind: "user", Name: "test"})
 	if !trace.IsNotFound(err) {
-		c.Errorf("Expected err to be a not found error but got %T", err)
+		c.Error("Expected the error to be of type NotFound.")
 	}
 }
 

--- a/lib/processconfig/config.go
+++ b/lib/processconfig/config.go
@@ -54,13 +54,17 @@ func ReadConfig(configDir string) (*Config, *telecfg.FileConfig, error) {
 		searchPaths = defaults.GravityConfigDirs
 	}
 
+	log.Debugf("got search paths: %v", searchPaths)
 	for _, path := range searchPaths {
+		log.Debugf("look up configs in %v", path)
+
 		gravityName := filepath.Join(path, defaults.GravityYAMLFile)
 		data, err := teleutils.ReadPath(gravityName)
 		if err != nil {
 			if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 				return nil, nil, trace.Wrap(err)
 			}
+			log.Debugf("%v not found in search path", gravityName)
 			continue
 		}
 
@@ -78,6 +82,7 @@ func ReadConfig(configDir string) (*Config, *telecfg.FileConfig, error) {
 			if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 				return nil, nil, trace.Wrap(err)
 			}
+			log.Debugf("%v not found in search path", teleportName)
 			continue
 		}
 

--- a/lib/processconfig/config.go
+++ b/lib/processconfig/config.go
@@ -54,17 +54,13 @@ func ReadConfig(configDir string) (*Config, *telecfg.FileConfig, error) {
 		searchPaths = defaults.GravityConfigDirs
 	}
 
-	log.Debugf("got search paths: %v", searchPaths)
 	for _, path := range searchPaths {
-		log.Debugf("look up configs in %v", path)
-
 		gravityName := filepath.Join(path, defaults.GravityYAMLFile)
 		data, err := teleutils.ReadPath(gravityName)
 		if err != nil {
 			if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 				return nil, nil, trace.Wrap(err)
 			}
-			log.Debugf("%v not found in search path", gravityName)
 			continue
 		}
 
@@ -82,7 +78,6 @@ func ReadConfig(configDir string) (*Config, *telecfg.FileConfig, error) {
 			if !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 				return nil, nil, trace.Wrap(err)
 			}
-			log.Debugf("%v not found in search path", teleportName)
 			continue
 		}
 

--- a/lib/storage/keyval/tokens.go
+++ b/lib/storage/keyval/tokens.go
@@ -81,7 +81,7 @@ func (b *backend) GetOperationProvisioningToken(clusterName, operationID string)
 			return t, nil
 		}
 	}
-	return nil, trace.Wrap(err)
+	return nil, trace.NotFound("not provisioning token for cluster %v and operation %v", clusterName, operationID)
 }
 
 // GetSiteProvisioningTokens returns install token for site

--- a/lib/storage/keyval/tokens.go
+++ b/lib/storage/keyval/tokens.go
@@ -81,7 +81,7 @@ func (b *backend) GetOperationProvisioningToken(clusterName, operationID string)
 			return t, nil
 		}
 	}
-	return nil, trace.NotFound("not provisioning token for cluster %v and operation %v", clusterName, operationID)
+	return nil, trace.NotFound("no provisioning token for cluster %v and operation %v", clusterName, operationID)
 }
 
 // GetSiteProvisioningTokens returns install token for site

--- a/lib/users/acl.go
+++ b/lib/users/acl.go
@@ -308,11 +308,20 @@ func (i *IdentityACL) UpsertLocalClusterName(clusterName string) error {
 	return i.identity.UpsertLocalClusterName(clusterName)
 }
 
+// CreateProvisioningToken creates a provisioning token from the specified template
 func (i *IdentityACL) CreateProvisioningToken(t storage.ProvisioningToken) (*storage.ProvisioningToken, error) {
 	if err := i.clusterAction(t.SiteDomain, teleservices.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return i.identity.CreateProvisioningToken(t)
+}
+
+// DeleteProvisioningToken deletes the specified provisioning token
+func (i *IdentityACL) DeleteProvisioningToken(t storage.ProvisioningToken) error {
+	if err := i.clusterAction(t.SiteDomain, teleservices.VerbDelete); err != nil {
+		return trace.Wrap(err)
+	}
+	return i.identity.DeleteProvisioningToken(t)
 }
 
 func (i *IdentityACL) GetSiteProvisioningTokens(siteDomain string) ([]storage.ProvisioningToken, error) {

--- a/lib/users/users.go
+++ b/lib/users/users.go
@@ -83,8 +83,11 @@ type Users interface {
 	// GetOperationProvisioningToken returns token created for the particular site operation
 	GetOperationProvisioningToken(clusterName, operationID string) (*storage.ProvisioningToken, error)
 
-	// CreateProvisioningToken creates a provisioning token for the given user
+	// CreateProvisioningToken creates a provisioning token from the specified template
 	CreateProvisioningToken(storage.ProvisioningToken) (*storage.ProvisioningToken, error)
+
+	// DeleteProvisioningToken deletes the specified provisioning token
+	DeleteProvisioningToken(storage.ProvisioningToken) error
 
 	// CreateInstallToken creates a new one-time installation token
 	CreateInstallToken(storage.InstallToken) (*storage.InstallToken, error)

--- a/lib/users/usersservice/usersservice.go
+++ b/lib/users/usersservice/usersservice.go
@@ -134,8 +134,14 @@ func (u *UsersService) DeleteAPIKey(userEmail, token string) error {
 	return trace.Wrap(u.backend.DeleteAPIKey(userEmail, token))
 }
 
+// CreateProvisioningToken creates a new token from the specified template t
 func (u *UsersService) CreateProvisioningToken(t storage.ProvisioningToken) (*storage.ProvisioningToken, error) {
 	return u.backend.CreateProvisioningToken(t)
+}
+
+// DeleteProvisioningToken deletes the specified provisioning token
+func (u *UsersService) DeleteProvisioningToken(t storage.ProvisioningToken) error {
+	return u.backend.DeleteProvisioningToken(t.Token)
 }
 
 func (u *UsersService) GetSiteProvisioningTokens(siteDomain string) ([]storage.ProvisioningToken, error) {

--- a/lib/utils/signals.go
+++ b/lib/utils/signals.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
+
+	"github.com/gravitational/gravity/lib/defaults"
 
 	"github.com/sirupsen/logrus"
 )
@@ -39,7 +40,7 @@ func WatchTerminationSignals(ctx context.Context, cancel context.CancelFunc, sto
 	log.Debugf("Installed signal handler: %v.", signals)
 	go func() {
 		defer func() {
-			localCtx, localCancel := context.WithTimeout(ctx, 5*time.Second)
+			localCtx, localCancel := context.WithTimeout(context.Background(), defaults.ShutdownTimeout)
 			stopper.Stop(localCtx)
 			localCancel()
 			cancel()

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -902,7 +902,7 @@ func (m *Handler) agentReport(w http.ResponseWriter, r *http.Request, p httprout
 	case ops.OperationInstall:
 		agentReport, err = context.Operator.GetSiteInstallOperationAgentReport(opKey)
 	case ops.OperationExpand:
-		agentReport, err = context.Operator.GetSiteExpandOperationAgentReport(opKey)
+		agentReport, err = context.Operator.GetSiteExpandOperationAgentReport(r.Context(), opKey)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1397,7 +1397,7 @@ func (m *Handler) uploadApp(w http.ResponseWriter, r *http.Request, p httprouter
 		return nil, trace.Wrap(err)
 	}
 
-	for _ = range progressC {
+	for range progressC {
 	}
 
 	if err = <-errorC; err != nil {

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -204,7 +204,7 @@ func newCollector(env *localenv.LocalEnvironment) (*vacuum.Collector, error) {
 	return collector, nil
 }
 
-func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhaseParams, operation *ops.SiteOperation) error {
+func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	clusterPackages, err := env.ClusterPackages()
 	if err != nil {
 		return trace.Wrap(err)
@@ -223,13 +223,6 @@ func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhasePara
 	cluster, err := operator.GetLocalSite()
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	if operation == nil {
-		operation, _, err = ops.GetLastOperation(cluster.Key(), operator)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	runtimePath, err := getAnyRuntimePackagePath(env.Packages)
@@ -252,7 +245,7 @@ func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhasePara
 		Packages:      clusterPackages,
 		LocalPackages: env.Packages,
 		Operator:      operator,
-		Operation:     operation,
+		Operation:     &operation,
 		Servers:       cluster.ClusterState.Servers,
 		ClusterKey:    cluster.Key(),
 		RuntimePath:   runtimePath,

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -459,7 +459,7 @@ func findLocalServer(site ops.Site) (*storage.Server, error) {
 	return server, nil
 }
 
-func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, operation *ops.SiteOperation) error {
+func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	localApps, err := localEnv.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -468,13 +468,6 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, ope
 	wizardEnv, err := localenv.NewRemoteEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	if operation == nil {
-		operation, err = ops.GetWizardOperation(wizardEnv.Operator)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	installFSM, err := install.NewFSM(install.FSMConfig{
@@ -512,7 +505,7 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, ope
 	return nil
 }
 
-func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation *ops.SiteOperation) error {
+func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	operator, err := joinEnv.CurrentOperator(httplib.WithInsecure())
 	if err != nil {
 		return trace.Wrap(err)
@@ -524,14 +517,6 @@ func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParam
 	packages, err := joinEnv.CurrentPackages(httplib.WithInsecure())
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	if operation == nil {
-		// determine the ongoing expand operation, it should be the only
-		// operation present in the local join-specific backend
-		operation, err = ops.GetExpandOperation(joinEnv.Backend)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 	joinFSM, err := expand.NewFSM(expand.FSMConfig{
 		OperationKey:  operation.Key(),
@@ -562,7 +547,7 @@ func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParam
 	})
 }
 
-func rollbackJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation *ops.SiteOperation) error {
+func rollbackJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	operator, err := joinEnv.CurrentOperator(httplib.WithInsecure(), httplib.WithTimeout(5*time.Second))
 	if err != nil {
 		return trace.Wrap(err)
@@ -574,14 +559,6 @@ func rollbackJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhasePara
 	packages, err := joinEnv.CurrentPackages(httplib.WithInsecure(), httplib.WithTimeout(5*time.Second))
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	if operation == nil {
-		// determine the ongoing expand operation, it should be the only
-		// operation present in the local join-specific backend
-		operation, err = ops.GetExpandOperation(joinEnv.Backend)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 	joinFSM, err := expand.NewFSM(expand.FSMConfig{
 		OperationKey:  operation.Key(),
@@ -622,7 +599,7 @@ func ResumeInstall(ctx context.Context, machine *fsm.FSM, progress utils.Progres
 	return nil
 }
 
-func rollbackInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, operation *ops.SiteOperation) error {
+func rollbackInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	localApps, err := localEnv.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -631,13 +608,6 @@ func rollbackInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, op
 	wizardEnv, err := localenv.NewRemoteEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	if operation == nil {
-		operation, err = ops.GetWizardOperation(wizardEnv.Operator)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	installFSM, err := install.NewFSM(install.FSMConfig{
@@ -667,7 +637,7 @@ func rollbackInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, op
 	})
 }
 
-func completeInstallPlan(localEnv *localenv.LocalEnvironment, operation *ops.SiteOperation) error {
+func completeInstallPlan(localEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
 	localApps, err := localEnv.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -676,13 +646,6 @@ func completeInstallPlan(localEnv *localenv.LocalEnvironment, operation *ops.Sit
 	wizardEnv, err := localenv.NewRemoteEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	if operation == nil {
-		operation, err = ops.GetWizardOperation(wizardEnv.Operator)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	installFSM, err := install.NewFSM(install.FSMConfig{

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -240,7 +240,7 @@ func (r *backendOperations) getOperationAndUpdateCache(backend storage.Backend, 
 	if err == nil {
 		// Operation from the backend takes precedence over the existing operation (from cluster state)
 		r.operations[op.ID] = (ops.SiteOperation)(*op)
-	} else {
+	} else if !trace.IsNotFound(err) {
 		logger.WithError(err).Warn("Failed to query operation.")
 	}
 	return (*ops.SiteOperation)(op)

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -99,7 +99,10 @@ func completeOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironme
 		// There's only one install operation
 		return completeInstallPlan(localEnv, op)
 	case ops.OperationExpand:
-		return completeJoinPlan(localEnv, joinEnv, op)
+		if op == nil {
+			return trace.BadParameter("operation ID must be specified")
+		}
+		return completeJoinPlan(localEnv, joinEnv, *op)
 	case ops.OperationUpdate:
 		return completeUpdatePlan(localEnv, updateEnv, *op)
 	case ops.OperationUpdateRuntimeEnviron:

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -65,10 +65,16 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 }
 
 func displayOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string, format constants.Format) error {
-	op, err := getLastOperation(localEnv, updateEnv, joinEnv, operationID)
+	operations, err := getLastOperation(localEnv, updateEnv, joinEnv, operationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	if len(operations) != 1 {
+		log.WithField("operations", oplist(operations).String()).Warn("Multiple operations found.")
+		localEnv.Println("Multiple operations found: \n%v\n, please specify operation with --operation-id.\n" +
+			"Displaying the most recent operation.")
+	}
+	op := operations[0]
 	if op.IsCompleted() {
 		return displayClusterOperationPlan(localEnv, op.Key(), format)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -134,7 +134,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.RemoveCmd.Confirm = g.RemoveCmd.Flag("confirm", "Do not ask for confirmation").Bool()
 
 	g.PlanCmd.CmdClause = g.Command("plan", "Manage operation plan")
-	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. It not specified, the last operation will be used").Hidden().String()
+	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. It not specified, the last operation will be used").String()
 	g.PlanCmd.SkipVersionCheck = g.PlanCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation").Default()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -315,11 +315,15 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.InstallCmd.Force = false
 		}
 		if *g.InstallCmd.Phase != "" {
+			op, err := getActiveOperation(localEnv, nil, nil, *g.JoinCmd.OperationID)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			return executeInstallPhase(localEnv, PhaseParams{
 				PhaseID: *g.InstallCmd.Phase,
 				Force:   *g.InstallCmd.Force,
 				Timeout: *g.InstallCmd.PhaseTimeout,
-			}, nil)
+			}, *op)
 		}
 		return startInstall(localEnv, NewInstallConfig(g))
 	case g.JoinCmd.FullCommand():
@@ -328,12 +332,16 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.JoinCmd.Force = false
 		}
 		if *g.JoinCmd.Phase != "" {
+			op, err := getActiveOperation(localEnv, nil, joinEnv, *g.JoinCmd.OperationID)
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			return executeJoinPhase(localEnv, joinEnv, PhaseParams{
 				PhaseID:     *g.JoinCmd.Phase,
 				Force:       *g.JoinCmd.Force,
 				Timeout:     *g.JoinCmd.PhaseTimeout,
 				OperationID: *g.JoinCmd.OperationID,
-			}, nil)
+			}, *op)
 		}
 		return Join(localEnv, joinEnv, NewJoinConfig(g))
 	case g.AutoJoinCmd.FullCommand():

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -68,6 +68,12 @@ func Run(g *Application) error {
 		return trace.Wrap(err)
 	}
 
+	if *g.Debug {
+		utils.InitGRPCLoggerWithDefaults()
+	} else {
+		utils.InitGRPCLoggerFromEnvironment()
+	}
+
 	if *g.UID != -1 || *g.GID != -1 {
 		return SwitchPrivileges(*g.UID, *g.GID)
 	}
@@ -139,7 +145,7 @@ func InitAndCheck(g *Application, cmd string) error {
 	if *g.ProfileEndpoint != "" {
 		err := process.StartProfiling(context.TODO(), *g.ProfileEndpoint, *g.ProfileTo)
 		if err != nil {
-			log.Warningf("Failed to setup profiling: %v.", trace.DebugReport(err))
+			log.WithError(err).Warn("Failed to setup profiling.")
 		}
 	}
 

--- a/tool/gravity/main.go
+++ b/tool/gravity/main.go
@@ -20,23 +20,20 @@ import (
 	stdlog "log"
 	"os"
 
-	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/tool/common"
 	"github.com/gravitational/gravity/tool/gravity/cli"
 
 	teleutils "github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func main() {
 	teleutils.InitLogger(teleutils.LoggingForCLI, log.InfoLevel)
-	utils.InitGRPCLogger()
 	stdlog.SetOutput(log.StandardLogger().Writer())
 	app := kingpin.New("gravity", "Cluster management tool")
 	if err := run(app); err != nil {
-		log.Error(trace.DebugReport(err))
+		log.WithError(err).Error("Command failed.")
 		common.PrintError(err)
 		os.Exit(255)
 	}


### PR DESCRIPTION
* Debug logging includes gRPC logs by default
* Controller reconnect loop (running inside the active gravity-site Pod) expires the peer connections after a certain timeout
* `plan complete` can now fail the expand operation from any controller node
* Joining agent loop will properly fail the operation is if exits with an error. Also, agent report API is now context-aware to be able to cancel/abort operation if network communication is one-way - i.e. joining node -> controller node but not the other way around),

Requires https://github.com/gravitational/gravity.e/pull/4287.
Updates https://github.com/gravitational/gravity/issues/1077.