### PR TITLE
(5.5) Unpack packages during bootstrap upgrade phase.

### DIFF
--- a/lib/pack/localpack/packageserver.go
+++ b/lib/pack/localpack/packageserver.go
@@ -402,7 +402,7 @@ func (p *PackageServer) Unpack(loc loc.Locator, targetDir string) error {
 		return trace.Wrap(err)
 	}
 	if unpacked {
-		log.Infof("%v is already unpacked", loc)
+		log.WithField("package", loc).Info("Package is already unpacked.")
 		return nil
 	}
 	if err := pack.Unpack(p, loc, targetDir, nil); err != nil {

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -468,6 +468,13 @@ func (p *updatePhaseBootstrap) pullSystemUpdates(ctx context.Context) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		if !update.IsEqualTo(p.GravityPackage) {
+			p.Infof("Unpacking package %v.", update)
+			err = pack.Unpack(p.LocalPackages, update, "", nil)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
 	}
 	// after having pulled packages as root we need to set proper ownership
 	// on the blobs dir

--- a/lib/update/system/system.go
+++ b/lib/update/system/system.go
@@ -689,5 +689,5 @@ func unpack(packages update.LocalPackageService, loc loc.Locator) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(pack.Unpack(packages, loc, path, nil))
+	return packages.Unpack(loc, path)
 }

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -1276,7 +1276,7 @@ func unpack(p *localpack.PackageServer, loc loc.Locator) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(pack.Unpack(p, loc, path, nil))
+	return p.Unpack(loc, path)
 }
 
 func maybeConvertLegacyPlanetConfigPackage(configPackage loc.Locator) (*loc.Locator, error) {


### PR DESCRIPTION
This PR attempts to resolve https://github.com/gravitational/gravity/issues/1279. While I couldn't reproduce the _exact_ scenario, I got a sort of similar behavior to the one described by repeatedly executing/rolling back the system-upgrade phase and watching the changes to /etc/passwd inside planet's rootfs.

As it turns out, some of the code that performs upgrade actually re-unpacks the planet package in a way that overrides its rootfs (in /var/lib/gravity/local/packages/unpacked/...) even if it had already been unpacked before. Both @a-palchikov and I came to a conclusion that there may be a race between this and the "gravity package command" command that actually starts the planet and also unpacks the package.

So, this PR does the following:

* Explicitly unpack new packages during upgrade's bootstrap phase. This is the same behavior as during install actually, and it makes sure that when gravity starts installing the package, it is already unpacked.
* Update the "updater" code to not unpack the package if it's already been unpacked (which it will be, since we unpack it at bootstrap) by calling a corresponding PackageService method rather than using the one from pack/utils.go which always overwrites it.

Closes https://github.com/gravitational/gravity/issues/1279. Should be forward-ported.