### PR TITLE
(6.1) Add pull flag to tele build.

### DIFF
--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -134,6 +134,8 @@ type VendorRequest struct {
 	ProgressReporter utils.Progress
 	// Helm contains parameters for rendering Helm charts.
 	Helm helm.RenderParameters
+	// Pull allows to force-pull Docker images even if they're already present.
+	Pull bool
 }
 
 // vendorer is a helper struct that encapsulates all services needed to vendor/rewrite images in
@@ -265,7 +267,7 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 
 			// pull all missing images (this will correctly fail for images without a remote
 			// registry that do not exist i.e. due to failed image build)
-			if err := pullMissingRemoteImage(image, v.dockerPuller, log, req.ProgressReporter); err != nil {
+			if err := pullMissingRemoteImage(image, v.dockerPuller, log, req); err != nil {
 				return trace.Wrap(err)
 			}
 

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -83,6 +83,8 @@ type BuildCmd struct {
 	Set *[]string
 	// Values is a list of YAML files with Helm chart values.
 	Values *[]string
+	// Pull allows to force-pull Docker images even if they're already present.
+	Pull *bool
 }
 
 type ListCmd struct {

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -56,7 +56,7 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any output to stdout.").Short('q').Bool()
 	tele.BuildCmd.Set = tele.BuildCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
 	tele.BuildCmd.Values = tele.BuildCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
-	tele.BuildCmd.Pull = tele.BuildCmd.Flag("pull", "Pull Docker images even if they're already present in local Docker. Useful if a remote image changes.").Bool()
+	tele.BuildCmd.Pull = tele.BuildCmd.Flag("pull", "Always attempt to pull newer versions of Docker images.").Bool()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "List cluster and application images published to Gravity Hub.")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes.").Short('r').Hidden().Bool()

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -56,6 +56,7 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.Quiet = tele.BuildCmd.Flag("quiet", "Suppress any output to stdout.").Short('q').Bool()
 	tele.BuildCmd.Set = tele.BuildCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
 	tele.BuildCmd.Values = tele.BuildCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
+	tele.BuildCmd.Pull = tele.BuildCmd.Flag("pull", "Pull Docker images even if they're already present in local Docker. Useful if a remote image changes.").Bool()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "List cluster and application images published to Gravity Hub.")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes.").Short('r').Hidden().Bool()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -73,6 +73,7 @@ func Run(tele Application) error {
 				Values: *tele.BuildCmd.Values,
 				Set:    *tele.BuildCmd.Set,
 			},
+			Pull: *tele.BuildCmd.Pull,
 		})
 	}
 


### PR DESCRIPTION
This PR adds a `--pull` flag to tele build (same as docker build accepts) to allow to force-pull images that are cached in the local Docker. This is useful when a remote image changes.

Closes https://github.com/gravitational/gravity/issues/351. Needs forward-ports.