### PR TITLE
(5.5) Fix server version in gravity status.

### DIFF
--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -423,6 +423,14 @@ func (r statusOperator) GetApplicationEndpoints(clusterKey ops.SiteKey) ([]ops.E
 	return r.Operator.GetApplicationEndpoints(clusterKey)
 }
 
+// GetVersion returns version of Gravity running the operator service.
+func (r statusOperator) GetVersion(ctx context.Context) (*modules.Version, error) {
+	if r.clusterOperator != nil {
+		return r.clusterOperator.GetVersion(ctx)
+	}
+	return r.Operator.GetVersion(ctx)
+}
+
 // statusOperator is a thin-wrapper around operator that uses
 // etcd directly but falls back the cluster controller if available for certain APIs
 type statusOperator struct {


### PR DESCRIPTION
Just found out that "server version" in gravity status I added a couple of weeks back is actually not a server version but the binary version as well because the operator passed into status.FromCluster is a local operator.

This PR makes sure cluster operator is used to determine server version and I've now verified it correctly displays the server version.