### PR TITLE
Fix jenkins config lag & try build support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,11 @@ def propagateParamsToEnv() {
 properties([
   disableConcurrentBuilds(),
   parameters([
+    // WARNING: changing parameters will not affect the next build, only the following one
+    // see issue #1315 or https://stackoverflow.com/questions/46680573/ -- 2020-04 walt
+
+    // For choice parameters, the first choice will be the default.
     choice(choices: ["run", "skip"].join("\n"),
-           // defaultValue is not applicable to choices. The first choice will be the default.
            description: 'Run or skip robotest system wide tests.',
            name: 'RUN_ROBOTEST'),
     choice(choices: ["true", "false"].join("\n"),
@@ -23,24 +26,6 @@ properties([
     choice(choices: ["true", "false"].join("\n"),
            description: 'Abort all tests upon first failure.',
            name: 'FAIL_FAST'),
-    choice(choices: ["gce"].join("\n"),
-           description: 'Cloud provider to deploy to.',
-           name: 'DEPLOY_TO'),
-    string(name: 'PARALLEL_TESTS',
-           defaultValue: '4',
-           description: 'Number of parallel tests to run.'),
-    string(name: 'REPEAT_TESTS',
-           defaultValue: '1',
-           description: 'How many times to repeat each test.'),
-    string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'uid-gid',
-           description: 'Robotest tag to use.'),
-    choice(choices: ["false", "true"].join("\n"),
-           description: 'Whether to use preemptible VMs.',
-           name: 'GCE_PREEMPTIBLE'),
-    choice(choices: ["custom-4-8192", "custom-8-8192"].join("\n"),
-           description: 'VM type to use.',
-           name: 'GCE_VM'),
   ]),
 ])
 
@@ -90,7 +75,7 @@ timestamps {
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
                 ]) {
-                  sh "make -C e robotest-run-suite ROBOTEST_VERSION=$ROBOTEST_VERSION"
+                  sh 'make -C e robotest-run-suite'
             }
           }else {
             echo 'skipped system tests'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,22 +85,12 @@ timestamps {
         robotest : {
           if (params.RUN_ROBOTEST == 'run') {
             withCredentials([
-                [
-                  $class: 'UsernamePasswordMultiBinding',
-                  credentialsId: 'jenkins-aws-s3',
-                  usernameVariable: 'AWS_ACCESS_KEY_ID',
-                  passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                ],
                 [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                 [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
                 ]) {
-                  sh """
-                  make -C e robotest-run-suite \
-                    AWS_KEYPAIR=ops \
-                    AWS_REGION=us-east-1 \
-                    ROBOTEST_VERSION=$ROBOTEST_VERSION"""
+                  sh "make -C e robotest-run-suite ROBOTEST_VERSION=$ROBOTEST_VERSION"
             }
           }else {
             echo 'skipped system tests'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -53,6 +53,10 @@ properties([
   // Schedule a daily build between 6:00am and 6:30am UTC (10:00pm-10:30pm PST)
   pipelineTriggers([cron('H(0-30) 06 * * 1-5')]),
   parameters([
+    // WARNING: changing parameters will not affect the next build, only the following one
+    // see issue #1315 or https://stackoverflow.com/questions/46680573/ -- 2020-04 walt
+
+    // For choice parameters, the first choice will be the default.
     choice(choices: ["run", "skip"].join("\n"),
            // defaultValue is not applicable to choices. The first choice will be the default.
            description: 'Run or skip robotest system wide tests.',
@@ -66,24 +70,6 @@ properties([
     choice(choices: ["true", "false"].join("\n"),
            description: 'Abort all tests upon first failure.',
            name: 'FAIL_FAST'),
-    choice(choices: ["gce"].join("\n"),
-           description: 'Cloud provider to deploy to.',
-           name: 'DEPLOY_TO'),
-    string(name: 'PARALLEL_TESTS',
-           defaultValue: '4',
-           description: 'Number of parallel tests to run.'),
-    string(name: 'REPEAT_TESTS',
-           defaultValue: '1',
-           description: 'How many times to repeat each test.'),
-    string(name: 'ROBOTEST_VERSION',
-           defaultValue: 'uid-gid',
-           description: 'Robotest tag to use.'),
-    choice(choices: ["false", "true"].join("\n"),
-           description: 'Whether to use preemptible VMs.',
-           name: 'GCE_PREEMPTIBLE'),
-    choice(choices: ["custom-4-8192", "custom-8-8192"].join("\n"),
-           description: 'VM type to use.',
-           name: 'GCE_VM'),
   ]),
 ])
 
@@ -134,7 +120,7 @@ timestamps {
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
                   ]) {
-                    sh "make -C e robotest-run-nightly ROBOTEST_VERSION=$ROBOTEST_VERSION"
+                    sh 'make -C e robotest-run-nightly'
               }
             } else {
               echo 'skipped system tests'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,11 +1,32 @@
 #!/usr/bin/env groovy
-def propagateParamsToEnv() {
-  for (param in params) {
-    if (env."${param.key}" == null) {
-      env."${param.key}" = param.value
-    }
-  }
-}
+
+// Nightly jobs are configured for critical release branches in Jenkins.
+//
+// To set up a new nightly job, configure a new job with the following by hand
+// or by machine:
+//
+// properties([
+//   disableConcurrentBuilds(),
+//   // Schedule a daily build between 6:00am and 6:30am UTC (10:00pm-10:30pm PST)
+//   pipelineTriggers([cron('H(0-30) 06 * * 1-5')]),
+//   parameters([
+//     choice(choices: ["run", "skip"].join("\n"),
+//            description: 'Run or skip robotest system wide tests.',
+//            name: 'RUN_ROBOTEST'),
+//     choice(choices: ["true", "false"].join("\n"),
+//            description: 'Destroy all VMs on success.',
+//            name: 'DESTROY_ON_SUCCESS'),
+//     choice(choices: ["true", "false"].join("\n"),
+//            description: 'Destroy all VMs on failure.',
+//            name: 'DESTROY_ON_FAILURE'),
+//     choice(choices: ["true", "false"].join("\n"),
+//            description: 'Abort all tests upon first failure.',
+//            name: 'FAIL_FAST'),
+//   ]),
+// ])
+//
+// The above Jenkins job config code is intentionally not active in this file
+// because of issue #1315 -- 2020-04 walt
 
 def withBuildResult(Closure body) {
   def previousBuildResult = currentBuild.previousBuild?.result
@@ -48,31 +69,6 @@ def sendBuildNotification(String currentBuildResult, String previousBuildResult)
   }
 }
 
-properties([
-  disableConcurrentBuilds(),
-  // Schedule a daily build between 6:00am and 6:30am UTC (10:00pm-10:30pm PST)
-  pipelineTriggers([cron('H(0-30) 06 * * 1-5')]),
-  parameters([
-    // WARNING: changing parameters will not affect the next build, only the following one
-    // see issue #1315 or https://stackoverflow.com/questions/46680573/ -- 2020-04 walt
-
-    // For choice parameters, the first choice will be the default.
-    choice(choices: ["run", "skip"].join("\n"),
-           // defaultValue is not applicable to choices. The first choice will be the default.
-           description: 'Run or skip robotest system wide tests.',
-           name: 'RUN_ROBOTEST'),
-    choice(choices: ["true", "false"].join("\n"),
-           description: 'Destroy all VMs on success.',
-           name: 'DESTROY_ON_SUCCESS'),
-    choice(choices: ["true", "false"].join("\n"),
-           description: 'Destroy all VMs on failure.',
-           name: 'DESTROY_ON_FAILURE'),
-    choice(choices: ["true", "false"].join("\n"),
-           description: 'Abort all tests upon first failure.',
-           name: 'FAIL_FAST'),
-  ]),
-])
-
 timestamps {
   withBuildResult {
     node {
@@ -82,8 +78,8 @@ timestamps {
         sh "sudo git clean -ffdx" // supply -f flag twice to force-remove untracked dirs with .git subdirs (e.g. submodules)
       }
       stage('params') {
-        echo "${params}"
-        propagateParamsToEnv()
+        echo "Jenkins Job Parameters:"
+        for (param in params) { echo "${param}" }
       }
       stage('clean') {
         sh "make -C e clean"
@@ -113,7 +109,7 @@ timestamps {
             }
           },
           robotest : {
-            if (params.RUN_ROBOTEST == 'run') {
+            if (env.RUN_ROBOTEST == 'run') {
               withCredentials([
                   [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                   [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -129,22 +129,12 @@ timestamps {
           robotest : {
             if (params.RUN_ROBOTEST == 'run') {
               withCredentials([
-                  [
-                    $class: 'UsernamePasswordMultiBinding',
-                    credentialsId: 'jenkins-aws-s3',
-                    usernameVariable: 'AWS_ACCESS_KEY_ID',
-                    passwordVariable: 'AWS_SECRET_ACCESS_KEY',
-                  ],
                   [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                   [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
                   ]) {
-                    sh """
-                    make -C e robotest-run-nightly \
-                      AWS_KEYPAIR=ops \
-                      AWS_REGION=us-east-1 \
-                      ROBOTEST_VERSION=$ROBOTEST_VERSION"""
+                    sh "make -C e robotest-run-nightly ROBOTEST_VERSION=$ROBOTEST_VERSION"
               }
             } else {
               echo 'skipped system tests'

--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -25,15 +25,23 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-stable-gce}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity
-export DEPLOY_TO=${DEPLOY_TO:-gce}
 export TAG=$(git rev-parse --short HEAD)
+# cloud provider that test clusters will be provisioned on
+# see https://github.com/gravitational/robotest/blob/master/infra/gravity/config.go#L72
+export DEPLOY_TO=${DEPLOY_TO:-gce}
 export GCL_PROJECT_ID=${GCL_PROJECT_ID:-"kubeadm-167321"}
 export GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
+# GCE_VM tuned down from the Robotest's 7 cpu default in 09cec0e49e9d51c3603950209cec3c26dfe0e66b
+# We should consider changing Robotest's default so that we can drop the override here. -- 2019-04 walt
+export GCE_VM=${GCE_VM:-custom-4-8192}
+# Parallelism & retry, tuned for GCE
+export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
+export REPEAT_TESTS=${REPEAT_TESTS:-1}
 
 function build_resize_suite {
   cat <<EOF

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -22,15 +22,23 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-stable-gce}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity
-export DEPLOY_TO=${DEPLOY_TO:-gce}
 export TAG=$(git rev-parse --short HEAD)
+# cloud provider that test clusters will be provisioned on
+# see https://github.com/gravitational/robotest/blob/master/infra/gravity/config.go#L72
+export DEPLOY_TO=${DEPLOY_TO:-gce}
 export GCL_PROJECT_ID=${GCL_PROJECT_ID:-"kubeadm-167321"}
 export GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
+# GCE_VM tuned down from the Robotest's 7 cpu default in 09cec0e49e9d51c3603950209cec3c26dfe0e66b
+# We should consider changing Robotest's default so that we can drop the override here. -- 2019-04 walt
+export GCE_VM=${GCE_VM:-custom-4-8192}
+# Parallelism & retry, tuned for GCE
+export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
+export REPEAT_TESTS=${REPEAT_TESTS:-1}
 
 function build_resize_suite {
   cat <<EOF


### PR DESCRIPTION
This change set brings two substantial edits: 

* Remove Robotest Jenkins parameters for #1315 
* Add a flag to skip Jenkins parameter definition to better support try builds

and one piece of cleanup:

* Remove unused AWS config.

See the commit messages for more context as to why I made each change.

Fixes #1315 and unblocks backporting #1312 (at least it will prevent 1312 backports from breaking other developers in-flight PRs).

### Testing Done
[Try Build 40](https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/40/) tests the PR Jenkinsfile & script edits.
[Try Build 41](https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/41/) tests the Nightly Jenkinsfile & script edits.

Although these are still running at the time of posting, I've gotten several previously green PR tests (38 & 39) and I will check results to be sure there aren't any Nightly regressions before merging -- the PR build will show there aren't any PR regressions.  I didn't want to wait another day to get feedback, as this work is already several days into development.

### Notes
With this merge, I'm getting close to having reliably Gravity Try Builds ready for GA.  I've been included work on them for my own purposes because I need a way t test nightly & PR edits outside of the official runs.  But I believe they'll be useful to other Gravity developers as well, as a way to pre-vet code.  For example PRs that are for testing like https://github.com/gravitational/gravity/pull/1242 can be replaced by try builds. The remaining work is largely UI/UX to make sure it is easy for Gravity developers to kick off try builds.