### PR TITLE
Add ability to view operations in cli.

### DIFF
--- a/docs/7.x/config.md
+++ b/docs/7.x/config.md
@@ -23,6 +23,7 @@ Resource Name             | Resource Description
 `runtimeenvironment`      | Cluster runtime environment variables
 `clusterconfiguration`    | General Cluster configuration
 `authgateway`             | Authentication gateway configuration
+`operations`              | Cluster operations
 
 
 ## General Cluster Configuration
@@ -72,7 +73,7 @@ to the `gravity install` command:
 root$ ./gravity install --cluster=<cluster-name> ... --config=Cluster-config.yaml
 ```
 
-!!! note 
+!!! note
     You can combine multiple kubernetes and Gravity-specific resources in the config file prior to
     running the install command to have the installer automatically create all resources upon installation.
 
@@ -115,6 +116,31 @@ root$ ./gravity resource rm config
     Updating the configuration of an active Cluster is disruptive and might necessitate the restart
     of runtime containers either on master or on all Cluster nodes. Take this into account and plan
     each update accordingly.
+
+## Cluster Operations
+
+Operations performed on a cluster (install, upgrade, node join or removal, etc.)
+are exposed via an `operation` resource.
+
+To see a list of cluster operations:
+
+```bsh
+$ sudo gravity resource get operations
+ID                                       Description                                   State         Created
+--                                       -----------                                   -----         -------
+eb0d0a68-f835-471b-9ceb-500460ffcd0b     Remove node node-2 (192.168.99.103)           Completed     Tue Apr  7 21:56 UTC
+7e95deca-3a71-4abe-8616-097bab26c943     Join node node-2 (192.168.99.103) as node     Completed     Tue Apr  7 21:50 UTC
+b75f28bc-b8e9-403f-9cda-972013a652e8     1-node install                                Completed     Tue Apr  7 21:37 UTC
+```
+
+To view a particular operation details:
+
+```bsh
+$ sudo gravity resource get operation 7e95deca-3a71-4abe-8616-097bab26c943 --format=json
+```
+
+The `operation` resource is read-only and, as such, not supported by the
+resource create and delete commands.
 
 ## Cluster Access
 
@@ -290,7 +316,7 @@ The new user can now log into the Cluster via the Web UI with the user
 credentials created above.
 
 !!! tip "Username and Password Restrictions"
-    Usernames should be composed of characters, hyphens, the at symbol and dots. 
+    Usernames should be composed of characters, hyphens, the at symbol and dots.
     Passwords must be between 6 and 128 characters long.
 
 
@@ -332,7 +358,7 @@ $ gravity resource create github.yaml
 Once the connector has been created, the Cluster login screen will start
 presenting "Login with GitHub" button.
 
-!!! note 
+!!! note
     When going through the Github authentication flow for the first time, the
     application must be granted the access to all organizations that are present
     in the "teams to logins" mapping, otherwise Gravity will not be able to
@@ -423,7 +449,7 @@ The `hd` scope contains the hosted Google suite domain of the user so in the
 above example, any user who belongs to the "example.com" domain will be
 allowed to log in and granted the admin role.
 
-!!! note 
+!!! note
     The user must belong to a hosted domain, otherwise the `hd` claim will
     not be populated.
 
@@ -459,7 +485,7 @@ spec:
     ...
 ```
 
-!!! note 
+!!! note
     For an example of configuring a SAML application with Okta take a look
     at the following guide: [SSH Authentication With Okta](https://gravitational.com/teleport/docs/ssh_okta/).
 
@@ -533,7 +559,7 @@ To update authentication gateway configuration, run:
 $ gravity resource create gateway.yaml
 ```
 
-!!! note 
+!!! note
     The `gravity-site` pods will be restarted upon resource creation in order
     for the new settings to take effect, so the Cluster management UI / API
     will become briefly unavailable.
@@ -609,7 +635,7 @@ Create it:
 $ gravity resource create auth.yaml
 ```
 
-!!! note 
+!!! note
     Make sure to configure a proper [OIDC connector](config.md#configuring-openid-connect)
     when using "oidc" authentication type.
 
@@ -853,4 +879,3 @@ To disconnect the Cluster Gravity Hub, remove the Trusted Cluster:
 $ gravity resource rm trustedCluster hub.example.com
 Trusted Cluster "hub.example.com" has been deleted
 ```
-

--- a/docs/7.x/quickstart.md
+++ b/docs/7.x/quickstart.md
@@ -1,7 +1,7 @@
 # Introduction
 
 This guide will help you quickly evaluate Gravity by packaging, and installing
-a sample multi-node Kubernetes application. 
+a sample multi-node Kubernetes application.
 
 We will use [Mattermost](https://www.mattermost.org/), an open source chat
 application for teams. Mattermost represents a fairly typical web application
@@ -69,10 +69,10 @@ $ cd quickstart
 
 To build a Cluster Image we'll perform the following steps:
 
-1. Create Docker containers for application services. 
+1. Create Docker containers for application services.
 2. Create definitions of Kubernetes resources (pods, etc) for application
-   components. This makes an application capable of running on Kubernetes. 
-   You can place all Kubernetes resource files (usually in YAML format) in the 
+   components. This makes an application capable of running on Kubernetes.
+   You can place all Kubernetes resource files (usually in YAML format) in the
    same directory or you can use Helm.
 3. Create a Cluster Image Manifest to describe the system requirements
    for a Kubernetes cluster capable of running your application. A Cluster Image Manifest
@@ -308,9 +308,10 @@ Cluster status:	active
 Application:	mattermost, version 2.2.0
 Join token:	3f59d1923ed4e2f1499f3e272c86310b46666c8ddce708f3131b16f256f10004
 Last completed operation:
-    * operation_install (6784ad01-530a-45f0-a303-119ac8cd3417)
-      started:		Tue Jan 22 22:40 UTC (10 minutes ago)
-      completed:	Tue Jan 22 22:40 UTC (10 minutes ago)
+    * 1-node install
+      ID:		    b75f28bc-b8e9-403f-9cda-972013a652e8
+      Started:		Tue Apr  7 21:37 UTC (13 minutes ago)
+      Completed:	Tue Apr  7 21:37 UTC (13 minutes ago)
 Cluster:		friendlypoincare4048
     Masters:
         * host (10.5.5.28, node)
@@ -433,9 +434,9 @@ You can press `Ctrl+C` to stop the `install` script.
 
 ## Conclusion
 
-This is a brief overview of how Kubernetes clusters can be packaged into simple 
-`tar` files and then installed anywhere. Gravity's image-based approach is quite 
-similar to how virtual machines/instances are treated by using disk images in 
+This is a brief overview of how Kubernetes clusters can be packaged into simple
+`tar` files and then installed anywhere. Gravity's image-based approach is quite
+similar to how virtual machines/instances are treated by using disk images in
 virtualized environments.
 
 This dramatically lowers the operational overhead of running multiple Kubernetes

--- a/lib/ops/operation.go
+++ b/lib/ops/operation.go
@@ -49,12 +49,16 @@ func NewOperation(op storage.SiteOperation) (storage.Operation, error) {
 			Nodes: newNodes(op.Servers),
 		}
 	case OperationExpand:
-		operation.Spec.Expand = &storage.OperationExpand{
-			Node: newNode(op.Servers[0]),
+		if len(op.Servers) != 0 {
+			operation.Spec.Expand = &storage.OperationExpand{
+				Node: newNode(op.Servers[0]),
+			}
 		}
 	case OperationShrink:
-		operation.Spec.Shrink = &storage.OperationShrink{
-			Node: newNode(op.Shrink.Servers[0]),
+		if len(op.Shrink.Servers) != 0 {
+			operation.Spec.Shrink = &storage.OperationShrink{
+				Node: newNode(op.Shrink.Servers[0]),
+			}
 		}
 	case OperationUpdate:
 		locator, err := loc.ParseLocator(op.Update.UpdatePackage)
@@ -84,13 +88,13 @@ func NewOperation(op storage.SiteOperation) (storage.Operation, error) {
 func DescribeOperation(o storage.Operation) string {
 	switch o.GetType() {
 	case OperationInstall:
-		return fmt.Sprintf("Install on %v nodes",
+		return fmt.Sprintf("%v-node install",
 			len(o.GetInstall().Nodes))
 	case OperationExpand:
-		return fmt.Sprintf("Node %s join as %v",
+		return fmt.Sprintf("Join node %s as %v",
 			o.GetExpand().Node, o.GetExpand().Node.Role)
 	case OperationShrink:
-		return fmt.Sprintf("Node %s leave",
+		return fmt.Sprintf("Remove node %s",
 			o.GetShrink().Node)
 	case OperationUpdate:
 		return fmt.Sprintf("Upgrade to version %v",

--- a/lib/ops/operation.go
+++ b/lib/ops/operation.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ops
+
+import (
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// NewOperation creates a new operation resource from storage operation.
+func NewOperation(op storage.SiteOperation) storage.Operation {
+	operation := &storage.OperationV2{
+		Kind:    storage.KindOperation,
+		Version: services.V2,
+		Metadata: services.Metadata{
+			Name:      op.ID,
+			Namespace: defaults.Namespace,
+		},
+		Spec: storage.OperationSpecV2{
+			Type:    op.Type,
+			Created: op.Created,
+			Updated: op.Updated,
+			State:   op.State,
+		},
+	}
+	switch op.Type {
+	case OperationInstall:
+		operation.Spec.Install = &storage.OperationInstall{
+			Nodes: newNodes(op.Servers),
+		}
+	case OperationExpand:
+		operation.Spec.Expand = &storage.OperationExpand{
+			Node: newNode(op.Servers[0]),
+		}
+	case OperationShrink:
+		operation.Spec.Shrink = &storage.OperationShrink{
+			Node: newNode(op.Shrink.Servers[0]),
+		}
+	case OperationUpdate:
+		operation.Spec.Upgrade = &storage.OperationUpgrade{
+			Package: op.Update.UpdatePackage,
+		}
+	case OperationUpdateRuntimeEnviron:
+		operation.Spec.UpdateEnviron = &storage.OperationUpdateEnviron{
+			Env: op.UpdateEnviron.Env,
+		}
+	case OperationUpdateConfig:
+		operation.Spec.UpdateConfig = &storage.OperationUpdateConfig{
+			Config: op.UpdateConfig.Config,
+		}
+	case OperationReconfigure:
+		operation.Spec.Reconfigure = &storage.OperationReconfigure{
+			IP: op.Reconfigure.AdvertiseAddr,
+		}
+	}
+	return operation
+}
+
+func newNodes(servers []storage.Server) (nodes []storage.OperationNode) {
+	for _, server := range servers {
+		nodes = append(nodes, newNode(server))
+	}
+	return nodes
+}
+
+func newNode(server storage.Server) storage.OperationNode {
+	return storage.OperationNode{
+		IP:       server.AdvertiseIP,
+		Hostname: server.Hostname,
+		Role:     server.Role,
+	}
+}

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -729,6 +729,65 @@ func formatFeatureGates(features map[string]bool) string {
 	return strings.Join(result, ",")
 }
 
+////////////
+
+type operationsCollection struct {
+	operations []storage.Operation
+}
+
+// Resources returns the operations collection in the generic format.
+func (c *operationsCollection) Resources() (resources []teleservices.UnknownResource, err error) {
+	for _, item := range c.operations {
+		resource, err := utils.ToUnknownResource(item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		resources = append(resources, *resource)
+	}
+	return resources, nil
+}
+
+// WriteText serializes operations in human-friendly text format.
+func (c *operationsCollection) WriteText(w io.Writer) error {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	common.PrintTableHeader(t, []string{"ID", "Type", "State", "Created", "Updated", "Notes"})
+	for _, o := range c.operations {
+		fmt.Fprintf(t, "%v\t%v\t%v\n",
+			o.GetName(),
+			o.GetType(),
+			o.GetState(),
+			o.GetCreated(),
+			o.GetUpdated(),
+			formatOperationNotes(o))
+	}
+	_, err := io.WriteString(w, t.String())
+	return trace.Wrap(err)
+}
+
+func formatOperationNotes(o storage.Operation) string {
+	return ""
+}
+
+// WriteJSON serializes collection into json format.
+func (c *operationsCollection) WriteJSON(w io.Writer) error {
+	return utils.WriteJSON(c, w)
+}
+
+// ToMarshal returns objects to marshal.
+func (c *operationsCollection) ToMarshal() interface{} {
+	if len(c.operations) == 1 {
+		return c.operations[0]
+	}
+	return c.operations
+}
+
+// WriteYAML serializes collection into yaml format.
+func (c *operationsCollection) WriteYAML(w io.Writer) error {
+	return utils.WriteYAML(c, w)
+}
+
+//////////////
+
 type storageCollection struct {
 	storage.PersistentStorage
 }

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/utils"
@@ -729,8 +730,6 @@ func formatFeatureGates(features map[string]bool) string {
 	return strings.Join(result, ",")
 }
 
-////////////
-
 type operationsCollection struct {
 	operations []storage.Operation
 }
@@ -750,22 +749,16 @@ func (c *operationsCollection) Resources() (resources []teleservices.UnknownReso
 // WriteText serializes operations in human-friendly text format.
 func (c *operationsCollection) WriteText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	common.PrintTableHeader(t, []string{"ID", "Type", "State", "Created", "Updated", "Notes"})
+	common.PrintTableHeader(t, []string{"ID", "Description", "State", "Created"})
 	for _, o := range c.operations {
-		fmt.Fprintf(t, "%v\t%v\t%v\n",
+		fmt.Fprintf(t, "%v\t%v\t%v\t%v\n",
 			o.GetName(),
-			o.GetType(),
-			o.GetState(),
-			o.GetCreated(),
-			o.GetUpdated(),
-			formatOperationNotes(o))
+			ops.DescribeOperation(o),
+			strings.Title(o.GetState()),
+			o.GetCreated().Format(constants.HumanDateFormat))
 	}
 	_, err := io.WriteString(w, t.String())
 	return trace.Wrap(err)
-}
-
-func formatOperationNotes(o storage.Operation) string {
-	return ""
 }
 
 // WriteJSON serializes collection into json format.
@@ -785,8 +778,6 @@ func (c *operationsCollection) ToMarshal() interface{} {
 func (c *operationsCollection) WriteYAML(w io.Writer) error {
 	return utils.WriteYAML(c, w)
 }
-
-//////////////
 
 type storageCollection struct {
 	storage.PersistentStorage

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -421,11 +421,17 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		}
 		var resources []storage.Operation
 		for _, op := range operations {
+			if req.Name != "" && req.Name != op.ID {
+				continue
+			}
 			resource, err := ops.NewOperation(op)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			resources = append(resources, resource)
+		}
+		if req.Name != "" && len(resources) == 0 {
+			return nil, trace.NotFound("operation %v not found", req.Name)
 		}
 		return &operationsCollection{operations: resources}, nil
 	case "":

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -421,7 +421,11 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 		}
 		var resources []storage.Operation
 		for _, op := range operations {
-			resources = append(resources, ops.NewOperation(op))
+			resource, err := ops.NewOperation(op)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			resources = append(resources, resource)
 		}
 		return &operationsCollection{operations: resources}, nil
 	case "":

--- a/lib/ops/resources/gravity/gravity.go
+++ b/lib/ops/resources/gravity/gravity.go
@@ -414,6 +414,16 @@ func (r *Resources) GetCollection(req resources.ListRequest) (resources.Collecti
 			return nil, trace.Wrap(err)
 		}
 		return storageCollection{PersistentStorage: ps}, nil
+	case storage.KindOperation:
+		operations, err := r.Operator.GetSiteOperations(req.SiteKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		var resources []storage.Operation
+		for _, op := range operations {
+			resources = append(resources, ops.NewOperation(op))
+		}
+		return &operationsCollection{operations: resources}, nil
 	case "":
 		return nil, trace.BadParameter("missing resource kind")
 	}

--- a/lib/ops/resources/gravity/gravity_test.go
+++ b/lib/ops/resources/gravity/gravity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -32,6 +33,7 @@ import (
 
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"gopkg.in/check.v1"
 )
 
@@ -42,10 +44,12 @@ type GravityResourcesSuite struct {
 	r       *Resources
 	cluster *ops.Site
 	server  *httptest.Server
+	clock   clockwork.Clock
 }
 
 var _ = check.Suite(&GravityResourcesSuite{
-	s: &Suite{},
+	s:     &Suite{},
+	clock: clockwork.NewFakeClock(),
 })
 
 func (s *GravityResourcesSuite) SetUpSuite(c *check.C) {
@@ -128,6 +132,111 @@ func (s *GravityResourcesSuite) TestToken(c *check.C) {
 	if !trace.IsNotFound(err) {
 		c.Errorf("Expected err of type NotFound but got %T", err)
 	}
+}
+
+func (s *GravityResourcesSuite) TestOperation(c *check.C) {
+	node1 := storage.Server{AdvertiseIP: "192.168.1.1", Hostname: "node-1", Role: "master"}
+	node2 := storage.Server{AdvertiseIP: "192.168.1.2", Hostname: "node-2", Role: "master"}
+	node3 := storage.Server{AdvertiseIP: "192.168.1.3", Hostname: "node-3", Role: "worker"}
+
+	installOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationInstall,
+		State:      ops.OperationStateCompleted,
+		Servers:    storage.Servers{node1, node2},
+		Created:    s.clock.Now(),
+	})
+	c.Assert(err, check.IsNil)
+
+	expandOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationExpand,
+		State:      ops.OperationStateCompleted,
+		Servers:    storage.Servers{node3},
+		Created:    s.clock.Now().Add(time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	shrinkOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationShrink,
+		State:      ops.OperationStateCompleted,
+		Shrink: &storage.ShrinkOperationState{
+			Servers: storage.Servers{node2},
+		},
+		Created: s.clock.Now().Add(2 * time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	upgradeOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationUpdate,
+		State:      ops.OperationStateCompleted,
+		Update: &storage.UpdateOperationState{
+			UpdatePackage: "gravitational.io/example:0.0.2",
+		},
+		Created: s.clock.Now().Add(3 * time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	runtimeOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationUpdateRuntimeEnviron,
+		State:      ops.OperationStateCompleted,
+		UpdateEnviron: &storage.UpdateEnvarsOperationState{
+			Env: map[string]string{"a": "b"},
+		},
+		Created: s.clock.Now().Add(4 * time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	configOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationUpdateConfig,
+		State:      ops.OperationStateCompleted,
+		UpdateConfig: &storage.UpdateConfigOperationState{
+			Config: []byte("config"),
+		},
+		Created: s.clock.Now().Add(5 * time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	reconfigureOp, err := s.s.Services.Backend.CreateSiteOperation(storage.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationReconfigure,
+		State:      ops.OperationStateCompleted,
+		Reconfigure: &storage.ReconfigureOperationState{
+			AdvertiseAddr: "192.168.100.1",
+		},
+		Created: s.clock.Now().Add(6 * time.Hour),
+	})
+	c.Assert(err, check.IsNil)
+
+	collection, err := s.r.GetCollection(resources.ListRequest{SiteKey: s.cluster.Key(), Kind: storage.KindOperation})
+	c.Assert(err, check.IsNil)
+	// Should be returned in newest-to-oldest order.
+	compare.DeepCompare(c, collection, &operationsCollection{[]storage.Operation{
+		toOperation(c, reconfigureOp),
+		toOperation(c, configOp),
+		toOperation(c, runtimeOp),
+		toOperation(c, upgradeOp),
+		toOperation(c, shrinkOp),
+		toOperation(c, expandOp),
+		toOperation(c, installOp),
+	}})
+}
+
+func toOperation(c *check.C, operation *storage.SiteOperation) storage.Operation {
+	resource, err := ops.NewOperation(*operation)
+	c.Assert(err, check.IsNil)
+	return resource
 }
 
 func toUnknown(c *check.C, resource teleservices.Resource) teleservices.UnknownResource {

--- a/lib/storage/operation.go
+++ b/lib/storage/operation.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// Operation represents a single cluster operation.
+type Operation interface {
+	// Resource provides common resource methods.
+	services.Resource
+	// CheckAndSetDefaults validates the object and sets defaults.
+	CheckAndSetDefaults() error
+	// GetType returns the operation type.
+	GetType() string
+	// GetCreates returns the operation created timestamp.
+	GetCreated() time.Time
+	// GetUpdated returns the operation last updated timestamp.
+	GetUpdated() time.Time
+	// GetState returns the operation state.
+	GetState() string
+	// GetInstall returns install operation data.
+	GetInstall() *OperationInstall
+	// GetExpand returns expand operation data.
+	GetExpand() *OperationExpand
+	// GetShrink returns shrink operation data.
+	GetShrink() *OperationShrink
+	// GetUpgrade returns upgrade operation data.
+	GetUpgrade() *OperationUpgrade
+	// GetUpdateEnviron returns environment update operation data.
+	GetUpdateEnviron() *OperationUpdateEnviron
+	// GetUpdateConfig returns runtime configuration update operation data.
+	GetUpdateConfig() *OperationUpdateConfig
+	// GetReconfigure returns reconfigure operation data.
+	GetReconfigure() *OperationReconfigure
+}
+
+// OperationV2 is the operation resource spec.
+type OperationV2 struct {
+	// Kind is the operation resource kind.
+	Kind string `json:"kind"`
+	// Version is the operation resource version.
+	Version string `json:"version"`
+	// Metadata is the operation metadata.
+	Metadata services.Metadata `json:"metadata"`
+	// Spec is the operation spec.
+	Spec OperationSpecV2 `json:"spec"`
+}
+
+type OperationSpecV2 struct {
+	// Type is the operation type.
+	Type string `json:"type"`
+	// Created is when the operation was created.
+	Created time.Time `json:"created"`
+	// Updated is when the operation was last updated.
+	Updated time.Time `json:"updated"`
+	// State is the operation state.
+	State string `json:"state"`
+	// Install is install operation data.
+	Install *OperationInstall `json:"install,omitempty"`
+	// Expand is expand operation data.
+	Expand *OperationExpand `json:"expand,omitempty"`
+	// Shrink is shrink operation data.
+	Shrink *OperationShrink `json:"shrink,omitempty"`
+	// Upgrade is upgrade operation data.
+	Upgrade *OperationUpgrade `json:"upgrade,omitempty"`
+	// UpdateEnviron is environment update operation data.
+	UpdateEnviron *OperationUpdateEnviron `json:"updateEnviron,omitempty"`
+	// UpdateConfig is runtime configuration update operation data.
+	UpdateConfig *OperationUpdateConfig `json:"updateConfig,omitempty"`
+	// Reconfigure is advertise IP reconfiguration operation data.
+	Reconfigure *OperationReconfigure `json:"reconfigure,omitempty"`
+}
+
+type OperationNode struct {
+	// IP is the node advertise IP address.
+	IP string `json:"ip"`
+	// Hostname is the node hostname.
+	Hostname string `json:"hostname"`
+	// Role is the node role.
+	Role string `json:"role"`
+}
+
+type OperationInstall struct {
+	// Nodes is a list of nodes participating in installation.
+	Nodes []OperationNode `json:"nodes"`
+}
+
+type OperationExpand struct {
+	// Node is the joining node.
+	Node OperationNode `json:"node"`
+}
+
+type OperationShrink struct {
+	// Node is the node that's leaving.
+	Node OperationNode `json:"node"`
+}
+
+type OperationUpgrade struct {
+	// Package is the upgrade package.
+	Package string `json:"package"`
+}
+
+type OperationUpdateEnviron struct {
+	// Env is the new environment.
+	Env map[string]string `json:"env"`
+}
+
+type OperationUpdateConfig struct {
+	// Config is the new runtime config.
+	Config []byte `json:"config"`
+}
+
+type OperationReconfigure struct {
+	// IP is the new advertise IP address.
+	IP string `json:"ip"`
+}
+
+// GetName returns operation id.
+func (o *OperationV2) GetName() string {
+	return o.Metadata.Name
+}
+
+// SetName sets operation id.
+func (o *OperationV2) SetName(id string) {
+	o.Metadata.Name = id
+}
+
+// GetMetadata returns operation metadata.
+func (o *OperationV2) GetMetadata() services.Metadata {
+	return o.Metadata
+}
+
+// SetExpiry sets the resource expiration time.
+func (o *OperationV2) SetExpiry(expires time.Time) {
+	o.Metadata.SetExpiry(expires)
+}
+
+// Expires returns the resource expiration time.
+func (o *OperationV2) Expiry() time.Time {
+	return o.Metadata.Expiry()
+}
+
+// SetTTL sets the resource ttl.
+func (o *OperationV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+	o.Metadata.SetTTL(clock, ttl)
+}
+
+// GetType returns the operation type.
+func (o *OperationV2) GetType() string {
+	return o.Spec.Type
+}
+
+// GetCreates returns the operation created timestamp.
+func (o *OperationV2) GetCreated() time.Time {
+	return o.Spec.Created
+}
+
+// GetUpdated returns the operation last updated timestamp.
+func (o *OperationV2) GetUpdated() time.Time {
+	return o.Spec.Updated
+}
+
+// GetState returns the operation state.
+func (o *OperationV2) GetState() string {
+	return o.Spec.State
+}
+
+// GetInstall returns install operation data.
+func (o *OperationV2) GetInstall() *OperationInstall {
+	return o.Spec.Install
+}
+
+// GetExpand returns expand operation data.
+func (o *OperationV2) GetExpand() *OperationExpand {
+	return o.Spec.Expand
+}
+
+// GetShrink returns shrink operation data.
+func (o *OperationV2) GetShrink() *OperationShrink {
+	return o.Spec.Shrink
+}
+
+// GetUpgrade returns upgrade operation data.
+func (o *OperationV2) GetUpgrade() *OperationUpgrade {
+	return o.Spec.Upgrade
+}
+
+// GetUpdateEnviron returns environment update operation data.
+func (o *OperationV2) GetUpdateEnviron() *OperationUpdateEnviron {
+	return o.Spec.UpdateEnviron
+}
+
+// GetUpdateConfig returns runtime configuration update operation data.
+func (o *OperationV2) GetUpdateConfig() *OperationUpdateConfig {
+	return o.Spec.UpdateConfig
+}
+
+// GetReconfigure returns reconfigure operation data.
+func (o *OperationV2) GetReconfigure() *OperationReconfigure {
+	return o.Spec.Reconfigure
+}
+
+// CheckAndSetDefaults validates operation resource and sets defaults.
+func (o *OperationV2) CheckAndSetDefaults() error {
+	if o.Metadata.Name == "" {
+		return trace.BadParameter("operation name can't be empty")
+	}
+	if o.Spec.Type == "" {
+		return trace.BadParameter("operation type can't be empty")
+	}
+	if o.Spec.State == "" {
+		return trace.BadParameter("operation state can't be empty")
+	}
+	return nil
+}
+
+// UnmarshalOperation unmarshals operation resource from json.
+func UnmarshalOperation(data []byte) (Operation, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("empty operation resource data")
+	}
+	jsonData, err := utils.ToJSON(data)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var h services.ResourceHeader
+	err = json.Unmarshal(jsonData, &h)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	switch h.Version {
+	case services.V2:
+		var operation OperationV2
+		err := utils.UnmarshalWithSchema(GetOperationSchema(), &operation, jsonData)
+		if err != nil {
+			return nil, trace.BadParameter(err.Error())
+		}
+		//nolint:errcheck
+		operation.Metadata.CheckAndSetDefaults()
+		return &operation, nil
+	}
+	return nil, trace.BadParameter(
+		"operation resource version %q is not supported", h.Version)
+}
+
+// MarshalOperation marshals operation resource as json.
+func MarshalOperation(operation Operation, opts ...services.MarshalOption) ([]byte, error) {
+	return json.Marshal(operation)
+}
+
+// GetOperationSchema returns a cluster operation schema.
+func GetOperationSchema() string {
+	return fmt.Sprintf(services.V2SchemaTemplate, services.MetadataSchema,
+		OperationSpecV2Schema, "")
+}
+
+// OperationSpecV2Schema is the operation json schema.
+var OperationSpecV2Schema = fmt.Sprintf(`{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {"type": "string"},
+    "created": {"type": "string"},
+    "updated": {"type": "string"},
+    "install": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": %[0]v
+        }
+      }
+    },
+    "expand": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "node": %[0]v
+      }
+    },
+    "shrink": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "node": %[0]v
+      }
+    },
+    "upgrade": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "package": {"type": "string"}
+      }
+    },
+    "updateEnviron": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {"type": "object"}
+      }
+    },
+    "updateConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "config": {"type": "string"}
+      }
+    },
+    "reconfigure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ip": {"type": "string"}
+      }
+    }
+  }
+}`, OperationNodeSchema)
+
+// OperationNodeSchema is a single operation node json schema.
+var OperationNodeSchema = `{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ip": {"type": "string"},
+    "hostname": {"type": "string"},
+    "role": {"type": "string"}
+  }
+}
+`

--- a/lib/storage/operation.go
+++ b/lib/storage/operation.go
@@ -43,19 +43,19 @@ type Operation interface {
 	// GetState returns the operation state.
 	GetState() string
 	// GetInstall returns install operation data.
-	GetInstall() *OperationInstall
+	GetInstall() OperationInstall
 	// GetExpand returns expand operation data.
-	GetExpand() *OperationExpand
+	GetExpand() OperationExpand
 	// GetShrink returns shrink operation data.
-	GetShrink() *OperationShrink
+	GetShrink() OperationShrink
 	// GetUpgrade returns upgrade operation data.
-	GetUpgrade() *OperationUpgrade
+	GetUpgrade() OperationUpgrade
 	// GetUpdateEnviron returns environment update operation data.
-	GetUpdateEnviron() *OperationUpdateEnviron
+	GetUpdateEnviron() OperationUpdateEnviron
 	// GetUpdateConfig returns runtime configuration update operation data.
-	GetUpdateConfig() *OperationUpdateConfig
+	GetUpdateConfig() OperationUpdateConfig
 	// GetReconfigure returns reconfigure operation data.
-	GetReconfigure() *OperationReconfigure
+	GetReconfigure() OperationReconfigure
 }
 
 // OperationV2 is the operation resource definition.
@@ -197,38 +197,59 @@ func (o *OperationV2) GetState() string {
 }
 
 // GetInstall returns install operation data.
-func (o *OperationV2) GetInstall() *OperationInstall {
-	return o.Spec.Install
+func (o *OperationV2) GetInstall() OperationInstall {
+	if o.Spec.Install != nil {
+		return *o.Spec.Install
+	}
+	return OperationInstall{}
 }
 
 // GetExpand returns expand operation data.
-func (o *OperationV2) GetExpand() *OperationExpand {
-	return o.Spec.Expand
+func (o *OperationV2) GetExpand() OperationExpand {
+	if o.Spec.Expand != nil {
+		return *o.Spec.Expand
+	}
+	return OperationExpand{}
 }
 
 // GetShrink returns shrink operation data.
-func (o *OperationV2) GetShrink() *OperationShrink {
-	return o.Spec.Shrink
+func (o *OperationV2) GetShrink() OperationShrink {
+	if o.Spec.Shrink != nil {
+		return *o.Spec.Shrink
+	}
+	return OperationShrink{}
 }
 
 // GetUpgrade returns upgrade operation data.
-func (o *OperationV2) GetUpgrade() *OperationUpgrade {
-	return o.Spec.Upgrade
+func (o *OperationV2) GetUpgrade() OperationUpgrade {
+	if o.Spec.Upgrade != nil {
+		return *o.Spec.Upgrade
+	}
+	return OperationUpgrade{}
 }
 
 // GetUpdateEnviron returns environment update operation data.
-func (o *OperationV2) GetUpdateEnviron() *OperationUpdateEnviron {
-	return o.Spec.UpdateEnviron
+func (o *OperationV2) GetUpdateEnviron() OperationUpdateEnviron {
+	if o.Spec.UpdateEnviron != nil {
+		return *o.Spec.UpdateEnviron
+	}
+	return OperationUpdateEnviron{}
 }
 
 // GetUpdateConfig returns runtime configuration update operation data.
-func (o *OperationV2) GetUpdateConfig() *OperationUpdateConfig {
-	return o.Spec.UpdateConfig
+func (o *OperationV2) GetUpdateConfig() OperationUpdateConfig {
+	if o.Spec.UpdateConfig != nil {
+		return *o.Spec.UpdateConfig
+	}
+	return OperationUpdateConfig{}
 }
 
 // GetReconfigure returns reconfigure operation data.
-func (o *OperationV2) GetReconfigure() *OperationReconfigure {
-	return o.Spec.Reconfigure
+func (o *OperationV2) GetReconfigure() OperationReconfigure {
+	if o.Spec.Reconfigure != nil {
+		return *o.Spec.Reconfigure
+	}
+	return OperationReconfigure{}
 }
 
 // CheckAndSetDefaults validates operation resource and sets defaults.
@@ -298,7 +319,7 @@ var OperationSpecV2Schema = fmt.Sprintf(`{
       "properties": {
         "nodes": {
           "type": "array",
-          "items": %[0]v
+          "items": %[1]v
         }
       }
     },
@@ -306,14 +327,14 @@ var OperationSpecV2Schema = fmt.Sprintf(`{
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "node": %[0]v
+        "node": %[1]v
       }
     },
     "shrink": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "node": %[0]v
+        "node": %[1]v
       }
     },
     "upgrade": {

--- a/lib/storage/resources.go
+++ b/lib/storage/resources.go
@@ -71,6 +71,8 @@ const (
 	KindClusterConfiguration = "clusterconfiguration"
 	// KindPersistentStorage is the resource for managing persistent storage in the cluster
 	KindPersistentStorage = "persistentstorage"
+	// KindOperation is the cluster operation resource type.
+	KindOperation = "operation"
 	// KindRelease defines the application release resource type
 	KindRelease = "release"
 	// KindInvite defines the user invite token.
@@ -109,6 +111,8 @@ func CanonicalKind(kind string) string {
 		return KindPersistentStorage
 	case KindAuthGateway, "gw":
 		return KindAuthGateway
+	case KindOperation, "operations", "op", "ops":
+		return KindOperation
 	}
 	return kind
 }
@@ -176,6 +180,7 @@ var SupportedGravityResources = []string{
 	KindRuntimeEnvironment,
 	KindClusterConfiguration,
 	KindPersistentStorage,
+	KindOperation,
 }
 
 // SupportedGravityResourcesToRemove is a list of resources supported by

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -323,17 +324,18 @@ func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 }
 
 func printOperation(operation *statusapi.ClusterOperation, w io.Writer) {
-	fmt.Fprintf(w, "    * %v (%v)\n", operation.Type, operation.ID)
-	fmt.Fprintf(w, "      started:\t%v (%v)\n",
+	fmt.Fprintf(w, "    * %v\n", operation.Description)
+	fmt.Fprintf(w, "      ID:\t%v\n", operation.ID)
+	fmt.Fprintf(w, "      Started:\t%v (%v)\n",
 		operation.Created.Format(constants.HumanDateFormat),
 		humanize.RelTime(operation.Created, time.Now(), "ago", ""))
 	if operation.Progress.IsCompleted() {
-		fmt.Fprintf(w, "      %v:\t%v (%v)\n", operation.State,
+		fmt.Fprintf(w, "      %v:\t%v (%v)\n", strings.Title(operation.State),
 			operation.Progress.Created.Format(constants.HumanDateFormat),
 			humanize.RelTime(operation.Progress.Created, time.Now(), "ago", ""))
 	} else {
 		if operation.Type == ops.OperationUpdate {
-			fmt.Fprintf(w, "      use 'gravity plan --operation-id=%v' to check operation status\n",
+			fmt.Fprintf(w, `      Use "gravity plan --operation-id=%v" to check operation status\n`,
 				operation.ID)
 		} else {
 			fmt.Fprint(w, "      ")


### PR DESCRIPTION
Also, better operation details in gravity status.

Better show than tell:

```
$ ./gravity resource get operations
ID                                       Description                         State         Created
--                                       -----------                         -----         -------
2af46ef1-7c6c-44c4-8058-18eee7f2a6e8     Upgrade to version 5.5.40-dev.6     Completed     Thu Apr  2 23:02 UTC
60078163-4a2b-4578-a05c-720d05618ffc     Upgrade to version 5.5.39           Completed     Mon Mar 30 18:45 UTC
ce830126-1b82-4736-b04b-a11b5cd3336e     Install on 3 nodes                  Completed     Fri Mar 27 19:19 UTC
```

```
$ ./gravity status
Cluster name:		lucidknuth3007
...
Last completed operation:
    * Upgrade to version 5.5.40-dev.6
      ID:		2af46ef1-7c6c-44c4-8058-18eee7f2a6e8
      Started:		Thu Apr  2 23:02 UTC (4 days ago)
      Completed:	Thu Apr  2 23:11 UTC (4 days ago)
...
```

Closes https://github.com/gravitational/gravity/issues/897, closes https://github.com/gravitational/gravity/issues/900.