### PR TITLE
Clarify End of Life for non-LTS releases

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -8,11 +8,21 @@
 | 6.1.20        | Yes | March 31st, 2020     | November 10th, 2021  | 1.15.11            | 3.2.12           |
 | 5.5.40        | Yes | April 3rd, 2020      | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 
+Gravity offers one Long Term Support (LTS) release for every 2nd Kubernetes
+minor version, allowing for seamless upgrades per Kubernetes
+[supported version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-version-skew).
+LTS Gravity versions are supported with security and bug fixes for two years
+after the x.x.0 release date.
+
+Non-LTS (regular) versions of Gravity have the latest features and offer
+more current versions of Kubernetes. Regular versions of Gravity are supported
+with security and bug fixes until the subsequent Gravity release is published.
+
 ## Unsupported Releases
 
 These releases are past their End of Life date, and no longer receive security
-fixes and features. [Paying Gravity customers](https://gravitational.com/gravity/demo/)
-may conditionally receive extended support.
+and bug fixes. [Gravity customers](https://gravitational.com/gravity/demo/) can
+extend updates past EOL through customer agreements if required.
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -16,8 +16,8 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | 5.5.40        | Yes | April 3rd, 2020      | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
 | 5.4.10*       | No  | March 26th, 2019     | March 8th, 2019      | 1.13.5             | 2.4.10           |
 | 5.3.9*        | No  | March 7th, 2019      | December 14, 2018    | 1.12.3             | 2.4.7            |
-| 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
-| 5.0.35        | Yes | September 2nd, 2019  | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
+| 5.2.16*       | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
+| 5.0.35*       | Yes | September 2nd, 2019  | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
 | 4.68.0*       | Yes | January 17th, 2019   | November 16th, 2018  | 1.7.18-gravitational | 2.3.5          |
 | 3.64.0*       | Yes | December 21st, 2017  | June 2nd, 2018       | 1.5.7              | 2.0.6            |
 | 1.30.0*       | Yes | March 21st, 2017     | March 21st, 2018     | 1.3.8              | 1.2.0            |

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -8,7 +8,7 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 7.0.0         | No  | April 3rd, 2020      | -                    | 1.17.4             | 3.2.13           |
-| 6.3.9         | No  | April 3rd, 2020      | -                    | 1.17.4             | 3.2.13           |
+| 6.3.9*        | No  | April 3rd, 2020      | -                    | 1.17.4             | 3.2.13           |
 | 6.2.5*        | No  | December 3rd, 2019   | -                    | 1.16.3             | 3.2.13           |
 | 6.1.20        | Yes | March 31st, 2020     | November 10th, 2021  | 1.15.11            | 3.2.12           |
 | 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -1,26 +1,33 @@
 # Releases
 
-## Current Releases
-
-Every major Gravity version `x.0.0` has it's long term support release, e.g. for `3.0.0` version
-LTS starts with `3.51.0` with minor backwards compatible changes added over time until the end of support cycle.
+## Supported Releases
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
 | 7.0.0         | No  | April 3rd, 2020      | 7.1 is released      | 1.17.4             | 3.2.13           |
-| 6.3.9*        | No  | April 3rd, 2020      | April 3rd, 2020      | 1.17.4             | 3.2.13           |
-| 6.2.5*        | No  | December 3rd, 2019   | December 18th, 2019  | 1.16.3             | 3.2.13           |
 | 6.1.20        | Yes | March 31st, 2020     | November 10th, 2021  | 1.15.11            | 3.2.12           |
-| 6.0.10*       | No  | October 17th, 2019   | August 2nd, 2019     | 1.14.7             | 3.2.12           |
-| 5.6.8*        | No  | September 18th, 2019 | July 17th, 2019      | 1.14.7             | 3.0.6-gravity    |
 | 5.5.40        | Yes | April 3rd, 2020      | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
-| 5.4.10*       | No  | March 26th, 2019     | March 8th, 2019      | 1.13.5             | 2.4.10           |
-| 5.3.9*        | No  | March 7th, 2019      | December 14, 2018    | 1.12.3             | 2.4.7            |
-| 5.2.16*       | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
-| 5.0.35*       | Yes | September 2nd, 2019  | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
-| 4.68.0*       | Yes | January 17th, 2019   | November 16th, 2018  | 1.7.18-gravitational | 2.3.5          |
-| 3.64.0*       | Yes | December 21st, 2017  | June 2nd, 2018       | 1.5.7              | 2.0.6            |
-| 1.30.0*       | Yes | March 21st, 2017     | March 21st, 2018     | 1.3.8              | 1.2.0            |
+
+## Unsupported Releases
+
+These releases are past their End of Life date, and no longer receive security
+fixes and features. [Paying Gravity customers](https://gravitational.com/gravity/demo/)
+may conditionally receive extended support.
+
+| Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
+| --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
+| 6.3.9         | No  | April 3rd, 2020      | April 3rd, 2020      | 1.17.4             | 3.2.13           |
+| 6.2.5         | No  | December 3rd, 2019   | December 18th, 2019  | 1.16.3             | 3.2.13           |
+| 6.0.10        | No  | October 17th, 2019   | August 2nd, 2019     | 1.14.7             | 3.2.12           |
+| 5.6.8         | No  | September 18th, 2019 | July 17th, 2019      | 1.14.7             | 3.0.6-gravity    |
+| 5.4.10        | No  | March 26th, 2019     | March 8th, 2019      | 1.13.5             | 2.4.10           |
+| 5.3.9         | No  | March 7th, 2019      | December 14, 2018    | 1.12.3             | 2.4.7            |
+| 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
+| 5.0.35        | Yes | September 2nd, 2019  | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
+| 4.68.0        | Yes | January 17th, 2019   | November 16th, 2018  | 1.7.18-gravitational | 2.3.5          |
+| 3.64.0        | Yes | December 21st, 2017  | June 2nd, 2018       | 1.5.7              | 2.0.6            |
+| 1.30.0        | Yes | March 21st, 2017     | March 21st, 2018     | 1.3.8              | 1.2.0            |
+
 
 !!! tip "Cluster certificates expiration"
     If you have a Gravity cluster of version before `5.0.0-alpha.12` that
@@ -29,13 +36,11 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
     expired, please refer to the [Gravity Manual Certificates Renewal](https://gravitational.zendesk.com/hc/en-us/articles/360000755967-Telekube-Manual-Certificates-Renewal)
     article in our Help Center.
 
-!!! note "Unsupported releases"
-    Releases marked with `*` in the table above are no longer supported and
-    do not receive updates and bugfixes.
-
 !!! note "Direct upgrades"
     You can now upgrade existing 5.0.x clusters directly to 5.5.x.
     See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
+
+# Release Notes
 
 ## 7.x Releases
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -28,18 +28,6 @@ may conditionally receive extended support.
 | 3.64.0        | Yes | December 21st, 2017  | June 2nd, 2018       | 1.5.7              | 2.0.6            |
 | 1.30.0        | Yes | March 21st, 2017     | March 21st, 2018     | 1.3.8              | 1.2.0            |
 
-
-!!! tip "Cluster certificates expiration"
-    If you have a Gravity cluster of version before `5.0.0-alpha.12` that
-    hasn't been upgraded in about a year, its certificates may be expiring soon.
-    If you are unable to upgrade, or your cluster certificates have already
-    expired, please refer to the [Gravity Manual Certificates Renewal](https://gravitational.zendesk.com/hc/en-us/articles/360000755967-Telekube-Manual-Certificates-Renewal)
-    article in our Help Center.
-
-!!! note "Direct upgrades"
-    You can now upgrade existing 5.0.x clusters directly to 5.5.x.
-    See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
-
 # Release Notes
 
 ## 7.x Releases
@@ -847,6 +835,10 @@ to learn how to gain insight into how the cluster status changes over time.
     [Teleport Announcement](https://github.com/gravitational/teleport/releases/tag/v4.0.5) for more information.
 
 ### 5.5.21 LTS (September 26th, 2019)
+
+!!! note "Direct upgrades"
+    You can now upgrade existing 5.0.x clusters directly to 5.5.x.
+    See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
 
 #### Improvements
 
@@ -2064,6 +2056,13 @@ install/upgrade.
 * Increase lifetime of CA certificates used internally within the cluster.
 * Add support for separating the endpoint for cluster and user traffic, see [Configuring Ops Center Endpoints](hub.md#post-provisioning) for details.
 * Add support for using flags with ./install script.
+
+!!! tip "Cluster certificates expiration"
+    If you have a Gravity cluster of version before `5.0.0-alpha.12` that
+    hasn't been upgraded in about a year, its certificates may be expiring soon.
+    If you are unable to upgrade, or your cluster certificates have already
+    expired, please refer to the [Gravity Manual Certificates Renewal](https://gravitational.zendesk.com/hc/en-us/articles/360000755967-Telekube-Manual-Certificates-Renewal)
+    article in our Help Center.
 
 #### Bugfixes
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -7,15 +7,15 @@ LTS starts with `3.51.0` with minor backwards compatible changes added over time
 
 | Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
 | --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 7.0.0         | No  | April 3rd, 2020      | -                    | 1.17.4             | 3.2.13           |
-| 6.3.9*        | No  | April 3rd, 2020      | -                    | 1.17.4             | 3.2.13           |
-| 6.2.5*        | No  | December 3rd, 2019   | -                    | 1.16.3             | 3.2.13           |
+| 7.0.0         | No  | April 3rd, 2020      | 7.1 is released      | 1.17.4             | 3.2.13           |
+| 6.3.9*        | No  | April 3rd, 2020      | April 3rd, 2020      | 1.17.4             | 3.2.13           |
+| 6.2.5*        | No  | December 3rd, 2019   | December 18th, 2019  | 1.16.3             | 3.2.13           |
 | 6.1.20        | Yes | March 31st, 2020     | November 10th, 2021  | 1.15.11            | 3.2.12           |
-| 6.0.10*       | No  | October 17th, 2019   | -                    | 1.14.7             | 3.2.12           |
-| 5.6.8*        | No  | September 18th, 2019 | -                    | 1.14.7             | 3.0.6-gravity    |
+| 6.0.10*       | No  | October 17th, 2019   | August 2nd, 2019     | 1.14.7             | 3.2.12           |
+| 5.6.8*        | No  | September 18th, 2019 | July 17th, 2019      | 1.14.7             | 3.0.6-gravity    |
 | 5.5.40        | Yes | April 3rd, 2020      | September 7th, 2020  | 1.13.11            | 3.0.6-gravity    |
-| 5.4.10*       | No  | March 26th, 2019     | -                    | 1.13.5             | 2.4.10           |
-| 5.3.9*        | No  | March 7th, 2019      | -                    | 1.12.3             | 2.4.7            |
+| 5.4.10*       | No  | March 26th, 2019     | March 8th, 2019      | 1.13.5             | 2.4.10           |
+| 5.3.9*        | No  | March 7th, 2019      | December 14, 2018    | 1.12.3             | 2.4.7            |
 | 5.2.16        | Yes | October 11th, 2019   | October 15th, 2019   | 1.11.9             | 2.4.10           |
 | 5.0.35        | Yes | September 2nd, 2019  | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
 | 4.68.0*       | Yes | January 17th, 2019   | November 16th, 2018  | 1.7.18-gravitational | 2.3.5          |


### PR DESCRIPTION
This changeset documents our soon to be official :crossed_fingers:  release support policy and refactors how we display supported & EoL'd releases to use two different tables.  I deemphasized notes related to unsupported releases as well.

Non-LTS EoL'd releases now all have a "Supported Until" date determined these via the `published_at` field for the subsequent x.x.0 release here: https://api.github.com/repos/gravitational/gravity/releases

### Testing Done
I ran `make run-docs` and got the following screenshot:
![Screenshot_2020-04-08 Releases - Gravitational Gravity](https://user-images.githubusercontent.com/187314/78841554-7efef880-79b2-11ea-85e6-6bb37de1b705.png)

### Original Remarks
I've now added a table split per Ben's advice.  The following is context from the PR description that started of that discussion.

I'm considering a more prominent division between supported & EOL'd releases.  Currently we have the `*` marker and a `Supported Until` in the past.  We may consider any of the following:

1. Different color for EOL'd rows
2. Two seperate tables, one for supported lines of development and one for EOL'd ones
3. Everything in the same table, but EOL hidden/collapsed until some sort of toggle is punched.

I lean towards option 2 as it doesn't require any css or javascript work and keeps things simple for future maintainers.  If you are in favor of any of the above, let me know and I can add it to this PR.