### PR TITLE
Prevent running some commands from planet.

### DIFF
--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -216,10 +216,16 @@ func InitAndCheck(g *Application, cmd string) error {
 	// following commands must be run outside the planet container
 	switch cmd {
 	case g.SystemUpdateCmd.FullCommand(),
+		g.SystemRollbackCmd.FullCommand(),
 		g.UpdateSystemCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
 		g.SystemGCRegistryCmd.FullCommand(),
+		g.SystemUninstallCmd.FullCommand(),
 		g.PlanetEnterCmd.FullCommand(),
+		g.ResumeCmd.FullCommand(),
+		g.PlanExecuteCmd.FullCommand(),
+		g.PlanRollbackCmd.FullCommand(),
+		g.PlanResumeCmd.FullCommand(),
 		g.EnterCmd.FullCommand():
 		if utils.CheckInPlanet() {
 			return trace.BadParameter("this command must be run outside of planet container")


### PR DESCRIPTION
Add more commands to the "not in planet" list. Several times I've encountered a situation where a "plan execute/rollback" command was run inside planet which resulted into the planet attempting to start inside the planet.