### PR TITLE
[5.5.x] add a sub-command to rotate RPC credentials on a cluster

### DIFF
--- a/lib/app/handler/handler_test.go
+++ b/lib/app/handler/handler_test.go
@@ -72,7 +72,7 @@ func (r *HandlerSuite) SetUpTest(c *C) {
 	r.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(r.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(r.dir)
+	objects, err := fs.New(fs.Config{Path: r.dir})
 	c.Assert(err, IsNil)
 
 	clock := &timetools.FreezedTime{

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -81,7 +81,9 @@ func (r *applications) GetAppInstaller(req appservice.InstallerRequest) (install
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(filepath.Join(tempDir, defaults.PackagesDir))
+	objects, err := fs.New(fs.Config{
+		Path: filepath.Join(tempDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/service/pull_test.go
+++ b/lib/app/service/pull_test.go
@@ -166,7 +166,7 @@ func setupServices(c *C) (storage.Backend, pack.PackageService, *applications) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/blob/fs/fs.go
+++ b/lib/blob/fs/fs.go
@@ -27,17 +27,19 @@ import (
 
 	"github.com/gravitational/gravity/lib/blob"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/systeminfo"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 )
 
-func New(path string) (blob.Objects, error) {
-	if path == "" {
-		return nil, trace.BadParameter("missing Path parameter")
+// New creates a new instance of the local fs blob service
+func New(config Config) (blob.Objects, error) {
+	if err := config.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	o := &objects{dir: path}
-	for _, d := range []string{o.tempDir(), o.blobDir()} {
+	o := &objects{config: config}
+	for _, d := range []string{config.tempDir(), config.blobDir()} {
 		if err := os.MkdirAll(d, defaults.SharedDirMask); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -45,16 +47,31 @@ func New(path string) (blob.Objects, error) {
 	return o, nil
 }
 
+// Config defines the blob service configuration
+type Config struct {
+	// Path specifies the directory for blobs
+	Path string
+	// User optionally specifies the user context for file operations
+	User *systeminfo.User
+}
+
+func (r *Config) checkAndSetDefaults() error {
+	if r.Path == "" {
+		return trace.BadParameter("missing Path parameter")
+	}
+	return nil
+}
+
+func (r Config) tempDir() string {
+	return filepath.Join(r.Path, "tmp")
+}
+
+func (r Config) blobDir() string {
+	return filepath.Join(r.Path, "blobs")
+}
+
 type objects struct {
-	dir string
-}
-
-func (o *objects) tempDir() string {
-	return filepath.Join(o.dir, "tmp")
-}
-
-func (o *objects) blobDir() string {
-	return filepath.Join(o.dir, "blobs")
+	config Config
 }
 
 // hashDir helps us to organize the blobs in the folder -
@@ -63,7 +80,7 @@ func (o *objects) blobDir() string {
 // of the sha512 hash - this will allow to scale in cases
 // when there are too many files in one directory
 func (o *objects) hashDir(h string) string {
-	return filepath.Join(o.blobDir(), h[0:3])
+	return filepath.Join(o.config.blobDir(), h[0:3])
 }
 
 func (o *objects) Close() error {
@@ -73,7 +90,7 @@ func (o *objects) Close() error {
 // GetBLOBs returns a list of BLOBs in the storage
 func (o *objects) GetBLOBs() ([]string, error) {
 	var out []string
-	blobDir := o.blobDir()
+	blobDir := o.config.blobDir()
 	err := filepath.Walk(blobDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Warningf("error while traversing %v: %v", blobDir, err)
@@ -97,7 +114,7 @@ func (o *objects) GetBLOBs() ([]string, error) {
 func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	// step1 : write data and compute it's hash to the temporary file,
 	// then move it to the proper location based on it's hash
-	f, err := ioutil.TempFile(o.tempDir(), "blob")
+	f, err := ioutil.TempFile(o.config.tempDir(), "blob")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -125,8 +142,16 @@ func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	// now place it to the right place in the filesystem
 	targetPath := filepath.Join(targetDir, hash)
 	if err := os.Rename(f.Name(), targetPath); err != nil {
-		defer os.Remove(f.Name())
+		os.Remove(f.Name())
 		return nil, trace.Wrap(err)
+	}
+	if o.config.User != nil && os.Geteuid() != o.config.User.UID {
+		// Set proper file ownership if configured.
+		// This will fail as expected if the command is not run as root or
+		// under a different user context
+		if err := os.Chown(targetPath, o.config.User.UID, o.config.User.GID); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	fileInfo, err := os.Stat(targetPath)
 	if err != nil {

--- a/lib/blob/fs/fs_test.go
+++ b/lib/blob/fs/fs_test.go
@@ -39,7 +39,7 @@ func (s *FSSuite) SetUpTest(c *C) {
 	log.SetOutput(os.Stderr)
 	s.dir = c.MkDir()
 
-	obj, err := New(s.dir)
+	obj, err := New(Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.suite.Objects = obj

--- a/lib/blob/handler/blobhandler_test.go
+++ b/lib/blob/handler/blobhandler_test.go
@@ -69,7 +69,7 @@ func (s *HandlerSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -411,7 +411,7 @@ func (b *Builder) initServices() (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	objects, err := blobfs.New(filepath.Join(b.Dir, defaults.PackagesDir))
+	objects, err := blobfs.New(blobfs.Config{Path: filepath.Join(b.Dir, defaults.PackagesDir)})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -584,6 +584,9 @@ const (
 	// SiteStatusCheckInterval is how often local gravity site will invoke app status hook
 	SiteStatusCheckInterval = 1 * time.Minute
 
+	// ClusterStatusTimeout specifies the time limit for cluster status check
+	ClusterStatusTimeout = 5 * time.Minute
+
 	// OfflineCheckInterval is how often OpsCenter checks whether its sites are online/offline
 	OfflineCheckInterval = 10 * time.Second
 

--- a/lib/expand/fsm.go
+++ b/lib/expand/fsm.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
-	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
@@ -92,7 +91,7 @@ func (c *FSMConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing LocalPackages")
 	}
 	if c.Credentials == nil {
-		c.Credentials, err = rpc.ClientCredentials(defaults.RPCAgentSecretsDir)
+		c.Credentials, err = rpc.ClientCredentials(c.Packages)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -206,7 +206,7 @@ func (p *Peer) dialSite(addr string) (*operationContext, error) {
 	if err != nil {
 		return nil, utils.Abort(err) // stop retrying on failed checks
 	}
-	creds, err := install.LoadRPCCredentials(p.Context, packages, p.FieldLogger)
+	creds, err := install.LoadRPCCredentials(p.Context, packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -296,7 +296,7 @@ func (p *Peer) dialWizard(addr string) (*operationContext, error) {
 	if err != nil {
 		return nil, utils.Abort(err) // stop retrying on failed checks
 	}
-	creds, err := install.LoadRPCCredentials(p.Context, env.Packages, p.FieldLogger)
+	creds, err := install.LoadRPCCredentials(p.Context, env.Packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -130,7 +130,7 @@ func NewAgentStop(p fsm.ExecutorParams, operator ops.Operator, packages pack.Pac
 		Key:      opKey(p.Plan),
 		Operator: operator,
 	}
-	credentials, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	credentials, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/fsm/rpc.go
+++ b/lib/fsm/rpc.go
@@ -247,13 +247,18 @@ func IsMasterServer(server storage.Server) bool {
 	return server.ClusterRole == string(schema.ServiceRoleMaster)
 }
 
-// GetClientCredentials returns the RPC credentials for an update operation
+// GetClientCredentials reads the RPC credentials for an update operation from a predefined directory.
+//
+// The reason credentials are not read from the cluster package service is that
+// during certain operations (cluster upgrades, cluster or environment configuration updates), the etcd backend
+// might be temporarily inaccessible between commands hence in this mode, the credentials
+// are cached on disk.
 func GetClientCredentials() (credentials.TransportCredentials, error) {
 	secretsDir, err := AgentSecretsDir()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	creds, err := rpc.ClientCredentials(secretsDir)
+	creds, err := rpc.ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/httplib/client.go
+++ b/lib/httplib/client.go
@@ -154,11 +154,17 @@ func WithIdleConnTimeout(timeout time.Duration) ClientOption {
 
 // GetClient returns secure or insecure client based on settings
 func GetClient(insecure bool, options ...ClientOption) *http.Client {
+	if insecure {
+		options = append(options, WithInsecure())
+	}
+	return NewClient(options...)
+}
+
+// NewClient creates a new HTTP client with the specified list of configuration
+// options
+func NewClient(options ...ClientOption) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{},
-	}
-	if insecure {
-		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
 	client := &http.Client{Transport: transport}
 	for _, o := range options {

--- a/lib/install/agent.go
+++ b/lib/install/agent.go
@@ -54,7 +54,7 @@ func NewAgent(ctx context.Context, config AgentConfig, log log.FieldLogger, watc
 		return nil, trace.Wrap(err)
 	}
 
-	creds, err := LoadRPCCredentials(ctx, packages, log)
+	creds, err := LoadRPCCredentials(ctx, packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/bootstrap.go
+++ b/lib/install/bootstrap.go
@@ -35,19 +35,16 @@ import (
 // bootstrap prepares the local installer state for the operation based
 // on the installation mode
 func (i *Installer) bootstrap(ctx context.Context) error {
-	if i.Mode != constants.InstallModeInteractive {
-		err := installBinary(i.ServiceUser.UID, i.ServiceUser.GID)
-		if err != nil {
-			return trace.Wrap(err, "failed to install binary")
-		}
-		err = i.configureStateDirectory()
-		if err != nil {
-			return trace.Wrap(err, "failed to configure state directory")
-		}
+	if i.Mode == constants.InstallModeInteractive {
+		return nil
 	}
-	err := exportRPCCredentials(ctx, i.Packages, i.FieldLogger)
+	err := installBinary(i.ServiceUser.UID, i.ServiceUser.GID)
 	if err != nil {
-		return trace.Wrap(err, "failed to export RPC credentials")
+		return trace.Wrap(err, "failed to install binary")
+	}
+	err = i.configureStateDirectory()
+	if err != nil {
+		return trace.Wrap(err, "failed to configure state directory")
 	}
 	return nil
 }

--- a/lib/install/flow.go
+++ b/lib/install/flow.go
@@ -211,7 +211,7 @@ func (i *Installer) StartAgent(agentURL string) (rpcserver.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	serverCreds, clientCreds, err := rpc.Credentials(defaults.RPCAgentSecretsDir)
+	serverCreds, clientCreds, err := rpc.Credentials(i.Packages)
 	if err != nil {
 		listener.Close()
 		return nil, trace.Wrap(err)

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
-	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/opsclient"
@@ -114,7 +113,7 @@ func (c *FSMConfig) CheckAndSetDefaults() (err error) {
 		c.Spec = FSMSpec(*c)
 	}
 	if c.Credentials == nil {
-		c.Credentials, err = rpc.ClientCredentials(defaults.RPCAgentSecretsDir)
+		c.Credentials, err = rpc.ClientCredentials(c.Packages)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/install/phases/app.go
+++ b/lib/install/phases/app.go
@@ -45,7 +45,7 @@ func NewHook(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications,
 		return nil, trace.BadParameter("service user is required")
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -51,7 +51,7 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		return nil, trace.BadParameter("application package is required: %#v", p.Phase.Data)
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -91,7 +91,6 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		ExecutorParams:   p,
 		ServiceUser:      *serviceUser,
 		remote:           remote,
-		dnsConfig:        p.Plan.DNSConfig,
 	}, nil
 }
 
@@ -108,8 +107,6 @@ type bootstrapExecutor struct {
 	ServiceUser systeminfo.User
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
-	// dnsConfig specifies local cluster DNS configuration to set
-	dnsConfig storage.DNSConfig
 	// remote specifies the server remote control interface
 	remote fsm.Remote
 }
@@ -138,7 +135,7 @@ func (p *bootstrapExecutor) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.configureDNS()
+	err = p.configureSystemMetadata()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -322,13 +319,47 @@ func (p *bootstrapExecutor) logIntoCluster() error {
 	return nil
 }
 
-// configureDNS creates local cluster DNS configuration
+func (p *bootstrapExecutor) configureSystemMetadata() error {
+	if err := p.configureDNS(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.configureNodeAddr(); err != nil {
+		return trace.Wrap(err)
+	}
+	return p.configureServiceUser()
+}
+
+// configureDNS creates local cluster DNS configuration in local state database
 func (p *bootstrapExecutor) configureDNS() error {
-	err := p.LocalBackend.SetDNSConfig(p.dnsConfig)
+	err := p.LocalBackend.SetDNSConfig(p.Plan.DNSConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	p.Infof("Created DNS configuration: %v.", p.dnsConfig)
+	p.Infof("Created DNS configuration: %v.", p.Plan.DNSConfig)
+	return nil
+}
+
+// configureNodeAddr persists the node advertise IP in local state database
+func (p *bootstrapExecutor) configureNodeAddr() error {
+	err := p.LocalBackend.SetNodeAddr(p.Phase.Data.Server.AdvertiseIP)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Set node address: %v.", p.Phase.Data.Server.AdvertiseIP)
+	return nil
+}
+
+// configureServiceUser persists the service user in local state database
+func (p *bootstrapExecutor) configureServiceUser() error {
+	err := p.LocalBackend.SetServiceUser(storage.OSUser{
+		Name: p.ServiceUser.Name,
+		UID:  strconv.Itoa(p.ServiceUser.UID),
+		GID:  strconv.Itoa(p.ServiceUser.GID),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Set service user: %v.", p.ServiceUser)
 	return nil
 }
 
@@ -357,22 +388,4 @@ func opKey(plan storage.OperationPlan) ops.SiteOperationKey {
 		SiteDomain:  plan.ClusterName,
 		OperationID: plan.OperationID,
 	}
-}
-
-func userFromOSUser(user storage.OSUser) (*systeminfo.User, error) {
-	uid, err := strconv.Atoi(user.UID)
-	if err != nil {
-		return nil, trace.BadParameter("expected a numeric UID but got %v", user.UID)
-	}
-
-	gid, err := strconv.Atoi(user.GID)
-	if err != nil {
-		return nil, trace.BadParameter("expected a numeric GID but got %v", user.GID)
-	}
-
-	return &systeminfo.User{
-		Name: user.Name,
-		UID:  uid,
-		GID:  gid,
-	}, nil
 }

--- a/lib/install/phases/pull.go
+++ b/lib/install/phases/pull.go
@@ -45,7 +45,7 @@ func NewPull(p fsm.ExecutorParams, operator ops.Operator, wizardPack, localPack 
 		return nil, trace.BadParameter("service user is required")
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -17,10 +17,13 @@ limitations under the License.
 package localenv
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/blob"
+	libcluster "github.com/gravitational/gravity/lib/blob/cluster"
 	"github.com/gravitational/gravity/lib/blob/fs"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
@@ -28,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack/localpack"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
+	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/users/usersservice"
 
@@ -40,11 +44,27 @@ import (
 func (r *LocalEnvironment) NewClusterEnvironment(opts ...ClusterEnvironmentOption) (*ClusterEnvironment, error) {
 	client, _, err := httplib.GetClusterKubeClient(r.DNS.Addr())
 	if err != nil {
-		log.Errorf("Failed to create Kubernetes client: %v.",
-			trace.DebugReport(err))
+		log.WithError(err).Warn("Failed to create Kubernetes client.")
+	}
+	user, err := r.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.FromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := r.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
 	}
 	config := clusterEnvironmentConfig{
-		client: client,
+		client:      client,
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
 	}
 	for _, opt := range opts {
 		opt(&config)
@@ -74,7 +94,30 @@ type ClusterEnvironment struct {
 // returns a new instance of cluster environment.
 // The resulting environment will not have a kubernetes client
 func NewClusterEnvironment() (*ClusterEnvironment, error) {
-	return newClusterEnvironment(clusterEnvironmentConfig{})
+	stateDir, err := LocalGravityDir()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := New(stateDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := env.Backend.GetServiceUser()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	serviceUser, err := systeminfo.FromOSUser(*user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	nodeAddr, err := env.Backend.GetNodeAddr()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newClusterEnvironment(clusterEnvironmentConfig{
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
+	})
 }
 
 // WithClient is an option to override the kubernetes client to use
@@ -112,9 +155,38 @@ func newClusterEnvironment(config clusterEnvironmentConfig) (*ClusterEnvironment
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(packagesDir)
+	localObjects, err := fs.New(fs.Config{
+		Path: packagesDir,
+		User: config.serviceUser,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	var objects blob.Objects
+	if config.nodeAddr == "" {
+		objects, err = fs.New(fs.Config{Path: packagesDir})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// TODO(dmitri): leaving this as a workaround.
+		// To be able to use cluster-level package service,
+		// a node address is required. This is not available on nodes prior to upgrade
+		// with an version that did not support the necessary system metadata (node address
+		// and service user).
+		// This is normally not a problem as the cluster-level package service is not required
+		// during the upgrade.
+		objects, err = libcluster.New(libcluster.Config{
+			Local:         localObjects,
+			WriteFactor:   1,
+			Backend:       backend,
+			ID:            config.nodeAddr,
+			AdvertiseAddr: fmt.Sprintf("https://%v", config.nodeAddr),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unpackedDir, err := SiteUnpackedDir()
@@ -187,4 +259,6 @@ type clusterEnvironmentConfig struct {
 	// etcdTimeout specifies the timeout for etcd queries.
 	// Falls back to defaults.EtcdRetryInterval if unspecified
 	etcdTimeout time.Duration
+	serviceUser *systeminfo.User
+	nodeAddr    string
 }

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -103,15 +103,18 @@ func NewClusterEnvironment() (*ClusterEnvironment, error) {
 		return nil, trace.Wrap(err)
 	}
 	user, err := env.Backend.GetServiceUser()
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	serviceUser, err := systeminfo.FromOSUser(*user)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.FromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	nodeAddr, err := env.Backend.GetNodeAddr()
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
 	return newClusterEnvironment(clusterEnvironmentConfig{

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -181,7 +181,9 @@ func (env *LocalEnvironment) init() error {
 		env.DNS = DNSConfig(*dns)
 	}
 
-	env.Objects, err = fs.New(filepath.Join(env.StateDir, defaults.PackagesDir))
+	env.Objects, err = fs.New(fs.Config{
+		Path: filepath.Join(env.StateDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/testhelpers.go
+++ b/lib/ops/opsservice/testhelpers.go
@@ -70,7 +70,7 @@ func SetupTestServices(c *check.C) TestServices {
 	backend, err := keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(dir, "bolt.db")})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, check.IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/pack/layerpack/layer_test.go
+++ b/lib/pack/layerpack/layer_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/timetools"
+	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -63,9 +63,9 @@ func (s *LayerSuite) SetUpTest(c *C) {
 	s.outerBackend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(outerDir, "storage.db")})
 	c.Assert(err, IsNil)
 
-	innerObjects, err := fs.New(innerDir)
+	innerObjects, err := fs.New(fs.Config{Path: innerDir})
 	c.Assert(err, IsNil)
-	outerObjects, err := fs.New(outerDir)
+	outerObjects, err := fs.New(fs.Config{Path: outerDir})
 	c.Assert(err, IsNil)
 
 	inner, err := localpack.New(localpack.Config{

--- a/lib/pack/localpack/local_test.go
+++ b/lib/pack/localpack/local_test.go
@@ -64,7 +64,7 @@ func (s *LocalSuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.server, err = New(Config{

--- a/lib/pack/webpack/webpack_test.go
+++ b/lib/pack/webpack/webpack_test.go
@@ -78,7 +78,7 @@ func (s *WebpackSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -70,7 +70,9 @@ func newImporter(dir string) (*importer, error) {
 		}),
 	}
 	err = func() error {
-		objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
+		objects, err := fs.New(fs.Config{
+			Path: filepath.Join(dir, defaults.PackagesDir),
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/process/process_test.go
+++ b/lib/process/process_test.go
@@ -224,11 +224,11 @@ func (s *ProcessSuite) TestReverseTunnelsFromTrustedClusters(c *check.C) {
 				}),
 			},
 			tunnels: []telecfg.ReverseTunnel{
-				telecfg.ReverseTunnel{
+				{
 					DomainName: "cluster1",
 					Addresses:  []string{"cluster1:3024"},
 				},
-				telecfg.ReverseTunnel{
+				{
 					DomainName: "cluster2",
 					Addresses:  []string{"cluster2:3024"},
 				},
@@ -304,7 +304,7 @@ func (s *importerSuite) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, check.IsNil)
 
 	s.pack, err = localpack.New(localpack.Config{

--- a/lib/rpc/tls.go
+++ b/lib/rpc/tls.go
@@ -197,7 +197,7 @@ func ValidateCredentials(archive utils.TLSArchive, now time.Time) error {
 }
 
 // Credentials returns both server and client credentials read from the
-// specified directory
+// specified package service
 func Credentials(packages pack.PackageService) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
 	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
@@ -221,7 +221,7 @@ func Credentials(packages pack.PackageService) (server credentials.TransportCred
 	return server, client, nil
 }
 
-// ClientCredentials reads client credentials from specified packages
+// ClientCredentials reads client credentials from specified package service
 func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
 	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
@@ -236,7 +236,7 @@ func ClientCredentials(packages pack.PackageService) (credentials.TransportCrede
 		*tlsArchive[pb.CA])
 }
 
-// ServerCredentials reads server credentials from the specified package
+// ServerCredentials reads server credentials from the specified package service
 func ServerCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
 	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
@@ -304,7 +304,7 @@ func ServerCredentialsFromDir(secretsDir string) (credentials.TransportCredentia
 	return creds, nil
 }
 
-// DeleteCredentials deletes the package with RPC credentials from the specified package store
+// DeleteCredentials deletes the package with RPC credentials from the specified package service
 func DeleteCredentials(packages pack.PackageService) error {
 	return packages.DeletePackage(loc.RPCSecrets)
 }

--- a/lib/rpc/tls.go
+++ b/lib/rpc/tls.go
@@ -33,14 +33,19 @@ import (
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/gravitational/license/authority"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
 )
 
 // GenerateAgentCredentialsPackage creates or updates a package in packages with client/server credentials.
 // pkgTemplate specifies the naming template for the resulting package
-func GenerateAgentCredentialsPackage(packages pack.PackageService, pkgTemplate loc.Locator,
-	archive utils.TLSArchive) (secretsLocator *loc.Locator, err error) {
+func GenerateAgentCredentialsPackage(
+	packages pack.PackageService,
+	pkgTemplate loc.Locator,
+	archive utils.TLSArchive,
+) (secretsLocator *loc.Locator, err error) {
 	secretsLocator, err = loc.NewLocator(
 		pkgTemplate.Repository,
 		defaults.RPCAgentSecretsPackage,
@@ -52,8 +57,21 @@ func GenerateAgentCredentialsPackage(packages pack.PackageService, pkgTemplate l
 	if err != nil {
 		return secretsLocator, trace.Wrap(err)
 	}
-
 	return secretsLocator, nil
+}
+
+// LoadCredentials returns the RPC credentials package as a TLS archive
+func LoadCredentials(packages pack.PackageService) (tls utils.TLSArchive, err error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	tlsArchive, err := utils.ReadTLSArchive(reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tlsArchive, nil
 }
 
 // GenerateAgentCredentials creates client/server credentials archive.
@@ -111,8 +129,8 @@ func GenerateAgentCredentials(hosts []string, commonName string, longLivedClient
 	return archive, nil
 }
 
-// ClientCredentials loads the client agent credentials from the specified location
-func ClientCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// ClientCredentialsFromDir loads the client agent credentials from the specified location
+func ClientCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	clientCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Cert))
 	clientKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -161,9 +179,51 @@ func ClientCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
-// ClientCredentialsFromPackage reads client credentials from specified packages
-func ClientCredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Locator) (credentials.TransportCredentials, error) {
-	_, reader, err := packages.ReadPackage(secretsPackage)
+// ValidateCredentials checks the credentials from the specified archive for validity
+func ValidateCredentials(archive utils.TLSArchive, now time.Time) error {
+	clientKeyPair := archive[pb.Client]
+	if err := validateCertificateExpiration(clientKeyPair.CertPEM, now); err != nil {
+		return trace.Wrap(err, "invalid client certificate")
+	}
+	serverKeyPair := archive[pb.Server]
+	if err := validateCertificateExpiration(serverKeyPair.CertPEM, now); err != nil {
+		return trace.Wrap(err, "invalid server certificate")
+	}
+	caKeyPair := archive[pb.CA]
+	if err := validateCertificateExpiration(caKeyPair.CertPEM, now); err != nil {
+		return trace.Wrap(err, "invalid CA certificate")
+	}
+	return nil
+}
+
+// Credentials returns both server and client credentials read from the
+// specified directory
+func Credentials(packages pack.PackageService) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	tlsArchive, err := utils.ReadTLSArchive(reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	server, err = ServerCredentialsFromKeyPairs(*tlsArchive[pb.Server],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	client, err = ClientCredentialsFromKeyPairs(*tlsArchive[pb.Client],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return server, client, nil
+}
+
+// ClientCredentials reads client credentials from specified packages
+func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -176,8 +236,45 @@ func ClientCredentialsFromPackage(packages pack.PackageService, secretsPackage l
 		*tlsArchive[pb.CA])
 }
 
-// ServerCredentials loads server agent credentials from the specified location
-func ServerCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// ServerCredentials reads server credentials from the specified package
+func ServerCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	tlsArchive, err := utils.ReadTLSArchive(reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return ServerCredentialsFromKeyPairs(*tlsArchive[pb.Server],
+		*tlsArchive[pb.CA])
+}
+
+// ServerCredentialsFromKeyPairs loads server agent credentials from the specified
+// set of key pairs
+func ServerCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentials.TransportCredentials, error) {
+	cert, err := tls.X509KeyPair(keys.CertPEM, keys.KeyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(caKeys.CertPEM); !ok {
+		return nil, trace.BadParameter("failed to append CA to cert pool")
+	}
+
+	// Create the TLS credentials
+	creds := credentials.NewTLS(&tls.Config{
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    certPool,
+	})
+	return creds, nil
+}
+
+// ServerCredentialsFromDir loads server agent credentials from the specified location
+func ServerCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	serverCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Cert))
 	serverKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -207,8 +304,13 @@ func ServerCredentials(secretsDir string) (credentials.TransportCredentials, err
 	return creds, nil
 }
 
-// InitRPCCredentials creates a package with RPC secrets in the specified package service
-func InitRPCCredentials(packages pack.PackageService) (*loc.Locator, error) {
+// DeleteCredentials deletes the package with RPC credentials from the specified package store
+func DeleteCredentials(packages pack.PackageService) error {
+	return packages.DeletePackage(loc.RPCSecrets)
+}
+
+// InitCredentials creates a package with RPC secrets in the specified package service
+func InitCredentials(packages pack.PackageService) (*loc.Locator, error) {
 	longLivedClient := true
 	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
 	if err != nil {
@@ -223,25 +325,30 @@ func InitRPCCredentials(packages pack.PackageService) (*loc.Locator, error) {
 	return &loc.RPCSecrets, nil
 }
 
-// ServerCredentialsFromKeyPairs loads server agent credentials from the specified
-// set of key pairs
-func ServerCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentials.TransportCredentials, error) {
-	cert, err := tls.X509KeyPair(keys.CertPEM, keys.KeyPEM)
+// UpsertCredentials creates or updates RPC secrets package in the specified package service
+func UpsertCredentials(packages pack.PackageService) (*loc.Locator, error) {
+	longLivedClient := true
+	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
 	if err != nil {
-		return nil, err
+		return nil, trace.Wrap(err)
 	}
 
-	return credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{cert}}), nil
+	err = upsertPackage(packages, loc.RPCSecrets, keys)
+	if err != nil {
+		return &loc.RPCSecrets, trace.Wrap(err)
+	}
+
+	return &loc.RPCSecrets, nil
 }
 
-// Credentials returns both server and client credentials read from the
+// CredentialsFromDir returns both server and client credentials read from the
 // specified secrets dir
-func Credentials(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
-	server, err = ServerCredentials(secretsDir)
+func CredentialsFromDir(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	server, err = ServerCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	client, err = ClientCredentials(secretsDir)
+	client, err = ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -263,7 +370,6 @@ func createPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 		return trace.Wrap(err)
 	}
 	defer reader.Close()
-
 	err = packages.UpsertRepository(pkg.Repository, time.Time{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -294,4 +400,31 @@ func upsertPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 	}
 	_, err = packages.UpsertPackage(pkg, reader, pack.WithLabels(labels))
 	return trace.Wrap(err)
+}
+
+func validateCertificateExpiration(pemBytes []byte, now time.Time) error {
+	cert, err := tlsca.ParseCertificatePEM(pemBytes)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	logrus.WithFields(logrus.Fields{
+		"now":        now,
+		"not-before": cert.NotBefore.String(),
+		"not-after":  cert.NotAfter.String(),
+	}).Info("Validate certificate.")
+	if now.Before(cert.NotBefore) {
+		return trace.BadParameter("certificate is valid in the future").
+			AddFields(trace.Fields{
+				"now":        now,
+				"not-before": cert.NotBefore,
+			})
+	}
+	if now.After(cert.NotAfter) {
+		return trace.BadParameter("certificate is valid in the past").
+			AddFields(trace.Fields{
+				"now":       now,
+				"not-after": cert.NotAfter,
+			})
+	}
+	return nil
 }

--- a/lib/storage/keyval/constants.go
+++ b/lib/storage/keyval/constants.go
@@ -75,6 +75,8 @@ const (
 	remoteClustersP             = "remoteclusters"
 	systemP                     = "system"
 	dnsP                        = "dns"
+	nodeAddrP                   = "nodeaddress"
+	serviceUserP                = "serviceuser"
 	chartsP                     = "charts"
 	indexP                      = "index"
 

--- a/lib/storage/keyval/system.go
+++ b/lib/storage/keyval/system.go
@@ -37,3 +37,33 @@ func (b *backend) SetDNSConfig(config storage.DNSConfig) error {
 	err := b.upsertVal(b.key(systemP, dnsP), &config, forever)
 	return trace.Wrap(err)
 }
+
+// GetNodeAddr returns the current node advertise IP
+func (b *backend) GetNodeAddr() (addr string, err error) {
+	var nodeAddr string
+	err = b.getVal(b.key(systemP, nodeAddrP), &nodeAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return nodeAddr, nil
+}
+
+// SetNodeAddr sets current node advertise IP
+func (b *backend) SetNodeAddr(addr string) error {
+	return b.upsertVal(b.key(systemP, nodeAddrP), addr, forever)
+}
+
+// GetServiceUser returns the current serviceo user
+func (b *backend) GetServiceUser() (*storage.OSUser, error) {
+	var user storage.OSUser
+	err := b.getVal(b.key(systemP, serviceUserP), &user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &user, nil
+}
+
+// SetServiceUser sets current service user
+func (b *backend) SetServiceUser(user storage.OSUser) error {
+	return b.upsertVal(b.key(systemP, serviceUserP), &user, forever)
+}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -38,10 +38,9 @@ import (
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/utils"
 
+	"github.com/dustin/go-humanize"
 	teleservices "github.com/gravitational/teleport/lib/services"
 	teleutils "github.com/gravitational/teleport/lib/utils"
-
-	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -1060,6 +1059,14 @@ type SystemMetadata interface {
 	GetDNSConfig() (*DNSConfig, error)
 	// SetDNSConfig sets current DNS configuration
 	SetDNSConfig(DNSConfig) error
+	// GetNodeAddr returns the current node advertise IP
+	GetNodeAddr() (addr string, err error)
+	// SetNodeAddr sets current node advertise IP
+	SetNodeAddr(addr string) error
+	// GetServiceUser returns the current service user
+	GetServiceUser() (*OSUser, error)
+	// SetServiceUser sets current service user
+	SetServiceUser(OSUser) error
 }
 
 // DefaultDNSConfig defines the default cluster local DNS configuration

--- a/lib/systeminfo/user.go
+++ b/lib/systeminfo/user.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -104,6 +105,25 @@ func LookupUserByUID(uid int) (*User, error) {
 	}
 	return &User{
 		Name: usr.Username,
+		UID:  uid,
+		GID:  gid,
+	}, nil
+}
+
+// FromOSUser converts the user to this package format
+func FromOSUser(user storage.OSUser) (*User, error) {
+	uid, err := strconv.Atoi(user.UID)
+	if err != nil {
+		return nil, trace.BadParameter("expected a numeric UID but got %v", user.UID)
+	}
+
+	gid, err := strconv.Atoi(user.GID)
+	if err != nil {
+		return nil, trace.BadParameter("expected a numeric GID but got %v", user.GID)
+	}
+
+	return &User{
+		Name: user.Name,
 		UID:  uid,
 		GID:  gid,
 	}, nil

--- a/lib/systeminfo/user.go
+++ b/lib/systeminfo/user.go
@@ -116,12 +116,10 @@ func FromOSUser(user storage.OSUser) (*User, error) {
 	if err != nil {
 		return nil, trace.BadParameter("expected a numeric UID but got %v", user.UID)
 	}
-
 	gid, err := strconv.Atoi(user.GID)
 	if err != nil {
 		return nil, trace.BadParameter("expected a numeric GID but got %v", user.GID)
 	}
-
 	return &User{
 		Name: user.Name,
 		UID:  uid,

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -211,7 +211,7 @@ func (p *updatePhaseInit) initRPCCredentials() error {
 	// to restart the cluster controller (gravity-site) to make sure it has
 	// reloaded its copy of the credentials.
 	// See: https://github.com/gravitational/gravity/issues/3607.
-	pkg, err := rpc.InitRPCCredentials(p.Packages)
+	pkg, err := rpc.InitCredentials(p.Packages)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/backup_restore.go
+++ b/tool/gravity/cli/backup_restore.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -134,7 +135,7 @@ func runBackupRestore(env *localenv.LocalEnvironment, operation string,
 		return trace.Wrap(err)
 	}
 
-	node, err := findLocalServer(*site)
+	node, err := ops.FindLocalServer(site.ClusterState)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -240,6 +240,8 @@ type Application struct {
 	SystemCmd SystemCmd
 	// SystemRotateCertsCmd renews cluster certificates on local node
 	SystemRotateCertsCmd SystemRotateCertsCmd
+	// SystemRotateRPCCredsCmd renews cluster RPC credentials
+	SystemRotateRPCCredsCmd SystemRotateRPCCredsCmd
 	// SystemExportCACmd exports cluster CA
 	SystemExportCACmd SystemExportCACmd
 	// SystemUninstallCmd uninstalls all gravity services from local node
@@ -1326,6 +1328,14 @@ type SystemRotateCertsCmd struct {
 	ValidFor *time.Duration
 	// CAPath is CA to use
 	CAPath *string
+}
+
+// SystemRotateRPCCredsCmd renews cluster RPC credentials
+type SystemRotateRPCCredsCmd struct {
+	*kingpin.CmdClause
+	// Show controls whether to actually rotate the credentials.
+	// If true, only verifies the certificate
+	Show *bool
 }
 
 // SystemExportCACmd exports cluster CA

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -25,6 +25,7 @@ import (
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/vacuum"
@@ -230,7 +231,7 @@ func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhasePara
 		return trace.Wrap(err, "failed to fetch the path to the container's rootfs")
 	}
 
-	creds, err := libfsm.GetClientCredentials()
+	creds, err := rpc.ClientCredentials(clusterPackages)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -53,7 +53,7 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	leader, err := findLocalServer(*cluster)
+	leader, err := ops.FindLocalServer(cluster.ClusterState)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -564,9 +564,12 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemCmd.CmdClause = g.Command("system", "operations on system components")
 
 	g.SystemRotateCertsCmd.CmdClause = g.SystemCmd.Command("rotate-certs", "Renew cluster certificates on a node").Hidden()
-	g.SystemRotateCertsCmd.ClusterName = g.SystemRotateCertsCmd.Arg("cluster-name", "Name of the local cluster").Required().String()
+	g.SystemRotateCertsCmd.ClusterName = g.SystemRotateCertsCmd.Arg("cluster-name", "Name of the local cluster").String()
 	g.SystemRotateCertsCmd.ValidFor = g.SystemRotateCertsCmd.Flag("valid-for", "Validity duration in Go format").Default("26280h").Duration()
 	g.SystemRotateCertsCmd.CAPath = g.SystemRotateCertsCmd.Flag("ca-path", "Use previously exported CA file instead of package").String()
+
+	g.SystemRotateRPCCredsCmd.CmdClause = g.SystemCmd.Command("rotate-rpc-creds", "Renew cluster RPC credentials")
+	g.SystemRotateRPCCredsCmd.Show = g.SystemRotateRPCCredsCmd.Flag("show", "Verify but do not actually rotate credentials").Bool()
 
 	g.SystemExportCACmd.CmdClause = g.SystemCmd.Command("export-ca", "Export cluster CA, must be run on a master node").Hidden()
 	g.SystemExportCACmd.ClusterName = g.SystemExportCACmd.Arg("cluster-name", "Name of the local cluster").Required().String()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -244,7 +244,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.SiteInitCmd.FullCommand():
 		return initCluster(*g.SiteInitCmd.ConfigPath, *g.SiteInitCmd.InitPath)
 	case g.SiteStatusCmd.FullCommand():
-		return statusSite()
+		return statusSite(localenv.Silent(*g.Silent))
 	}
 
 	localEnv, err := g.LocalEnv(cmd)
@@ -716,6 +716,10 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			clusterName: *g.SystemRotateCertsCmd.ClusterName,
 			validFor:    *g.SystemRotateCertsCmd.ValidFor,
 			caPath:      *g.SystemRotateCertsCmd.CAPath,
+		})
+	case g.SystemRotateRPCCredsCmd.FullCommand():
+		return rotateRPCCredentials(localEnv, rotateRPCCredsOptions{
+			show: *g.SystemRotateRPCCredsCmd.Show,
 		})
 	case g.SystemExportCACmd.FullCommand():
 		return exportCertificateAuthority(localEnv,

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -40,7 +40,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func statusSite() error {
+func statusSite(printer localenv.Printer) error {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
@@ -54,7 +54,7 @@ func statusSite() error {
 	}
 	defer re.Body.Close()
 	if re.StatusCode == http.StatusOK {
-		fmt.Printf("site is up and running\n")
+		printer.Println("site is up and running")
 		return nil
 	}
 	out, _ := ioutil.ReadAll(re.Body)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -95,7 +95,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	leader, err := findLocalServer(*cluster)
+	leader, err := ops.FindLocalServer(cluster.ClusterState)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to find local node in cluster state.\n"+
 			"Make sure you start the operation from one of the cluster master nodes.")


### PR DESCRIPTION
This PR addresses the issue with RPC credentials rotation by introducing a new system sub-command:
```sh
usage: gravity system rotate-rpc-creds [<flags>]

Renew cluster RPC credentials

Flags:
      --help                 Show context-sensitive help (also try --help-long and --help-man).
      --debug                Enable debug mode
  -q, --quiet                Suppress any extra output to stdout
      --insecure             Skip TLS verification
      --state-dir=STATE-DIR  Directory for local state
      --log-file="/var/log/gravity-install.log"  
                             log file with diagnostic information
      --show                 Verify but do not actually rotate credentials
```
It is capable of verifying as well as generating new credentials package to avoid user-unfriendly and  fragile workarounds.
It is supposed to work even in case of controller Pod not running.
