### PR TITLE
[5.5.x] fix operation list format

### DIFF
--- a/lib/rpc/deploy.go
+++ b/lib/rpc/deploy.go
@@ -146,7 +146,7 @@ func DeployAgents(ctx context.Context, req DeployAgentsRequest) error {
 					logger.WithError(err).Warn("Failed to deploy agent.")
 					return trace.Wrap(err)
 				}
-				req.Progress.Print(color.GreenString("Deployed agent on %v (%v)", server.Hostname, server.AdvertiseIP))
+				req.Progress.Print(color.GreenString("Deployed agent on %v (%v)", stateServer.Hostname, stateServer.AdvertiseIP))
 				logger.Info("Agent deployed.")
 				return nil
 			})

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -17,14 +17,18 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/tool/common"
 
+	"github.com/buger/goterm"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -281,6 +285,17 @@ func getActiveOperationsFromList(operations []ops.SiteOperation) (result []ops.S
 		return nil, trace.NotFound("no active operations found")
 	}
 	return result, nil
+}
+
+// formatTable formats this operation list as a table
+func (r oplist) formatTable() string {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	common.PrintTableHeader(t, []string{"Type", "ID", "State", "Created"})
+	for _, op := range r {
+		fmt.Fprintf(t, "%v\t%v\t%v\t%v\n",
+			op.Type, op.ID, op.State, op.Created.Format(constants.ShortDateFormat))
+	}
+	return t.String()
 }
 
 func (r oplist) String() string {

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -69,10 +69,10 @@ func displayOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironmen
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(operations) != 1 {
+	if len(operations) != 1 && format == constants.EncodingText {
 		log.WithField("operations", oplist(operations).String()).Warn("Multiple operations found.")
-		localEnv.Printf("Multiple operations found: \n\t%v\n, please specify operation with --operation-id.\n"+
-			"Displaying the most recent operation.", oplist(operations))
+		localEnv.Printf("Multiple operations found: \n%v\nPlease specify operation with --operation-id. "+
+			"Displaying the most recent operation.\n\n", oplist(operations).formatTable())
 	}
 	op := operations[0]
 	if op.IsCompleted() {

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -71,8 +71,8 @@ func displayOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironmen
 	}
 	if len(operations) != 1 {
 		log.WithField("operations", oplist(operations).String()).Warn("Multiple operations found.")
-		localEnv.Println("Multiple operations found: \n%v\n, please specify operation with --operation-id.\n" +
-			"Displaying the most recent operation.")
+		localEnv.Printf("Multiple operations found: \n\t%v\n, please specify operation with --operation-id.\n"+
+			"Displaying the most recent operation.", oplist(operations))
 	}
 	op := operations[0]
 	if op.IsCompleted() {


### PR DESCRIPTION
Format multiple operations in `gravity plan` if outputting as text as a table.