### PR TITLE
Show EULA in CLI installer.

### DIFF
--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -261,6 +261,14 @@ func (m Manifest) ImageType() string {
 	}
 }
 
+// EULA returns the end-user license agreement text.
+func (m Manifest) EULA() string {
+	if m.Installer != nil {
+		return m.Installer.EULA.Source
+	}
+	return ""
+}
+
 func dockerConfigWithDefaults(config *Docker) Docker {
 	if config == nil {
 		return defaultDocker

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -121,7 +121,6 @@ const manifestSchema = `
             },
             "flavors": {
               "type": "object",
-              "required": ["items"],
               "additionalProperties": false,
               "properties": {
                 "prompt": {"type": "string"},

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -402,6 +402,8 @@ type InstallCmd struct {
 	// the client will simply connect to the service and stream its output and errors
 	// and control whether it should stop
 	FromService *bool
+	// AcceptEULA allows to auto-accept end-user license agreement.
+	AcceptEULA *bool
 }
 
 // JoinCmd joins to the installer or existing cluster

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -301,7 +301,7 @@ func (i *InstallConfig) CheckAndSetDefaults() (err error) {
 	return nil
 }
 
-// checkEULA asks the user to accept the end-user license agreement is one
+// checkEULA asks the user to accept the end-user license agreement if one
 // is required.
 func (i *InstallConfig) checkEULA() error {
 	if i.Mode != constants.InstallModeCLI || i.FromService {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -57,7 +57,6 @@ import (
 
 func startInstall(env *localenv.LocalEnvironment, config InstallConfig) error {
 	env.PrintStep("Starting installer")
-
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -97,6 +97,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.InstallCmd.DNSZones = g.InstallCmd.Flag("dns-zone", "Specify an upstream server for the given zone within the cluster. Accepts <zone>/<nameserver> format where <nameserver> can be either <ip> or <ip>:<port>. Can be specified multiple times.").Strings()
 	g.InstallCmd.Remote = g.InstallCmd.Flag("remote", "Do not use this node in the cluster.").Bool()
 	g.InstallCmd.FromService = g.InstallCmd.Flag("from-service", "Run in service mode.").Hidden().Bool()
+	g.InstallCmd.AcceptEULA = g.InstallCmd.Flag("accept-eula", "Auto-accept the end-user license agreement if the application requires it.").Bool()
 
 	g.JoinCmd.CmdClause = g.Command("join", "Join the existing cluster or an on-going install operation.")
 	g.JoinCmd.PeerAddr = g.JoinCmd.Arg("peer-addrs", "One or several IP addresses of cluster nodes to join, as comma-separated values.").String()


### PR DESCRIPTION
If EULA is specified in the manifest, it is only displayed in the UI installer.

This PR makes sure it is displayed in CLI installer as well. Also add `--accept-eula` flag to auto-accept it for unattended installations.

Closes https://github.com/gravitational/gravity/issues/799.