### PR TITLE
Remove information about devicemapper.

### DIFF
--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -7,20 +7,16 @@ Kubernetes and Gravity.
 
 Gravity supports the following Linux distributions:
 
-| Linux Distribution        | Version         | Docker Storage Drivers                |
+| Linux Distribution       | Version         | Docker Storage Drivers                |
 |--------------------------|-----------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.2-7.3         | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.7, 8.0    | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7         | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8-9             | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu                   | 16.04, 18.04    | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu-Core              | 16.04           | `devicemapper`*, `overlay`, `overlay2` |
+| Red Hat Enterprise Linux | 7.4-7.7, 8.0    | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.7         | `overlay`, `overlay2`                 |
+| Debian                   | 8-9             | `overlay`, `overlay2`                 |
+| Ubuntu                   | 16.04, 18.04    | `overlay`, `overlay2`                 |
+| Ubuntu-Core              | 16.04           | `overlay`, `overlay2`                 |
 | openSuse                 | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
 | Suse Linux Enterprise    | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
 | Amazon Linux             | 2               | `overlay`, `overlay2`                 |
-
-!!! note
-    devicemapper has been deprecated by the docker project, and is not supported by gravity 5.3.4 or later
 
 ### Identifying OS Distributions In Manifest
 
@@ -35,7 +31,7 @@ specified in the manifest:
 
 | Distribution Name        | ID                         | Version        |
 |--------------------------|----------------------------|----------------|
-| Red Hat Enterprise Linux | rhel                       | 7.2-7.7, 8.0   |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.7, 8.0   |
 | CentOS                   | centos                     | 7.2-7.7        |
 | Debian                   | debian                     | 8-9            |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04   |
@@ -257,7 +253,6 @@ Gravity requires that these modules are loaded prior to installation.
 | Linux Distribution                     | Version | Modules |
 |--------------------------|-----------|---------------------------|
 | CentOS                    | 7.2     | bridge, ebtable_filter, iptables, overlay  |
-| RedHat Linux | 7.2     | bridge, ebtable_filter, iptables  |
 | CentOS                  | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay  |
 | RedHat Linux | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay     |
 | Debian | 8-9 | br_netfilter, ebtable_filter, iptables, overlay |

--- a/docs/7.x/workshops.md
+++ b/docs/7.x/workshops.md
@@ -2189,8 +2189,7 @@ collected, forwarded and rotated.
 
 Every time you write something to container's filesystem, it activates [copy on write strategy](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/#container-and-layers).
 
-New storage layer is created using a storage driver (devicemapper, overlayfs or others). In case of active usage,
-it can put a lot of load on storage drivers, especially in case of Devicemapper or BTRFS.
+New storage layer is created using a storage driver (overlayfs or others).
 
 Make sure your containers write data only to volumes. You can use `tmpfs` for small (as tmpfs stores everything in memory) temporary files:
 


### PR DESCRIPTION
We have not supported devicemapper since Gravity 5.3.X, which is now
past its end of life date.  As a consequence, we no longer support RHEL
7.2.

### Context
In our 1x1 yesterday, @r0mant and I nixed the Robotest work item for alternative storage driver testing (https://github.com/gravitational/robotest/issues/199), because we only support overlay/overlay2.  When I was reading through our docs just now, I realized they were a bit behind the code.

### Testing
<details>
<summary><code>make docs</code> & <code>make docs-lint</code></summary>
<pre>
$ make docs
make -C docs
make[1]: Entering directory '/home/walt/git/gravity/docs'
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-compile-docs
mkdocs build --strict --config-file 4.x.yaml --site-dir ../build/docs/4.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/4.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 5.x.yaml --site-dir ../build/docs/5.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/5.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 6.x.yaml --site-dir ../build/docs/6.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/6.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 7.x.yaml --site-dir ../build/docs/7.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/7.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
cd ../build/docs && rm -f latest && ln -s 7.x latest
make[1]: Leaving directory '/home/walt/git/gravity/docs'
walt@work:~/git/gravity$ make docs-lint
make -C docs lint
make[1]: Entering directory '/home/walt/git/gravity/docs'
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-lint
cd 4.x && milv -ignore-external
NO ISSUES :-)
cd 5.x && milv -ignore-external
NO ISSUES :-)
cd 6.x && milv -ignore-external
NO ISSUES :-)
cd 7.x && milv -ignore-external
NO ISSUES :-)
make[1]: Leaving directory '/home/walt/git/gravity/docs'
</pre>
</details>