### PR TITLE
Call status hook after install/upgrade.

### DIFF
--- a/lib/install/phases/app.go
+++ b/lib/install/phases/app.go
@@ -36,7 +36,10 @@ import (
 
 // NewApp returns executor that runs install and post-install hooks
 func NewApp(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications) (*hookExecutor, error) {
-	return NewHook(p, operator, apps, schema.HookInstall, schema.HookInstalled)
+	return NewHook(p, operator, apps,
+		schema.HookInstall,
+		schema.HookInstalled,
+		schema.HookStatus)
 }
 
 // NewHook returns executor that runs specified application hooks

--- a/lib/update/cluster/phases/app.go
+++ b/lib/update/cluster/phases/app.go
@@ -82,7 +82,11 @@ func (p *updatePhaseApp) Execute(ctx context.Context) error {
 		// permissions to launch jobs just yet
 		err = p.createBootstrapResources()
 	} else {
-		err = p.runHooks(ctx, schema.HookNetworkUpdate, schema.HookUpdate, schema.HookUpdated)
+		err = p.runHooks(ctx,
+			schema.HookNetworkUpdate,
+			schema.HookUpdate,
+			schema.HookUpdated,
+			schema.HookStatus)
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -92,7 +96,10 @@ func (p *updatePhaseApp) Execute(ctx context.Context) error {
 
 // Rollback runs rollback/post-rollback hooks for the app
 func (p *updatePhaseApp) Rollback(ctx context.Context) error {
-	err := p.runHooks(ctx, schema.HookRollback, schema.HookRolledBack, schema.HookNetworkRollback)
+	err := p.runHooks(ctx,
+		schema.HookRollback,
+		schema.HookRolledBack,
+		schema.HookNetworkRollback)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Some customers mention that install operation finishes too soon before their application has had a change to come up properly. This PR makes sure to call application status hook before declaring install/upgrade a success. Closes https://github.com/gravitational/gravity/issues/1274.