### PR TITLE
Update v5.X req docs to mention RHEL8

### DIFF
--- a/docs/5.x/requirements.md
+++ b/docs/5.x/requirements.md
@@ -10,7 +10,7 @@ Gravity supports the following distributions:
 | Linux Distribution       | Version         | Docker Storage Drivers                 |
 |--------------------------|-----------------|----------------------------------------|
 | Red Hat Enterprise Linux | 7.2-7.3         | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.7         | `devicemapper`*, `overlay`, `overlay2` |
+| Red Hat Enterprise Linux | 7.4-7.7, 8.0    | `devicemapper`*, `overlay`, `overlay2` |
 | CentOS                   | 7.2-7.7         | `devicemapper`*, `overlay`, `overlay2` |
 | Debian                   | 8-9             | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu                   | 16.04           | `devicemapper`*, `overlay`, `overlay2` |
@@ -33,7 +33,7 @@ Following table lists all the supported distributions and how they can be specif
 
 | Distribution Name        | ID                         | Version        |
 |--------------------------|----------------------------|----------------|
-| Red Hat Enterprise Linux | rhel                       | 7.2-7.7        |
+| Red Hat Enterprise Linux | rhel                       | 7.2-7.7, 8.0   |
 | CentOS                   | centos                     | 7.2-7.7        |
 | Debian                   | debian                     | 8-9            |
 | Ubuntu                   | ubuntu                     | 16.04          |


### PR DESCRIPTION
RHEL8 was tested in #1144 for 5.5 - this just updates the doc to reflect. 