### PR TITLE
Adjust upgrade instructions heading level.

### DIFF
--- a/docs/4.x/changelog.md
+++ b/docs/4.x/changelog.md
@@ -376,7 +376,7 @@ to invite users and reset user passwords from CLI.
 
 ## 4.x Releases
 
-## Instructions on upgrading to 4.23.0+
+### Instructions on upgrading to 4.23.0+
 
 Upgrading clusters to Telekube 4.23.0 works via the command line interface (CLI) only.
 To upgrade a cluster with an application packaged with the Telekube 4.23+

--- a/docs/5.x/changelog.md
+++ b/docs/5.x/changelog.md
@@ -1328,7 +1328,7 @@ to invite users and reset user passwords from CLI.
 
 ## 4.x Releases
 
-## Instructions on upgrading to 4.23.0+
+### Instructions on upgrading to 4.23.0+
 
 Upgrading clusters to Gravity 4.23.0 works via the command line interface (CLI) only.
 To upgrade a cluster with an application packaged with the Gravity 4.23+

--- a/docs/6.x/changelog.md
+++ b/docs/6.x/changelog.md
@@ -2041,7 +2041,7 @@ to invite users and reset user passwords from CLI.
 
 ## 4.x Releases
 
-## Instructions on upgrading to 4.23.0+
+### Instructions on upgrading to 4.23.0+
 
 Upgrading clusters to Gravity 4.23.0 works via the command line interface (CLI) only.
 To upgrade a cluster with an application packaged with the Gravity 4.23+

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -2232,7 +2232,7 @@ to invite users and reset user passwords from CLI.
 
 ## 4.x Releases
 
-## Instructions on upgrading to 4.23.0+
+### Instructions on upgrading to 4.23.0+
 
 Upgrading clusters to Gravity 4.23.0 works via the command line interface (CLI) only.
 To upgrade a cluster with an application packaged with the Gravity 4.23+


### PR DESCRIPTION
The "Instructions on upgrading to 4.23.0+" heading was at the same level
as 4.x.  This resulted in all the 4.x releases nesting under
"Instructions..." and caused "Instructions..." to show up as in the ToC.

Perhaps it may have been important to highlight these upgrade
instructions at one point in the past, but we no longer support 4.x or
anything prior.  Thus a cleaner ToC hierarchy is probably more important
these days.

### Testing Done
`make run-docs` and grabbed the following screenshots

Before:
![Screenshot_2020-04-17 Releases - Gravitational Gravity(1)](https://user-images.githubusercontent.com/187314/79617764-1eac3d00-80bd-11ea-8a1f-2ec26178fc44.png)
After
![Screenshot_2020-04-17 Releases - Gravitational Gravity](https://user-images.githubusercontent.com/187314/79617763-1d7b1000-80bd-11ea-87b3-1b59b14578ea.png)

