### PR TITLE
Add centos 8 and rhel 7.8 to supported distros.

### DIFF
--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -74,7 +74,7 @@ nodeProfiles:
         min: "2GB"
       os:
         - name: centos
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
@@ -112,7 +112,7 @@ nodeProfiles:
         min: "2GB"
       os:
         - name: centos
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
@@ -155,7 +155,7 @@ nodeProfiles:
         min: "2GB"
       os:
         - name: centos
-          versions: ["7"]
+          versions: ["7", "8"]
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu

--- a/docs/5.x/requirements.md
+++ b/docs/5.x/requirements.md
@@ -7,16 +7,16 @@ Gravity Clusters.
 
 Gravity supports the following distributions:
 
-| Linux Distribution       | Version         | Docker Storage Drivers                 |
-|--------------------------|-----------------|----------------------------------------|
-| Red Hat Enterprise Linux | 7.2-7.3         | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.7         | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7         | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8-9             | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu                   | 16.04           | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu-Core              | 16.04           | `devicemapper`*, `overlay`, `overlay2` |
-| openSuse                 | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                  |
-| Suse Linux Enterprise    | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                  |
+| Linux Distribution       | Version          | Docker Storage Drivers                 |
+|--------------------------|------------------|----------------------------------------|
+| Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
+| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.7, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
+| Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu                   | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
+| openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                  |
+| Suse Linux Enterprise    | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                  |
 
 !!! note
     devicemapper has been deprecated by the docker project, and is not supported by gravity 5.3.4 or later
@@ -31,15 +31,15 @@ During validation, values from the `name` attribute are matched against `ID` att
 
 Following table lists all the supported distributions and how they can be specified in the manifest:
 
-| Distribution Name        | ID                         | Version        |
-|--------------------------|----------------------------|----------------|
-| Red Hat Enterprise Linux | rhel                       | 7.2-7.7        |
-| CentOS                   | centos                     | 7.2-7.7        |
-| Debian                   | debian                     | 8-9            |
-| Ubuntu                   | ubuntu                     | 16.04          |
-| Ubuntu-Core              | ubuntu                     | 16.04          |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3 |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3 |
+| Distribution Name        | ID                         | Version          |
+|--------------------------|----------------------------|------------------|
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.1 |
+| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
+| Debian                   | debian                     | 8-9              |
+| Ubuntu                   | ubuntu                     | 16.04            |
+| Ubuntu-Core              | ubuntu                     | 16.04            |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3   |
 
 For example, to specify openSUSE as a dependency and support both services packs:
 

--- a/docs/6.x/requirements.md
+++ b/docs/6.x/requirements.md
@@ -8,16 +8,16 @@ Kubernetes and Gravity.
 Gravity supports the following Linux distributions:
 
 | Linux Distribution        | Version         | Docker Storage Drivers                |
-|--------------------------|-----------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.2-7.3         | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.7, 8.0    | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7         | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8-9             | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu                   | 16.04, 18.04    | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu-Core              | 16.04           | `devicemapper`*, `overlay`, `overlay2` |
-| openSuse                 | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
-| Suse Linux Enterprise    | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
-| Amazon Linux             | 2               | `overlay`, `overlay2`                 |
+|--------------------------|------------------|---------------------------------------|
+| Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
+| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.7, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
+| Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu                   | 16.04, 18.04     | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
+| openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| Suse Linux Enterprise    | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| Amazon Linux             | 2                | `overlay`, `overlay2`                 |
 
 !!! note
     devicemapper has been deprecated by the docker project, and is not supported by gravity 5.3.4 or later
@@ -33,16 +33,16 @@ against `ID` attribute of the `/etc/os-release` file on a host.
 The following table lists all supported Linux distributions and how they can be
 specified in the manifest:
 
-| Distribution Name        | ID                         | Version        |
-|--------------------------|----------------------------|----------------|
-| Red Hat Enterprise Linux | rhel                       | 7.2-7.7, 8.0   |
-| CentOS                   | centos                     | 7.2-7.7        |
-| Debian                   | debian                     | 8-9            |
-| Ubuntu                   | ubuntu                     | 16.04, 18.04   |
-| Ubuntu-Core              | ubuntu                     | 16.04          |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3 |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3 |
-| Amazon Linux             | amz                        | 2              |
+| Distribution Name        | ID                         | Version          |
+|--------------------------|----------------------------|------------------|
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.1 |
+| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
+| Debian                   | debian                     | 8-9              |
+| Ubuntu                   | ubuntu                     | 16.04, 18.04     |
+| Ubuntu-Core              | ubuntu                     | 16.04            |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3   |
+| Amazon Linux             | amz                        | 2                |
 
 For example, to specify openSUSE as a dependency and support both services packs:
 

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -5,18 +5,18 @@ Kubernetes and Gravity.
 
 ## Linux Distributions
 
-Gravity supports the following Linux distributions:
+Gravity officially supports the following Linux distributions:
 
-| Linux Distribution       | Version         | Docker Storage Drivers                |
-|--------------------------|-----------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.7, 8.0    | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.7         | `overlay`, `overlay2`                 |
-| Debian                   | 8-9             | `overlay`, `overlay2`                 |
-| Ubuntu                   | 16.04, 18.04    | `overlay`, `overlay2`                 |
-| Ubuntu-Core              | 16.04           | `overlay`, `overlay2`                 |
-| openSuse                 | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
-| Suse Linux Enterprise    | 12 SP2 - 12 SP3 | `overlay`, `overlay2`                 |
-| Amazon Linux             | 2               | `overlay`, `overlay2`                 |
+| Linux Distribution       | Version          | Docker Storage Drivers                |
+|--------------------------|------------------|---------------------------------------|
+| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.1 | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.7, 8.0-8.1 | `overlay`, `overlay2`                 |
+| Debian                   | 8-9              | `overlay`, `overlay2`                 |
+| Ubuntu                   | 16.04, 18.04     | `overlay`, `overlay2`                 |
+| Ubuntu-Core              | 16.04            | `overlay`, `overlay2`                 |
+| openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| Suse Linux Enterprise    | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| Amazon Linux             | 2                | `overlay`, `overlay2`                 |
 
 ### Identifying OS Distributions In Manifest
 
@@ -26,19 +26,19 @@ image manifest.
 During infrastructure validation, the values from `name` attribute are matched
 against `ID` attribute of the `/etc/os-release` file on a host.
 
-The following table lists all supported Linux distributions and how they can be
+The following table lists all officially supported Linux distributions and how they can be
 specified in the manifest:
 
-| Distribution Name        | ID                         | Version        |
-|--------------------------|----------------------------|----------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.7, 8.0   |
-| CentOS                   | centos                     | 7.2-7.7        |
-| Debian                   | debian                     | 8-9            |
-| Ubuntu                   | ubuntu                     | 16.04, 18.04   |
-| Ubuntu-Core              | ubuntu                     | 16.04          |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3 |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3 |
-| Amazon Linux             | amz                        | 2              |
+| Distribution Name        | ID                         | Version          |
+|--------------------------|----------------------------|------------------|
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.1 |
+| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
+| Debian                   | debian                     | 8-9              |
+| Ubuntu                   | ubuntu                     | 16.04, 18.04     |
+| Ubuntu-Core              | ubuntu                     | 16.04            |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3   |
+| Amazon Linux             | amz                        | 2                |
 
 For example, to specify openSUSE as a dependency and support both services packs:
 


### PR DESCRIPTION
And update the docs accordingly. Closes https://github.com/gravitational/gravity/issues/1390 and closes https://github.com/gravitational/gravity/issues/1330.