### PR TITLE
[6.3.x] expand leave group

### DIFF
--- a/lib/expand/bootstrap.go
+++ b/lib/expand/bootstrap.go
@@ -32,10 +32,10 @@ import (
 )
 
 // init initializes the peer after a successful connect
-func (p *Peer) init(ctx operationContext) error {
+func (p *Peer) init(ctx operationContext) (*rpcserver.PeerServer, error) {
 	err := p.initEnviron(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	return p.startAgent(ctx)
 }
@@ -145,15 +145,15 @@ func (p *Peer) syncOperation(operator ops.Operator, cluster ops.Site, operationK
 
 // startAgent starts a new RPC agent using the specified operation context.
 // The agent will signal p.errC once it has terminated
-func (p *Peer) startAgent(ctx operationContext) error {
+func (p *Peer) startAgent(ctx operationContext) (*rpcserver.PeerServer, error) {
 	agent, err := p.newAgent(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	go func() {
 		p.errC <- agent.Serve()
 	}()
-	return nil
+	return agent, nil
 }
 
 // newAgent returns an instance of the RPC agent to handle remote calls

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -153,13 +153,13 @@ type agentStopExecutor struct {
 	fsm.ExecutorParams
 }
 
-// Execute starts an RPC agent on a node
+// Execute stops an RPC agent on a node
 func (p *agentStopExecutor) Execute(ctx context.Context) error {
 	err := rpc.ShutdownAgents(ctx, []string{p.Master.AdvertiseIP},
 		p.FieldLogger, p.AgentClient)
 	if err != nil {
-		p.Errorf("Failed to stop agent on master node %v: %v.",
-			p.Master.AdvertiseIP, trace.DebugReport(err))
+		p.WithError(err).Errorf("Failed to stop agent on master node %v.",
+			p.Master.AdvertiseIP)
 	} else {
 		p.Infof("Stopped agent on master node %v.", p.Master.AdvertiseIP)
 	}

--- a/lib/install/client/automatic_lifecycle.go
+++ b/lib/install/client/automatic_lifecycle.go
@@ -102,7 +102,7 @@ func (r *AutomaticLifecycle) Abort(ctx context.Context, c *Client) error {
 type AutomaticLifecycle struct {
 	// Aborter specifies the completion handler for when the operation is aborted
 	Aborter func(context.Context) error
-	// Completer specifies the optional completion handler for when the operation
+	// Completer specifies the completion handler for when the operation
 	// is completed successfully
 	Completer CompletionHandler
 	// DebugReportPath specifies the path to the debug report file
@@ -129,7 +129,7 @@ func (r *AutomaticLifecycle) generateDebugReport(ctx context.Context, c *Client)
 	err := c.generateDebugReport(clusterCtx, r.DebugReportPath)
 	if err != nil {
 		if r.LocalDebugReporter != nil {
-			r.LocalDebugReporter(ctx, r.DebugReportPath)
+			err = r.LocalDebugReporter(ctx, r.DebugReportPath)
 		}
 	}
 	return trace.Wrap(err)

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -119,6 +119,10 @@ func (r *InstallerStrategy) checkAndSetDefaults() (err error) {
 	return nil
 }
 
+func (r *InstallerStrategy) serviceName() string {
+	return serviceNameFromPath(r.ServicePath)
+}
+
 // InstallerStrategy implements the strategy that creates a new installer service
 // before attempting to connect.
 // This strategy also validates the environment before attempting to set up the service
@@ -145,17 +149,16 @@ type InstallerStrategy struct {
 // isServiceFailed returns an error if the service has failed.
 func isServiceFailed(serviceName string) func() error {
 	return func() error {
-		failed, err := service.IsFailed(serviceName)
-		if err == nil && failed {
+		err := service.IsFailed(serviceName)
+		if err == nil {
 			return trace.Errorf("service %q has failed. Check journal log for details.",
 				serviceName)
 		}
-		return trace.Wrap(err)
+		if !trace.IsCompareFailed(err) {
+			return trace.Wrap(err)
+		}
+		return nil
 	}
-}
-
-func serviceName(path string) (name string) {
-	return filepath.Base(path)
 }
 
 var (

--- a/lib/install/client/resume.go
+++ b/lib/install/client/resume.go
@@ -38,7 +38,7 @@ func (r *ResumeStrategy) connect(ctx context.Context) (installpb.AgentClient, er
 	r.Info("Connect to running service.")
 	ctx, cancel := context.WithTimeout(ctx, r.ConnectTimeout)
 	defer cancel()
-	serviceName := serviceName(r.ServicePath)
+	serviceName := serviceNameFromPath(r.ServicePath)
 	client, err := installpb.NewClient(ctx, installpb.ClientConfig{
 		FieldLogger:     r.FieldLogger,
 		SocketPath:      r.SocketPath,
@@ -82,13 +82,13 @@ func (r *ResumeStrategy) checkAndSetDefaults() (err error) {
 	return nil
 }
 
-// restartService starts the installer's systemd unit unless it's already active
-func (r *ResumeStrategy) restartService() error {
-	return trace.Wrap(service.Start(r.serviceName()))
+func (r *ResumeStrategy) serviceName() string {
+	return serviceNameFromPath(r.ServicePath)
 }
 
-func (r *ResumeStrategy) serviceName() (name string) {
-	return service.Name(r.ServicePath)
+// restartService starts the installer's systemd unit unless it's already active
+func (r *ResumeStrategy) restartService() error {
+	return trace.Wrap(service.Start(serviceNameFromPath(r.ServicePath)))
 }
 
 // ResumeStrategy implements the strategy to connect to the existing installer service

--- a/lib/install/server/server.go
+++ b/lib/install/server/server.go
@@ -18,7 +18,6 @@ package server
 import (
 	"context"
 	"net"
-	"sync"
 
 	installpb "github.com/gravitational/gravity/lib/install/proto"
 	"github.com/gravitational/gravity/lib/ops"
@@ -83,7 +82,7 @@ func (r *Server) Interrupted(ctx context.Context) error {
 // This cannot block or invoke blocking APIs since it might be invoked
 // by the RPC agent during shutdown
 func (r *Server) ManualStop(ctx context.Context, completed bool) error {
-	r.WithField("completed", completed).Info("Stop.")
+	r.WithField("completed", completed).Info("Manual stop.")
 	if completed {
 		r.complete(ctx)
 	} else {
@@ -196,8 +195,6 @@ type Server struct {
 	// rpc is the internal gRPC server instance
 	rpc      *grpc.Server
 	executor Executor
-
-	doneOnce sync.Once
 
 	// errC signals the error from either the execute or
 	// operation being aborted

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1201,6 +1201,11 @@ func (s SiteOperationKey) Check() error {
 	return nil
 }
 
+// String returns a text presentation of this operation key
+func (s SiteOperationKey) String() string {
+	return fmt.Sprintf("operation(id=%v)", s.OperationID)
+}
+
 // CreateSiteInstallOperationRequest is a request to create
 // install operation - the operation that provisions servers, gravity software
 // and sets up everything

--- a/lib/ops/opsservice/operationgroup.go
+++ b/lib/ops/opsservice/operationgroup.go
@@ -25,11 +25,9 @@ import (
 	"github.com/gravitational/gravity/lib/ops/events"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
-	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -271,6 +269,7 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	logger := log.WithField("operation", operation.String())
 
 	operations, err := ops.GetActiveOperationsByType(g.siteKey, g.operator, operation.Type)
 	if err != nil && !trace.IsNotFound(err) {
@@ -278,7 +277,7 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	}
 
 	if len(operations) > 0 {
-		log.Debugf("%v more %q operation(-s) in progress for %v: %#v %#v",
+		logger.Debugf("%v more %q operation(-s) in progress for %v: %#v %#v",
 			len(operations), operation.Type, key.SiteDomain, key, operations)
 		return nil
 	}
@@ -286,15 +285,6 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	cluster, err := g.operator.openSite(g.siteKey)
 	if err != nil {
 		return trace.Wrap(err)
-	}
-
-	if operation.IsCompleted() {
-		if err := deleteProvisioningTokenForOperation(cluster.users(), key); err != nil && !trace.IsNotFound(err) {
-			log.WithFields(logrus.Fields{
-				logrus.ErrorKey: err,
-				"operation":     operation.String(),
-			}).Warn("Failed to delete provisioning token.")
-		}
 	}
 
 	state, err := operation.ClusterState()
@@ -308,14 +298,6 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	}
 
 	return nil
-}
-
-func deleteProvisioningTokenForOperation(users users.Identity, key ops.SiteOperationKey) error {
-	token, err := users.GetOperationProvisioningToken(key.SiteDomain, key.OperationID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return users.DeleteProvisioningToken(*token)
 }
 
 // addClusterStateServers adds the provided servers to the cluster state

--- a/lib/ops/opsservice/site.go
+++ b/lib/ops/opsservice/site.go
@@ -421,10 +421,10 @@ func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOp
 	opErr := fn(ctx)
 
 	if opErr == nil {
-		return trace.Wrap(opErr)
+		return nil
 	}
 
-	ctx.Errorf("operation failure: %v", trace.DebugReport(opErr))
+	ctx.WithError(opErr).Error("Operation failure.")
 
 	// change the state without "compare" part just to take leverage of
 	// the operation group locking to ensure atomicity
@@ -433,7 +433,7 @@ func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOp
 		newOpState: ops.OperationStateFailed,
 	})
 	if err != nil {
-		ctx.Errorf("failed to compare and swap operation state: %v", trace.DebugReport(err))
+		ctx.WithError(err).Error("Failed to compare and swap operation state.")
 	}
 
 	s.reportProgress(ctx, ops.ProgressEntry{
@@ -441,7 +441,7 @@ func (s *site) executeOperationWithContext(ctx *operationContext, op *ops.SiteOp
 		Completion: constants.Completed,
 		Message:    opErr.Error(),
 	})
-	return trace.Wrap(err)
+	return trace.Wrap(opErr)
 }
 
 type transformFn func(reader io.Reader) (io.ReadCloser, error)

--- a/lib/rpc/server/peers.go
+++ b/lib/rpc/server/peers.go
@@ -95,14 +95,14 @@ func (r *peers) tryPeer(ctx context.Context, peer *peer) error {
 	if err != nil {
 		r.WithFields(log.Fields{
 			log.ErrorKey: err,
-			"peer":       peer,
+			"peer":       peer.String(),
 		}).Warn("Failed to connect.")
 		return trace.Wrap(err, "RPC agent could not connect to %v", peer.Addr())
 	}
 	if err := client.Close(); err != nil {
 		r.WithFields(log.Fields{
 			log.ErrorKey: err,
-			"peer":       peer,
+			"peer":       peer.String(),
 		}).Warn("Failed to close client.")
 	}
 	return nil
@@ -180,7 +180,7 @@ func (r *peers) monitorPeer(p Peer, clt Client, reconnectCh chan<- chan clientUp
 // a disconnect.
 // Returns the client to the peer or error if reconnecting failed.
 func (r *peers) checkPeer(p Peer, clt Client, reconnectCh chan<- chan clientUpdate, respCh chan clientUpdate, doneCh chan struct{}) (Client, error) {
-	log := r.WithField("checked", p)
+	log := r.WithField("checked", p.String())
 	if clt != nil {
 		resp, err := clt.Check(r.ctx, &healthpb.HealthCheckRequest{})
 		if err == nil && isPeerHealthy(*resp) {
@@ -217,7 +217,7 @@ func (r *peers) checkPeer(p Peer, clt Client, reconnectCh chan<- chan clientUpda
 }
 
 func (r *peers) reconnectPeer(p Peer, reqCh <-chan chan clientUpdate, doneCh chan struct{}) {
-	log := r.WithField("reconnected", p)
+	log := r.WithField("reconnected", p.String())
 	log.Info("Reconnecting")
 	defer log.Info("Reconnect loop closing.")
 	for {
@@ -227,6 +227,7 @@ func (r *peers) reconnectPeer(p Peer, reqCh <-chan chan clientUpdate, doneCh cha
 			err := utils.RetryWithInterval(r.ctx, r.Backoff(), func() (err error) {
 				clt, err = p.Reconnect(r.ctx)
 				if err != nil {
+					log.WithError(err).Info("Failed to reconnect.")
 					return r.ShouldReconnect(err)
 				}
 				return nil


### PR DESCRIPTION
Backports https://github.com/gravitational/gravity/pull/1361.

The joining agent will attempt to leave the operation agent group upon operation completion so that the cluster controller will not be attempting to reconnect to it.

Also, it does not remove the expand provisioning token after operation completion.