### PR TITLE
Added note on oidc re auth0

### DIFF
--- a/docs/7.x/config.md
+++ b/docs/7.x/config.md
@@ -13,7 +13,7 @@ Resource Name             | Resource Description
 `role`                    | User role (Enterprise only)
 `user`                    | Cluster user
 `token`                   | User tokens such as API keys
-`logforwarder`            | Forwarding logs to a remote rsyslog server
+`logforwarder`            | Forwarding logs to a remote rsyslog server!
 `trusted_cluster`         | Managing access to remote Gravity Hubs (Enterprise Only)
 `endpoints`               | Gravity Hub endpoints for user and Cluster traffic (Enterprise Only)
 `cluster_auth_preference` | Cluster authentication settings such as second-factor
@@ -404,7 +404,8 @@ spec:
     - {% raw %}{claim: "roles", value: "gravitational/admins", roles: ["@teleadmin"]}{% endraw %}
 ```
 
-!!! note For Auth0 the OIDC Conformant setting should be off in Advanced Setting -> OAuth or Claims will not populate properly 
+!!! note 
+    For Auth0 the "OIDC Conformant" setting should be off in Advanced Setting -> OAuth or Claims will not populate properly 
 
 Add this connector to the Cluster:
 

--- a/docs/7.x/config.md
+++ b/docs/7.x/config.md
@@ -13,7 +13,7 @@ Resource Name             | Resource Description
 `role`                    | User role (Enterprise only)
 `user`                    | Cluster user
 `token`                   | User tokens such as API keys
-`logforwarder`            | Forwarding logs to a remote rsyslog server!
+`logforwarder`            | Forwarding logs to a remote rsyslog server
 `trusted_cluster`         | Managing access to remote Gravity Hubs (Enterprise Only)
 `endpoints`               | Gravity Hub endpoints for user and Cluster traffic (Enterprise Only)
 `cluster_auth_preference` | Cluster authentication settings such as second-factor

--- a/docs/7.x/config.md
+++ b/docs/7.x/config.md
@@ -404,6 +404,8 @@ spec:
     - {% raw %}{claim: "roles", value: "gravitational/admins", roles: ["@teleadmin"]}{% endraw %}
 ```
 
+!!! note For Auth0 the OIDC Conformant setting should be off in Advanced Setting -> OAuth or Claims will not populate properly 
+
 Add this connector to the Cluster:
 
 ```bsh


### PR DESCRIPTION
Note on turning off OIDC Conformant settings that prevents auth0 connectors from populating claims.  Otherwise a warning will show like "Error validating callback: unable to map claims to role for connector:" in the log.