### PR TITLE
[5.5.x] wait for agent to leave cluster

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -126,6 +126,9 @@ const (
 	// has been completed/or failed
 	InstallTokenTTL = time.Hour
 
+	// ExpandTokenTTL is the TTL for the expand token during the operation
+	ExpandTokenTTL = 24 * time.Hour
+
 	// MaxOperationConcurrency defines a number of servers an operation can run on concurrently
 	MaxOperationConcurrency = 5
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -207,9 +207,6 @@ const (
 	// AgentConnectTimeout specifies the timeout for the initial connect
 	AgentConnectTimeout = 1 * time.Minute
 
-	// AgentStopTimeout is amount of time agent gets to gracefully shut down
-	AgentStopTimeout = 10 * time.Second
-
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -511,11 +511,7 @@ func (p *Peer) run() error {
 	// schedule a cleanup function to fail the operation if this exits
 	// with error
 	defer func() {
-		if err == nil {
-			return
-		}
-		p.WithError(err).Warn("Peer is exiting with error.")
-		stopCtx, cancel := context.WithTimeout(context.Background(), defaults.AgentStopTimeout)
+		stopCtx, cancel := context.WithTimeout(context.Background(), defaults.ShutdownTimeout)
 		defer cancel()
 		if p.agent != nil {
 			p.Info("Stopping peer.")
@@ -523,6 +519,10 @@ func (p *Peer) run() error {
 				p.WithError(err).Error("Failed to stop peer.")
 			}
 		}
+		if err == nil {
+			return
+		}
+		p.WithError(err).Warn("Peer is exiting with error.")
 		if ctx != nil && ctx.Operation.ID != "" {
 			if err2 := ops.FailOperation(ctx.Operation.Key(), ctx.Operator, err.Error()); err2 != nil {
 				p.WithError(err2).Error("Failed to mark the operation as failed.")

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -128,8 +128,10 @@ func (s *site) createInstallExpandOperation(operationType, operationInitialState
 	}
 
 	tokenType := storage.ProvisioningTokenTypeInstall
+	tokenTTL := defaults.InstallTokenTTL
 	if op.Type == ops.OperationExpand {
 		tokenType = storage.ProvisioningTokenTypeExpand
+		tokenTTL = defaults.ExpandTokenTTL
 	}
 
 	_, err = s.users().CreateProvisioningToken(storage.ProvisioningToken{
@@ -137,6 +139,7 @@ func (s *site) createInstallExpandOperation(operationType, operationInitialState
 		AccountID:   s.key.AccountID,
 		SiteDomain:  s.key.SiteDomain,
 		Type:        storage.ProvisioningTokenType(tokenType),
+		Expires:     s.clock().UtcNow().Add(tokenTTL),
 		OperationID: op.ID,
 		UserEmail:   agentUser.GetName(),
 	})

--- a/lib/ops/opsservice/operationgroup.go
+++ b/lib/ops/opsservice/operationgroup.go
@@ -23,11 +23,9 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
-	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -264,15 +262,6 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 		return trace.Wrap(err)
 	}
 
-	if operation.IsCompleted() {
-		if err := deleteProvisioningTokenForOperation(cluster.users(), key); err != nil && !trace.IsNotFound(err) {
-			log.WithFields(logrus.Fields{
-				logrus.ErrorKey: err,
-				"operation":     operation.String(),
-			}).Warn("Failed to delete provisioning token.")
-		}
-	}
-
 	state, err := operation.ClusterState()
 	if err != nil {
 		return trace.Wrap(err)
@@ -284,14 +273,6 @@ func (g *operationGroup) onSiteOperationComplete(key ops.SiteOperationKey) error
 	}
 
 	return nil
-}
-
-func deleteProvisioningTokenForOperation(users users.Identity, key ops.SiteOperationKey) error {
-	token, err := users.GetOperationProvisioningToken(key.SiteDomain, key.OperationID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return users.DeleteProvisioningToken(*token)
 }
 
 // addClusterStateServers adds the provided servers to the cluster state


### PR DESCRIPTION
During expand, after operation completion, wait for agent to exit the cluster so the cluster controller does not re-attempt to reconnect.
Also, do not remove the expand token as the agent will have to validated when it leaves.