### PR TITLE
Fix some join token issues

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1109,16 +1109,9 @@ func (s *site) getTeleportMasterConfig(ctx *operationContext, configPackage loc.
 	fileConf.AdvertiseIP = advertiseIP.String()
 	fileConf.Global.NodeName = master.FQDN(s.domainName)
 
-	joinToken, err := s.service.GetExpandToken(s.key)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// turn on auth service
 	fileConf.Auth.EnabledFlag = "yes"
 	fileConf.Auth.ClusterName = telecfg.ClusterName(s.domainName)
-	fileConf.Auth.StaticTokens = telecfg.StaticTokens{
-		telecfg.StaticToken(fmt.Sprintf("node:%v", joinToken.Token))}
 
 	// turn on proxy and Kubernetes integration
 	fileConf.Proxy.EnabledFlag = "yes"

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -885,6 +885,10 @@ func (s *site) newProvisioningToken(operation ops.SiteOperation) (token string, 
 		OperationID: operation.ID,
 		UserEmail:   agentUser.GetName(),
 	}
+	if operation.Type == ops.OperationExpand {
+		// Set a TTL for expand provisioning token.
+		tokenRequest.Expires = s.clock().UtcNow().Add(24 * time.Hour)
+	}
 	_, err = s.users().CreateProvisioningToken(tokenRequest)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		log.WithError(err).Warn("Failed to create provisioning token.")

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -17,17 +17,17 @@ limitations under the License.
 package process
 
 import (
-	"fmt"
-
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
 	teledefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -69,14 +69,12 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 		serviceConfig.AuthServers = append(serviceConfig.AuthServers, serviceConfig.Auth.SSHAddr)
 	}
 	// Configure auth tokens so nodes can join.
-	tokens, err := storage.GetExpandTokens(p.backend)
-	if err != nil {
+	tokens, err := p.getTeleportAuthTokens()
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	for _, token := range tokens {
-		serviceConfig.Auth.StaticTokens = append(serviceConfig.Auth.StaticTokens,
-			config.StaticToken(fmt.Sprintf("node:%v", token.Token)))
-	}
+	serviceConfig.Auth.StaticTokens.SetStaticTokens(append(tokens,
+		serviceConfig.Auth.StaticTokens.GetStaticTokens()...))
 	// Teleport will be using Gravity backend implementation.
 	serviceConfig.Identity = p.identity
 	serviceConfig.Trust = p.identity
@@ -91,6 +89,29 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	// faster when auth gateway settings are updated.
 	serviceConfig.PollingPeriod = teledefaults.HighResPollingPeriod
 	return serviceConfig, nil
+}
+
+// getTeleportAuthTokens returns tokens Teleport nodes can use to authenticate
+// with auth server to join the cluster.
+func (p *Process) getTeleportAuthTokens() (result []services.ProvisionToken, err error) {
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tokens, err := p.backend.GetSiteProvisioningTokens(cluster.Domain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, token := range tokens {
+		// Teleport nodes use persistent join tokens to join.
+		if token.Type == storage.ProvisioningTokenTypeExpand && token.Expires.IsZero() {
+			result = append(result, services.ProvisionToken{
+				Roles: teleport.Roles{teleport.RoleNode},
+				Token: token.Token,
+			})
+		}
+	}
+	return result, nil
 }
 
 // getOrInitAuthGatewayConfig returns auth gateway configuration.

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -292,24 +292,6 @@ func GetDNSConfig(backend Backend, fallback DNSConfig) (config *DNSConfig, err e
 	return config, nil
 }
 
-// GetExpandTokens returns all persistent (non-expiring) join tokens.
-func GetExpandTokens(backend Backend) (result []storage.ProvisioningToken, err error) {
-	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tokens, err := backend.GetSiteProvisioningTokens(cluster.Domain)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	for _, token := range tokens {
-		if token.Type == ProvisioningTokenTypeExpand && token.Expires.IsZero() {
-			result = append(result, token)
-		}
-	}
-	return result, nil
-}
-
 // DeepComparePhases compares the actual phase to the expected phase omitting
 // some insignificant fields like description or UI step number
 func DeepComparePhases(c *check.C, expected, actual OperationPhase) {

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -292,6 +292,24 @@ func GetDNSConfig(backend Backend, fallback DNSConfig) (config *DNSConfig, err e
 	return config, nil
 }
 
+// GetExpandTokens returns all persistent (non-expiring) join tokens.
+func GetExpandTokens(backend Backend) (result []storage.ProvisioningToken, err error) {
+	cluster, err := backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tokens, err := backend.GetSiteProvisioningTokens(cluster.Domain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, token := range tokens {
+		if token.Type == ProvisioningTokenTypeExpand && token.Expires.IsZero() {
+			result = append(result, token)
+		}
+	}
+	return result, nil
+}
+
 // DeepComparePhases compares the actual phase to the expected phase omitting
 // some insignificant fields like description or UI step number
 func DeepComparePhases(c *check.C, expected, actual OperationPhase) {


### PR DESCRIPTION
Fix a couple of issues surfaced after recent expand improvements:

* Bring back ttl for the join token created for an expand operation as some logic depends on it.
* Dynamically determine teleport auth tokens when the process starts instead of hardcoding them in teleport configuration.

Refs https://github.com/gravitational/gravity/issues/1445.