### PR TITLE
Fix join token issues.

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1105,16 +1105,9 @@ func (s *site) getTeleportMasterConfig(ctx *operationContext, configPackage loc.
 	fileConf.AdvertiseIP = advertiseIP.String()
 	fileConf.Global.NodeName = master.FQDN(s.domainName)
 
-	joinToken, err := s.service.GetExpandToken(s.key)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// turn on auth service
 	fileConf.Auth.EnabledFlag = "yes"
 	fileConf.Auth.ClusterName = telecfg.ClusterName(s.domainName)
-	fileConf.Auth.StaticTokens = telecfg.StaticTokens{
-		telecfg.StaticToken(fmt.Sprintf("node:%v", joinToken.Token))}
 
 	// turn on proxy and Kubernetes integration
 	fileConf.Proxy.EnabledFlag = "yes"


### PR DESCRIPTION
https://github.com/gravitational/gravity/pull/1434 backport. In 6.1 we didn't remove token ttl but I think backporting this change with determining auth tokens on startup is good anyway. Refs https://github.com/gravitational/gravity/issues/1445.