### PR TITLE
Add internal commands to fix teleport tokens.

### DIFF
--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -244,6 +244,10 @@ var (
 	Gravity = MustParseLocator(
 		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, defaults.TelekubePackage, LatestVersion))
 
+	// Teleport is teleport package locator
+	Teleport = MustParseLocator(
+		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, constants.TeleportPackage, LatestVersion))
+
 	// Bandwagon is the bandwagon application locator
 	Bandwagon = MustParseLocator(
 		fmt.Sprintf("%v/%v:%v", defaults.SystemAccountOrg, defaults.BandwagonPackageName, LatestVersion))

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -235,7 +235,7 @@ func (i *importer) findLatestTeleportConfigPackage(clusterName string, teleportV
 	config, err := pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
 		Packages:   i.packages,
 		Repository: clusterName,
-		Match:      matchTeleportConfigPackage(teleportVersion),
+		Match:      MatchTeleportConfigPackage(teleportVersion),
 	})
 	if err == nil {
 		return config, nil
@@ -254,7 +254,9 @@ func (i *importer) findLatestLegacyTeleportConfigPackage(clusterName string) (*l
 	})
 }
 
-func matchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
+// MatchTeleportConfigPackage returns a match function that matches Teleport
+// master configuration package with specified version.
+func MatchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
 	return func(env pack.PackageEnvelope) bool {
 		if !env.HasLabel(pack.PurposeLabel, pack.PurposeTeleportMasterConfig) {
 			return false

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -238,6 +238,14 @@ type Application struct {
 	RPCAgentRunCmd RPCAgentRunCmd
 	// SystemCmd combines system subcommands
 	SystemCmd SystemCmd
+	// SystemTeleportCmd combines internal Teleport commands
+	SystemTeleportCmd SystemTeleportCmd
+	// SystemTeleportShowConfigCmd displays Teleport config
+	SystemTeleportShowConfigCmd SystemTeleportShowConfigCmd
+	// SystemTeleportMasterTokenCmd updates Teleport master auth tokens
+	SystemTeleportMasterTokenCmd SystemTeleportMasterTokenCmd
+	// SystemTeleportNodeTokenCmd updates Teleport node auth token
+	SystemTeleportNodeTokenCmd SystemTeleportNodeTokenCmd
 	// SystemRotateCertsCmd renews cluster certificates on local node
 	SystemRotateCertsCmd SystemRotateCertsCmd
 	// SystemRotateRPCCredsCmd renews cluster RPC credentials
@@ -1317,6 +1325,36 @@ type RPCAgentRunCmd struct {
 // SystemCmd combines system subcommands
 type SystemCmd struct {
 	*kingpin.CmdClause
+}
+
+// SystemTeleportCmd combines internal Teleport commands
+type SystemTeleportCmd struct {
+	*kingpin.CmdClause
+}
+
+// SystemTeleportShowConfigCmd displays Teleport config from specified package
+type SystemTeleportShowConfigCmd struct {
+	*kingpin.CmdClause
+	// Package is the package to show config from
+	Package *string
+}
+
+// SystemTeleportMasterTokenCmd updates Teleport master auth tokens
+type SystemTeleportMasterTokenCmd struct {
+	*kingpin.CmdClause
+	// Package is the Teleport master config package
+	Package *string
+	// Tokens is a list of auth tokens to add to the config
+	Tokens *[]string
+}
+
+// SystemTeleportNodeTokenCmd updates Teleport node auth token
+type SystemTeleportNodeTokenCmd struct {
+	*kingpin.CmdClause
+	// Package is the Teleport node config package
+	Package *string
+	// Token is the auth token to set
+	Token *string
 }
 
 // SystemRotateCertsCmd renews cluster certificates on local node

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -563,6 +563,16 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.SystemCmd.CmdClause = g.Command("system", "operations on system components")
 
+	g.SystemTeleportCmd.CmdClause = g.SystemCmd.Command("teleport", "System level operations with Teleport service").Hidden()
+	g.SystemTeleportShowConfigCmd.CmdClause = g.SystemTeleportCmd.Command("show-config", "Display Teleport configuration from the specified package")
+	g.SystemTeleportShowConfigCmd.Package = g.SystemTeleportShowConfigCmd.Flag("package", "Package with Teleport configuration").Required().String()
+	g.SystemTeleportMasterTokenCmd.CmdClause = g.SystemTeleportCmd.Command("set-master-tokens", "Set auth tokens in Teleport master config")
+	g.SystemTeleportMasterTokenCmd.Package = g.SystemTeleportMasterTokenCmd.Flag("package", "Package with Teleport master config").Required().String()
+	g.SystemTeleportMasterTokenCmd.Tokens = g.SystemTeleportMasterTokenCmd.Flag("token", "Auth tokens to set").Required().Strings()
+	g.SystemTeleportNodeTokenCmd.CmdClause = g.SystemTeleportCmd.Command("set-node-token", "Set auth token in Teleport node config")
+	g.SystemTeleportNodeTokenCmd.Package = g.SystemTeleportNodeTokenCmd.Flag("package", "Package with Teleport node config").Required().String()
+	g.SystemTeleportNodeTokenCmd.Token = g.SystemTeleportNodeTokenCmd.Flag("token", "Auth token to set").Required().String()
+
 	g.SystemRotateCertsCmd.CmdClause = g.SystemCmd.Command("rotate-certs", "Renew cluster certificates on a node").Hidden()
 	g.SystemRotateCertsCmd.ClusterName = g.SystemRotateCertsCmd.Arg("cluster-name", "Name of the local cluster").String()
 	g.SystemRotateCertsCmd.ValidFor = g.SystemRotateCertsCmd.Flag("valid-for", "Validity duration in Go format").Default("26280h").Duration()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -563,14 +563,14 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.SystemCmd.CmdClause = g.Command("system", "operations on system components")
 
-	g.SystemTeleportCmd.CmdClause = g.SystemCmd.Command("teleport", "System level operations with Teleport service").Hidden()
+	g.SystemTeleportCmd.CmdClause = g.SystemCmd.Command("teleport", "System level operations on Teleport service").Hidden()
 	g.SystemTeleportShowConfigCmd.CmdClause = g.SystemTeleportCmd.Command("show-config", "Display Teleport configuration from the specified package")
-	g.SystemTeleportShowConfigCmd.Package = g.SystemTeleportShowConfigCmd.Flag("package", "Package with Teleport configuration").Required().String()
+	g.SystemTeleportShowConfigCmd.Package = g.SystemTeleportShowConfigCmd.Flag("package", "Package with Teleport configuration. Can also be 'master' or 'node' to auto-detect package").Required().String()
 	g.SystemTeleportMasterTokenCmd.CmdClause = g.SystemTeleportCmd.Command("set-master-tokens", "Set auth tokens in Teleport master config")
-	g.SystemTeleportMasterTokenCmd.Package = g.SystemTeleportMasterTokenCmd.Flag("package", "Package with Teleport master config").Required().String()
+	g.SystemTeleportMasterTokenCmd.Package = g.SystemTeleportMasterTokenCmd.Flag("package", "Package with Teleport master config. Provide 'master' to try and auto-detect package").Required().String()
 	g.SystemTeleportMasterTokenCmd.Tokens = g.SystemTeleportMasterTokenCmd.Flag("token", "Auth tokens to set").Required().Strings()
 	g.SystemTeleportNodeTokenCmd.CmdClause = g.SystemTeleportCmd.Command("set-node-token", "Set auth token in Teleport node config")
-	g.SystemTeleportNodeTokenCmd.Package = g.SystemTeleportNodeTokenCmd.Flag("package", "Package with Teleport node config").Required().String()
+	g.SystemTeleportNodeTokenCmd.Package = g.SystemTeleportNodeTokenCmd.Flag("package", "Package with Teleport node config. Provide 'node' to try and auto-detect package").Required().String()
 	g.SystemTeleportNodeTokenCmd.Token = g.SystemTeleportNodeTokenCmd.Flag("token", "Auth token to set").Required().String()
 
 	g.SystemRotateCertsCmd.CmdClause = g.SystemCmd.Command("rotate-certs", "Renew cluster certificates on a node").Hidden()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -725,6 +725,17 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return exportCertificateAuthority(localEnv,
 			*g.SystemExportCACmd.ClusterName,
 			*g.SystemExportCACmd.CAPath)
+	case g.SystemTeleportShowConfigCmd.FullCommand():
+		return showTeleportConfig(localEnv,
+			*g.SystemTeleportShowConfigCmd.Package)
+	case g.SystemTeleportMasterTokenCmd.FullCommand():
+		return updateTeleportMasterTokens(localEnv,
+			*g.SystemTeleportMasterTokenCmd.Package,
+			*g.SystemTeleportMasterTokenCmd.Tokens)
+	case g.SystemTeleportNodeTokenCmd.FullCommand():
+		return updateTeleportNodeToken(localEnv,
+			*g.SystemTeleportNodeTokenCmd.Package,
+			*g.SystemTeleportNodeTokenCmd.Token)
 	case g.SystemReinstallCmd.FullCommand():
 		return systemReinstall(localEnv,
 			*g.SystemReinstallCmd.Package,

--- a/tool/gravity/cli/teleport.go
+++ b/tool/gravity/cli/teleport.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/pack"
+
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v2"
+)
+
+func showTeleportConfig(env *localenv.LocalEnvironment, packageName string) error {
+	locators, err := getTeleportLocators(env, packageName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	config, err := readTeleportFileConfig(locators.configReader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	configBytes, err := yaml.Marshal(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println(string(configBytes))
+	return nil
+}
+
+func updateTeleportMasterTokens(env *localenv.LocalEnvironment, packageName string, tokens []string) error {
+	locators, err := getTeleportLocators(env, packageName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fileConfig, err := readTeleportFileConfig(locators.configReader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, token := range tokens {
+		fileConfig.Auth.StaticTokens = append(fileConfig.Auth.StaticTokens, config.StaticToken(
+			fmt.Sprintf("node:%v", token)))
+	}
+	err = saveTeleportFileConfig(env.Packages, fileConfig, locators.teleportLocator, locators.configLocator, locators.configEnvelope.RuntimeLabels)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("Teleport master auth token updated. Please restart gravity-site using 'kubectl -nkube-system delete pods -lapp=gravity-site'.")
+	return nil
+}
+
+func updateTeleportNodeToken(env *localenv.LocalEnvironment, packageName, token string) error {
+	locators, err := getTeleportLocators(env, packageName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fileConfig, err := readTeleportFileConfig(locators.configReader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fileConfig.AuthToken = token
+	err = saveTeleportFileConfig(env.Packages, fileConfig, locators.teleportLocator, locators.configLocator, locators.configEnvelope.RuntimeLabels)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("Teleport node auth token updated. Please restart Teleport service using 'sudo systemctl restart *teleport*'.")
+	return nil
+}
+
+func readTeleportFileConfig(reader io.ReadCloser) (*config.FileConfig, error) {
+	vars, err := pack.ReadConfigPackage(reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	configBase64 := vars[defaults.ConfigEnvar]
+	if configBase64 == "" {
+		return nil, trace.BadParameter("empty teleport config")
+	}
+	configBytes, err := base64.StdEncoding.DecodeString(configBase64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var config config.FileConfig
+	if err := yaml.Unmarshal(configBytes, &config); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &config, nil
+}
+
+func saveTeleportFileConfig(packages pack.PackageService, config *config.FileConfig, teleportLocator, configLocator loc.Locator, labels map[string]string) error {
+	configBytes, err := yaml.Marshal(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	args := []string{
+		fmt.Sprintf("--config-string=%v", base64.StdEncoding.EncodeToString(configBytes)),
+	}
+	reader, err := pack.GetConfigPackage(packages, teleportLocator, configLocator, args)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = packages.UpsertPackage(configLocator, reader, pack.WithLabels(labels))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+type teleportLocators struct {
+	teleportLocator loc.Locator
+	configLocator   loc.Locator
+	configEnvelope  pack.PackageEnvelope
+	configReader    io.ReadCloser
+}
+
+func getTeleportLocators(env *localenv.LocalEnvironment, packageName string) (*teleportLocators, error) {
+	teleportLocator, err := pack.FindInstalledPackage(env.Packages, loc.Teleport)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	configLocator, err := loc.ParseLocator(packageName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	envelope, reader, err := env.Packages.ReadPackage(*configLocator)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &teleportLocators{
+		teleportLocator: *teleportLocator,
+		configLocator:   *configLocator,
+		configEnvelope:  *envelope,
+		configReader:    reader,
+	}, nil
+}


### PR DESCRIPTION
### Description

This PR adds a few internal commands that should help us recover clusters that may have been affected by https://github.com/gravitational/gravity/issues/1445, in case we encounter any.

The background of the issue is Teleport on the nodes joined to a 5.5.40 cluster fails to join the cluster which means further upgrades will fail (and node isn't accessible via Teleport).

It adds the following commands.

#### Display teleport config from package

```
$ gravity system teleport show-config --package=<config-package>
```

#### Update auth token used by Teleport node

```
$ gravity system teleport set-node-token --package=<config-package> --token=token
```

#### Update auth tokens used by Teleport auth server

```
$ gravity system teleport set-master-tokens --package=<config-package> --token=token1 --token=token2
```

### Testing done

First I've done the following setup to reproduce the issue:

* Install single-node 5.5.40 cluster and join a node to it.
* Verify Teleport on the joined node isn't able to join due to bad token.

Then I fixed the Teleport node:

* Used above set-node-token command to update config to use join token.
* Restarted Teleport service and verified it joined successfully.

Also tested the Teleport master part:

* Set different node token via set-node-token command.
* Cleared /var/lib/gravity/teleport, restarted and verified it's failing to join.
* Used set-master-tokens to update auth token on master to include the one I used above.
* Restarted gravity-site and verified the node also joined now.
