### PR TITLE
Fix join token issue.

### DIFF
--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1118,16 +1118,9 @@ func (s *site) getTeleportMasterConfig(ctx *operationContext, configPackage loc.
 	fileConf.AdvertiseIP = advertiseIP.String()
 	fileConf.Global.NodeName = master.FQDN(s.domainName)
 
-	joinToken, err := s.service.GetExpandToken(s.key)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	// turn on auth service
 	fileConf.Auth.EnabledFlag = "yes"
 	fileConf.Auth.ClusterName = telecfg.ClusterName(s.domainName)
-	fileConf.Auth.StaticTokens = telecfg.StaticTokens{
-		telecfg.StaticToken(fmt.Sprintf("node:%v", joinToken.Token))}
 
 	// turn on proxy and Kubernetes integration
 	fileConf.Proxy.EnabledFlag = "yes"

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -886,6 +886,10 @@ func (s *site) newProvisioningToken(operation ops.SiteOperation) (token string, 
 		OperationID: operation.ID,
 		UserEmail:   agentUser.GetName(),
 	}
+	if operation.Type == ops.OperationExpand {
+		// Set a TTL for expand provisioning token.
+		tokenRequest.Expires = s.clock().UtcNow().Add(24 * time.Hour)
+	}
 	_, err = s.users().CreateProvisioningToken(tokenRequest)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		log.WithError(err).Warn("Failed to create provisioning token.")

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -887,7 +887,11 @@ func (s *site) newProvisioningToken(operation ops.SiteOperation) (token string, 
 		UserEmail:   agentUser.GetName(),
 	}
 	if operation.Type == ops.OperationExpand {
-		// Set a TTL for expand provisioning token.
+		// TODO(r0mant): Due to current implementation this TTL is required to
+		// make sure that when a new node joins, it doesn't select this token
+		// for Teleport since it picks non-expiring tokens. Otherwise, Teleport
+		// node won't be authenticate with existing auth servers that initialize
+		// their tokens upon startup: https://github.com/gravitational/gravity/issues/1445.
 		tokenRequest.Expires = s.clock().UtcNow().Add(24 * time.Hour)
 	}
 	_, err = s.users().CreateProvisioningToken(tokenRequest)

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -22,11 +22,13 @@ import (
 	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/teleport"
 
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
 	teledefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -67,6 +69,13 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	if len(serviceConfig.AuthServers) == 0 && serviceConfig.Auth.Enabled {
 		serviceConfig.AuthServers = append(serviceConfig.AuthServers, serviceConfig.Auth.SSHAddr)
 	}
+	// Configure auth tokens so nodes can join.
+	tokens, err := p.getTeleportAuthTokens()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	serviceConfig.Auth.StaticTokens.SetStaticTokens(append(tokens,
+		serviceConfig.Auth.StaticTokens.GetStaticTokens()...))
 	// Teleport will be using Gravity backend implementation.
 	serviceConfig.Identity = p.identity
 	serviceConfig.Trust = p.identity
@@ -81,6 +90,29 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	// faster when auth gateway settings are updated.
 	serviceConfig.PollingPeriod = teledefaults.HighResPollingPeriod
 	return serviceConfig, nil
+}
+
+// getTeleportAuthTokens returns tokens Teleport nodes can use to authenticate
+// with auth server to join the cluster.
+func (p *Process) getTeleportAuthTokens() (result []services.ProvisionToken, err error) {
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tokens, err := p.backend.GetSiteProvisioningTokens(cluster.Domain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, token := range tokens {
+		// Teleport nodes use persistent join tokens to join.
+		if token.Type == storage.ProvisioningTokenTypeExpand && token.Expires.IsZero() {
+			result = append(result, services.ProvisionToken{
+				Roles: teleport.Roles{teleport.RoleNode},
+				Token: token.Token,
+			})
+		}
+	}
+	return result, nil
 }
 
 // getOrInitAuthGatewayConfig returns auth gateway configuration.


### PR DESCRIPTION
## Description
<!--Provide high-level overview of what the change is for.-->

This PR addresses the recent join token related regression described in https://github.com/gravitational/gravity/issues/1445 in branch 7.0.

It does 2 things:

* Brings back the TTL for a join token.
* Instead of hardcoding auth tokens in Teleport config during install/upgrade, Teleport auth server (gravity-site) now reads them from the backend during startup.

## Type of change
<!--Select all options appropriate for this change.-->

- [x] Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Keep only relevant items.-->

<!--This PR addresses the following issues.-->
* Refs #1445
* Ports #1434

## TODOs
<!--Keep only relevant items and check them as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing

## Implementation
<!--Add any relevant implementation details that might help the reviewers.-->

Forward-ported the same changes from 6.3.

## Testing done
<!--Explain what kind of testing these changes underwent.-->

Install a single node cluster:

```
node-1:~/installer$ sudo ./gravity install --advertise-addr=192.168.99.102
```

Add a node to it:

```
node-2:~$ sudo ./gravity join 192.168.99.102 --token=bf75c3d3015132bca18286001de50e4f --role=knode --advertise-addr=192.168.99.103
```

Verify Teleport on the new node connects successfully:

```
node-2:~$ journalctl -u *teleport* -f
..
Apr 24 22:09:16 node-2 gravity[5707]: INFO [PROC:1]    The new service has started successfully. Starting syncing rotation status with period 1m30s. service/connect.go:379
```