### PR TITLE
[6.3.x] clean up object peers and lost objects during upgrade

### DIFF
--- a/lib/blob/blob.go
+++ b/lib/blob/blob.go
@@ -17,9 +17,18 @@ limitations under the License.
 package blob
 
 import (
+	"fmt"
 	"io"
 	"time"
+
+	"github.com/gravitational/gravity/lib/constants"
 )
+
+// String returns text representation of this blob envelope
+func (r Envelope) String() string {
+	return fmt.Sprintf("blob(size=%v, hash=%v, modified=%v)",
+		r.SizeBytes, r.SHA512, r.Modified.Format(constants.ShortDateFormat))
+}
 
 // Envelope specifies the metadata about BLOB - it's SHA512 hash and size
 type Envelope struct {

--- a/lib/blob/cluster/cluster.go
+++ b/lib/blob/cluster/cluster.go
@@ -295,7 +295,7 @@ func (c *Cluster) fetchObject(hash string) error {
 			errors = append(errors, err)
 			continue
 		}
-		logger.WithField("package", envelope).Error("Successfully fetched object from peer.")
+		logger.WithField("package", envelope).Debug("Successfully fetched object from peer.")
 		err = c.Backend.UpsertObjectPeers(hash, []string{c.ID}, 0)
 		if err != nil {
 			logger.WithError(err).Error("Failed to upsert peer to the object's list of peers.")

--- a/lib/blob/cluster/cluster.go
+++ b/lib/blob/cluster/cluster.go
@@ -29,14 +29,14 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
 // GetPeer returns a new client peer for Object storage
 type GetPeer func(peer storage.Peer) (blob.Objects, error)
 
-// Config is a cluster BLOB storage config
+// Config is a cluster BLOB storage configuration
 type Config struct {
 	// Local is a local BLOB storage managed by this peer
 	Local blob.Objects
@@ -44,8 +44,8 @@ type Config struct {
 	Backend storage.Backend
 	// GetPeer returns new peer client based on ID
 	GetPeer GetPeer
-	// WriteFactor defines how many ack peer writes should be acknowledged
-	// before write is considered successfull
+	// WriteFactor defines how many peer writes should be acknowledged
+	// before write is considered successful
 	WriteFactor int
 	// ID is a peer local ID
 	ID string
@@ -55,11 +55,9 @@ type Config struct {
 	Clock clockwork.Clock
 	// HeartbeatPeriod defines the period between heartbeats
 	HeartbeatPeriod time.Duration
-	// MissedHeartbeats is how mahy heartbeats the peer
+	// MissedHeartbeats is how many heartbeats the peer
 	// should miss before we consider it closed
 	MissedHeartbeats int
-	// TestMode turns off some goroutines
-	TestMode bool
 	// GracePeriod is a period for GC not to delete undetected files
 	// to prevent accidental deletion. Defaults to 1 hour
 	GracePeriod time.Duration
@@ -68,74 +66,85 @@ type Config struct {
 // New returns cluster BLOB storage that takes care of replication
 // of BLOBs across cluster of nodes. It is designed for small clusters O(10)
 // and small amount of objects managed O(100)
-func New(config Config) (blob.Objects, error) {
-	if config.Local == nil {
-		return nil, trace.BadParameter("missing parameter Local")
+func New(config Config) (*Cluster, error) {
+	if err := config.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	if config.Backend == nil {
-		return nil, trace.BadParameter("missing parameter Backend")
-	}
-	if config.GetPeer == nil {
-		return nil, trace.BadParameter("missing parameter GetPeer")
-	}
-	if config.ID == "" {
-		return nil, trace.BadParameter("missing parameter ID")
-	}
-	if config.AdvertiseAddr == "" {
-		return nil, trace.BadParameter("missing parameter AdvertiseAddr")
-	}
-	if config.WriteFactor < 1 {
-		config.WriteFactor = defaults.WriteFactor
-	}
-	if config.Clock == nil {
-		config.Clock = clockwork.NewRealClock()
-	}
-	if config.HeartbeatPeriod == 0 {
-		config.HeartbeatPeriod = defaults.HeartbeatPeriod
-	}
-	if config.MissedHeartbeats == 0 {
-		config.MissedHeartbeats = defaults.MissedHeartbeats
-	}
-	if config.GracePeriod == 0 {
-		config.GracePeriod = defaults.GracePeriod
-	}
-
-	close, cancelFn := context.WithCancel(context.TODO())
-
-	entry := log.WithFields(log.Fields{
-		trace.Component: constants.ComponentBLOB,
-		"id":            config.ID,
-		"addr":          config.AdvertiseAddr,
-	})
-
-	c := &cluster{Config: config, close: close, cancelFn: cancelFn, Entry: entry}
-	if !c.TestMode {
-		go c.periodically("heartbeat", c.heartbeat)
-		go c.periodically("purgeDeleted", c.purgeDeletedObjects)
-		go c.periodically("fetchNew", c.fetchNewObjects)
-	}
-
-	return c, nil
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Cluster{
+		Config:   config,
+		close:    ctx,
+		cancelFn: cancel,
+		FieldLogger: logrus.WithFields(logrus.Fields{
+			trace.Component: constants.ComponentBLOB,
+			"id":            config.ID,
+			"addr":          config.AdvertiseAddr,
+		}),
+	}, nil
 }
 
-type cluster struct {
-	*log.Entry
+func (r *Config) checkAndSetDefaults() error {
+	if r.Local == nil {
+		return trace.BadParameter("missing parameter Local")
+	}
+	if r.Backend == nil {
+		return trace.BadParameter("missing parameter Backend")
+	}
+	if r.GetPeer == nil {
+		return trace.BadParameter("missing parameter GetPeer")
+	}
+	if r.ID == "" {
+		return trace.BadParameter("missing parameter ID")
+	}
+	if r.AdvertiseAddr == "" {
+		return trace.BadParameter("missing parameter AdvertiseAddr")
+	}
+	if r.WriteFactor < 1 {
+		r.WriteFactor = defaults.WriteFactor
+	}
+	if r.Clock == nil {
+		r.Clock = clockwork.NewRealClock()
+	}
+	if r.HeartbeatPeriod == 0 {
+		r.HeartbeatPeriod = defaults.HeartbeatPeriod
+	}
+	if r.MissedHeartbeats == 0 {
+		r.MissedHeartbeats = defaults.MissedHeartbeats
+	}
+	if r.GracePeriod == 0 {
+		r.GracePeriod = defaults.GracePeriod
+	}
+	return nil
+}
+
+// Cluster is the distributed blob storage
+type Cluster struct {
+	logrus.FieldLogger
 	Config
 	close    context.Context
 	cancelFn context.CancelFunc
 }
 
-func (c *cluster) Close() error {
+// Start starts internal processes
+func (c *Cluster) Start() {
+	go c.periodically("heartbeat", c.heartbeat)
+	go c.periodically("purgeDeleted", c.purgeDeletedObjects)
+	go c.periodically("fetchNew", c.fetchNewObjects)
+}
+
+// Close stops internal processes
+func (c *Cluster) Close() error {
 	c.cancelFn()
 	return nil
 }
 
 // GetBLOBs returns a list of BLOBs in the storage
-func (c *cluster) GetBLOBs() ([]string, error) {
+func (c *Cluster) GetBLOBs() ([]string, error) {
 	return c.Backend.GetObjects()
 }
 
-func (c *cluster) GetBLOBEnvelope(hash string) (*blob.Envelope, error) {
+// GetBLOBEnvelope returns the blob envelope for the given hash
+func (c *Cluster) GetBLOBEnvelope(hash string) (*blob.Envelope, error) {
 	return c.Local.GetBLOBEnvelope(hash)
 }
 
@@ -145,7 +154,7 @@ type resultTuple struct {
 	peer     storage.Peer
 }
 
-func (c *cluster) periodically(name string, fn func() error) {
+func (c *Cluster) periodically(name string, fn func() error) {
 	ticker := time.NewTicker(defaults.HeartbeatPeriod)
 	defer ticker.Stop()
 	if err := fn(); err != nil {
@@ -164,7 +173,7 @@ func (c *cluster) periodically(name string, fn func() error) {
 	}
 }
 
-func (c *cluster) localPeer() storage.Peer {
+func (c *Cluster) localPeer() storage.Peer {
 	return storage.Peer{
 		ID:            c.ID,
 		AdvertiseAddr: c.AdvertiseAddr,
@@ -172,17 +181,18 @@ func (c *cluster) localPeer() storage.Peer {
 	}
 }
 
-func (c *cluster) heartbeat() error {
+func (c *Cluster) heartbeat() error {
 	err := c.Backend.UpsertPeer(c.localPeer())
 	return trace.Wrap(err)
 }
 
-func (c *cluster) purgeDeletedObjects() error {
+func (c *Cluster) purgeDeletedObjects() error {
 	hashes, err := c.Local.GetBLOBs()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	for _, hash := range hashes {
+		logger := c.WithField("hash", hash)
 		_, err := c.Backend.GetObjectPeers(hash)
 		if err == nil {
 			continue
@@ -195,7 +205,7 @@ func (c *cluster) purgeDeletedObjects() error {
 			return trace.Wrap(err)
 		}
 		if envelope.Modified.IsZero() {
-			log.Warningf("%v has zero modified time!", envelope.Modified)
+			logger.WithField("package", envelope.String()).Warn("Blob envelope with zero modification, will ignore.")
 			continue
 		}
 		// prevent accidental deletion by using grace period -
@@ -204,21 +214,24 @@ func (c *cluster) purgeDeletedObjects() error {
 		if diff < c.GracePeriod {
 			continue
 		} else {
-			log.Infof("%v has exceeded grace period(%v) - current diff: %v, going to delete", hash, c.GracePeriod, diff)
+			logger.WithFields(logrus.Fields{
+				"grace-period": c.GracePeriod,
+				"diff":         diff,
+			}).Info("Object exceeded grace period - will delete.")
 		}
 		err = c.Local.DeleteBLOB(hash)
 		if err != nil {
-			c.Errorf("Failed to delete object %v, error: %v.", hash, trace.DebugReport(err))
+			logger.WithError(err).Warn("Failed to delete object.")
 		}
 	}
 	return nil
 }
 
-// fetchNewObjects downloads the objects that has been recorded in the database
+// fetchNewObjects downloads the objects that have been recorded in the database
 // but not available locally.
 // It works on best-effort basis - pulling all missing objects before returning
 // whatever error(s) it has encountered
-func (c *cluster) fetchNewObjects() error {
+func (c *Cluster) fetchNewObjects() error {
 	objects, err := c.Backend.GetObjects()
 	if err != nil {
 		return trace.Wrap(err)
@@ -237,14 +250,17 @@ func (c *cluster) fetchNewObjects() error {
 		c.Infof("Found missing object %v.", hash)
 		err = c.fetchObject(hash)
 		if err != nil {
-			c.WithError(err).Warnf("Failed to fetch object(%v).", hash)
+			c.WithFields(logrus.Fields{
+				logrus.ErrorKey: err,
+				"hash":          hash,
+			}).Warn("Failed to fetch object.")
 			errors = append(errors, err)
 		}
 	}
 	return trace.NewAggregate(errors...)
 }
 
-func (c *cluster) fetchObject(hash string) error {
+func (c *Cluster) fetchObject(hash string) error {
 	peerIDs, err := c.Backend.GetObjectPeers(hash)
 	if err != nil {
 		return trace.Wrap(err)
@@ -257,17 +273,19 @@ func (c *cluster) fetchObject(hash string) error {
 	if len(peers) == 0 {
 		return trace.NotFound("no active remote peers found for %v", hash)
 	}
+	logger := c.WithField("hash", hash)
 	var errors []error
 	for _, p := range peers {
+		logger := logger.WithField("peer", p.String())
 		objects, err := c.getObjects(p)
 		if err != nil {
-			c.WithError(err).Errorf("Failure to fetch %v from %v.", hash, p)
+			logger.WithError(err).Error("Failed to fetch object from peer.")
 			errors = append(errors, err)
 			continue
 		}
 		f, err := objects.OpenBLOB(hash)
 		if err != nil {
-			c.WithError(err).Errorf("Failure to fetch %v from %v.", hash, p)
+			logger.WithError(err).Error("Failed to fetch object from peer.")
 			errors = append(errors, err)
 			continue
 		}
@@ -277,11 +295,12 @@ func (c *cluster) fetchObject(hash string) error {
 			errors = append(errors, err)
 			continue
 		}
-		c.Infof("Successfully fetched %v from %v.", envelope, p)
+		logger.WithField("package", envelope).Error("Successfully fetched object from peer.")
 		err = c.Backend.UpsertObjectPeers(hash, []string{c.ID}, 0)
 		if err != nil {
-			c.Errorf("Failed to upsert %v object peers: %v.", hash, err)
-			return trace.Wrap(err)
+			logger.WithError(err).Error("Failed to upsert peer to the object's list of peers.")
+			errors = append(errors, err)
+			continue
 		}
 		return nil
 	}
@@ -289,7 +308,7 @@ func (c *cluster) fetchObject(hash string) error {
 }
 
 // WriteBLOB writes object to the storage, returns object envelope
-func (c *cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
+func (c *Cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	peers, err := c.getPeers()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -306,7 +325,10 @@ func (c *cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 
 	successWrites := []string{c.ID}
 	if len(successWrites) >= c.WriteFactor {
-		c.Debugf("Got enough success writes (%v) for %v.", successWrites, envelope.SHA512)
+		c.WithFields(logrus.Fields{
+			"peers": successWrites,
+			"hash":  envelope.SHA512,
+		}).Debug("Got enough success writes.")
 		err := c.Backend.UpsertObjectPeers(envelope.SHA512, successWrites, 0)
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to write object metadata %v", err)
@@ -321,6 +343,7 @@ func (c *cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 
 	var errors []error
 	for _, p := range peers {
+		logger := c.WithField("peer", p.String())
 		if p.ID == c.ID {
 			continue
 		}
@@ -330,22 +353,26 @@ func (c *cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 		}
 		peerClient, err := c.GetPeer(p)
 		if err != nil {
-			c.Warnf("failed to create clien to peer %v: %v", p, err)
+			logger.WithError(err).Warn("Failed to create client to peer.")
 			errors = append(errors, err)
 			continue
 		}
 		_, err = peerClient.WriteBLOB(f)
 		if err != nil {
-			c.Warnf("%v returned error: %v", p, err)
+			logger.WithError(err).Warn("Failed to write blob remotely.")
 			errors = append(errors, err)
 			continue
 		}
 		successWrites = append(successWrites, p.ID)
 		if len(successWrites) >= c.WriteFactor {
-			c.Debugf("Got enough success writes (%v) for %v.", successWrites, envelope.SHA512)
+			logger.WithFields(logrus.Fields{
+				"peers": successWrites,
+				"hash":  envelope.SHA512,
+			}).Debug("Got enough success writes.")
 			err := c.Backend.UpsertObjectPeers(envelope.SHA512, successWrites, 0)
 			if err != nil {
-				return nil, trace.Wrap(err, "failed to write object metadata %v", err)
+				return nil, trace.Wrap(err, "failed to write metadata for object %v: %v",
+					envelope.SHA512, err)
 			}
 			return envelope, nil
 		}
@@ -354,10 +381,11 @@ func (c *cluster) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	if len(errors) == 0 {
 		return nil, trace.NotFound("not enough peers")
 	}
-	return nil, trace.Wrap(trace.NewAggregate(errors...), "not enough successful writes")
+	return nil, trace.Wrap(trace.NewAggregate(errors...), "not enough successful writes (want >= %v, got %v)",
+		c.WriteFactor, len(successWrites))
 }
 
-func (c *cluster) getObjects(p storage.Peer) (blob.Objects, error) {
+func (c *Cluster) getObjects(p storage.Peer) (blob.Objects, error) {
 	if p.ID == c.ID {
 		return c.Local, nil
 	}
@@ -365,7 +393,8 @@ func (c *cluster) getObjects(p storage.Peer) (blob.Objects, error) {
 }
 
 // OpenBLOB opens file identified by hash and returns reader
-func (c *cluster) OpenBLOB(hash string) (blob.ReadSeekCloser, error) {
+func (c *Cluster) OpenBLOB(hash string) (blob.ReadSeekCloser, error) {
+	logger := c.WithField("hash", hash)
 	ids, err := c.Backend.GetObjectPeers(hash)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -379,14 +408,15 @@ func (c *cluster) OpenBLOB(hash string) (blob.ReadSeekCloser, error) {
 	}
 	var reader blob.ReadSeekCloser
 	for _, p := range peers {
+		logger := logger.WithField("peer", p.String())
 		objects, err := c.getObjects(p)
 		if err != nil {
-			c.Warnf("%v returned %v", p, err)
+			logger.WithError(err).Warn("Failed to connect to the blob store.")
 			continue
 		}
 		reader, err = objects.OpenBLOB(hash)
 		if err != nil {
-			c.Warnf("%v returned %v", p, err)
+			logger.WithError(err).Warn("Failed to access blob.")
 			continue
 		}
 		return reader, nil
@@ -395,7 +425,7 @@ func (c *cluster) OpenBLOB(hash string) (blob.ReadSeekCloser, error) {
 }
 
 // DeleteBLOB deletes BLOB from the storage
-func (c *cluster) DeleteBLOB(hash string) error {
+func (c *Cluster) DeleteBLOB(hash string) error {
 	return trace.Wrap(c.Backend.DeleteObject(hash))
 }
 
@@ -408,7 +438,7 @@ func matchPeer(ids []string, id string) bool {
 	return utils.StringInSlice(ids, id)
 }
 
-func (c *cluster) withoutSelf(in []storage.Peer) []storage.Peer {
+func (c *Cluster) withoutSelf(in []storage.Peer) []storage.Peer {
 	out := make([]storage.Peer, 0, len(in))
 	for i := range in {
 		if in[i].ID == c.ID {
@@ -419,7 +449,7 @@ func (c *cluster) withoutSelf(in []storage.Peer) []storage.Peer {
 	return out
 }
 
-func (c *cluster) getPeers(ids ...string) ([]storage.Peer, error) {
+func (c *Cluster) getPeers(ids ...string) ([]storage.Peer, error) {
 	in, err := c.Backend.GetPeers()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -438,8 +468,11 @@ func (c *cluster) getPeers(ids ...string) ([]storage.Peer, error) {
 			}
 			// if its last heartbeat is older than the acceptance time frame
 			if c.Clock.Now().UTC().Sub(p.LastHeartbeat) > missedWindow {
-				c.Warnf("Excluding %v, missed heartbeat window %v, last heartbeat: %v.",
-					p.ID, missedWindow, p.LastHeartbeat)
+				c.WithFields(logrus.Fields{
+					"peer":           p.String(),
+					"time-window":         missedWindow,
+					"last-heartbeat": p.LastHeartbeat,
+				}).Warn("Exclude stale peer.")
 				continue
 			}
 		}

--- a/lib/blob/cluster/cluster.go
+++ b/lib/blob/cluster/cluster.go
@@ -470,7 +470,7 @@ func (c *Cluster) getPeers(ids ...string) ([]storage.Peer, error) {
 			if c.Clock.Now().UTC().Sub(p.LastHeartbeat) > missedWindow {
 				c.WithFields(logrus.Fields{
 					"peer":           p.String(),
-					"time-window":         missedWindow,
+					"time-window":    missedWindow,
 					"last-heartbeat": p.LastHeartbeat,
 				}).Warn("Exclude stale peer.")
 				continue

--- a/lib/blob/cluster/cluster_test.go
+++ b/lib/blob/cluster/cluster_test.go
@@ -38,10 +38,10 @@ import (
 	"github.com/gravitational/gravity/lib/storage/keyval"
 	"github.com/gravitational/gravity/lib/users/usersservice"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -50,7 +50,7 @@ func TestCluster(t *testing.T) { TestingT(t) }
 type ClusterSinglePeer struct {
 	suite   suite.BLOBSuite
 	dir     string
-	cluster *cluster
+	cluster *Cluster
 }
 
 var _ = Suite(&ClusterSinglePeer{})
@@ -124,7 +124,7 @@ type ClusterMultiPeers struct {
 	suite        suite.BLOBSuite
 	clusterSuite clusterSuite
 	dir          string
-	objects      []*cluster
+	objects      []*Cluster
 }
 
 func (s *ClusterMultiPeers) SetUpTest(c *C) {
@@ -140,7 +140,7 @@ func (s *ClusterMultiPeers) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	peers := make([]blob.Objects, peersCount)
-	objects := make([]*cluster, peersCount)
+	objects := make([]*Cluster, peersCount)
 	clients := make([]blob.Objects, peersCount)
 
 	getPeer := func(p storage.Peer) (blob.Objects, error) {
@@ -165,11 +165,10 @@ func (s *ClusterMultiPeers) SetUpTest(c *C) {
 			Clock:            fakeClock,
 			ID:               fmt.Sprintf("%v", i),
 			AdvertiseAddr:    "https://localhost",
-			TestMode:         true,
 			GracePeriod:      gracePeriod,
 		})
 		c.Assert(err, IsNil)
-		objects[i] = obj.(*cluster)
+		objects[i] = obj
 		objects[i].heartbeat()
 		clients[i] = obj
 	}
@@ -214,7 +213,7 @@ type RPCSuite struct {
 	suite        suite.BLOBSuite
 	clusterSuite clusterSuite
 	dir          string
-	objects      []*cluster
+	objects      []*Cluster
 }
 
 func (s *RPCSuite) SetUpTest(c *C) {
@@ -238,7 +237,7 @@ func (s *RPCSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	peers := make([]blob.Objects, peersCount)
-	objects := make([]*cluster, peersCount)
+	objects := make([]*Cluster, peersCount)
 	clients := make([]blob.Objects, peersCount)
 	localClients := make([]blob.Objects, peersCount)
 
@@ -267,7 +266,6 @@ func (s *RPCSuite) SetUpTest(c *C) {
 			Clock:            fakeClock,
 			ID:               fmt.Sprintf("%v", i),
 			AdvertiseAddr:    "https://localhost",
-			TestMode:         true,
 			GracePeriod:      gracePeriod,
 		})
 
@@ -300,7 +298,7 @@ func (s *RPCSuite) SetUpTest(c *C) {
 		)
 
 		c.Assert(err, IsNil)
-		objects[i] = obj.(*cluster)
+		objects[i] = obj
 		objects[i].heartbeat()
 		clients[i] = clusterClient
 		localClients[i] = localClient
@@ -340,7 +338,7 @@ func (s *RPCSuite) TestCleanup(c *C) {
 }
 
 type clusterSuite struct {
-	objects []*cluster
+	objects []*Cluster
 	clients []blob.Objects
 	clock   clockwork.FakeClock
 }

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -75,8 +75,8 @@ func (s *LocatorSuite) TestLocatorFail(c *C) {
 		"example:0.0.1",                 // missing repository
 		"example.com/example:blabla",    // not a sem ver
 		"example.com/example com:0.0.2", // unallowed chars
-		"", //emtpy
-		"arffewfaef aefeafaesf e", //garbage
+		"",                              //emtpy
+		"arffewfaef aefeafaesf e",       //garbage
 		"-:.",
 	}
 	for i, tc := range tcs {

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -630,6 +630,19 @@ func (s *site) unlabelNode(server storage.Server, runner *serverRunner) error {
 }
 
 func (s *site) removeObjectPeer(peerID string) error {
+	objects, err := s.backend().GetObjects()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var errors []error
+	for _, hash := range objects {
+		if err := s.backend().DeleteObjectPeers(hash, []string{peerID}); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	if len(errors) != 0 {
+		return trace.NewAggregate(errors...)
+	}
 	return trace.Wrap(s.backend().DeletePeer(peerID))
 }
 

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -266,7 +266,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		if !force {
 			return trace.Wrap(err, "failed to unregister the node")
 		}
-		ctx.Warningf("failed to unregister the node, force continue: %v", trace.DebugReport(err))
+		ctx.WithError(err).Warn("Failed to unregister the node, force continue.")
 	}
 
 	if s.app.Manifest.HasHook(schema.HookNodeRemoving) {
@@ -280,7 +280,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 			if !force {
 				return trace.Wrap(err, "failed to run %v hook", schema.HookNodeRemoving)
 			}
-			ctx.Warningf("failed to run %v hook, force continue: %v", schema.HookNodeRemoving, trace.DebugReport(err))
+			ctx.WithError(err).Warnf("Failed to run %v hook, force continue.", schema.HookNodeRemoving)
 		}
 	}
 
@@ -298,7 +298,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 			if !force {
 				return trace.Wrap(err, "failed to remove the node from the serf cluster")
 			}
-			ctx.Warnf("Failed to remove node %q from serf cluster: %v.", serverName, trace.DebugReport(err))
+			ctx.WithError(err).Warnf("Failed to remove node %q from serf cluster.", serverName)
 		}
 	}
 
@@ -307,8 +307,16 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		if !force {
 			return trace.Wrap(err, "failed to remove the node from the cluster")
 		}
-		ctx.Warningf("Failed to remove node %q from the cluster, force continue: %v.",
-			serverName, trace.DebugReport(err))
+		ctx.WithError(err).Warnf("Failed to remove node %q from the cluster, force continue.",
+			serverName)
+	}
+
+	if err = s.removeObjectPeer(server.ObjectPeerID()); err != nil && !trace.IsNotFound(err) {
+		if !force {
+			return trace.Wrap(err, "failed to remove the object peer for the node")
+		}
+		ctx.WithError(err).Warnf("Failed to remove the object peer for the node %q, force continue.",
+			serverName)
 	}
 
 	s.reportProgress(ctx, ops.ProgressEntry{
@@ -324,7 +332,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		if !force {
 			return trace.Wrap(err, "failed to remove the node from the database")
 		}
-		ctx.Warningf("failed to remove the node from the database, force continue: %v", trace.DebugReport(err))
+		ctx.WithError(err).Warn("Failed to remove the node from the database, force continue.")
 	}
 
 	if online {
@@ -335,7 +343,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		})
 
 		if err = s.uninstallSystem(ctx, agentRunner); err != nil {
-			ctx.Warningf("error uninstalling the system software: %v", trace.DebugReport(err))
+			ctx.WithError(err).Warn("Error uninstalling system software.")
 		}
 	}
 
@@ -363,7 +371,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 			if !force {
 				return trace.Wrap(err, "failed to run %v hook", schema.HookNodeRemoved)
 			}
-			ctx.Warningf("failed to run %v hook, force continue: %v", schema.HookNodeRemoved, trace.DebugReport(err))
+			ctx.WithError(err).Warnf("Failed to run %v hook, force continue.", schema.HookNodeRemoved)
 		}
 	}
 
@@ -378,7 +386,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 		if !force {
 			return trace.Wrap(err, "failed to clean up packages")
 		}
-		ctx.Warningf("failed to clean up packages, force continue: %v", trace.DebugReport(err))
+		ctx.WithError(err).Warn("Failed to clean up packages, force continue.")
 	}
 
 	s.reportProgress(ctx, ops.ProgressEntry{
@@ -388,7 +396,7 @@ func (s *site) shrinkOperationStart(ctx *operationContext) (err error) {
 	})
 
 	if err = s.waitForServerToDisappear(serverName); err != nil {
-		ctx.Warningf("failed to wait for server %v to disappear: %v", serverName, trace.DebugReport(err))
+		ctx.WithError(err).Warnf("Failed to wait for server %v to disappear.", serverName)
 	}
 
 	if err = s.removeClusterStateServers([]string{server.Hostname}); err != nil {
@@ -619,6 +627,10 @@ func (s *site) unlabelNode(server storage.Server, runner *serverRunner) error {
 	})
 
 	return trace.Wrap(err)
+}
+
+func (s *site) removeObjectPeer(peerID string) error {
+	return trace.Wrap(s.backend().DeletePeer(peerID))
 }
 
 func (s *site) removeNodeFromCluster(server storage.Server, runner *serverRunner) (err error) {

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -244,6 +244,7 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clusterObjects.Start()
 
 	packages, err := localpack.New(localpack.Config{
 		Backend:     backend,

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -118,7 +118,7 @@ func (p *Process) getTeleportAuthTokens() (result []services.ProvisionToken, err
 //
 // If it's not found, it's first initialized with default values.
 func (p *Process) getOrInitAuthGatewayConfig() (storage.AuthGateway, error) {
-	if !p.inKubernetes() {
+	if !inKubernetes() {
 		// We're not running inside Kubernetes, so this is likely an installer
 		// process which doesn't support auth gateway reconfiguration.
 		return nil, nil

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -703,16 +703,6 @@ func (s ClusterState) HasServer(hostname string) bool {
 	return err == nil
 }
 
-// NumMasters returns the number of master servers in this state
-func (s ClusterState) NumMasters() (result int) {
-	for _, server := range s.Servers {
-		if server.IsMaster() {
-			result += 1
-		}
-	}
-	return result
-}
-
 // Applications defines operations on the site applications
 type Applications interface {
 	// GetApplication queries an existing application
@@ -1611,6 +1601,11 @@ func (s *Server) KubeNodeID() string {
 	if s.Nodename != "" {
 		return s.Nodename
 	}
+	return s.AdvertiseIP
+}
+
+// ObjectPeerID returns the peer ID of this server
+func (s *Server) ObjectPeerID() string {
 	return s.AdvertiseIP
 }
 

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -703,6 +703,16 @@ func (s ClusterState) HasServer(hostname string) bool {
 	return err == nil
 }
 
+// NumMasters returns the number of master servers in this state
+func (s ClusterState) NumMasters() (result int) {
+	for _, server := range s.Servers {
+		if server.IsMaster() {
+			result += 1
+		}
+	}
+	return result
+}
+
 // Applications defines operations on the site applications
 type Applications interface {
 	// GetApplication queries an existing application

--- a/lib/update/cluster/phases/init_test.go
+++ b/lib/update/cluster/phases/init_test.go
@@ -44,7 +44,7 @@ func (*S) TestPeerCleaner(c *C) {
 			comment: "no changes to peer state",
 			c: peerCleaner{
 				log: log.WithField("test", "TestPeerCleaner"),
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -59,7 +59,7 @@ func (*S) TestPeerCleaner(c *C) {
 				existingPeers: []string{"peer2", "peer1"},
 			},
 			expected: peerCleaner{
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -77,7 +77,7 @@ func (*S) TestPeerCleaner(c *C) {
 			comment: "removes stale peer and its references",
 			c: peerCleaner{
 				log: log.WithField("test", "TestPeerCleaner"),
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -96,7 +96,7 @@ func (*S) TestPeerCleaner(c *C) {
 				existingPeers: []string{"peer2"},
 			},
 			expected: peerCleaner{
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -117,7 +117,7 @@ func (*S) TestPeerCleaner(c *C) {
 			comment: "removes stale peer and its references; removes lost object",
 			c: peerCleaner{
 				log: log.WithField("test", "TestPeerCleaner"),
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -136,7 +136,7 @@ func (*S) TestPeerCleaner(c *C) {
 				existingPeers: []string{"peer2"},
 			},
 			expected: peerCleaner{
-				p: &testPeerManager{
+				m: &testPeerManager{
 					objects: []blobObject{
 						{
 							hash:  "hash1",
@@ -153,7 +153,7 @@ func (*S) TestPeerCleaner(c *C) {
 	for _, tc := range testCases {
 		comment := Commentf(tc.comment)
 		c.Assert(tc.c.cleanPeers(), IsNil, comment)
-		c.Assert(tc.c.p, DeepEquals, tc.expected.p, comment)
+		c.Assert(tc.c.m, DeepEquals, tc.expected.m, comment)
 	}
 }
 

--- a/lib/update/cluster/phases/init_test.go
+++ b/lib/update/cluster/phases/init_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"testing"
+
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+func TestPhases(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+// TestPeerCleaner tests peer clean up scenarios.
+// TODO(dmitri): this is ideally implemented as an integration test on a real etcd backend
+func (*S) TestPeerCleaner(c *C) {
+	var testCases = []struct {
+		comment  string
+		c        peerCleaner
+		expected peerCleaner
+	}{
+		{
+			comment: "no changes to peer state",
+			c: peerCleaner{
+				log: log.WithField("test", "TestPeerCleaner"),
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"peer1", "peer2"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "peer1"},
+						{ID: "peer2"},
+					},
+				},
+				existingPeers: []string{"peer2", "peer1"},
+			},
+			expected: peerCleaner{
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"peer1", "peer2"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "peer1"},
+						{ID: "peer2"},
+					},
+				},
+			},
+		},
+		{
+			comment: "removes stale peer and its references",
+			c: peerCleaner{
+				log: log.WithField("test", "TestPeerCleaner"),
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"stale_peer", "peer2"},
+						},
+						{
+							hash:  "hash2",
+							peers: []string{"peer2"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "stale_peer"},
+						{ID: "peer2"},
+					},
+				},
+				existingPeers: []string{"peer2"},
+			},
+			expected: peerCleaner{
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"peer2"},
+						},
+						{
+							hash:  "hash2",
+							peers: []string{"peer2"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "peer2"},
+					},
+				},
+			},
+		},
+		{
+			comment: "removes stale peer and its references; removes lost object",
+			c: peerCleaner{
+				log: log.WithField("test", "TestPeerCleaner"),
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"stale_peer", "peer2"},
+						},
+						{
+							hash:  "lost_object",
+							peers: []string{"stale_peer"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "peer2"},
+						{ID: "stale_peer"},
+					},
+				},
+				existingPeers: []string{"peer2"},
+			},
+			expected: peerCleaner{
+				p: &testPeerManager{
+					objects: []blobObject{
+						{
+							hash:  "hash1",
+							peers: []string{"peer2"},
+						},
+					},
+					peers: []storage.Peer{
+						{ID: "peer2"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		comment := Commentf(tc.comment)
+		c.Assert(tc.c.cleanPeers(), IsNil, comment)
+		c.Assert(tc.c.p, DeepEquals, tc.expected.p, comment)
+	}
+}
+
+func (r *testPeerManager) GetObjects() (hashes []string, err error) {
+	hashes = make([]string, 0, len(r.objects))
+	for _, o := range r.objects {
+		hashes = append(hashes, o.hash)
+	}
+	return hashes, nil
+}
+
+func (r *testPeerManager) GetObjectPeers(hash string) (peers []string, err error) {
+	for _, o := range r.objects {
+		if o.hash == hash {
+			return o.peers, nil
+		}
+	}
+	return nil, trace.NotFound("no peers for %v", hash)
+}
+
+func (r *testPeerManager) GetPeers() (peers []storage.Peer, err error) {
+	return r.peers, nil
+}
+
+func (r *testPeerManager) DeleteObject(hash string) error {
+	for i, o := range r.objects {
+		if o.hash == hash {
+			r.objects = append(r.objects[:i], r.objects[i+1:]...)
+			return nil
+		}
+	}
+	return trace.NotFound("no object with hash %v", hash)
+}
+
+func (r *testPeerManager) DeletePeer(peerID string) error {
+	for i, p := range r.peers {
+		if p.ID == peerID {
+			r.peers = append(r.peers[:i], r.peers[i+1:]...)
+			return nil
+		}
+	}
+	return trace.NotFound("no peer with ID %v", peerID)
+}
+
+func (r *testPeerManager) DeleteObjectPeers(hash string, removePeers []string) error {
+	for i, o := range r.objects {
+		if o.hash == hash {
+			for j, peer := range o.peers {
+				for _, removePeer := range removePeers {
+					if peer == removePeer {
+						r.objects[i].peers = append(r.objects[i].peers[:j], r.objects[i].peers[j+1:]...)
+					}
+				}
+				// Etcd backend does not return an error if a peer to be removed
+				// is not in the object's peer list
+			}
+			return nil
+		}
+	}
+	return trace.NotFound("no object with hash %v", hash)
+}
+
+func deleteItems(items []string, remove ...string) []string {
+	for i, item := range items {
+		for _, r := range remove {
+			if item == r {
+				items = append(items[:i], items[i+1:]...)
+			}
+		}
+	}
+	return items
+}
+
+type testPeerManager struct {
+	objects []blobObject
+	peers   []storage.Peer
+}
+
+type blobObject struct {
+	hash  string
+	peers []string
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
 * Implements stale object peer cleanup as a preliminary step to using the cluster package service.
 * Changes the implementation of the cluster controller's package blob synchronizer loop to work on best-effort basis - i.e. attempting to fetch as many blobs as possible even if some blobs are not accessible.
 * Adds a step to the shrink operation that removes the server's peer reference from the database.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/1469

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Implemented unit tests for the new upgrade step that cleans up peer state.
Tested on a two-node cluster with manually injected invalid peer state (peer + object that only had the invalid peer in its peer list).

## Additional Information
A somewhat better solution would probably be adding the explicit time-to-live to peer records, which will mean:
  * nodes won't have to clean up upon leaving
  * no need for redundant `last_heartbeat` attribute
  * package blob synchronizer loop will be to consider peers as accessible based on record existence
  * each node will have to have an explicit heartbeat loop to bump TTL
