### PR TITLE
Add Teleport node status checks

### DIFF
--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -235,6 +235,15 @@ func (b *planBuilder) AddWaitPhase(plan *storage.OperationPlan) {
 				},
 				Requires: []string{WaitPlanetPhase},
 			},
+			{
+				ID:          WaitTeleportPhase,
+				Description: "Wait for the Teleport node to join cluster",
+				Data: &storage.OperationPhaseData{
+					Server:     &b.JoiningNode,
+					ExecServer: &b.JoiningNode,
+				},
+				Requires: []string{WaitPlanetPhase},
+			},
 		},
 	})
 }

--- a/lib/expand/fsmspec.go
+++ b/lib/expand/fsmspec.go
@@ -94,6 +94,10 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 			return phases.NewWaitK8s(p,
 				config.Operator)
 
+		case strings.HasPrefix(p.Phase.ID, WaitTeleportPhase):
+			return phases.NewWaitTeleport(p,
+				config.Operator)
+
 		case strings.HasPrefix(p.Phase.ID, PostHookPhase):
 			return installphases.NewHook(p,
 				config.Operator,
@@ -125,6 +129,8 @@ const (
 	WaitPlanetPhase = "/wait/planet"
 	// WaitK8sPhase waits for joining node to register with Kubernetes
 	WaitK8sPhase = "/wait/k8s"
+	// WaitTeleportPhase waits for Teleport on the joining node to join the cluster
+	WaitTeleportPhase = "/wait/teleport"
 	// PostHookPhase runs post-expand application hook
 	PostHookPhase = "/postHook"
 	// ElectPhase enables leader election on master node

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -722,9 +722,7 @@ func (p *Peer) Wait() error {
 				return nil
 			}
 			if progress.State == ops.ProgressStateFailed {
-				p.Silent.Println(color.RedString("Failed to join the cluster"))
-				p.Silent.Printf("---\nAgent process will keep running so you can re-run certain steps.\n" +
-					"Once no longer needed, this process can be shutdown using Ctrl-C.\n")
+				return trace.BadParameter("failed to join the cluster")
 			}
 		}
 	}

--- a/lib/expand/phases/wait.go
+++ b/lib/expand/phases/wait.go
@@ -158,3 +158,69 @@ func (*waitK8sExecutor) PreCheck(ctx context.Context) error {
 func (*waitK8sExecutor) PostCheck(ctx context.Context) error {
 	return nil
 }
+
+// NewWaitTeleport returns executor that waits for Teleport node to register
+func NewWaitTeleport(p fsm.ExecutorParams, operator ops.Operator) (*waitK8sExecutor, error) {
+	logger := &fsm.Logger{
+		FieldLogger: logrus.WithFields(logrus.Fields{
+			constants.FieldPhase: p.Phase.ID,
+		}),
+		Key:      opKey(p.Plan),
+		Operator: operator,
+		Server:   p.Phase.Data.Server,
+	}
+	return &waitK8sExecutor{
+		FieldLogger:    logger,
+		Operator:       operator,
+		ExecutorParams: p,
+	}, nil
+}
+
+type waitTeleportExecutor struct {
+	// FieldLogger is used for logging
+	logrus.FieldLogger
+	// Operator is the cluster operator service
+	Operator ops.Operator
+	// ExecutorParams is common executor params
+	fsm.ExecutorParams
+}
+
+// Execute blocks until Teleport node has registered with the auth server
+func (p *waitTeleportExecutor) Execute(ctx context.Context) error {
+	p.Progress.NextStep("Waiting for the Teleport node to join the cluster")
+	p.Info("Waiting for the Teleport node to join the cluster.")
+	err := utils.Retry(defaults.RetryInterval, defaults.RetryAttempts,
+		func() error {
+			nodes, err := p.Operator.GetClusterNodes(p.Key().SiteKey())
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			for _, node := range nodes {
+				if node.AdvertiseIP == p.Phase.Data.Server.AdvertiseIP {
+					p.WithField("node", node).Info("Teleport node has registered.")
+					return nil
+				}
+			}
+			return trace.NotFound("Teleport on %s hasn't registered yet.",
+				p.Phase.Data.Server)
+		})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Rollback is no-op for this phase
+func (*waitTeleportExecutor) Rollback(ctx context.Context) error {
+	return nil
+}
+
+// PreCheck is no-op for this phase
+func (*waitTeleportExecutor) PreCheck(ctx context.Context) error {
+	return nil
+}
+
+// PostCheck is no-op for this phase
+func (*waitTeleportExecutor) PostCheck(ctx context.Context) error {
+	return nil
+}

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -367,6 +367,14 @@ func (s *PlanSuite) verifyWaitPhase(c *check.C, phase storage.OperationPhase) {
 				},
 				Requires: []string{WaitPlanetPhase},
 			},
+			{
+				ID: WaitTeleportPhase,
+				Data: &storage.OperationPhaseData{
+					Server:     &s.joiningNode,
+					ExecServer: &s.joiningNode,
+				},
+				Requires: []string{WaitPlanetPhase},
+			},
 		},
 	}, phase)
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -590,6 +590,19 @@ type Node struct {
 	InstanceType string `json:"instance_type"`
 }
 
+// Nodes is a list of nodes.
+type Nodes []Node
+
+// FindByIP returns node with specified IP or nil.
+func (n Nodes) FindByIP(ip string) *Node {
+	for _, node := range n {
+		if node.AdvertiseIP == ip {
+			return &node
+		}
+	}
+	return nil
+}
+
 // Operations installs and uninstalls gravity on a given site,
 // it takes care of provisioning, configuring and deploying end user application
 // as well as our system packages like planet and teleport

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1346,15 +1346,7 @@ func (o *Operator) GetAppInstaller(req ops.AppInstallerRequest) (io.ReadCloser, 
 
 // GetClusterNodes returns a real-time information about cluster nodes
 func (o *Operator) GetClusterNodes(key ops.SiteKey) ([]ops.Node, error) {
-	remote, err := o.cfg.Tunnel.GetSite(key.SiteDomain)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	client, err := remote.GetClient()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	nodes, err := client.GetNodes(defaults.Namespace)
+	nodes, err := o.backend().GetNodes(defaults.Namespace)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -134,6 +134,15 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		return status, trace.Wrap(err, "failed to collect system status from agents")
 	}
 
+	// Collect registered Teleport nodes.
+	teleportNodes, err := operator.GetClusterNodes(cluster.Key())
+	if err != nil {
+		return status, trace.Wrap(err, "failed to query teleport nodes")
+	}
+	for i, server := range status.Agent.Nodes {
+		status.Agent.Nodes[i].TeleportNode = ops.Nodes(teleportNodes).FindByIP(server.AdvertiseIP)
+	}
+
 	status.State = cluster.State
 	return status, nil
 }
@@ -360,6 +369,8 @@ type ClusterServer struct {
 	Status string `json:"status"`
 	// FailedProbes lists all failed probes if the node is not healthy
 	FailedProbes []string `json:"failed_probes,omitempty"`
+	// TeleportNode contains information about Teleport node running on this server
+	TeleportNode *ops.Node `json:"teleport_node,omitempty"`
 }
 
 func (r ClusterOperation) isFailed() bool {

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -387,9 +387,9 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 		}
 	}
 	if node.TeleportNode != nil {
-		fmt.Fprintf(w, "            Teleport:\t%v\n", color.GreenString("connected"))
+		fmt.Fprintf(w, "            Remote access:\t%v\n", color.GreenString("online"))
 	} else {
-		fmt.Fprintf(w, "            Teleport:\t%v\n", color.YellowString("disconnected"))
+		fmt.Fprintf(w, "            Remote access:\t%v\n", color.YellowString("offline"))
 	}
 }
 

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -382,6 +382,9 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 		fmt.Fprintf(w, "            Status:\t%v\n", color.GreenString("healthy"))
 	case statusapi.NodeDegraded:
 		fmt.Fprintf(w, "            Status:\t%v\n", color.RedString("degraded"))
+		if node.TeleportNode == nil {
+			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgYellow).SprintFunc()(""))
+		}
 		for _, probe := range node.FailedProbes {
 			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgRed).SprintFunc()(probe))
 		}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -382,12 +382,14 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 		fmt.Fprintf(w, "            Status:\t%v\n", color.GreenString("healthy"))
 	case statusapi.NodeDegraded:
 		fmt.Fprintf(w, "            Status:\t%v\n", color.RedString("degraded"))
-		if node.TeleportNode == nil {
-			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgYellow).SprintFunc()(""))
-		}
 		for _, probe := range node.FailedProbes {
 			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgRed).SprintFunc()(probe))
 		}
+	}
+	if node.TeleportNode != nil {
+		fmt.Fprintf(w, "            Teleport:\t%v\n", color.GreenString("connected"))
+	} else {
+		fmt.Fprintf(w, "            Teleport:\t%v\n", color.YellowString("disconnected"))
 	}
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR implements a few changes to better handle Teleport node failures and provide more visibility in their statuses. The lack of these things recently resulted in a [regression](https://github.com/gravitational/gravity/issues/1445) that went unnoticed for some time.

* Add additional step to "gravity join" operation to check that Teleport node on the joined node has successfully registered with the cluster, and fail operation if it hasn't.
* Related to the above, I found out that "gravity join" would exit with 0 return code even in case of a failed join. I wonder if this is the reason our "resize" robotest scenarios rarely fail 😄Fixed that too.
* Add Teleport status to node statuses in "gravity status" output. Note, it does not affect the cluster status at the moment and serves informational purposes. Here's how it looks:

```
Cluster nodes:
    Masters:
        * node-1 (192.168.99.102, node)
            Status:	healthy
            Teleport:	connected
    Nodes:
        * node-2 (192.168.99.103, knode)
            Status:	healthy
            Teleport:	connected
```

Note that I considered just displaying it similar to how we display failed probes, but decided this way would give better visibility - for example, a node may be offline but Teleport may be still running on it (and thus, it's still accessible via it).

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1445.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Make sure join fails if Teleport node doesn't connect

```
// Launch join operation
ubuntu@node-2:~$ sudo ./gravity join 192.168.99.102 --advertise-addr=192.168.99.103 --token=f11415da6889 --role=knode

// In another tab, break some Teleport-specific directory
ubuntu@node-2:~$ sudo chattr +i /var/lib/gravity/teleport/log

// Make sure join fails and exits with a non-successful return code
Wed Apr 29 22:17:00 UTC	Wait for the Teleport node to join cluster
Wed Apr 29 22:19:01 UTC	Operation failure: failed to execute phase "/wait"
	retry exceeded 2m0s
		Teleport on node(addr=192.168.99.103, hostname=node-2, role=knode, cluster_role=node) hasn't registered yet
[ERROR]: failed to join the cluster
ubuntu@node-2:~$ echo $?
255
```

### Make sure gravity status detects down Teleport nodes

```
// Stop Teleport node on one node
ubuntu@node-2:~$ sudo systemctl stop gravity__gravitational.io__teleport__3.0.5.service

// Call gravity status and make sure Teleport is shown as disconnected
ubuntu@node-1:~$ gravity status
...
Cluster nodes:
    Masters:
        * node-1 (192.168.99.102, node)
            Status:	healthy
            Teleport:	connected
    Nodes:
        * node-2 (192.168.99.103, knode)
            Status:	healthy
            Teleport:	disconnected
```

## Additional information
<!--Optional. Anything else that may be relevant.-->

Needs forward-ports to 6.1, 7.0 and master.