### PR TITLE
[5.5.x] avoid crashes when working with operational state

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -433,7 +433,8 @@ func (p *Peer) tryConnect() (op *operationContext, err error) {
 			return op, trace.Wrap(err)
 		}
 		if trace.IsCompareFailed(err) {
-			p.sendMessage("Waiting for another operation to finish at %v", addr)
+			p.WithError(err).Info("Failed to create expand operation.")
+			p.sendMessage("Waiting to create expand operation at %v: %v", addr, err)
 		}
 	}
 	return op, trace.Wrap(err)

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -122,6 +122,14 @@ func (r *Updater) Complete(fsmErr error) error {
 	return r.machine.Complete(fsmErr)
 }
 
+// Activate activates the cluster.
+func (r *Updater) Activate() error {
+	return r.Operator.ActivateSite(ops.ActivateSiteRequest{
+		AccountID:  r.Operation.AccountID,
+		SiteDomain: r.Operation.SiteDomain,
+	})
+}
+
 // GetPlan returns the up-to-date operation plan
 func (r *Updater) GetPlan() (*storage.OperationPlan, error) {
 	return r.machine.GetPlan()

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -83,7 +83,7 @@ func newConfigUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func executeConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -98,7 +98,7 @@ func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	return trace.Wrap(err)
 }
 
-func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -113,7 +113,7 @@ func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
-func completeConfigPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+func completeConfigPlanForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -83,7 +83,12 @@ func newConfigUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeConfigPhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getConfigUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)
@@ -93,7 +98,12 @@ func executeConfigPhase(env, updateEnv *localenv.LocalEnvironment, params PhaseP
 	return trace.Wrap(err)
 }
 
-func rollbackConfigPhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getConfigUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)
@@ -103,7 +113,12 @@ func rollbackConfigPhase(env, updateEnv *localenv.LocalEnvironment, params Phase
 	return trace.Wrap(err)
 }
 
-func completeConfigPlan(env, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeConfigPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getConfigUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -124,7 +124,13 @@ func completeConfigPlanForOperation(env *localenv.LocalEnvironment, environ Loca
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getConfigUpdater(localEnv, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) (*update.Updater, error) {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -98,6 +98,9 @@ func newClusterUpdater(
 func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
 	operation, err := getActiveOperation(env, environ, params.OperationID)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound("no active update operation found")
+		}
 		return trace.Wrap(err)
 	}
 	if operation.Type != ops.OperationUpdate {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -147,7 +147,13 @@ func completeUpdatePlanForOperation(env *localenv.LocalEnvironment, environ Loca
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getClusterUpdater(localEnv, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation, noValidateVersion bool) (*update.Updater, error) {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -55,13 +55,11 @@ func updateCheck(env *localenv.LocalEnvironment, updatePackage string) error {
 }
 
 func updateTrigger(
-	localEnv *localenv.LocalEnvironment,
-	updateEnv *localenv.LocalEnvironment,
+	localEnv, updateEnv *localenv.LocalEnvironment,
 	updatePackage string,
 	manual, noValidateVersion bool,
 ) error {
-	ctx := context.TODO()
-	updater, err := newClusterUpdater(ctx, localEnv, updateEnv, updatePackage, manual, noValidateVersion)
+	updater, err := newClusterUpdater(context.TODO(), localEnv, updateEnv, updatePackage, manual, noValidateVersion)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -97,7 +95,11 @@ func newClusterUpdater(
 	return updater, nil
 }
 
-func executeUpdatePhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	updater, err := getClusterUpdater(env, updateEnv, operation, params.SkipVersionCheck)
 	if err != nil {
 		return trace.Wrap(err)
@@ -107,7 +109,11 @@ func executeUpdatePhase(env, updateEnv *localenv.LocalEnvironment, params PhaseP
 	return trace.Wrap(err)
 }
 
-func rollbackUpdatePhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	updater, err := getClusterUpdater(env, updateEnv, operation, params.SkipVersionCheck)
 	if err != nil {
 		return trace.Wrap(err)
@@ -117,7 +123,11 @@ func rollbackUpdatePhase(env, updateEnv *localenv.LocalEnvironment, params Phase
 	return trace.Wrap(err)
 }
 
-func completeUpdatePlan(env, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeUpdatePlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	updater, err := getClusterUpdater(env, updateEnv, operation, true)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -103,7 +103,7 @@ func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	if operation.Type != ops.OperationUpdate {
 		return trace.NotFound("no active update operation found")
 	}
-	return executeUpdatePhaseForOperation(env, environ, params, *operation)
+	return executeUpdatePhaseForOperation(env, environ, params, operation.SiteOperation)
 }
 
 func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -72,7 +72,12 @@ func newEnvironUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalE
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeEnvironPhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getEnvironUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)
@@ -82,7 +87,12 @@ func executeEnvironPhase(env, updateEnv *localenv.LocalEnvironment, params Phase
 	return trace.Wrap(err)
 }
 
-func rollbackEnvironPhase(env, updateEnv *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getEnvironUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)
@@ -92,7 +102,12 @@ func rollbackEnvironPhase(env, updateEnv *localenv.LocalEnvironment, params Phas
 	return trace.Wrap(err)
 }
 
-func completeEnvironPlan(env, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeEnvironPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer updateEnv.Close()
 	updater, err := getEnvironUpdater(env, updateEnv, operation)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -113,7 +113,13 @@ func completeEnvironPlanForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	return trace.Wrap(updater.Complete(nil))
+	if err := updater.Complete(nil); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := updater.Activate(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 func getEnvironUpdater(env, updateEnv *localenv.LocalEnvironment, operation ops.SiteOperation) (*update.Updater, error) {

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -72,7 +72,7 @@ func newEnvironUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalE
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func executeEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -87,7 +87,7 @@ func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
-func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -102,7 +102,7 @@ func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironme
 	return trace.Wrap(err)
 }
 
-func completeEnvironPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+func completeEnvironPlanForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -205,7 +205,7 @@ func newCollector(env *localenv.LocalEnvironment) (*vacuum.Collector, error) {
 	return collector, nil
 }
 
-func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeGarbageCollectPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	clusterPackages, err := env.ClusterPackages()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -502,7 +502,7 @@ func executeJoinPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironm
 	if operation.Type != ops.OperationExpand {
 		return trace.NotFound("no active expand operation found")
 	}
-	return executeJoinPhaseForOperation(localEnv, environ, p, *operation)
+	return executeJoinPhaseForOperation(localEnv, environ, p, operation.SiteOperation)
 }
 
 func executeJoinPhaseForOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p PhaseParams, operation ops.SiteOperation) error {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -435,19 +435,6 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams) err
 	return executeInstallPhaseForOperation(localEnv, p, *operation)
 }
 
-// CheckInstallOperationComplete verifies whether there's a completed install operation.
-// Returns nil if there is a completed install operation
-func CheckInstallOperationComplete(localEnv *localenv.LocalEnvironment) error {
-	operations, err := getLastOperation(localEnv, nil, "")
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if len(operations) == 1 && operations[0].Type == ops.OperationInstall && operations[0].IsCompleted() {
-		return nil
-	}
-	return trace.NotFound("no operation found")
-}
-
 func executeInstallPhaseForOperation(localEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
 	localApps, err := localEnv.AppServiceLocal(localenv.AppConfig{})
 	if err != nil {
@@ -497,6 +484,9 @@ func executeInstallPhaseForOperation(localEnv *localenv.LocalEnvironment, p Phas
 func executeJoinPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p PhaseParams) error {
 	operation, err := getActiveOperation(localEnv, environ, p.OperationID)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound("no active expand operation found")
+		}
 		return trace.Wrap(err)
 	}
 	if operation.Type != ops.OperationExpand {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -460,7 +460,12 @@ func executeInstallPhase(localEnv *localenv.LocalEnvironment, p PhaseParams, ope
 	return nil
 }
 
-func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
+func executeJoinPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p PhaseParams, operation ops.SiteOperation) error {
+	joinEnv, err := environ.NewJoinEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer joinEnv.Close()
 	operator, err := joinEnv.CurrentOperator(httplib.WithInsecure())
 	if err != nil {
 		return trace.Wrap(err)
@@ -502,7 +507,12 @@ func executeJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParam
 	})
 }
 
-func rollbackJoinPhase(localEnv, joinEnv *localenv.LocalEnvironment, p PhaseParams, operation ops.SiteOperation) error {
+func rollbackJoinPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p PhaseParams, operation ops.SiteOperation) error {
+	joinEnv, err := environ.NewJoinEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer joinEnv.Close()
 	operator, err := joinEnv.CurrentOperator(httplib.WithInsecure(), httplib.WithTimeout(5*time.Second))
 	if err != nil {
 		return trace.Wrap(err)
@@ -624,7 +634,12 @@ func completeInstallPlan(localEnv *localenv.LocalEnvironment, operation ops.Site
 	return nil
 }
 
-func completeJoinPlan(localEnv, joinEnv *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeJoinPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+	joinEnv, err := environ.NewJoinEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer joinEnv.Close()
 	operator, err := joinEnv.CurrentOperator(httplib.WithInsecure())
 	if err != nil {
 		if !trace.IsAccessDenied(err) {

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -50,8 +50,8 @@ type PhaseParams struct {
 	SkipVersionCheck bool
 }
 
-func executePhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, params PhaseParams) error {
-	operations, err := getActiveOperations(localEnv, updateEnv, joinEnv, params.OperationID)
+func executePhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
+	operations, err := getActiveOperations(localEnv, environ, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -64,13 +64,13 @@ func executePhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, param
 	case ops.OperationInstall:
 		return executeInstallPhase(localEnv, params, op)
 	case ops.OperationExpand:
-		return executeJoinPhase(localEnv, joinEnv, params, op)
+		return executeJoinPhase(localEnv, environ, params, op)
 	case ops.OperationUpdate:
-		return executeUpdatePhase(localEnv, updateEnv, params, op)
+		return executeUpdatePhase(localEnv, environ, params, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		return executeEnvironPhase(localEnv, updateEnv, params, op)
+		return executeEnvironPhase(localEnv, environ, params, op)
 	case ops.OperationUpdateConfig:
-		return executeConfigPhase(localEnv, updateEnv, params, op)
+		return executeConfigPhase(localEnv, environ, params, op)
 	case ops.OperationGarbageCollect:
 		return executeGarbageCollectPhase(localEnv, params, op)
 	default:
@@ -78,8 +78,8 @@ func executePhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, param
 	}
 }
 
-func rollbackPhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, params PhaseParams) error {
-	operations, err := getActiveOperations(localEnv, updateEnv, joinEnv, params.OperationID)
+func rollbackPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
+	operations, err := getActiveOperations(localEnv, environ, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -92,20 +92,20 @@ func rollbackPhase(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, para
 	case ops.OperationInstall:
 		return rollbackInstallPhase(localEnv, params, op)
 	case ops.OperationExpand:
-		return rollbackJoinPhase(localEnv, joinEnv, params, op)
+		return rollbackJoinPhase(localEnv, environ, params, op)
 	case ops.OperationUpdate:
-		return rollbackUpdatePhase(localEnv, updateEnv, params, op)
+		return rollbackUpdatePhase(localEnv, environ, params, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		return rollbackEnvironPhase(localEnv, updateEnv, params, op)
+		return rollbackEnvironPhase(localEnv, environ, params, op)
 	case ops.OperationUpdateConfig:
-		return rollbackConfigPhase(localEnv, updateEnv, params, op)
+		return rollbackConfigPhase(localEnv, environ, params, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan rollback", op.Type)
 	}
 }
 
-func completeOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) error {
-	operations, err := getActiveOperations(localEnv, updateEnv, joinEnv, operationID)
+func completeOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) error {
+	operations, err := getActiveOperations(localEnv, environ, operationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -119,13 +119,13 @@ func completeOperationPlan(localEnv, updateEnv, joinEnv *localenv.LocalEnvironme
 		// There's only one install operation
 		err = completeInstallPlan(localEnv, op)
 	case ops.OperationExpand:
-		err = completeJoinPlan(localEnv, joinEnv, op)
+		err = completeJoinPlan(localEnv, environ, op)
 	case ops.OperationUpdate:
-		err = completeUpdatePlan(localEnv, updateEnv, op)
+		err = completeUpdatePlan(localEnv, environ, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		err = completeEnvironPlan(localEnv, updateEnv, op)
+		err = completeEnvironPlan(localEnv, environ, op)
 	case ops.OperationUpdateConfig:
-		err = completeConfigPlan(localEnv, updateEnv, op)
+		err = completeConfigPlan(localEnv, environ, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan completion", op.Type)
 	}
@@ -153,8 +153,8 @@ func completeClusterOperationPlan(localEnv *localenv.LocalEnvironment, operation
 
 // getLastOperation returns the list of operations found across the specified backends.
 // If no operation is found, the returned error will indicate a not found operation
-func getLastOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) ([]ops.SiteOperation, error) {
-	operations, err := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+func getLastOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) ([]ops.SiteOperation, error) {
+	operations, err := getBackendOperations(localEnv, environ, operationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -168,8 +168,8 @@ func getLastOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, o
 	return operations, nil
 }
 
-func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (*ops.SiteOperation, error) {
-	operations, err := getActiveOperations(localEnv, updateEnv, joinEnv, operationID)
+func getActiveOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (*ops.SiteOperation, error) {
+	operations, err := getActiveOperations(localEnv, environ, operationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -180,8 +180,8 @@ func getActiveOperation(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment,
 	return &operations[0], nil
 }
 
-func getActiveOperations(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) ([]ops.SiteOperation, error) {
-	operations, err := getBackendOperations(localEnv, updateEnv, joinEnv, operationID)
+func getActiveOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) ([]ops.SiteOperation, error) {
+	operations, err := getBackendOperations(localEnv, environ, operationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -197,9 +197,9 @@ func getActiveOperations(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment
 
 // getBackendOperations returns the list of operation from the specified backends
 // in descending order (sorted by creation time)
-func getBackendOperations(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment, operationID string) (result []ops.SiteOperation, err error) {
+func getBackendOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (result []ops.SiteOperation, err error) {
 	b := newBackendOperations()
-	err = b.List(localEnv, updateEnv, joinEnv)
+	err = b.List(localEnv, environ)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -220,7 +220,7 @@ func newBackendOperations() backendOperations {
 	}
 }
 
-func (r *backendOperations) List(localEnv, updateEnv, joinEnv *localenv.LocalEnvironment) error {
+func (r *backendOperations) List(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory) error {
 	clusterEnv, err := localEnv.NewClusterEnvironment(localenv.WithEtcdTimeout(1 * time.Second))
 	if err != nil {
 		log.WithError(err).Debug("Failed to create cluster environment.")
@@ -231,27 +231,17 @@ func (r *backendOperations) List(localEnv, updateEnv, joinEnv *localenv.LocalEnv
 			log.WithError(err).Warn("Failed to query cluster operations.")
 		}
 	}
-	if updateEnv != nil {
-		r.getOperationAndUpdateCache(updateEnv.Backend, log.WithField("context", "update"))
+	if err := r.listUpdateOperation(environ); err != nil && !trace.IsNotFound(err) {
+		log.WithError(err).Warn("Failed to list update operation.")
 	}
-	if joinEnv != nil {
-		r.getOperationAndUpdateCache(joinEnv.Backend, log.WithField("context", "expand"))
+	if err := r.listJoinOperation(environ); err != nil && !trace.IsNotFound(err) {
+		log.WithError(err).Warn("Failed to list join operation.")
 	}
 	// Only fetch operation from remote (install) environment if the install operation is ongoing
 	// or we failed to fetch the operation details from the cluster
 	if r.isActiveInstallOperation() {
-		wizardEnv, err := localenv.NewRemoteEnvironment()
-		if err != nil {
-			log.WithError(err).Warn("Failed to create wizard environment.")
-		}
-		if wizardEnv != nil && wizardEnv.Operator != nil {
-			op, err := ops.GetWizardOperation(wizardEnv.Operator)
-			if err == nil {
-				log.Debug("Fetched install operation from wizard environment.")
-				r.operations[op.ID] = (ops.SiteOperation)(*op)
-			} else {
-				log.WithError(err).Warn("Failed to query install operation.")
-			}
+		if err := r.listInstallOperation(); err != nil {
+			return trace.Wrap(err)
 		}
 	}
 	return nil
@@ -270,7 +260,49 @@ func (r *backendOperations) init(clusterBackend storage.Backend) error {
 		r.operations[op.ID] = (ops.SiteOperation)(op)
 	}
 	r.clusterOperation = (*ops.SiteOperation)(&clusterOperations[0])
-	r.operations[r.clusterOperation.ID] = *r.clusterOperation
+	return nil
+}
+
+func (r *backendOperations) listUpdateOperation(environ LocalEnvironmentFactory) error {
+	env, err := environ.NewUpdateEnv()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer env.Close()
+	r.getOperationAndUpdateCache(env.Backend, log.WithField("context", "update"))
+	return nil
+}
+
+func (r *backendOperations) listJoinOperation(environ LocalEnvironmentFactory) error {
+	env, err := environ.NewJoinEnv()
+	if err != nil && !trace.IsConnectionProblem(err) {
+		return trace.Wrap(err)
+	}
+	if env == nil {
+		// Do not fail for timeout errors.
+		// Timeout error means the directory is used by the active installer process
+		// which means, it's the installer environment, not joining node's
+		return nil
+	}
+	defer env.Close()
+	r.getOperationAndUpdateCache(env.Backend, log.WithField("context", "expand"))
+	return nil
+}
+
+func (r *backendOperations) listInstallOperation() error {
+	wizardEnv, err := localenv.NewRemoteEnvironment()
+	if err != nil {
+		log.WithError(err).Warn("Failed to create wizard environment.")
+	}
+	if wizardEnv != nil && wizardEnv.Operator != nil {
+		op, err := ops.GetWizardOperation(wizardEnv.Operator)
+		if err == nil {
+			log.Debug("Fetched install operation from wizard environment.")
+			r.operations[op.ID] = (ops.SiteOperation)(*op)
+		} else {
+			log.WithError(err).Warn("Failed to query install operation.")
+		}
+	}
 	return nil
 }
 

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -69,8 +69,8 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound(`no operation found.
-This usually means that the installation has failed to start or was not started.
-Clean up the node with 'gravity leave' if necessary and start the installation with 'gravity install'.
+This usually means that the installation/join operation has failed to start or was not started.
+Clean up the node with 'gravity leave' if necessary and start the installation/join with either 'gravity install' or 'gravity join'.
 `)
 		}
 		return trace.Wrap(err)
@@ -86,17 +86,17 @@ Clean up the node with 'gravity leave' if necessary and start the installation w
 	}
 	switch op.Type {
 	case ops.OperationInstall:
-		return displayInstallOperationPlan(op.Key(), format)
+		err = displayInstallOperationPlan(op.Key(), format)
 	case ops.OperationExpand:
-		return displayExpandOperationPlan(environ, op.Key(), format)
+		err = displayExpandOperationPlan(environ, op.Key(), format)
 	case ops.OperationUpdate:
-		return displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
 	case ops.OperationUpdateRuntimeEnviron:
-		return displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
 	case ops.OperationUpdateConfig:
-		return displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
 	case ops.OperationGarbageCollect:
-		return displayClusterOperationPlan(localEnv, op.Key(), format)
+		err = displayClusterOperationPlan(localEnv, op.Key(), format)
 	default:
 		return trace.BadParameter("unknown operation type %q", op.Type)
 	}

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -84,9 +84,9 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 			// Use the active operation if available
 			op = activeOperation
 		} else if format == constants.EncodingText {
-			log.WithField("operations", oplist(operations).String()).Warn("Multiple operations found.")
+			log.WithField("operations", operationList(operations).String()).Warn("Multiple operations found.")
 			localEnv.Printf("Multiple operations found: \n%v\nPlease specify operation with --operation-id. "+
-				"Displaying the most recent operation.\n\n", oplist(operations).formatTable())
+				"Displaying the most recent operation.\n\n", operationList(operations).formatTable())
 		}
 	}
 	if op.IsCompleted() {

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -67,11 +67,12 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string, format constants.Format) error {
 	operations, err := getLastOperation(localEnv, environ, operationID)
 	if err != nil {
+		message := noOperationStateNoClusterStateBanner
+		if err2 := CheckLocalState(localEnv); err2 != nil {
+			message = NoOperationStateBanner
+		}
 		if trace.IsNotFound(err) {
-			return trace.NotFound(`no operation found.
-This usually means that the installation/join operation has failed to start or was not started.
-Clean up the node with 'gravity leave' if necessary and start the installation/join with either 'gravity install' or 'gravity join'.
-`)
+			return trace.NotFound(message)
 		}
 		return trace.Wrap(err)
 	}
@@ -246,3 +247,17 @@ func getPlanFromWizard(opKey ops.SiteOperationKey) (*storage.OperationPlan, erro
 	}
 	return plan, nil
 }
+
+const (
+	// NoOperationStateBanner specifies the message for when the operation
+	// cannot be retrieved from the installer process and that the operation
+	// should be restarted
+	NoOperationStateBanner = `no operation found.
+This usually means that the installation/join operation has failed to start or was not started.
+Clean up the node with 'gravity leave' and start the operation with either 'gravity install' or 'gravity join'.
+`
+	noOperationStateNoClusterStateBanner = `no operation found.
+This usually means that the installation/join operation has failed to start or was not started.
+Start the operation with either 'gravity install' or 'gravity join'.
+`
+)

--- a/tool/gravity/cli/resources.go
+++ b/tool/gravity/cli/resources.go
@@ -32,16 +32,6 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// LocalEnvironmentFactory defines an interface for creating operation-specific environments
-type LocalEnvironmentFactory interface {
-	// NewLocalEnv creates a new default environment
-	NewLocalEnv() (*localenv.LocalEnvironment, error)
-	// NewUpdateEnv creates a new environment for update operations
-	NewUpdateEnv() (*localenv.LocalEnvironment, error)
-	// NewJoinEnv creates a new environment for join operations
-	NewJoinEnv() (*localenv.LocalEnvironment, error)
-}
-
 // createResource updates or inserts one or many resources from the specified filename.
 // upsert controls whether the resource is expected to exist.
 // manual controls whether the operation is created in manual mode if resource creation is implemented

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -300,7 +300,7 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.InstallCmd.Force = false
 		}
 		if *g.InstallCmd.Phase != "" {
-			return executeInstallPhase(localEnv, g, PhaseParams{
+			return executeInstallPhase(localEnv, PhaseParams{
 				PhaseID: *g.InstallCmd.Phase,
 				Force:   *g.InstallCmd.Force,
 				Timeout: *g.InstallCmd.PhaseTimeout,

--- a/tool/gravity/cli/system.go
+++ b/tool/gravity/cli/system.go
@@ -1120,7 +1120,7 @@ func systemUninstall(env *localenv.LocalEnvironment, confirmed bool) error {
 	// remove all files and directories gravity might have created on the system
 	for _, path := range append(state.StateLocatorPaths, defaults.ModulesPath, defaults.SysctlPath, defaults.GravityEphemeralDir) {
 		// errors are expected since some of them may not exist
-		if err := os.Remove(path); err == nil {
+		if err := os.RemoveAll(path); err == nil {
 			env.PrintStep("Removed %v", path)
 		}
 	}

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -29,6 +29,16 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// LocalEnvironmentFactory defines an interface for creating operation-specific environments
+type LocalEnvironmentFactory interface {
+	// NewLocalEnv creates a new default environment
+	NewLocalEnv() (*localenv.LocalEnvironment, error)
+	// NewUpdateEnv creates a new environment for update operations
+	NewUpdateEnv() (*localenv.LocalEnvironment, error)
+	// NewJoinEnv creates a new environment for join operations
+	NewJoinEnv() (*localenv.LocalEnvironment, error)
+}
+
 // LocalEnv returns an instance of a local environment for the specified
 // command
 func (g *Application) LocalEnv(cmd string) (*localenv.LocalEnvironment, error) {
@@ -138,45 +148,6 @@ func (g *Application) isInstallCommand(cmd string) bool {
 func (g *Application) isJoinCommand(cmd string) bool {
 	switch cmd {
 	case g.JoinCmd.FullCommand():
-		return true
-	}
-	return false
-}
-
-// isUpdateCommand returns true if the specified commans is
-// an upgrade related command
-func (g *Application) isUpdateCommand(cmd string) bool {
-	switch cmd {
-	case g.PlanCmd.FullCommand(),
-		g.PlanDisplayCmd.FullCommand(),
-		g.PlanExecuteCmd.FullCommand(),
-		g.PlanRollbackCmd.FullCommand(),
-		g.PlanResumeCmd.FullCommand(),
-		g.PlanCompleteCmd.FullCommand(),
-		g.UpdatePlanInitCmd.FullCommand(),
-		g.UpdateTriggerCmd.FullCommand(),
-		g.UpgradeCmd.FullCommand():
-		return true
-	case g.RPCAgentRunCmd.FullCommand():
-		return len(*g.RPCAgentRunCmd.Args) > 0
-	case g.RPCAgentDeployCmd.FullCommand():
-		return len(*g.RPCAgentDeployCmd.LeaderArgs) > 0 ||
-			len(*g.RPCAgentDeployCmd.NodeArgs) > 0
-	}
-	return false
-}
-
-// isExpandCommand returns true if the specified commans is
-// expand-related command
-func (g *Application) isExpandCommand(cmd string) bool {
-	switch cmd {
-	case g.JoinCmd.FullCommand(), g.AutoJoinCmd.FullCommand(),
-		g.PlanCmd.FullCommand(),
-		g.PlanDisplayCmd.FullCommand(),
-		g.PlanExecuteCmd.FullCommand(),
-		g.PlanRollbackCmd.FullCommand(),
-		g.PlanCompleteCmd.FullCommand(),
-		g.PlanResumeCmd.FullCommand():
 		return true
 	}
 	return false


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR restructures the way operational environments are created by doing away with command comparisons in favor of creating the environments where they're actually needed. This alleviates the problems with command-specific logic to decide which environment to create for which command early in the process.
Additionally, this backports the change necessary to be able to complete an expand operation from another cluster node.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1468.
* Requires https://github.com/gravitational/gravity.e/pull/4295.
* Ports https://github.com/gravitational/gravity/pull/1347 (partially).

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Upgraded a 2-node cluster using the branch.
Attempted the `gravity upgrade --resume` with an active expand operation:
```
$ ./gravity upgrade --resume
no active update operation found
```
