### PR TITLE
Forward-port teleport tokens fixes.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -128,6 +128,9 @@ const (
 	// InstallTokenTTL is the TTL for the install token after the installation
 	// has been completed/or failed
 	InstallTokenTTL = time.Hour
+	// ExpandTokenTTL is used for temporary provisioning tokens created during
+	// expand operations.
+	ExpandTokenTTL = 24 * time.Hour
 
 	// MaxOperationConcurrency defines a number of servers an operation can run on concurrently
 	MaxOperationConcurrency = 5

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -887,8 +887,7 @@ func (s *site) newProvisioningToken(operation ops.SiteOperation) (token string, 
 		UserEmail:   agentUser.GetName(),
 	}
 	if operation.Type == ops.OperationExpand {
-		// Set a TTL for expand provisioning token.
-		tokenRequest.Expires = s.clock().UtcNow().Add(defaults.InstallTokenTTL)
+		tokenRequest.Expires = s.clock().UtcNow().Add(defaults.ExpandTokenTTL)
 	}
 	_, err = s.users().CreateProvisioningToken(tokenRequest)
 	if err != nil {

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -233,7 +233,7 @@ func (i *importer) findLatestTeleportConfigPackage(clusterName string, teleportV
 	config, err := pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
 		Packages:   i.packages,
 		Repository: clusterName,
-		Match:      matchTeleportConfigPackage(teleportVersion),
+		Match:      MatchTeleportConfigPackage(teleportVersion),
 	})
 	if err == nil {
 		return config, nil
@@ -252,7 +252,9 @@ func (i *importer) findLatestLegacyTeleportConfigPackage(clusterName string) (*l
 	})
 }
 
-func matchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
+// MatchTeleportConfigPackage returns a match function that matches Teleport
+// master configuration package with specified version.
+func MatchTeleportConfigPackage(teleportVersion semver.Version) pack.MatchFunc {
 	return func(env pack.PackageEnvelope) bool {
 		if !env.HasLabel(pack.PurposeLabel, pack.PurposeTeleportMasterConfig) {
 			return false

--- a/lib/process/teleport.go
+++ b/lib/process/teleport.go
@@ -23,10 +23,12 @@ import (
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
 	teledefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -67,6 +69,13 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	if len(serviceConfig.AuthServers) == 0 && serviceConfig.Auth.Enabled {
 		serviceConfig.AuthServers = append(serviceConfig.AuthServers, serviceConfig.Auth.SSHAddr)
 	}
+	// Configure auth tokens so nodes can join.
+	tokens, err := p.getTeleportAuthTokens()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	serviceConfig.Auth.StaticTokens.SetStaticTokens(append(tokens,
+		serviceConfig.Auth.StaticTokens.GetStaticTokens()...))
 	// Teleport will be using Gravity backend implementation.
 	serviceConfig.Identity = p.identity
 	serviceConfig.Trust = p.identity
@@ -81,6 +90,29 @@ func (p *Process) buildTeleportConfig(authGatewayConfig storage.AuthGateway) (*s
 	// faster when auth gateway settings are updated.
 	serviceConfig.PollingPeriod = teledefaults.HighResPollingPeriod
 	return serviceConfig, nil
+}
+
+// getTeleportAuthTokens returns tokens Teleport nodes can use to authenticate
+// with auth server to join the cluster.
+func (p *Process) getTeleportAuthTokens() (result []services.ProvisionToken, err error) {
+	cluster, err := p.backend.GetLocalSite(defaults.SystemAccountID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	allTokens, err := p.backend.GetSiteProvisioningTokens(cluster.Domain)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, t := range allTokens {
+		// Consider expand tokens as well for backwards compatibility.
+		if (t.IsTeleport() || t.IsExpand()) && t.IsPersistent() {
+			result = append(result, services.ProvisionToken{
+				Roles: teleport.Roles{teleport.RoleNode},
+				Token: t.Token,
+			})
+		}
+	}
+	return result, nil
 }
 
 // getOrInitAuthGatewayConfig returns auth gateway configuration.

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1242,6 +1242,21 @@ func (p *ProvisioningToken) Check() error {
 	return nil
 }
 
+// IsExpand returns true if this is an expand token.
+func (p *ProvisioningToken) IsExpand() bool {
+	return p.Type == ProvisioningTokenTypeExpand
+}
+
+// IsTeleport returns true if this is a teleport token.
+func (p *ProvisioningToken) IsTeleport() bool {
+	return p.Type == ProvisioningTokenTypeTeleport
+}
+
+// IsPersistent returns true if this token does not expire.
+func (p *ProvisioningToken) IsPersistent() bool {
+	return p.Expires.IsZero()
+}
+
 // ProvisioningTokenType specifies token type
 type ProvisioningTokenType string
 
@@ -1250,12 +1265,14 @@ const (
 	ProvisioningTokenTypeInstall = "install"
 	// ProvisioningTokenTypeExpand is used to validate joining nodes
 	ProvisioningTokenTypeExpand = "expand"
+	// ProvisioningTokenTypeTeleport is used by Teleport nodes to authenticate with auth server
+	ProvisioningTokenTypeTeleport = "teleport"
 )
 
 // Check returns nil if the value is correct, error otherwise
 func (s *ProvisioningTokenType) Check() error {
 	switch *s {
-	case ProvisioningTokenTypeInstall, ProvisioningTokenTypeExpand:
+	case ProvisioningTokenTypeInstall, ProvisioningTokenTypeExpand, ProvisioningTokenTypeTeleport:
 		return nil
 	}
 	return trace.BadParameter("unsupported token type: %v", *s)

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -250,6 +250,10 @@ type Application struct {
 	RPCAgentRunCmd RPCAgentRunCmd
 	// SystemCmd combines system subcommands
 	SystemCmd SystemCmd
+	// SystemTeleportCmd combines internal Teleport commands
+	SystemTeleportCmd SystemTeleportCmd
+	// SystemTeleportShowConfigCmd displays Teleport config
+	SystemTeleportShowConfigCmd SystemTeleportShowConfigCmd
 	// SystemRotateCertsCmd renews cluster certificates on local node
 	SystemRotateCertsCmd SystemRotateCertsCmd
 	// SystemExportCACmd exports cluster CA
@@ -1435,6 +1439,18 @@ type RPCAgentRunCmd struct {
 // SystemCmd combines system subcommands
 type SystemCmd struct {
 	*kingpin.CmdClause
+}
+
+// SystemTeleportCmd combines internal Teleport commands
+type SystemTeleportCmd struct {
+	*kingpin.CmdClause
+}
+
+// SystemTeleportShowConfigCmd displays Teleport config from specified package
+type SystemTeleportShowConfigCmd struct {
+	*kingpin.CmdClause
+	// Package is the package to show config from
+	Package *string
 }
 
 // SystemRotateCertsCmd renews cluster certificates on local node

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -617,6 +617,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.SystemCmd.CmdClause = g.Command("system", "operations on system components")
 
+	g.SystemTeleportCmd.CmdClause = g.SystemCmd.Command("teleport", "System level operations on Teleport service").Hidden()
+	g.SystemTeleportShowConfigCmd.CmdClause = g.SystemTeleportCmd.Command("show-config", "Display Teleport configuration from the specified package")
+	g.SystemTeleportShowConfigCmd.Package = g.SystemTeleportShowConfigCmd.Flag("package", "Package with Teleport configuration. Can also be 'master' or 'node' to auto-detect package").Required().String()
+
 	g.SystemRotateCertsCmd.CmdClause = g.SystemCmd.Command("rotate-certs", "Renew cluster certificates on a node").Hidden()
 	g.SystemRotateCertsCmd.ClusterName = g.SystemRotateCertsCmd.Arg("cluster-name", "Name of the local cluster").Required().String()
 	g.SystemRotateCertsCmd.ValidFor = g.SystemRotateCertsCmd.Flag("valid-for", "Validity duration in Go format").Default("26280h").Duration()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -794,6 +794,9 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		return exportCertificateAuthority(localEnv,
 			*g.SystemExportCACmd.ClusterName,
 			*g.SystemExportCACmd.CAPath)
+	case g.SystemTeleportShowConfigCmd.FullCommand():
+		return showTeleportConfig(localEnv,
+			*g.SystemTeleportShowConfigCmd.Package)
 	case g.SystemReinstallCmd.FullCommand():
 		return systemReinstall(localEnv,
 			*g.SystemReinstallCmd.Package,

--- a/tool/gravity/cli/teleport.go
+++ b/tool/gravity/cli/teleport.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/process"
+
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v2"
+)
+
+func showTeleportConfig(env *localenv.LocalEnvironment, packageName string) error {
+	locators, err := getTeleportLocators(env, packageName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	config, err := readTeleportFileConfig(locators.configReader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	configBytes, err := yaml.Marshal(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println(string(configBytes))
+	return nil
+}
+
+func readTeleportFileConfig(reader io.ReadCloser) (*config.FileConfig, error) {
+	vars, err := pack.ReadConfigPackage(reader)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	configBase64 := vars[defaults.ConfigEnvar]
+	if configBase64 == "" {
+		return nil, trace.BadParameter("empty teleport config")
+	}
+	configBytes, err := base64.StdEncoding.DecodeString(configBase64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var config config.FileConfig
+	if err := yaml.Unmarshal(configBytes, &config); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &config, nil
+}
+
+type teleportLocators struct {
+	teleportLocator loc.Locator
+	configLocator   loc.Locator
+	configEnvelope  pack.PackageEnvelope
+	configReader    io.ReadCloser
+}
+
+func getTeleportLocators(env *localenv.LocalEnvironment, packageName string) (*teleportLocators, error) {
+	teleportLocator, err := pack.FindInstalledPackage(env.Packages, loc.Teleport)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	teleportVersion, err := teleportLocator.SemVer()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var configLocator *loc.Locator
+	switch packageName {
+	case "master":
+		configLocator, err = findTeleportMasterConfig(env, *teleportVersion)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		fmt.Printf("Using Teleport master config from %s\n", configLocator)
+	case "node":
+		configLocator, err = findTeleportNodeConfig(env)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		fmt.Printf("Using Teleport node config from %s\n", configLocator)
+	default:
+		configLocator, err = loc.ParseLocator(packageName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	envelope, reader, err := env.Packages.ReadPackage(*configLocator)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &teleportLocators{
+		teleportLocator: *teleportLocator,
+		configLocator:   *configLocator,
+		configEnvelope:  *envelope,
+		configReader:    reader,
+	}, nil
+}
+
+func findTeleportMasterConfig(env *localenv.LocalEnvironment, teleportVersion semver.Version) (*loc.Locator, error) {
+	clusterEnv, err := env.NewClusterEnvironment()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cluster, err := clusterEnv.Operator.GetLocalSite()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return pack.FindLatestPackageCustom(pack.FindLatestPackageRequest{
+		Packages:   env.Packages,
+		Repository: cluster.Domain,
+		Match:      process.MatchTeleportConfigPackage(teleportVersion),
+	})
+}
+
+func findTeleportNodeConfig(env *localenv.LocalEnvironment) (*loc.Locator, error) {
+	return pack.FindInstalledConfigPackage(env.Packages, loc.Teleport)
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR forward-ports fixes related to teleport node token regression (https://github.com/gravitational/gravity/issues/1445) as well as some extra stuff.

* Same as in other branches, have gravity-site read auth tokens upon startup instead of hardcoding them in configuration.
* Use a new provisioning token type, "teleport", for teleport nodes authentication. But also fallback to "expand" tokens for backwards compatibility.
* Initialize this "teleport" prov. token during install/upgrade.
* Also forward port (from https://github.com/gravitational/gravity/pull/1446) the command that can show teleport configuration from a package. I thought that the other two commands may not really be useful anymore.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1445.
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1453, https://github.com/gravitational/gravity/pull/1446.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Fresh install scenario
- [x] Install cluster using this branch.
- [x] Join another node.
- [x] Verify Teleport joins ok and uses Teleport provisioning token.

### Upgrade scenario
- [x] Install 7.0.4 cluster.
- [x] Upgrade to this branch.
- [x] Verify Teleport provisioning token was created.
- [x] Join another node.
- [x] Verify Teleport joins ok and uses Teleport provisioning token.