### PR TITLE
[6.3.x] loosen same OS requirement

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -756,28 +756,56 @@ func checkRAM(info ServerInfo, ram schema.RAM) error {
 	return nil
 }
 
-// checkSameOS makes sure all servers have the same OS/version
+// checkSameOS verifies the OS distribution requirement for the specified set of servers.
+// The check will pass if all nodes in the cluster are based on the same OS distribution and major version.
+// Variance in minor/patch versions is acceptable.
 func checkSameOS(servers []Server) error {
-	osToNodes := make(map[string][]string)
+	// distros maps distribnution name to list of versions
+	distros := make(map[string][]string)
 	for _, server := range servers {
-		os := systeminfo.OS(server.GetOS()).Name()
-		osToNodes[os] = append(osToNodes[os], fmt.Sprintf("%v (%v)",
-			server.ServerInfo.GetHostname(), server.AdvertiseAddr))
+		info := server.GetOS()
+		distros[info.ID] = append(distros[info.ID], info.Version)
 	}
-
-	if len(osToNodes) > 1 {
-		var formatted []string
-		for os, nodes := range osToNodes {
-			formatted = append(formatted, fmt.Sprintf(
-				"%v: %v", os, strings.Join(nodes, ", ")))
+	if len(distros) != 1 {
+		return trace.BadParameter("servers have different OS distributions: %v", formatKeysAsList(distros))
+	}
+	// Version verification is purposedly simply and will compare the prefixes
+	// upto to either the first '.' or eol
+	for _, versions := range distros {
+		if !verifyCommonVersionPrefix(versions...) {
+			return trace.BadParameter("servers have different OS versions: %v", formatAsList(distros))
 		}
-		return trace.BadParameter(
-			"servers have different OSes/versions:\n%v",
-			strings.Join(formatted, "\n"))
 	}
-
-	log.Infof("Servers passed check for the same OS: %v.", osToNodes)
+	log.Info("Servers passed check for the same OS.")
 	return nil
+}
+
+func verifyCommonVersionPrefix(versions ...string) bool {
+	prefixes := make(map[string]struct{})
+	for _, v := range versions {
+		index := strings.Index(v, ".")
+		if index == -1 {
+			index = len(v)
+		}
+		prefixes[v[:index]] = struct{}{}
+	}
+	return len(prefixes) == 1
+}
+
+func formatAsList(m map[string][]string) (result []string) {
+	result = make([]string, 0, len(m))
+	for k, v := range m {
+		result = append(result, fmt.Sprintf("%v (%q)", k, v))
+	}
+	return result
+}
+
+func formatKeysAsList(m map[string][]string) (result []string) {
+	result = make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
 }
 
 // checkTime checks if time it out of sync between servers

--- a/lib/checks/checks_test.go
+++ b/lib/checks/checks_test.go
@@ -118,41 +118,80 @@ func (s *ChecksSuite) TestTime(c *check.C) {
 }
 
 func (s *ChecksSuite) TestCheckSameOS(c *check.C) {
-	infos := []Server{
+	var testCases = []struct {
+		comment string
+		servers []Server
+		err     string
+	}{
 		{
-			ServerInfo: ServerInfo{
-				System: storage.NewSystemInfo(storage.SystemSpecV2{
-					Hostname: "node-1",
-					OS: storage.OSInfo{
-						ID:      "centos",
-						Version: "7.1",
-					},
-				}),
+			comment: "servers match on the major version",
+			servers: []Server{
+				newServer("node-1", "centos", "7.1"),
+				newServer("node-2", "centos", "7.2"),
+				newServer("node-3", "centos", "7.2"),
 			},
 		},
 		{
-			ServerInfo: ServerInfo{
-				System: storage.NewSystemInfo(storage.SystemSpecV2{
-					Hostname: "node-2",
-					OS: storage.OSInfo{
-						ID:      "centos",
-						Version: "7.2",
-					},
-				}),
+			comment: "servers do not match on the major version",
+			servers: []Server{
+				newServer("node-1", "centos", "7.1"),
+				newServer("node-2", "centos", "6.2"),
+				newServer("node-3", "centos", "7.2"),
+			},
+			err: "servers have different OS versions.*",
+		},
+		{
+			comment: "match on the whole version",
+			servers: []Server{
+				newServer("node-1", "centos", "7"),
+				newServer("node-2", "centos", "7"),
 			},
 		},
 		{
-			ServerInfo: ServerInfo{
-				System: storage.NewSystemInfo(storage.SystemSpecV2{
-					Hostname: "node-3",
-					OS: storage.OSInfo{
-						ID:      "centos",
-						Version: "7.2",
-					},
-				}),
+			comment: "no match on the whole version",
+			servers: []Server{
+				newServer("node-1", "centos", "7"),
+				newServer("node-2", "centos", "6"),
 			},
+			err: "servers have different OS versions.*",
+		},
+		{
+			comment: "no match on distribution",
+			servers: []Server{
+				newServer("node-1", "centos", "7"),
+				newServer("node-2", "rhel", "7"),
+			},
+			err: "servers have different OS distributions.*",
+		},
+		// {
+		// 	comment: "no match on bogus input? (identical to previous behavior)",
+		// 	servers: []Server{
+		// 		newServer("node-1", "centos", "greatest release"),
+		// 		newServer("node-2", "centos", "greatest release. more text"),
+		// 	},
+		// 	err: "servers have different OS versions.*",
+		// },
+	}
+	for _, tc := range testCases {
+		comment := check.Commentf(tc.comment)
+		if tc.err != "" {
+			c.Assert(checkSameOS(tc.servers), check.ErrorMatches, tc.err, comment)
+		} else {
+			c.Assert(checkSameOS(tc.servers), check.IsNil, comment)
+		}
+	}
+}
+
+func newServer(hostname, os, version string) Server {
+	return Server{
+		ServerInfo: ServerInfo{
+			System: storage.NewSystemInfo(storage.SystemSpecV2{
+				Hostname: hostname,
+				OS: storage.OSInfo{
+					ID:      os,
+					Version: version,
+				},
+			}),
 		},
 	}
-	c.Assert(checkSameOS(infos[:2]), check.NotNil)
-	c.Assert(checkSameOS(infos[1:]), check.IsNil)
 }

--- a/lib/checks/checks_test.go
+++ b/lib/checks/checks_test.go
@@ -163,14 +163,6 @@ func (s *ChecksSuite) TestCheckSameOS(c *check.C) {
 			},
 			err: "servers have different OS distributions.*",
 		},
-		// {
-		// 	comment: "no match on bogus input? (identical to previous behavior)",
-		// 	servers: []Server{
-		// 		newServer("node-1", "centos", "greatest release"),
-		// 		newServer("node-2", "centos", "greatest release. more text"),
-		// 	},
-		// 	err: "servers have different OS versions.*",
-		// },
 	}
 	for _, tc := range testCases {
 		comment := check.Commentf(tc.comment)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR loosens the same OS requirement preflight check with the following semantics:

  * OS distributions are the same if both name and versions are exact match
  * OS distributions are compatible (and check succeeds) if name is an exact match and versions match on the prefix up to the first '.'
  * otherwise, OS distributions are not compatible

Also, this has been brought up multiple times (frequently in the form of asking whether it's possible to suppress just the OS check).

## Type of change

* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1112.

## TODOs

- [x] Self-review the change
- [x] Write tests
- [ ] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Unit-tested change.
