### PR TITLE
(6.1) Teleport status checks.

### DIFF
--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -236,6 +236,15 @@ func (b *planBuilder) AddWaitPhase(plan *storage.OperationPlan) {
 				},
 				Requires: []string{WaitPlanetPhase},
 			},
+			{
+				ID:          WaitTeleportPhase,
+				Description: "Wait for the Teleport node to join cluster",
+				Data: &storage.OperationPhaseData{
+					Server:     &b.JoiningNode,
+					ExecServer: &b.JoiningNode,
+				},
+				Requires: []string{WaitPlanetPhase},
+			},
 		},
 	})
 }

--- a/lib/expand/fsmspec.go
+++ b/lib/expand/fsmspec.go
@@ -95,6 +95,10 @@ func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 			return phases.NewWaitK8s(p,
 				config.Operator)
 
+		case strings.HasPrefix(p.Phase.ID, WaitTeleportPhase):
+			return phases.NewWaitTeleport(p,
+				config.Operator)
+
 		case strings.HasPrefix(p.Phase.ID, PostHookPhase):
 			return installphases.NewHook(p,
 				config.Operator,
@@ -126,6 +130,8 @@ const (
 	WaitPlanetPhase = "/wait/planet"
 	// WaitK8sPhase waits for joining node to register with Kubernetes
 	WaitK8sPhase = "/wait/k8s"
+	// WaitTeleportPhase waits for Teleport on the joining node to join the cluster
+	WaitTeleportPhase = "/wait/teleport"
 	// PostHookPhase runs post-expand application hook
 	PostHookPhase = "/postHook"
 	// ElectPhase enables leader election on master node

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -370,6 +370,14 @@ func (s *PlanSuite) verifyWaitPhase(c *check.C, phase storage.OperationPhase) {
 				},
 				Requires: []string{WaitPlanetPhase},
 			},
+			{
+				ID: WaitTeleportPhase,
+				Data: &storage.OperationPhaseData{
+					Server:     &s.joiningNode,
+					ExecServer: &s.joiningNode,
+				},
+				Requires: []string{WaitPlanetPhase},
+			},
 		},
 	}, phase)
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -702,6 +702,19 @@ type Node struct {
 	InstanceType string `json:"instance_type"`
 }
 
+// Nodes is a list of nodes.
+type Nodes []Node
+
+// FindByIP returns node with specified IP or nil.
+func (n Nodes) FindByIP(ip string) *Node {
+	for _, node := range n {
+		if node.AdvertiseIP == ip {
+			return &node
+		}
+	}
+	return nil
+}
+
 // Operations installs and uninstalls gravity on a given site,
 // it takes care of provisioning, configuring and deploying end user application
 // as well as our system packages like planet and teleport

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1402,15 +1402,7 @@ func (o *Operator) GetAppInstaller(req ops.AppInstallerRequest) (io.ReadCloser, 
 
 // GetClusterNodes returns a real-time information about cluster nodes
 func (o *Operator) GetClusterNodes(key ops.SiteKey) ([]ops.Node, error) {
-	remote, err := o.cfg.Tunnel.GetSite(key.SiteDomain)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	client, err := remote.GetClient()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	nodes, err := client.GetNodes(defaults.Namespace)
+	nodes, err := o.backend().GetNodes(defaults.Namespace)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -388,6 +388,11 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgRed).SprintFunc()(probe))
 		}
 	}
+	if node.TeleportNode != nil {
+		fmt.Fprintf(w, "            Remote access:\t%v\n", color.GreenString("online"))
+	} else {
+		fmt.Fprintf(w, "            Remote access:\t%v\n", color.YellowString("offline"))
+	}
 }
 
 func unknownFallback(text string) string {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Forward-port Teleport status checks improvements from https://github.com/gravitational/gravity/pull/1477.

* Check for Teleport node status during join.
* Add remote access status to "gravity status".

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Refs https://github.com/gravitational/gravity/issues/1445
* Ports https://github.com/gravitational/gravity/pull/1477

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Same as in https://github.com/gravitational/gravity/pull/1477.