### PR TITLE
[6.1.x] Separate critical and warning probes

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -675,6 +675,8 @@ const (
 	FailureMark = "×"
 	// InProgressMark is used in CLI to visually indicate progress
 	InProgressMark = "→"
+	// WarnMark is used in CLI to visually indicate a warning
+	WarnMark = "!"
 
 	// WireguardNetworkType is a network type that is used for wireguard/wormhole support
 	WireguardNetworkType = "wireguard"

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -416,6 +416,8 @@ type ClusterServer struct {
 	Status string `json:"status"`
 	// FailedProbes lists all failed probes if the node is not healthy
 	FailedProbes []string `json:"failed_probes,omitempty"`
+	// WarnProbes lists all warning probes
+	WarnProbes []string `json:"warn_probes,omitempty"`
 	// TeleportNode contains information about Teleport node running on this server
 	TeleportNode *ops.Node `json:"teleport_node,omitempty"`
 }
@@ -533,8 +535,13 @@ func fromNodeStatus(node pb.NodeStatus) (status ClusterServer) {
 	}
 	for _, probe := range node.Probes {
 		if probe.Status != pb.Probe_Running {
-			status.FailedProbes = append(status.FailedProbes,
-				probeErrorDetail(*probe))
+			if probe.Severity != pb.Probe_Warning {
+				status.FailedProbes = append(status.FailedProbes,
+					probeErrorDetail(*probe))
+			} else {
+				status.WarnProbes = append(status.WarnProbes,
+					probeErrorDetail(*probe))
+			}
 		}
 	}
 	if len(status.FailedProbes) != 0 {

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -382,10 +382,16 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 		fmt.Fprintf(w, "            Status:\t%v\n", color.YellowString("offline"))
 	case statusapi.NodeHealthy:
 		fmt.Fprintf(w, "            Status:\t%v\n", color.GreenString("healthy"))
+		for _, probe := range node.WarnProbes {
+			fmt.Fprintf(w, "            [%v]\t%v\n", constants.WarnMark, color.New(color.FgYellow).SprintFunc()(probe))
+		}
 	case statusapi.NodeDegraded:
 		fmt.Fprintf(w, "            Status:\t%v\n", color.RedString("degraded"))
 		for _, probe := range node.FailedProbes {
 			fmt.Fprintf(w, "            [%v]\t%v\n", constants.FailureMark, color.New(color.FgRed).SprintFunc()(probe))
+		}
+		for _, probe := range node.WarnProbes {
+			fmt.Fprintf(w, "            [%v]\t%v\n", constants.WarnMark, color.New(color.FgYellow).SprintFunc()(probe))
 		}
 	}
 	if node.TeleportNode != nil {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR modifies `gravity status` to display `Warning` and `Critical` probes separately.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/538

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Changed ipv4 forwarding check to have `Warning` severity and disabled ipv4 forwarding. Then verified that `gravity status` shows failed ipv4 as a warning.
```
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Application:            telekube, version 6.1.26-dev.1
Gravity version:        6.1.26-dev.1 (client) / 6.1.26-dev.1 (server)
[...]
Cluster nodes:
    Masters:
        * node-2 / 172.28.128.102 / node
            Status:     healthy
        * node-3 / 172.28.128.103 / node
            Status:     healthy
        * node-1 / 172.28.128.101 / node
            Status:     degraded
            [!]         ipv4 forwarding is off, see https://www.gravitational.com/docs/faq/#ipv4-forwarding
```