### PR TITLE
(6.3) Remove old roles migration

### DIFF
--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -2037,10 +2036,6 @@ func (p *Process) initAccount() error {
 		}
 	}
 
-	if err := p.fixOpsCenterRoles(*account); err != nil {
-		p.WithError(err).Warn("Failed to migrate Gravity Hub.")
-	}
-
 	return nil
 }
 
@@ -2119,47 +2114,6 @@ func (p *Process) ensureClusterState() error {
 		return trace.Wrap(err)
 	}
 
-	return nil
-}
-
-// fixOpsCenterRoles fixes use case when cert authorities
-// for remote ops center did not have any roles set to them,
-// so user could not SSH into terminal
-func (p *Process) fixOpsCenterRoles(account users.Account) error {
-	clusters, err := p.backend.GetTrustedClusters()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	currentUser, err := user.Current()
-	if err != nil {
-		p.Warningf("Failed to query current user: %v.", trace.ConvertSystemError(err))
-	}
-	p.Debugf("Going to update certificate authorities for %v.", clusters)
-	for _, cluster := range clusters {
-		certAuthority, err := p.backend.GetCertAuthority(teleservices.CertAuthID{
-			Type:       teleservices.UserCA,
-			DomainName: cluster.GetName(),
-		}, true)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if len(certAuthority.GetRoles()) != 0 {
-			p.Debugf("CA %v has assigned roles.", certAuthority.GetClusterName())
-			continue
-		}
-		p.Debugf("Migrating CA %v.", certAuthority.GetClusterName())
-		role := teleservices.RoleForCertAuthority(certAuthority)
-		role.SetLogins(teleservices.Allow, storage.GetAllowedLogins(currentUser))
-		err = p.backend.UpsertRole(role, storage.Forever)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		certAuthority.SetRoles([]string{role.GetName()})
-		err = p.backend.UpsertCertAuthority(certAuthority)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Remove the old "fix roles" migration from the code. This is related to the role_map fix I made yesterday (https://github.com/gravitational/gravity/pull/1504). This migration code updates certificate authorities to insert "roles" if they are not present but similar to trusted clusters fix, it does not account for "role_map" presence which leads to errors like this after gravity-site restart if 

```
2020-05-07T16:22:26Z ERRO [AUTH]      "failed to retrieve client pool: \nERROR REPORT:\nOriginal Error: *trace.BadParameterError should set either &#39;roles&#39; or &#39;role_map&#39;, not both\nStack Trace:\n\t/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services/authority.go:546 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services.(*CertAuthorityV2).Check\n\t/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services/authority.go:561 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services.(*CertAuthorityV2).CheckAndSetDefaults\n\t/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services/authority.go:994 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/services.(*TeleportCertAuthorityMarshaler).UnmarshalCertAuthority\n\t/gopath/src/github.com/gravitational/gravity/lib/storage/keyval/authorities.go:81 github.com/gravitational/gravity/lib/storage/keyval.(*backend).GetCertAuthority\n\t/gopath/src/github.com/gravitational/gravity/lib/users/usersservice/usersservice.go:1661 github.com/gravitational/gravity/lib/users/usersservice.(*UsersService).GetCertAuthority\n\t/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth/auth.go:735 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth.(*AuthServer).ClientCertPool\n\t/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth/middleware.go:141 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth.(*TLSServer).GetConfigForClient\n\t/go/src/crypto/tls/handshake_server.go:146 crypto/tls.(*Conn).readClientHello\n\t/go/src/crypto/tls/handshake_server.go:42 crypto/tls.(*Conn).serverHandshake\n\t/go/src/crypto/tls/conn.go:1345 crypto/tls.(*Conn).Handshake\n\t/go/src/net/http/server.go:1785 net/http.(*conn).serve\n\t/go/src/runtime/asm_amd64.s:1337 runtime.goexit\nUser Message: should set either &#39;roles&#39; or &#39;role_map&#39;, not both" auth/middleware.go:143
```

It would've been easy enough to fix it but I opted to just remove the migration code altogether because it is obsolete - all authorities that should have been migrated, have been by now, so this is a dead weight now.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/pull/1504.
## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Install hub/cluster and connect cluster to a hub via trusted cluster with role_map:

```yaml
kind: trusted_cluster
version: v2
metadata:
  name: hub.gravitational.io
spec:
  enabled: true
  token: ...
  tunnel_addr: "hub.gravitational.io:3024"
  web_proxy_addr: "hub.gravitational.io:32009"
  role_map:
  - remote: "@teleadmin"
    local: ["@teleadmin"]
```

#### Before the change

Restart gravity-site (`kubectl -nkube-system delete pods -lapp=gravity-site`) on the cluster and observe the above errors in the logs and remote tunnel connection is broken.

#### After the change

Restart gravity-site and remote tunnel connection stays intact.