### PR TITLE
Remove container name to avoid collisions on CI

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -694,7 +694,7 @@ $(SELINUX_OUT): | $(GRAVITY_BUILDDIR)
 		git fetch --all && \
 		git checkout $(SELINUX_BRANCH) && \
 		git pull origin $(SELINUX_BRANCH) && git submodule update --init --recursive && \
-		make -C $(BUILDDIR)/selinux && \
+		make -C $(BUILDDIR)/selinux BUILDBOX_INSTANCE= && \
 		tar czf $@ -C $(BUILDDIR)/selinux/output gravity.pp.bz2 container.pp.bz2 gravity.statedir.fc.template; \
 	fi
 

--- a/lib/system/selinux/Makefile
+++ b/lib/system/selinux/Makefile
@@ -1,7 +1,6 @@
 TOP:=$(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 DIR:=$(realpath $(TOP)/../../../)
 OS_RELEASE?=centos
-BUILDBOX_INSTANCE?=gravity-selinux-build
 BUILDBOX?=gravity-selinux-build
 CONTAINER_RUN_ARGS=
 CONTAINER_RUNTIME?=$(shell command -v podman 2> /dev/null || echo docker)
@@ -17,7 +16,6 @@ all: buildbox $(POLICY_OUT)
 $(POLICY_OUT): internal/policy/policy.go $(ASSETSDIR)/container.pp.bz2 $(ASSETSDIR)/gravity.pp.bz2 $(ASSETSDIR)/gravity.statedir.fc.template
 	$(CONTAINER_RUNTIME) run \
 		$(CONTAINER_RUN_ARGS) \
-		--name=$(BUILDBOX_INSTANCE) \
 		--volume $(DIR):/go/src/$(GRAVITY_REPOSITORY) \
 		--rm $(BUILDBOX) \
 		/go/bin/generate


### PR DESCRIPTION
## Description
Remove container name to avoid collisions on CI with multiple jobs executing in parallel.

## Type of change

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback
