### PR TITLE
[7.0.x] remove container name to avoid collisions on CI

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -685,7 +685,7 @@ $(SELINUX_OUT): | $(GRAVITY_BUILDDIR)
 		git fetch --all && \
 		git checkout $(SELINUX_BRANCH) && \
 		git pull origin $(SELINUX_BRANCH) && git submodule update --init --recursive && \
-		make -C $(BUILDDIR)/selinux && \
+		make -C $(BUILDDIR)/selinux BUILDBOX_INSTANCE= && \
 		tar czf $@ -C $(BUILDDIR)/selinux/output gravity.pp.bz2 container.pp.bz2 gravity.statedir.fc.template; \
 	fi
 


### PR DESCRIPTION
## Description
Remove container name to avoid collisions on CI with multiple jobs executing in parallel.
Backport of https://github.com/gravitational/gravity/pull/1517.

## Type of change

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback
