### PR TITLE
Collect status history in gravity report

### DIFF
--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/archive"
@@ -380,8 +379,4 @@ const (
 	// opLogsFilename defines the file pattern that stores operation log for a particular
 	// cluster operation
 	opLogsFilename = "%v.%v"
-	// statusHistoryFilename is the name of the file that stores the status history output
-	statusHistoryFilename = "status-history"
-	// timelineTimeout is maximum amount of time to wait for timeline response
-	timelineTimeout = 10 * time.Second
 )

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -48,6 +48,8 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
+		case FilterTimeline:
+			collectors = append(collectors, NewTimelineCollector())
 		}
 	}
 
@@ -111,7 +113,10 @@ const (
 
 	// FilterEtcd defines a report collection filter to fetch etcd data
 	FilterEtcd = "etcd"
+
+	// FilterTimeline defines a report collection filter to fetch the status timeline
+	FilterTimeline = "timeline"
 )
 
 // AllFilters lists all available collector filters
-var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd}
+var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd, FilterTimeline}

--- a/lib/report/timeline.go
+++ b/lib/report/timeline.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"context"
+	"io"
+
+	statusapi "github.com/gravitational/gravity/lib/status"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// NewTimelineCollector returns a new timeline collector.
+func NewTimelineCollector() *TimelineCollector {
+	return &TimelineCollector{}
+}
+
+// Collect collects the cluster status timeline.
+func (r TimelineCollector) Collect(ctx context.Context, reportWriter FileWriter, runner utils.CommandRunner) error {
+	w, err := reportWriter.NewWriter(timelineFilename)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	return trace.Wrap(collectTimeline(ctx, w))
+}
+
+// collectTimeline collects the cluster status timeline and writes to the
+// provided writer.
+func collectTimeline(ctx context.Context, w io.Writer) error {
+	resp, err := statusapi.Timeline(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, event := range resp.GetEvents() {
+		statusapi.PrintEvent(w, event)
+	}
+	return nil
+}
+
+// TimelineCollector collects the cluster status timeline.
+type TimelineCollector struct{}
+
+const (
+	// timelineFilename is the name of the file that stores the status timeline output
+	timelineFilename = "timeline"
+)

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -79,7 +79,7 @@ func PrintEvent(w io.Writer, event *pb.TimelineEvent) {
 		fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tprev=%s\tnew=%s",
 			timestamp, e.GetPrev(), e.GetNew()))
 	default:
-		fmt.Fprintln(w, color.YellowString("%s Unknown event", timestamp))
+		fmt.Fprintln(w, color.YellowString("%s [Unknown Event]\t%s", timestamp, event))
 		log.WithField("event", event).Warn("Received unknown event type.")
 	}
 }

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -18,9 +18,13 @@ package status
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"time"
 
 	"github.com/gravitational/gravity/lib/httplib"
 
+	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -38,4 +42,44 @@ func Timeline(ctx context.Context) (*pb.TimelineResponse, error) {
 		}
 	}()
 	return client.Timeline(ctx, &pb.TimelineRequest{})
+}
+
+// PrintEvent prints the event to the provided writer.
+func PrintEvent(w io.Writer, event *pb.TimelineEvent) {
+	timestamp := event.GetTimestamp().ToTime().Format(time.RFC3339)
+	switch event.GetData().(type) {
+	case *pb.TimelineEvent_ClusterDegraded:
+		fmt.Fprintln(w, color.RedString("%s [Cluster Degraded]",
+			timestamp))
+	case *pb.TimelineEvent_ClusterHealthy:
+		fmt.Fprintln(w, color.GreenString("%s [Cluster Healthy]",
+			timestamp))
+	case *pb.TimelineEvent_NodeAdded:
+		fmt.Fprintln(w, color.YellowString("%s [Node Added]\tnode=%s",
+			timestamp, event.GetNodeAdded().GetNode()))
+	case *pb.TimelineEvent_NodeRemoved:
+		fmt.Fprintln(w, color.YellowString("%s [Node Removed]\tnode=%s",
+			timestamp, event.GetNodeRemoved().GetNode()))
+	case *pb.TimelineEvent_NodeDegraded:
+		fmt.Fprintln(w, color.RedString("%s [Node Degraded]\tnode=%s",
+			timestamp, event.GetNodeDegraded().GetNode()))
+	case *pb.TimelineEvent_NodeHealthy:
+		fmt.Fprintln(w, color.GreenString("%s [Node Healthy]\tnode=%s",
+			timestamp, event.GetNodeHealthy().GetNode()))
+	case *pb.TimelineEvent_ProbeFailed:
+		e := event.GetProbeFailed()
+		fmt.Fprintln(w, color.RedString("%s [Probe Failed]\tnode=%s\tchecker=%s",
+			timestamp, e.GetNode(), e.GetProbe()))
+	case *pb.TimelineEvent_ProbeSucceeded:
+		e := event.GetProbeSucceeded()
+		fmt.Fprintln(w, color.GreenString("%s [Probe Succeeded]\tnode=%s\tchecker=%s",
+			timestamp, e.GetNode(), e.GetProbe()))
+	case *pb.TimelineEvent_LeaderElected:
+		e := event.GetLeaderElected()
+		fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tprev=%s\tnew=%s",
+			timestamp, e.GetPrev(), e.GetNew()))
+	default:
+		fmt.Fprintln(w, color.YellowString("%s Unknown event", timestamp))
+		log.WithField("event", event).Warn("Received unknown event type.")
+	}
 }

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -76,8 +76,13 @@ func PrintEvent(w io.Writer, event *pb.TimelineEvent) {
 			timestamp, e.GetNode(), e.GetProbe()))
 	case *pb.TimelineEvent_LeaderElected:
 		e := event.GetLeaderElected()
-		fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tprev=%s\tnew=%s",
-			timestamp, e.GetPrev(), e.GetNew()))
+		if e.GetPrev() == "" {
+			fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tnew leader %s",
+				timestamp, e.GetNew()))
+		} else {
+			fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tleader changed %s -> %s",
+				timestamp, e.GetPrev(), e.GetNew()))
+		}
 	default:
 		fmt.Fprintln(w, color.YellowString("%s [Unknown Event]\t%s", timestamp, event))
 		log.WithField("event", event).Warn("Received unknown event type.")

--- a/tool/gravity/cli/history.go
+++ b/tool/gravity/cli/history.go
@@ -19,15 +19,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"text/tabwriter"
-	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	statusapi "github.com/gravitational/gravity/lib/status"
 
-	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 )
@@ -53,47 +50,7 @@ func printEvents(events []*pb.TimelineEvent) error {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 	for _, event := range events {
-		printEvent(w, event)
+		statusapi.PrintEvent(w, event)
 	}
 	return w.Flush()
-}
-
-func printEvent(w io.Writer, event *pb.TimelineEvent) {
-	timestamp := event.GetTimestamp().ToTime().Format(time.RFC3339)
-	switch event.GetData().(type) {
-	case *pb.TimelineEvent_ClusterDegraded:
-		fmt.Fprintln(w, color.RedString("%s [Cluster Degraded]",
-			timestamp))
-	case *pb.TimelineEvent_ClusterHealthy:
-		fmt.Fprintln(w, color.GreenString("%s [Cluster Healthy]",
-			timestamp))
-	case *pb.TimelineEvent_NodeAdded:
-		fmt.Fprintln(w, color.YellowString("%s [Node Added]\tnode=%s",
-			timestamp, event.GetNodeAdded().GetNode()))
-	case *pb.TimelineEvent_NodeRemoved:
-		fmt.Fprintln(w, color.YellowString("%s [Node Removed]\tnode=%s",
-			timestamp, event.GetNodeRemoved().GetNode()))
-	case *pb.TimelineEvent_NodeDegraded:
-		fmt.Fprintln(w, color.RedString("%s [Node Degraded]\tnode=%s",
-			timestamp, event.GetNodeDegraded().GetNode()))
-	case *pb.TimelineEvent_NodeHealthy:
-		fmt.Fprintln(w, color.GreenString("%s [Node Healthy]\tnode=%s",
-			timestamp, event.GetNodeHealthy().GetNode()))
-	case *pb.TimelineEvent_ProbeFailed:
-		e := event.GetProbeFailed()
-		fmt.Fprintln(w, color.RedString("%s [Probe Failed]\tnode=%s\tchecker=%s",
-			timestamp, e.GetNode(), e.GetProbe()))
-	case *pb.TimelineEvent_ProbeSucceeded:
-		e := event.GetProbeSucceeded()
-		fmt.Fprintln(w, color.GreenString("%s [Probe Succeeded]\tnode=%s\tchecker=%s",
-			timestamp, e.GetNode(), e.GetProbe()))
-	case *pb.TimelineEvent_LeaderElected:
-		e := event.GetLeaderElected()
-		fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tprev=%s\tnew=%s",
-			timestamp, e.GetPrev(), e.GetNew()))
-
-	default:
-		fmt.Fprintln(w, color.YellowString("%s Unknown event", timestamp))
-		log.WithField("event", event).Warn("Received unknown event type.")
-	}
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Modifies the `gravity report` command to include the status history in the debug report.
- Edits output of leader elected events.
- Unknown events dump entire struct.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1516


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify `gravity status history` still functions the same.**
```
2020-05-11T18:17:35Z [Leader Elected]   new leader 172.28.128.102
2020-05-11T18:17:38Z [Leader Elected]   leader changed 172.28.128.102 -> 172.28.128.102
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_103.dev.test
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_102.dev.test
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_101.dev.test
[...]
```
**Verify `gravity report` now includes status history and contents are correct.**
```
[vagrant@node-1 ~]$ sudo gravity report
report for cluster(name=dev.test) exported to report.tar.gz

[vagrant@node-1 ~]$ tar xf report.tar.gz
[vagrant@node-1 ~]$ ls
node-1-debug-logs.tar.gz  node-2-etcd-backup.json.tar.gz  node-2-k8s-logs.tar.gz  node-2-status.tar.gz  node-3-debug-logs.tar.gz  report.tar.gz  site.json

[vagrant@node-1 ~]$ tar xf node-2-status.tar.gz
[vagrant@node-1 ~]$ ls
node-1-debug-logs.tar.gz  node-2-etcd-backup.json.tar.gz  node-2-k8s-logs.tar.gz  node-2-status.tar.gz  node-3-debug-logs.tar.gz  report.tar.gz  site.json  timeline

[vagrant@node-1 ~]$ cat timeline
2020-05-11T18:17:35Z [Leader Elected]   new leader 172.28.128.102
2020-05-11T18:17:38Z [Leader Elected]   leader changed 172.28.128.102 -> 172.28.128.102
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_103.dev.test
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_102.dev.test
2020-05-11T18:18:02Z [Node Degraded]    node=172_28_128_101.dev.test
[...]
```
