### PR TITLE
[6.3.x] upgrade/resume backport

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -854,7 +854,12 @@ func (p *Peer) tryConnect(operationID string) (ctx *operationContext, err error)
 			return nil, utils.Abort(err)
 		}
 		if trace.IsCompareFailed(err) {
-			p.printStep("Waiting for another operation to finish at %v", addr)
+			p.Warnf("Waiting for precondition to create expand operation: %v.", err)
+			if utils.IsClusterDegradedError(err) {
+				p.printStep("Cluster is degraded, waiting for it to become healthy")
+			} else {
+				p.printStep("Waiting for another operation to complete at %v", addr)
+			}
 		}
 	}
 	return ctx, trace.Wrap(err)

--- a/lib/install/client/resume.go
+++ b/lib/install/client/resume.go
@@ -61,8 +61,8 @@ func (r *ResumeStrategy) checkAndSetDefaults() (err error) {
 		r.ServicePath, err = environ.GetServicePath(stateDir)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return trace.Wrap(err,
-					"failed to find installer service. Start the installation with 'gravity install'")
+				return trace.Wrap(err, "failed to find installer service. "+
+					"Use 'gravity install' to start new installation or 'gravity join' to join an existing cluster.")
 			}
 			return trace.Wrap(err)
 		}

--- a/lib/ops/opsservice/operationgroup.go
+++ b/lib/ops/opsservice/operationgroup.go
@@ -168,8 +168,11 @@ func (g *operationGroup) canCreateExpandOperation(site ops.Site, operation ops.S
 	}
 
 	// cluster is not active, but there are no expand operations so there is either
-	// other type of operation is in progress, or it's degraded
+	// other type of operation in progress, or it's degraded
 	if len(operations) == 0 {
+		if site.State == ops.SiteStateDegraded {
+			return utils.ClusterDegradedError{}
+		}
 		return trace.CompareFailed("cannot expand %v cluster", site.State)
 	}
 

--- a/lib/system/environ/validate.go
+++ b/lib/system/environ/validate.go
@@ -70,7 +70,7 @@ func ValidateInstall(env *localenv.LocalEnvironment) func() error {
 				"(see https://gravitational.com/gravity/docs/cluster/#deleting-a-cluster for more details)",
 				stateDir)
 		}
-		if err := validateNoPackageState(env.Packages, env.StateDir); err != nil {
+		if err := ValidateNoPackageState(env.Packages, env.StateDir); err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
@@ -126,7 +126,9 @@ func validateNoActiveService(stateDir string) error {
 	}
 }
 
-func validateNoPackageState(packages pack.PackageService, stateDir string) error {
+// ValidateNoPackageState checks whether the specified package service
+// has state (i.e. has packages) and returns an error in this case.
+func ValidateNoPackageState(packages pack.PackageService, stateDir string) error {
 	// make sure that there are no packages in the local state left from
 	// some improperly cleaned up installation
 	installedPackages, err := packages.GetPackages(defaults.SystemAccountOrg)

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -420,10 +420,34 @@ func WrapExitCodeError(exitCode int, err error) error {
 	}
 }
 
+// IsCompareFailedError returns true to indicate this error
+// complies with compare failed error protocol
+func (ClusterDegradedError) IsCompareFailedError() bool {
+	return true
+}
+
+// Error returns the text representation of this error
+func (ClusterDegradedError) Error() string {
+	return "cluster is degraded"
+}
+
+// ClusterDegradedError indicates that the cluster is degraded
+type ClusterDegradedError struct{}
+
 // ExitCode interprets this value as exit code.
 // Implements ExitCodeError
 func (r exitCodeError) ExitCode() int {
 	return r.code
+}
+
+// IsClusterDegradedError determines if the error indicates that
+// the cluster is degraded
+func IsClusterDegradedError(err error) bool {
+	if _, ok := trace.Unwrap(err).(ClusterDegradedError); ok {
+		return true
+	}
+	// Handle the case when the error has come over the wire
+	return strings.Contains(err.Error(), "cluster is degraded")
 }
 
 // Error returns this exit code as error string.

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -83,7 +83,7 @@ func newConfigUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEn
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func executeConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -98,7 +98,7 @@ func executeConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	return trace.Wrap(err)
 }
 
-func setConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
+func setConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -112,7 +112,7 @@ func setConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFact
 	return updater.SetPhase(context.TODO(), params.PhaseID, params.State)
 }
 
-func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -127,7 +127,7 @@ func rollbackConfigPhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
-func completeConfigPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+func completeConfigPlanForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -96,7 +96,21 @@ func newClusterUpdater(
 	return updater, nil
 }
 
-func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
+	operation, err := getActiveOperation(env, environ, params.OperationID)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound("no active update operation found")
+		}
+		return trace.Wrap(err)
+	}
+	if operation.Type != ops.OperationUpdate {
+		return trace.NotFound("no active update operation found")
+	}
+	return executeUpdatePhaseForOperation(env, environ, params, operation.SiteOperation)
+}
+
+func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -111,7 +125,7 @@ func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	return trace.Wrap(err)
 }
 
-func rollbackUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -126,7 +140,7 @@ func rollbackUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
-func setUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
+func setUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,7 +154,7 @@ func setUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFact
 	return updater.SetPhase(context.TODO(), params.PhaseID, params.State)
 }
 
-func completeUpdatePlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+func completeUpdatePlanForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -72,7 +72,7 @@ func newEnvironUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalE
 	return newUpdater(ctx, localEnv, updateEnv, init)
 }
 
-func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func executeEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -87,7 +87,7 @@ func executeEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmen
 	return trace.Wrap(err)
 }
 
-func setEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
+func setEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -101,7 +101,7 @@ func setEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFac
 	return updater.SetPhase(context.TODO(), params.PhaseID, params.State)
 }
 
-func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)
@@ -116,7 +116,7 @@ func rollbackEnvironPhase(env *localenv.LocalEnvironment, environ LocalEnvironme
 	return trace.Wrap(err)
 }
 
-func completeEnvironPlan(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
+func completeEnvironPlanForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operation ops.SiteOperation) error {
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -254,7 +254,7 @@ func getGarbageCollector(env *localenv.LocalEnvironment, operation ops.SiteOpera
 	})
 }
 
-func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeGarbageCollectPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	collector, err := getGarbageCollector(env, operation)
 	if err != nil {
 		return trace.Wrap(err)
@@ -262,7 +262,7 @@ func executeGarbageCollectPhase(env *localenv.LocalEnvironment, params PhasePara
 	return collector.RunPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
 }
 
-func setGarbageCollectPhase(env *localenv.LocalEnvironment, params SetPhaseParams, operation ops.SiteOperation) error {
+func setGarbageCollectPhaseForOperation(env *localenv.LocalEnvironment, params SetPhaseParams, operation ops.SiteOperation) error {
 	collector, err := getGarbageCollector(env, operation)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -518,32 +518,32 @@ func agent(env *localenv.LocalEnvironment, config agentConfig) error {
 	return trace.Wrap(agent.Serve())
 }
 
-func executeInstallPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeInstallPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	return trace.Wrap(executePhaseFromService(
 		env, params, operation, "Connecting to installer", "Connected to installer"))
 }
 
-func rollbackInstallPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackInstallPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	return trace.Wrap(rollbackPhaseFromService(
 		env, params, operation, "Connecting to installer", "Connected to installer"))
 }
 
-func completeInstallPlan(env *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeInstallPlanForOperation(env *localenv.LocalEnvironment, operation ops.SiteOperation) error {
 	return trace.Wrap(completePlanFromService(
 		env, operation, "Connecting to installer", "Connected to installer"))
 }
 
-func executeJoinPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func executeJoinPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	return trace.Wrap(executePhaseFromService(
 		env, params, operation, "Connecting to agent", "Connected to agent"))
 }
 
-func rollbackJoinPhase(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
+func rollbackJoinPhaseForOperation(env *localenv.LocalEnvironment, params PhaseParams, operation ops.SiteOperation) error {
 	return trace.Wrap(rollbackPhaseFromService(
 		env, params, operation, "Connecting to agent", "Connected to agent"))
 }
 
-func completeJoinPlan(env *localenv.LocalEnvironment, operation ops.SiteOperation) error {
+func completeJoinPlanForOperation(env *localenv.LocalEnvironment, operation ops.SiteOperation) error {
 	err := completePlanFromService(
 		env, operation, "Connecting to agent", "Connected to agent")
 	if err == nil {

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	installerclient "github.com/gravitational/gravity/lib/install/client"
@@ -31,9 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/system/signals"
-	"github.com/gravitational/gravity/tool/common"
 
-	"github.com/buger/goterm"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -83,34 +80,35 @@ func resumeOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironme
 	if !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
+	if opErr, ok := trace.Unwrap(err).(operationNotFound); ok {
+		if opErr.existing {
+			return trace.Wrap(opErr)
+		}
+	}
 	log.WithError(err).Warn("No operation found - will attempt to restart installation (resume join).")
 	return trace.Wrap(restartInstallOrJoin(localEnv))
 }
 
 // executePhase executes a phase for the operation specified with params
 func executePhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
-	operations, err := getActiveOperations(localEnv, environ, params.OperationID)
+	operation, err := getActiveOperation(localEnv, environ, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(operations) != 1 {
-		log.WithField("operations", oplist(operations)).Warn("Multiple operations found.")
-		return trace.BadParameter("multiple operations found. Please specify operation with --operation-id")
-	}
-	op := operations[0]
+	op := operation.SiteOperation
 	switch op.Type {
 	case ops.OperationInstall:
-		return executeInstallPhase(localEnv, params, op)
+		return executeInstallPhaseForOperation(localEnv, params, op)
 	case ops.OperationExpand:
-		return executeJoinPhase(localEnv, params, op)
+		return executeJoinPhaseForOperation(localEnv, params, op)
 	case ops.OperationUpdate:
-		return executeUpdatePhase(localEnv, environ, params, op)
+		return executeUpdatePhaseForOperation(localEnv, environ, params, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		return executeEnvironPhase(localEnv, environ, params, op)
+		return executeEnvironPhaseForOperation(localEnv, environ, params, op)
 	case ops.OperationUpdateConfig:
-		return executeConfigPhase(localEnv, environ, params, op)
+		return executeConfigPhaseForOperation(localEnv, environ, params, op)
 	case ops.OperationGarbageCollect:
-		return executeGarbageCollectPhase(localEnv, params, op)
+		return executeGarbageCollectPhaseForOperation(localEnv, params, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan execution", op.Type)
 	}
@@ -118,26 +116,22 @@ func executePhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 
 // setPhase sets the specified phase state without executing it.
 func setPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params SetPhaseParams) error {
-	operations, err := getActiveOperations(env, environ, params.OperationID)
+	operation, err := getActiveOperation(env, environ, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(operations) != 1 {
-		log.WithField("operations", oplist(operations)).Warn("Multiple operations found.")
-		return trace.BadParameter("multiple operations found. Please specify operation with --operation-id")
-	}
-	op := operations[0]
+	op := operation.SiteOperation
 	switch op.Type {
 	case ops.OperationInstall, ops.OperationExpand:
 		err = setPhaseFromService(env, params, op)
 	case ops.OperationUpdate:
-		err = setUpdatePhase(env, environ, params, op)
+		err = setUpdatePhaseForOperation(env, environ, params, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		err = setEnvironPhase(env, environ, params, op)
+		err = setEnvironPhaseForOperation(env, environ, params, op)
 	case ops.OperationUpdateConfig:
-		err = setConfigPhase(env, environ, params, op)
+		err = setConfigPhaseForOperation(env, environ, params, op)
 	case ops.OperationGarbageCollect:
-		err = setGarbageCollectPhase(env, params, op)
+		err = setGarbageCollectPhaseForOperation(env, params, op)
 	default:
 		return trace.BadParameter("operation type %q does not support setting phase state", op.Type)
 	}
@@ -150,52 +144,44 @@ func setPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p
 
 // rollbackPhase rolls back a phase for the operation specified with params
 func rollbackPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
-	operations, err := getActiveOperations(localEnv, environ, params.OperationID)
+	operation, err := getActiveOperation(localEnv, environ, params.OperationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(operations) != 1 {
-		log.WithField("operations", oplist(operations)).Warn("Multiple operations found.")
-		return trace.BadParameter("multiple operations found. Please specify operation with --operation-id")
-	}
-	op := operations[0]
+	op := operation.SiteOperation
 	switch op.Type {
 	case ops.OperationInstall:
-		return rollbackInstallPhase(localEnv, params, op)
+		return rollbackInstallPhaseForOperation(localEnv, params, op)
 	case ops.OperationExpand:
-		return rollbackJoinPhase(localEnv, params, op)
+		return rollbackJoinPhaseForOperation(localEnv, params, op)
 	case ops.OperationUpdate:
-		return rollbackUpdatePhase(localEnv, environ, params, op)
+		return rollbackUpdatePhaseForOperation(localEnv, environ, params, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		return rollbackEnvironPhase(localEnv, environ, params, op)
+		return rollbackEnvironPhaseForOperation(localEnv, environ, params, op)
 	case ops.OperationUpdateConfig:
-		return rollbackConfigPhase(localEnv, environ, params, op)
+		return rollbackConfigPhaseForOperation(localEnv, environ, params, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan rollback", op.Type)
 	}
 }
 
 func completeOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) error {
-	operations, err := getActiveOperations(localEnv, environ, operationID)
+	operation, err := getActiveOperation(localEnv, environ, operationID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(operations) != 1 {
-		log.WithField("operations", oplist(operations)).Warn("Multiple operations found.")
-		return trace.BadParameter("multiple operations found. Please specify operation with --operation-id")
-	}
-	op := operations[0]
+	op := operation.SiteOperation
 	switch op.Type {
 	case ops.OperationInstall:
-		err = completeInstallPlan(localEnv, op)
+		err = completeInstallPlanForOperation(localEnv, op)
 	case ops.OperationExpand:
-		err = completeJoinPlan(localEnv, op)
+		err = completeJoinPlanForOperation(localEnv, op)
 	case ops.OperationUpdate:
-		err = completeUpdatePlan(localEnv, environ, op)
+		err = completeUpdatePlanForOperation(localEnv, environ, op)
 	case ops.OperationUpdateRuntimeEnviron:
-		err = completeEnvironPlan(localEnv, environ, op)
+		err = completeEnvironPlanForOperation(localEnv, environ, op)
 	case ops.OperationUpdateConfig:
-		err = completeConfigPlan(localEnv, environ, op)
+		err = completeConfigPlanForOperation(localEnv, environ, op)
 	default:
 		return trace.BadParameter("operation type %q does not support plan completion", op.Type)
 	}
@@ -221,58 +207,41 @@ func completeClusterOperationPlan(localEnv *localenv.LocalEnvironment, operation
 	return ops.FailOperation(context.TODO(), operation.Key(), clusterEnv.Operator, "completed manually")
 }
 
-func getLastOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) ([]ops.SiteOperation, error) {
+// getLastOperation returns the last operation found across the specified backends.
+// If no operation is found, the returned error will indicate a not found operation
+func getLastOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (*clusterOperation, error) {
 	operations, err := getBackendOperations(localEnv, environ, operationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.WithField("operations", oplist(operations).String()).Debug("Fetched backend operations.")
+	log.WithField("operations", operationList(operations).String()).Debug("Fetched backend operations.")
 	if len(operations) == 0 {
 		if operationID != "" {
-			return nil, trace.NotFound("no operation with ID %v found", operationID)
+			return nil, newOperationNotFound("no operation with ID %v found", operationID)
 		}
-		return nil, trace.NotFound("no operation found")
-	}
-	return operations, nil
-}
-
-func getActiveOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (*ops.SiteOperation, error) {
-	operations, err := getActiveOperations(localEnv, environ, operationID)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if len(operations) != 1 {
-		log.WithField("operations", oplist(operations)).Warn("Multiple operations found.")
-		return nil, trace.BadParameter("multiple operations found. Please specify operation with --operation-id")
+		return nil, newOperationNotFound("no operation found")
 	}
 	return &operations[0], nil
 }
 
-func getActiveOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) ([]ops.SiteOperation, error) {
-	operations, err := getBackendOperations(localEnv, environ, operationID)
+func getActiveOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (*clusterOperation, error) {
+	operation, err := getLastOperation(localEnv, environ, operationID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.WithField("operations", oplist(operations).String()).Debug("Fetched backend operations.")
-	if len(operations) == 0 {
-		if operationID != "" {
-			return nil, trace.NotFound("no operation with ID %v found", operationID)
-		}
-		return nil, trace.NotFound("no operation found")
+	if operation.IsCompleted() {
+		return nil, operationNotFound{message: "no active operation found", existing: true}
 	}
-	return getActiveOperationsFromList(operations)
+	return operation, nil
 }
 
 // getBackendOperations returns the list of operation from the specified backends
 // in descending order (sorted by creation time)
-func getBackendOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (result []ops.SiteOperation, err error) {
+func getBackendOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string) (result []clusterOperation, err error) {
 	b := newBackendOperations()
-	err = b.List(localEnv, environ)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	b.List(localEnv, environ)
 	for _, op := range b.operations {
-		if operationID == "" || operationID == op.ID {
+		if (operationID == "" || operationID == op.ID) && op.hasPlan {
 			result = append(result, op)
 		}
 	}
@@ -284,11 +253,11 @@ func getBackendOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 
 func newBackendOperations() backendOperations {
 	return backendOperations{
-		operations: make(map[string]ops.SiteOperation),
+		operations: make(map[string]clusterOperation),
 	}
 }
 
-func (r *backendOperations) List(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory) error {
+func (r *backendOperations) List(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory) {
 	clusterEnv, err := localEnv.NewClusterEnvironment(localenv.WithEtcdTimeout(1 * time.Second))
 	if err != nil {
 		log.WithError(err).Debug("Failed to create cluster environment.")
@@ -299,6 +268,11 @@ func (r *backendOperations) List(localEnv *localenv.LocalEnvironment, environ Lo
 			log.WithError(err).Debug("Failed to query cluster operations.")
 		}
 	}
+	if environ == nil {
+		return
+	}
+	// List operation from a local state store.
+	// This is required in cases when the cluster store is inaccessible (like during upgrades)
 	if err := r.listUpdateOperation(environ); err != nil && !trace.IsNotFound(err) {
 		log.WithError(err).Warn("Failed to list update operation.")
 	}
@@ -308,11 +282,10 @@ func (r *backendOperations) List(localEnv *localenv.LocalEnvironment, environ Lo
 	// Only fetch operation from remote (install) environment if the install operation is ongoing
 	// or we failed to fetch the operation details from the cluster
 	if r.isActiveInstallOperation() {
-		if err := r.listInstallOperation(); err != nil {
-			return trace.Wrap(err)
+		if r.listInstallOperation(); err != nil {
+			log.WithError(err).Warn("Failed to list install operation.")
 		}
 	}
-	return nil
 }
 
 func (r *backendOperations) init(clusterBackend storage.Backend) error {
@@ -323,24 +296,28 @@ func (r *backendOperations) init(clusterBackend storage.Backend) error {
 	if len(clusterOperations) == 0 {
 		return nil
 	}
-	// Initialize the operation state from the list of existing cluster operations
+	// Initialize the operation state from the list of existing cluster operations.
+	// operationsByType groups the operations by type to avoid looking at multiple operations
+	// of the same type as we are only interested in the latest operation
+	operationsByType := make(map[string]clusterOperation)
 	for _, op := range clusterOperations {
-		r.operations[op.ID] = (ops.SiteOperation)(op)
+		if _, exists := operationsByType[op.Type]; exists {
+			continue
+		}
+		clusterOperation := clusterOperation{
+			SiteOperation: (ops.SiteOperation)(op),
+		}
+		if _, err := clusterBackend.GetOperationPlan(op.SiteDomain, op.ID); err == nil {
+			clusterOperation.hasPlan = true
+		}
+		operationsByType[op.Type] = clusterOperation
 	}
-	r.clusterOperation = (*ops.SiteOperation)(&clusterOperations[0])
-	r.operations[r.clusterOperation.ID] = *r.clusterOperation
+	for _, op := range operationsByType {
+		r.operations[op.ID] = op
+	}
+	latestOperation := r.operations[clusterOperations[0].ID]
+	r.clusterOperation = &latestOperation
 	return nil
-}
-
-func (r *backendOperations) getOperationAndUpdateCache(getter operationGetter, logger logrus.FieldLogger) *ops.SiteOperation {
-	op, err := getter.getOperation()
-	if err == nil {
-		// Operation from the backend takes precedence over the existing operation (from cluster state)
-		r.operations[op.ID] = (ops.SiteOperation)(*op)
-	} else if !trace.IsNotFound(err) {
-		logger.WithError(err).Warn("Failed to query operation.")
-	}
-	return (*ops.SiteOperation)(op)
 }
 
 func (r *backendOperations) listUpdateOperation(environ LocalEnvironmentFactory) error {
@@ -349,7 +326,7 @@ func (r *backendOperations) listUpdateOperation(environ LocalEnvironmentFactory)
 		return trace.Wrap(err)
 	}
 	defer env.Close()
-	r.getOperationAndUpdateCache(getOperationFromBackend(env.Backend),
+	r.updateOperationInCache(getOperationFromBackend(env.Backend),
 		log.WithField("context", "update"))
 	return nil
 }
@@ -366,7 +343,7 @@ func (r *backendOperations) listJoinOperation(environ LocalEnvironmentFactory) e
 		return nil
 	}
 	defer env.Close()
-	r.getOperationAndUpdateCache(getOperationFromBackend(env.Backend),
+	r.updateOperationInCache(getOperationFromBackend(env.Backend),
 		log.WithField("context", "expand"))
 	return nil
 }
@@ -380,7 +357,7 @@ func (r *backendOperations) listInstallOperation() error {
 		cluster, err := getLocalClusterFromOperator(wizardEnv.Operator)
 		if err == nil {
 			log.Info("Fetching operation from wizard.")
-			r.getOperationAndUpdateCache(getOperationFromOperator(wizardEnv.Operator, cluster.Key()),
+			r.updateOperationInCache(getOperationFromOperator(wizardEnv.Operator, cluster.Key()),
 				log.WithField("context", "install"))
 			return nil
 		}
@@ -391,6 +368,24 @@ func (r *backendOperations) listInstallOperation() error {
 		log.WithError(err).Warn("Failed to connect to wizard.")
 	}
 	return trace.NotFound("no operation found")
+}
+
+func (r *backendOperations) updateOperationInCache(getter operationGetter, logger logrus.FieldLogger) {
+	op, err := getter.getLastOperation()
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			logger.WithError(err).Warn("Failed to query operation.")
+		}
+		return
+	}
+	clusterOperation := clusterOperation{
+		SiteOperation: (ops.SiteOperation)(*op),
+	}
+	if _, err := getter.getOperationPlan(op.Key()); err == nil {
+		clusterOperation.hasPlan = true
+	}
+	// Operation from the backend takes precedence over the existing operation (from cluster state)
+	r.operations[op.ID] = clusterOperation
 }
 
 func (r backendOperations) isActiveInstallOperation() bool {
@@ -410,38 +405,17 @@ func (r backendOperations) isActiveInstallOperation() bool {
 }
 
 type backendOperations struct {
-	operations       map[string]ops.SiteOperation
-	clusterOperation *ops.SiteOperation
+	// operations lists currently detected operations.
+	// Operations are queried over a variety of backends due to disparity of state storage
+	// locations (including cluster state store).
+	// Operations found outside the cluster state store (etcd) are considered to be
+	// more up-to-date and take precedence.
+	operations map[string]clusterOperation
+	// clusterOperation stores the first operation found in cluster state store (if any)
+	clusterOperation *clusterOperation
 }
 
-func getActiveOperationsFromList(operations []ops.SiteOperation) (result []ops.SiteOperation, err error) {
-	for _, op := range operations {
-		if !op.IsCompleted() {
-			result = append(result, op)
-		}
-	}
-	if len(result) == 0 {
-		return nil, trace.NotFound("no active operations found")
-	}
-	return result, nil
-}
-
-func isActiveOperation(op ops.SiteOperation) bool {
-	return op.IsFailed() || !op.IsCompleted()
-}
-
-// formatTable formats this operation list as a table
-func (r oplist) formatTable() string {
-	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	common.PrintTableHeader(t, []string{"Type", "ID", "State", "Created"})
-	for _, op := range r {
-		fmt.Fprintf(t, "%v\t%v\t%v\t%v\n",
-			op.Type, op.ID, op.State, op.Created.Format(constants.ShortDateFormat))
-	}
-	return t.String()
-}
-
-func (r oplist) String() string {
+func (r operationList) String() string {
 	var ops []string
 	for _, op := range r {
 		ops = append(ops, op.String())
@@ -449,62 +423,70 @@ func (r oplist) String() string {
 	return strings.Join(ops, "\n")
 }
 
-type oplist []ops.SiteOperation
+type operationList []clusterOperation
+
+type clusterOperation struct {
+	ops.SiteOperation
+	hasPlan bool
+}
 
 func getOperationFromOperator(operator ops.Operator, clusterKey ops.SiteKey) operationGetter {
-	return operationGetterFunc(func() (*ops.SiteOperation, error) {
-		op, _, err := ops.GetLastOperation(clusterKey, operator)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return op, nil
-	})
+	return operatorGetter{
+		operator:   operator,
+		clusterKey: clusterKey,
+	}
 }
 
-func getOperationFromBackend(backend storage.Backend) operationGetter {
-	return operationGetterFunc(func() (*ops.SiteOperation, error) {
-		op, err := storage.GetLastOperation(backend)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return (*ops.SiteOperation)(op), nil
-	})
-}
-
-func getOperationFromWizardBackend(backend storage.Backend) operationGetter {
-	return operationGetterFunc(func() (*ops.SiteOperation, error) {
-		cluster, err := getLocalClusterFromBackend(backend)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		op, err := storage.GetLastOperationForCluster(backend, cluster.Domain)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return (*ops.SiteOperation)(op), nil
-	})
-}
-
-func getLocalClusterFromBackend(backend storage.Backend) (cluster *storage.Site, err error) {
-	// TODO(dmitri): when cluster is created by the wizard, it is not local
-	// so resort to look up
-	clusters, err := backend.GetSites(defaults.SystemAccountID)
+func (r operatorGetter) getLastOperation() (*ops.SiteOperation, error) {
+	op, _, err := ops.GetLastOperation(r.clusterKey, r.operator)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.WithField("clusters", clusters).Info("Fetched clusters from wizard backend.")
-	if len(clusters) == 0 {
-		return nil, trace.NotFound("no clusters found")
+	return op, nil
+}
+
+func (r operatorGetter) getOperationPlan(key ops.SiteOperationKey) (*storage.OperationPlan, error) {
+	plan, err := r.operator.GetOperationPlan(key)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	if len(clusters) != 1 {
-		return nil, trace.BadParameter("expected a single cluster, but found %v", len(clusters))
+	return plan, nil
+}
+
+type operatorGetter struct {
+	operator   ops.Operator
+	clusterKey ops.SiteKey
+}
+
+func getOperationFromBackend(backend storage.Backend) operationGetter {
+	return backendGetter{
+		backend: backend,
 	}
-	return &clusters[0], nil
+}
+
+func (r backendGetter) getLastOperation() (*ops.SiteOperation, error) {
+	op, err := storage.GetLastOperation(r.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return (*ops.SiteOperation)(op), nil
+}
+
+func (r backendGetter) getOperationPlan(key ops.SiteOperationKey) (*storage.OperationPlan, error) {
+	plan, err := r.backend.GetOperationPlan(key.SiteDomain, key.OperationID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return plan, nil
+}
+
+type backendGetter struct {
+	backend storage.Backend
 }
 
 func getLocalClusterFromOperator(operator ops.Operator) (cluster *ops.Site, err error) {
 	// TODO(dmitri): when cluster is created by the wizard, it is not local
-	// so resort to look up
+	// so resort to looking it up
 	clusters, err := operator.GetSites(defaults.SystemAccountID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -519,14 +501,9 @@ func getLocalClusterFromOperator(operator ops.Operator) (cluster *ops.Site, err 
 	return &clusters[0], nil
 }
 
-func (r operationGetterFunc) getOperation() (*ops.SiteOperation, error) {
-	return r()
-}
-
-type operationGetterFunc func() (*ops.SiteOperation, error)
-
 type operationGetter interface {
-	getOperation() (*ops.SiteOperation, error)
+	getLastOperation() (*ops.SiteOperation, error)
+	getOperationPlan(key ops.SiteOperationKey) (*storage.OperationPlan, error)
 }
 
 func ensureInstallerServiceRunning() error {
@@ -542,4 +519,31 @@ func ensureInstallerServiceRunning() error {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func newOperationNotFound(format string, args ...interface{}) operationNotFound {
+	return operationNotFound{
+		message: fmt.Sprintf(format, args...),
+	}
+}
+
+// Error returns the text representation of this error.
+// Implement error
+func (r operationNotFound) Error() string {
+	if r.message != "" {
+		return r.message
+	}
+	return "no operation found"
+}
+
+// IsNotFoundError indicates that this is a not found error type.
+// Implements trace.IsNotFoundError
+func (r operationNotFound) IsNotFoundError() bool {
+	return true
+}
+
+type operationNotFound struct {
+	message string
+	// existing indicates whether an operation exists but is not active
+	existing bool
 }

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -357,7 +357,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.UpgradeCmd.Phase = fsm.RootPhase
 		}
 		if *g.UpgradeCmd.Phase != "" {
-			return executePhase(localEnv, g,
+			return executeUpdatePhase(localEnv, g,
 				PhaseParams{
 					PhaseID:          *g.UpgradeCmd.Phase,
 					Force:            *g.UpgradeCmd.Force,


### PR DESCRIPTION
## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1471.
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1495.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
### error for an unstarted install operation
```
$ ./gravity plan resume
...
Mon May  4 17:48:34 UTC	Connecting to installer
[ERROR]: failed to find installer service. Use 'gravity install' to start new installation or 'gravity join' to join the existing cluster.
	no service unit file in /home/centos/.gravity
```

### error for resuming on an existing cluster
```
# ./gravity plan resume
[ERROR]: no active operation found
```

### explicit resumption of the upgrade operation (also when another operation is in progress)
```
$ ./gravity upgrade --resume
[ERROR]: no active update operation found
```

### clear message on expand depending on whether the cluster is degraded or another operation is in progress:
```
Cluster is degraded, waiting for it to become healthy
```
vs
```
Waiting for another operation to complete at 10.128.0.104
```
