### PR TITLE
(7.0) Forward port role_map fixes

### DIFF
--- a/lib/storage/trustedcluster.go
+++ b/lib/storage/trustedcluster.go
@@ -123,7 +123,7 @@ type TrustedClusterSpecV2 struct {
 	SNIHost string `json:"sni_host"`
 	// Roles is a list of roles that users will be assuming when connecting to
 	// this cluster
-	Roles []string `json:"roles"`
+	Roles []string `json:"roles,omitempty"`
 	// RoleMap specifies role mappings to remote roles
 	RoleMap teleservices.RoleMap `json:"role_map,omitempty"`
 	// PullUpdates indicates whether the trusted cluster should pull updates
@@ -323,13 +323,19 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 	if c.Spec.ReverseTunnelAddress == "" {
 		return trace.BadParameter("tunnel_addr can't be empty")
 	}
+	if len(c.Spec.Roles) != 0 && len(c.Spec.RoleMap) != 0 {
+		return trace.BadParameter("either roles or role_map should be set, not both")
+	}
 	if err := c.Spec.RoleMap.Check(); err != nil {
 		return trace.Wrap(err)
 	}
 	if c.Metadata.Labels == nil {
 		c.Metadata.Labels = map[string]string{}
 	}
-	if len(c.Spec.Roles) == 0 {
+	// Fields "roles" and "role_map" are mutually exclusive so only populate
+	// default mapping if neither of those is set, otherwise it will lead to
+	// incorrect trusted cluster configuration.
+	if len(c.Spec.Roles)+len(c.Spec.RoleMap) == 0 {
 		c.Spec.Roles = []string{constants.RoleAdmin}
 	}
 	return nil
@@ -376,8 +382,12 @@ func MarshalTrustedCluster(cluster teleservices.TrustedCluster) ([]byte, error) 
 
 // UnmarshalTrustedCluster unmarshals the trusted cluster resource from bytes
 func UnmarshalTrustedCluster(bytes []byte) (TrustedCluster, error) {
+	jsonBytes, err := teleutils.ToJSON(bytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	var header teleservices.ResourceHeader
-	if err := json.Unmarshal(bytes, &header); err != nil {
+	if err := json.Unmarshal(jsonBytes, &header); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if header.Kind != teleservices.KindTrustedCluster {

--- a/lib/storage/trustedcluster_test.go
+++ b/lib/storage/trustedcluster_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/constants"
+
+	"github.com/gravitational/teleport/lib/services"
+	"gopkg.in/check.v1"
+)
+
+type TrustedClusterSuite struct{}
+
+var _ = check.Suite(&TrustedClusterSuite{})
+
+// TestTrustedClusterDefaults verifies basic trusted cluster resource parsing and
+// default field values.
+func (s *TrustedClusterSuite) TestTrustedClusterDefaults(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		Roles:                []string{constants.RoleAdmin},
+	}))
+}
+
+// TestTrustedClusterRoles makes sure roles field can be set.
+func (s *TrustedClusterSuite) TestTrustedClusterRoles(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  roles: ["admin", "developer"]
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		Roles:                []string{"admin", "developer"},
+	}))
+}
+
+// TestTrustedClusterRoleMap makes sure roles are not populated when role_map
+// is set.
+func (s *TrustedClusterSuite) TestTrustedClusterRoleMap(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  role_map:
+  - remote: "admin"
+    local: ["admin"]
+  - remote: "developer"
+    local: ["developer", "viewer"]
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		RoleMap: services.RoleMap{
+			{
+				Remote: "admin",
+				Local:  []string{"admin"},
+			},
+			{
+				Remote: "developer",
+				Local:  []string{"developer", "viewer"},
+			},
+		},
+	}))
+}
+
+// TestTrustedClusterRolesAndRoleMaps makes sure roles and role_map can't be both set.
+func (s *TrustedClusterSuite) TestTrustedClusterRolesAndRoleMaps(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  roles: ["admin"]
+  role_map:
+  - remote: "admin"
+    local: ["admin"]
+  - remote: "developer"
+    local: ["developer", "viewer"]
+`
+	_, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.NotNil)
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Forward-ports 2 pull requests from 6.3 related to fixing trusted cluster's role_map property.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Ports https://github.com/gravitational/gravity/pull/1504 and https://github.com/gravitational/gravity/pull/1510.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Same as for the original PRs. Install hub & cluster. Connect cluster to the hub via trusted cluster resource that includes role_map:

```yaml
kind: trusted_cluster
version: v2
metadata:
  name: hub.gravitational.io
spec:
  enabled: true
  token: 5167d7b7dfdebaa4ce221fb755312532d7e1a1c188036790891034f43cb42d06
  tunnel_addr: "hub.gravitational.io:3024"
  web_proxy_addr: "hub.gravitational.io:32009"
  role_map:
  - remote: "@teleadmin"
    local: ["@teleadmin"]
```

Make sure trusted cluster connection is ok. Restart gravity-site:

```
kubectl -nkube-system delete pods -lapp=gravity-site
```

Make sure trusted cluster connection is still ok.