### PR TITLE
Hook 'system cluster-info' command

### DIFF
--- a/lib/report/k8s.go
+++ b/lib/report/k8s.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/utils/kubectl"
@@ -38,7 +37,7 @@ func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner) Col
 		Cmd("k8s-nodes", utils.PlanetCommand(kubectl.Command("get", "nodes", "--output", "wide"))...),
 		Cmd("k8s-describe-nodes", utils.PlanetCommand(kubectl.Command("describe", "nodes"))...),
 		Cmd("k8s-cluster-info-dump.tgz",
-			constants.GravityBin, "system", "cluster-info"),
+			utils.Exe.Path, "system", "cluster-info"),
 	}
 	for _, resourceType := range defaults.KubernetesReportResourceTypes {
 		commands = append(commands,

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -264,6 +264,8 @@ type Application struct {
 	SystemReinstallCmd SystemReinstallCmd
 	// SystemHistoryCmd displays system update history
 	SystemHistoryCmd SystemHistoryCmd
+	// SystemClusterInfoCmd dumps cluster info suitable for debugging
+	SystemClusterInfoCmd SystemClusterInfoCmd
 	// SystemStepDownCmd asks active gravity master to step down
 	SystemStepDownCmd SystemStepDownCmd
 	// SystemRollbackCmd rolls back last system update
@@ -1511,6 +1513,12 @@ type SystemReinstallCmd struct {
 
 // SystemHistoryCmd displays system update history
 type SystemHistoryCmd struct {
+	*kingpin.CmdClause
+}
+
+// SystemClusterInfoCmd dumps kubernetes cluster info suitable for debugging.
+// It is a convenience wrapper around 'kubectl cluster-info dump --all-namespaces'
+type SystemClusterInfoCmd struct {
 	*kingpin.CmdClause
 }
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -647,6 +647,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.SystemHistoryCmd.CmdClause = g.SystemCmd.Command("history", "list system update history").Hidden()
 
+	g.SystemClusterInfoCmd.CmdClause = g.SystemCmd.Command("cluster-info", "dump kubernetes cluster info suitable for debugging").Hidden()
+
 	// ask the current active master to step down
 	g.SystemStepDownCmd.CmdClause = g.SystemCmd.Command("step-down", "Ask the active master to step down").Hidden()
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -809,6 +809,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.SystemReinstallCmd.ClusterRole)
 	case g.SystemHistoryCmd.FullCommand():
 		return systemHistory(localEnv)
+	case g.SystemClusterInfoCmd.FullCommand():
+		return systemClusterInfo(localEnv)
 	case g.SystemPullUpdatesCmd.FullCommand():
 		return systemPullUpdates(localEnv,
 			*g.SystemPullUpdatesCmd.OpsCenterURL,


### PR DESCRIPTION
## Description
This PR adds the hook up for the `system cluster-info` command added in https://github.com/gravitational/gravity/pull/1361. Without this, the debug reports will contain a figment of kubernetes resources (i.e. will not have container logs).
For some reason, the forward port did not have the command hook up code.

## Type of change

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/1081

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Debug logs (focused on kubernetes) captured before the change:
```
$ gravity system cluster-info --help
[ERROR]: expected command but got "cluster-info"
$ gravity system report --filter=kubernetes >report.tgz
$ tar tvf report.tgz
-rw-r--r-- root/root      2375 2020-05-08 20:49 k8s-daemonsets
-rw-r--r-- root/root      6142 2020-05-08 20:49 k8s-deployments
-rw-r--r-- root/root     18996 2020-05-08 20:49 k8s-describe-daemonsets
-rw-r--r-- root/root     40553 2020-05-08 20:49 k8s-describe-deployments
-rw-r--r-- root/root     17206 2020-05-08 20:49 k8s-describe-endpoints
-rw-r--r-- root/root     41833 2020-05-08 20:49 k8s-describe-jobs
-rw-r--r-- root/root     31004 2020-05-08 20:49 k8s-describe-nodes
-rw-r--r-- root/root    204307 2020-05-08 20:49 k8s-describe-pods
-rw-r--r-- root/root     37824 2020-05-08 20:49 k8s-describe-replicasets
-rw-r--r-- root/root     11683 2020-05-08 20:49 k8s-describe-services
-rw-r--r-- root/root      3796 2020-05-08 20:49 k8s-endpoints
-rw-r--r-- root/root      2501 2020-05-08 20:49 k8s-jobs
-rw-r--r-- root/root      5454 2020-05-08 20:49 k8s-logs-kube-system-coredns-98n5q-coredns-prev
... <more previous container logs skipped>
-rw-r--r-- root/root       614 2020-05-08 20:49 k8s-nodes
-rw-r--r-- root/root      6393 2020-05-08 20:49 k8s-pods
-rw-r--r-- root/root      6704 2020-05-08 20:49 k8s-replicasets
-rw-r--r-- root/root      2912 2020-05-08 20:49 k8s-services
```

### Debug logs after the change:
```
$ ./gravity system cluster-info --help
usage: gravity system cluster-info

dump kubernetes cluster info suitable for debugging

Flags:
      --help                 Show context-sensitive help (also try --help-long and --help-man).
      --debug                Enable debug mode.
  -q, --quiet                Suppress any extra output to stdout.
      --insecure             Skip TLS verification.
      --state-dir=STATE-DIR  Gravity local state directory.
      --log-file="/var/log/gravity-install.log"  
                             Path to the log file with diagnostic information.
$ ./gravity system report --filter=kubernetes >report.tgz
$ tar tvf report.tgz 
-rw-r--r-- root/root    307338 2020-05-08 20:46 k8s-cluster-info-dump.tgz
-rw-r--r-- root/root      2375 2020-05-08 20:46 k8s-daemonsets
-rw-r--r-- root/root      6142 2020-05-08 20:46 k8s-deployments
-rw-r--r-- root/root     18996 2020-05-08 20:46 k8s-describe-daemonsets
-rw-r--r-- root/root     40553 2020-05-08 20:46 k8s-describe-deployments
-rw-r--r-- root/root     17206 2020-05-08 20:46 k8s-describe-endpoints
-rw-r--r-- root/root     41833 2020-05-08 20:46 k8s-describe-jobs
-rw-r--r-- root/root     31004 2020-05-08 20:46 k8s-describe-nodes
-rw-r--r-- root/root    204307 2020-05-08 20:46 k8s-describe-pods
-rw-r--r-- root/root     37824 2020-05-08 20:46 k8s-describe-replicasets
-rw-r--r-- root/root     11683 2020-05-08 20:46 k8s-describe-services
-rw-r--r-- root/root      3796 2020-05-08 20:46 k8s-endpoints
-rw-r--r-- root/root      2501 2020-05-08 20:46 k8s-jobs
-rw-r--r-- root/root      5454 2020-05-08 20:46 k8s-logs-kube-system-coredns-98n5q-coredns-prev
... <more previous container logs skipped>
-rw-r--r-- root/root       614 2020-05-08 20:46 k8s-nodes
-rw-r--r-- root/root      6393 2020-05-08 20:46 k8s-pods
-rw-r--r-- root/root      6704 2020-05-08 20:46 k8s-replicasets
-rw-r--r-- root/root      2912 2020-05-08 20:46 k8s-services
```