### PR TITLE
[7.0.x] service stop conditions

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -83,7 +83,6 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 		closeC:    make(chan closeResponse),
 		connectC:  make(chan connectResult, 1),
 	}
-	// peer.startConnectLoop()
 	peer.startStatusLoop()
 	peer.startExecuteLoop()
 	peer.startReconnectWatchLoop()

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -418,7 +418,9 @@ func (p *Peer) startStatusLoop() {
 		for {
 			select {
 			case err := <-p.errC:
-				p.sendErrorResponse(err)
+				if err != nil {
+					p.sendErrorResponse(err)
+				}
 				p.exitWithError(err)
 				return
 			case <-p.ctx.Done():
@@ -1229,7 +1231,7 @@ func (p *Peer) sendCloseResponse(resp *installpb.ProgressResponse) bool {
 		<-doneC
 		return true
 	default:
-		// Do not block if otherwise
+		// Do not block otherwise
 		return false
 	}
 }

--- a/lib/install/client/client.go
+++ b/lib/install/client/client.go
@@ -257,9 +257,6 @@ func (r *Client) complete(ctx context.Context) error {
 
 func (r *Client) shutdown(ctx context.Context) error {
 	_, err := r.client.Shutdown(ctx, &installpb.ShutdownRequest{})
-	if err := r.waitForServiceStopped(ctx); err != nil {
-		log.WithError(err).Warn("Failed to wait for installer service to shut down.")
-	}
 	return trace.Wrap(err)
 }
 
@@ -267,8 +264,10 @@ func (r *Client) shutdownWithExitCode(ctx context.Context, code int) error {
 	_, err := r.client.Shutdown(ctx, &installpb.ShutdownRequest{
 		ExitCode: int32(code),
 	})
-	if err := r.waitForServiceStopped(ctx); err != nil {
-		log.WithError(err).Warn("Failed to wait for installer service to shut down.")
+	if isNoRestartExitCode(code) {
+		if err := r.waitForServiceStopped(ctx); err != nil {
+			log.WithError(err).Warn("Failed to wait for installer service to shut down.")
+		}
 	}
 	return trace.Wrap(err)
 }

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -72,8 +72,8 @@ func (r *InstallerStrategy) installSelfAsService() error {
 		ServiceSpec: systemservice.ServiceSpec{
 			StartCommand:             strings.Join(r.Args, " "),
 			User:                     constants.RootUIDString,
-			SuccessExitStatus:        successExitStatuses,
-			RestartPreventExitStatus: noRestartExitStatuses,
+			SuccessExitStatus:        successExitStatusList,
+			RestartPreventExitStatus: noRestartExitStatusList,
 			// Enable automatic restart of the service
 			Restart:          "always",
 			Timeout:          int(time.Duration(defaults.ServiceConnectTimeout).Seconds()),
@@ -161,17 +161,35 @@ func isServiceFailed(serviceName string) func() error {
 	}
 }
 
+func isNoRestartExitCode(code int) bool {
+	for _, s := range noRestartExitStatuses {
+		if code == s {
+			return true
+		}
+	}
+	return false
+}
+
+func toWhitespaceSeparated(vs ...int) string {
+	result := make([]string, 0, len(vs))
+	for _, v := range vs {
+		result = append(result, strconv.Itoa(v))
+	}
+	return strings.Join(result, " ")
+}
+
 var (
-	// successExitStatuses lists exit statuses considered a successful exit for the service
-	successExitStatuses = strings.Join([]string{
-		strconv.Itoa(defaults.AbortedOperationExitCode),
-		strconv.Itoa(defaults.CompletedOperationExitCode),
-	}, " ")
-	// noRestartExitStatuses lists exit statuses that prevent service from getting automatically
+	noRestartExitStatuses = []int{
+		defaults.AbortedOperationExitCode,
+		defaults.CompletedOperationExitCode,
+		defaults.FailedPreconditionExitCode,
+	}
+	// successExitStatusList lists exit statuses considered a successful exit for the service
+	successExitStatusList = toWhitespaceSeparated([]int{
+		defaults.AbortedOperationExitCode,
+		defaults.CompletedOperationExitCode,
+	}...)
+	// noRestartExitStatusList lists exit statuses that prevent service from getting automatically
 	// restarted by systemd
-	noRestartExitStatuses = strings.Join([]string{
-		strconv.Itoa(defaults.AbortedOperationExitCode),
-		strconv.Itoa(defaults.CompletedOperationExitCode),
-		strconv.Itoa(defaults.FailedPreconditionExitCode),
-	}, " ")
+	noRestartExitStatusList = toWhitespaceSeparated(noRestartExitStatuses...)
 )

--- a/lib/install/install.go
+++ b/lib/install/install.go
@@ -84,6 +84,7 @@ func (i *Installer) Run(listener net.Listener) error {
 	}()
 	err := <-i.errC
 	i.stop()
+	i.WithField("exit-error", err).Info("Exit with error.")
 	return installpb.WrapServiceError(err)
 }
 

--- a/lib/install/server/server.go
+++ b/lib/install/server/server.go
@@ -202,21 +202,22 @@ type Server struct {
 }
 
 func (r *Server) done(ctx context.Context, err error) {
-	r.errC <- r.executor.HandleStopped(ctx)
+	if err := r.executor.HandleStopped(ctx); err != nil {
+		r.WithError(err).Warn("Stop handler failed.")
+	}
+	r.errC <- err
 }
 
 func (r *Server) aborted(ctx context.Context) {
-	err := installpb.ErrAborted
-	if errAbort := r.executor.HandleAborted(ctx); errAbort != nil {
-		err = errAbort
+	if err := r.executor.HandleAborted(ctx); err != nil {
+		r.WithError(err).Warn("Abort handler failed.")
 	}
-	r.errC <- err
+	r.errC <- installpb.ErrAborted
 }
 
 func (r *Server) complete(ctx context.Context) {
-	err := installpb.ErrCompleted
-	if errComplete := r.executor.HandleCompleted(ctx); errComplete != nil {
-		err = errComplete
+	if err := r.executor.HandleCompleted(ctx); err != nil {
+		r.WithError(err).Warn("Completion handler failed.")
 	}
-	r.errC <- err
+	r.errC <- installpb.ErrCompleted
 }


### PR DESCRIPTION
## Description
This PR fixes the following issues with the install/expand code:
  * only wait for service to stop on terminal conditions (i.e. aborted or completed installation) but not on transient stops like a failure
  * initiate operation in expand case only explicitly - on client request. This avoids accidental operations after completion.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1523, https://github.com/gravitational/gravity/issues/1529.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
 * Installation on a 3-node cluster.
 * Installation on a 3-node cluster with simulated pre-flight failures to test resumption logic.
 * Repeated shrink/expand of a single node.

