### PR TITLE
Docs Update hub  install flag instructions to use --hub-advertise-addr

### DIFF
--- a/docs/7.x/hub.md
+++ b/docs/7.x/hub.md
@@ -71,14 +71,14 @@ $ ./gravity install --advertise-addr=10.1.1.5 \
                     --token=$TOKEN \
                     --flavor=standalone \
                     --cluster=hub.example.com \
-                    --ops-advertise-addr=hub.example.com:443
+                    --hub-advertise-addr=hub.example.com:443
 ```
 
 * `--advertise-addr` is an IP address the Hub machine will be visible as.
 * `--flavor=standalone` tells the installer to use a single machine to run
   Gravity Hub.  For production, we recommend to use a 3-node cluster for
   high-availability.
-* `--ops-advertise-addr` should be a DNS name publicly accessible via internet
+* `--hub-advertise-addr` should be a DNS name publicly accessible via internet
 * `--token` is a security token for nodes to join to the cluster
 * `--cluster` is a unique cluster name, e.g. `hub.example.com`
 


### PR DESCRIPTION
## Description
Existing hub install instructions say to use  --ops-advertise-addr when the current flag is --hub-advertise-addr.  Users will receive a warning with the current version when using that.

## Type of change
Documentation
