### PR TITLE
[7.0.x] expand resume

### DIFF
--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -7,7 +7,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 declare -A UPGRADE_MAP
 
 # latest patch release on this branch, keep this up to date
-UPGRADE_MAP[7.0.3]="ubuntu:18"
+UPGRADE_MAP[7.0.5]="ubuntu:18"
 
 # latest patch release on compatible LTS, keep this up to date
 UPGRADE_MAP[6.1.24]="ubuntu:18"

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -146,8 +146,8 @@ func (p *Peer) Run(listener net.Listener) error {
 				p.WithError(err).Warn("Failed to leave cluster.")
 			}
 		} else if !installpb.IsCompletedError(err) {
-			if err2 := p.fail(err.Error()); err2 != nil {
-				p.WithError(err2).Warn("Failed to mark operation as failed.")
+			if err := p.fail(err.Error()); err != nil {
+				p.WithError(err).Warn("Failed to mark operation as failed.")
 			}
 		}
 	}

--- a/lib/expand/phases/etcd.go
+++ b/lib/expand/phases/etcd.go
@@ -145,8 +145,11 @@ func (p *etcdExecutor) addEtcdMember(ctx context.Context) (member *etcd.Member, 
 	err = utils.RetryTransient(ctx, boff, func() error {
 		var err error
 		member, err = p.Etcd.Add(ctx, p.Phase.Data.Server.EtcdPeerURL())
-		if err != nil && !isMemberAlreadyExistsError(err) {
-			return trace.Wrap(err)
+		if err != nil {
+			if !isMemberAlreadyExistsError(err) {
+				return trace.Wrap(err)
+			}
+			p.Infof("Etcd peer %v already exists.", p.Phase.Data.Server.EtcdPeerURL())
 		}
 		return nil
 	})

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -158,7 +158,7 @@ func shouldReconnectService(serviceName string) func() error {
 		}
 		if !trace.IsCompareFailed(err) {
 			// Continue reconnecting if unable to query service status
-			log.Warn("Failed to query service status: %v.", err)
+			log.Warnf("Failed to query service status: %v.", err)
 		}
 		return nil
 	}

--- a/lib/install/client/resume.go
+++ b/lib/install/client/resume.go
@@ -40,9 +40,9 @@ func (r *ResumeStrategy) connect(ctx context.Context) (installpb.AgentClient, er
 	defer cancel()
 	serviceName := serviceNameFromPath(r.ServicePath)
 	client, err := installpb.NewClient(ctx, installpb.ClientConfig{
-		FieldLogger:     r.FieldLogger,
-		SocketPath:      r.SocketPath,
-		IsServiceFailed: isServiceFailed(serviceName),
+		FieldLogger:            r.FieldLogger,
+		SocketPath:             r.SocketPath,
+		ShouldReconnectService: shouldReconnectService(serviceName),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to connect to the installer service.\n"+

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -17,7 +17,6 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -381,19 +380,7 @@ type ExecResult struct {
 // FormatAbortError formats the specified error for output by the installer client.
 // Output will contain error message for err as well as any error it wraps.
 func FormatAbortError(err error) string {
-	switch err := err.(type) {
-	case trace.Error:
-		userMessage := trace.UserMessage(err)
-		if err.OrigError() != nil {
-			detail := trace.UserMessage(err.OrigError())
-			if detail != userMessage {
-				userMessage = fmt.Sprintf("%v (%v)", userMessage, detail)
-			}
-		}
-		return userMessage
-	default:
-		return trace.UserMessage(err)
-	}
+	return trace.UserMessage(err)
 }
 
 func isOperationSuccessful(progress ops.ProgressEntry) bool {

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -573,7 +573,7 @@ func (r *AgentPeerStore) isPartOfActiveOperation(addr string, token storage.Prov
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if op.Type != ops.OperationExpand || op.Type != ops.OperationInstall {
+	if op.Type != ops.OperationInstall && op.Type != ops.OperationExpand {
 		// Only relevant for install/expand operation
 		return nil
 	}

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -575,9 +575,10 @@ func (r *AgentPeerStore) isPartOfActiveOperation(addr string, token storage.Prov
 	if operation.IsCompleted() {
 		return trace.BadParameter("operation %v is already completed", token.OperationID)
 	}
-	if (storage.Servers)(op.Servers).FindByIP(addr) == nil {
+	serverAddr := utils.ExtractHost(addr)
+	if (storage.Servers)(op.Servers).FindByIP(serverAddr) == nil {
 		return trace.NotFound("server is not part of the active operation").AddFields(map[string]interface{}{
-			"server-addr": addr,
+			"server-addr": serverAddr,
 			"operation":   operation.String(),
 		})
 	}

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -379,7 +379,7 @@ func (r *AgentPeerStore) NewPeer(ctx context.Context, req pb.PeerJoinRequest, pe
 	}
 
 	if req.Config.KeyValues[ops.AgentMode] != ops.AgentModeShrink {
-		errCheck := r.validatePeer(ctx, group, info, req, token.SiteDomain)
+		errCheck := r.validatePeer(ctx, group, info, req, *token)
 		if errCheck != nil {
 			return errCheck
 		}
@@ -442,47 +442,32 @@ func (r *AgentPeerStore) authenticatePeer(token string) (*storage.ProvisioningTo
 }
 
 func (r *AgentPeerStore) validatePeer(ctx context.Context, group *agentGroup, info storage.System,
-	req pb.PeerJoinRequest, clusterName string) error {
+	req pb.PeerJoinRequest, token storage.ProvisioningToken) error {
 	if group.hasPeer(req.Addr, info.GetHostname()) {
 		return nil
 	}
 
-	if err := r.checkHostname(ctx, group, req.Addr, info.GetHostname(), clusterName); err != nil {
+	if err := r.checkHostname(ctx, group, req.Addr, info.GetHostname(), token); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := r.checkLicense(ctx, int(group.NumPeers()), clusterName, info); err != nil {
+	if err := r.checkLicense(ctx, int(group.NumPeers()), token.SiteDomain, info); err != nil {
 		return trace.Wrap(err)
 	}
 
 	return nil
 }
 
-func (r *AgentPeerStore) checkHostname(ctx context.Context, group *agentGroup, addr, hostname, clusterName string) error {
-	// collect hostnames from existing servers (for expand)
-	servers, err := r.teleport.GetServers(ctx, clusterName, nil)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-
-	var existingServers []string
-	for _, server := range servers {
-		hostname := server.GetLabels()[ops.Hostname]
-		if hostname == "" {
-			log.Warnf("Server hostname is empty: %+v.", server)
-			continue
+func (r *AgentPeerStore) checkHostname(ctx context.Context, group *agentGroup, addr, hostname string, token storage.ProvisioningToken) error {
+	if err := r.isPartOfActiveOperation(addr, token); err != nil {
+		r.WithError(err).Warn("Failed to check whether the server is part of the active operation.")
+		if err := r.isExistingServer(ctx, hostname, token.SiteDomain); err != nil {
+			return trace.Wrap(err)
 		}
-		existingServers = append(existingServers, hostname)
 	}
-
-	if utils.StringInSlice(existingServers, hostname) {
-		return trace.AccessDenied("One of existing servers already has hostname %q: %q.", hostname, existingServers)
-	}
-
 	if group.hasConflictingPeer(addr, hostname) {
 		return trace.AccessDenied("One of existing peers already has hostname %q.", hostname)
 	}
-
 	r.Debugf("Verified hostname %q.", hostname)
 	return nil
 }
@@ -579,6 +564,46 @@ func (r *AgentPeerStore) addGroup(key ops.SiteOperationKey) (*agentGroup, error)
 	r.WithField("key", key).Debug("Added group.")
 	r.groups[key] = agentGroup
 	return agentGroup, nil
+}
+
+func (r *AgentPeerStore) isPartOfActiveOperation(addr string, token storage.ProvisioningToken) error {
+	op, err := r.backend.GetSiteOperation(token.SiteDomain, token.OperationID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	operation := (ops.SiteOperation)(*op)
+	if operation.IsCompleted() {
+		return trace.BadParameter("operation %v is already completed", token.OperationID)
+	}
+	if (storage.Servers)(op.Servers).FindByIP(addr) == nil {
+		return trace.NotFound("server is not part of the active operation").AddFields(map[string]interface{}{
+			"server-addr": addr,
+			"operation":   operation.String(),
+		})
+	}
+	return nil
+}
+
+func (r *AgentPeerStore) isExistingServer(ctx context.Context, hostname, clusterName string) error {
+	// collect hostnames from existing servers (for expand)
+	servers, err := r.teleport.GetServers(ctx, clusterName, nil)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	var existingServers []string
+	for _, server := range servers {
+		hostname := server.GetLabels()[ops.Hostname]
+		if hostname == "" {
+			log.WithField("server", server).Warn("Server hostname is empty, will ignore.")
+			continue
+		}
+		existingServers = append(existingServers, hostname)
+	}
+	if utils.StringInSlice(existingServers, hostname) {
+		return trace.AccessDenied("One of existing servers already has hostname %q: %q.",
+			hostname, existingServers)
+	}
+	return nil
 }
 
 // AgentPeerStore manages groups of agents based on operation context.

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -421,7 +421,7 @@ type SiteOperation struct {
 	// in case of 'install' or 'provision_servers' it will store the
 	// servers that will be added and configured, for 'deprovision_servers'
 	// it will store the servers that will be deleted
-	Servers []Server `json:"servers"`
+	Servers Servers `json:"servers"`
 	// Shrink is set when the operation type is shrink (removing nodes from the cluster)
 	Shrink *ShrinkOperationState `json:"shrink,omitempty"`
 	// InstallExpand is set when the operation is install or expand


### PR DESCRIPTION
## Description
This PR refines the logic of the controller to validate whether an agent represents a valid server in the context of an ongoing operation - otherwise, expanding breaks at various points into the operation. As the last example - immediately after failing to add an etcd member (due to a transient connection error), the agent was not able to rejoin on the grounds of there already being a server with the same hostname.
Instead, the controller will first check whether the server is part of the currently active operation (by comparing the server's advertise address against the operation server state).

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1539

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
 * Install a 3-node cluster.
 * Remove a node and re-add simulating a failure on `etcd` step. Make sure it can be resumed with a correct binary.

While testing, I ran into an issue with etcd and was wondering if it was just me or anyone else ran into it as well. Basically one of the test scenarios is removing and re-introducing a node into the cluster. If the issue is time-related at all - the remove/join would be several minutes apart tops. When joining the node, the etcd would frequently panic on data inconsistency. Here's a snippet from the etcd log that captures the panic:
```
ay 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: 3830d8d1ab5f5cd0 switched to configuration voters=()
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: 3830d8d1ab5f5cd0 became follower at term 0
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: newRaft 3830d8d1ab5f5cd0 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
May 14 11:02:52 dmitri-centos-node-2 etcd[235]: starting member 3830d8d1ab5f5cd0 in cluster 10c90c1dbfb0f41d
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: simple token is not cryptographically signed
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting peer 66d74b9b9be85064...
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: added peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting peer 6c1ddcb80fda6234...
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (stream Message reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: added peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting server... [version: 3.4.7, cluster version: to_be_decided]
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (stream Message reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: peer 66d74b9b9be85064 became active
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: established a TCP streaming connection with peer 66d74b9b9be85064 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: ClientTLS: cert = /var/state/etcd.cert, key = /var/state/etcd.key, trusted-ca = /var/state/root.cert, client-cert-auth = true, crl-file = 
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 INFO: 3830d8d1ab5f5cd0 [term: 0] received a MsgHeartbeat message with higher term from 66d74b9b9be85064 [term: 101]
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 INFO: 3830d8d1ab5f5cd0 became follower at term 101
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 tocommit(83262) is out of range [lastIndex(0)]. Was the raft log corrupted, truncated, or lost?
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: listening for peers on 10.128.0.104:2380
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: panic: tocommit(83262) is out of range [lastIndex(0)]. Was the raft log corrupted, truncated, or lost?
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: goroutine 162 [running]:
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: log.(*Logger).Panicf(0xc0001f6230, 0x10cbbbf, 0x5d, 0xc0012891a0, 0x2, 0x2)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /usr/local/go/src/log/log.go:219 +0xc1
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*DefaultLogger).Panicf(0x1aa7080, 0x10cbbbf, 0x5d, 0xc0012891a0, 0x2, 0x2)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/logger.go:127 +0x60
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raftLog).commitTo(0xc0002b8070, 0x1453e)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/log.go:203 +0x131
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raft).handleHeartbeat(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:1396 +0x54
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.stepFollower(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:1341 +0x480
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raft).Step(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:984 +0x1113
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*node).run(0xc000346840)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/node.go:352 +0xab6
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: created by go.etcd.io/etcd/raft.RestartNode
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/node.go:240 +0x33c
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: etcd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: etcd.service: Failed with result 'exit-code'.
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: Failed to start Etcd Service.
```

The behavior with the change now is continuously retry the add etcd peer step which in this case would be failing with `cluster has not leader` until timeout.
To resolve, I had to manually remove the member from another node:
```
$ etcdctl member remove <failing-member-id>
```
remove the data directory on the joining node:
```
$ rm -r /var/lib/gravity/planet/etcd/v<etcd-version>
```
and rerun the step:
```
$ ./gravity resume
```