### PR TITLE
(6.3) Update default trusted cluster role mapping

### DIFF
--- a/lib/storage/trustedcluster.go
+++ b/lib/storage/trustedcluster.go
@@ -336,7 +336,12 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 	// default mapping if neither of those is set, otherwise it will lead to
 	// incorrect trusted cluster configuration.
 	if len(c.Spec.Roles)+len(c.Spec.RoleMap) == 0 {
-		c.Spec.Roles = []string{constants.RoleAdmin}
+		c.Spec.RoleMap = teleservices.RoleMap{
+			{
+				Remote: constants.RoleAdmin,
+				Local:  []string{constants.RoleAdmin},
+			},
+		}
 	}
 	return nil
 }

--- a/lib/storage/trustedcluster_test.go
+++ b/lib/storage/trustedcluster_test.go
@@ -48,7 +48,9 @@ spec:
 		Token:                "trusted_cluster_token",
 		ProxyAddress:         "hub.example.com:32009",
 		ReverseTunnelAddress: "hub.example.com:3024",
-		Roles:                []string{constants.RoleAdmin},
+		RoleMap: services.RoleMap{
+			{Remote: constants.RoleAdmin, Local: []string{constants.RoleAdmin}},
+		},
 	}))
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Update default trusted cluster role mapping to map the remote system admin role to the local system admin role, instead of mapping any remote role to the local system admin role.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Related to https://github.com/gravitational/gravity/pull/1504 which fixed role_map property on trusted clusters.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Create trusted cluster resource:

```yaml
kind: trusted_cluster
version: v2
metadata:
  name: hub.gravitational.io
spec:
  enabled: true
  token: <token>
  tunnel_addr: "hub.gravitational.io:3024"
  web_proxy_addr: "hub.gravitational.io:32009"
```

Fetch it back:

```yaml
ubuntu@node-2:~$ sudo gravity resource get trustedclusters --format=yaml
kind: trusted_cluster
metadata:
  name: hub.gravitational.io
spec:
  enabled: true
  pull_updates: false
  role_map:
  - local:
    - '@teleadmin'
    remote: '@teleadmin'
  sni_host: ""
  token: <token>
  tunnel_addr: hub.gravitational.io:3024
  web_proxy_addr: hub.gravitational.io:32009
version: v2
```

Also make sure mapping works by using control panel and kubectl.
## Additional information
<!--Optional. Anything else that may be relevant.-->

Will update trusted cluster related docs when porting this to master.