### PR TITLE
Fix wordpress cluster manifest link

### DIFF
--- a/docs/7.x/quickstart.md
+++ b/docs/7.x/quickstart.md
@@ -312,7 +312,7 @@ $ sudo ./gravity install \
         --flavor=medium
 ```
 
-Flavor details are in the Wordpress [Cluster Manifest](./resources/app.yaml) . Flavors provide for specifying the number and configuration of nodes for a deployment. 
+Flavor details are in the Wordpress [Cluster Manifest](https://github.com/gravitational/quickstart/blob/master/wordpress/resources/app.yaml) . Flavors provide for specifying the number and configuration of nodes for a deployment. 
 
 ## Adding a User
 The next step is to create a new Kubernetes user:

--- a/docs/7.x/terraform.md
+++ b/docs/7.x/terraform.md
@@ -11,7 +11,7 @@ The terraform provider will be automatically installed when getting the Gravity 
 curl https://get.gravitational.io/gravity/install/5.2.5 | bash
 ```
 
-Please see the [getting started guide](quickstart.md#getting-the-tools) for more information.
+Please see the [getting started guide](quickstart.md#step-1-getting-the-tools) for more information.
 
 ### Example Usage
 
@@ -204,7 +204,7 @@ The terraform provider will be automatically installed when getting the Gravity 
 curl https://get.gravitational.io/gravity/install/5.2.5 | bash
 ```
 
-Please see the [getting started guide](quickstart.md#getting-the-tools) for more information.
+Please see the [getting started guide](quickstart.md#step-1-getting-the-tools) for more information.
 
 ### Example Usage
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
* Fix Cluster Manifest link.
* Update `Getting The Tools` link.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
