### PR TITLE
(7.0) Fix a couple reconfigure issues

### DIFF
--- a/lib/install/reconfigure/fsmspec.go
+++ b/lib/install/reconfigure/fsmspec.go
@@ -45,6 +45,10 @@ func FSMSpec(config install.FSMConfig) fsm.FSMSpecFunc {
 		// so only "/masters" phase can be present.
 		case strings.HasPrefix(p.Phase.ID, installphases.MastersPhase):
 			return installphases.NewSystem(p, config.Operator, config.LocalPackages, remote)
+		case strings.HasPrefix(p.Phase.ID, phases.RestartPhase):
+			return phases.NewRestart(p,
+				config.Operator,
+				config.LocalPackages)
 		}
 		switch p.Phase.ID {
 		case installphases.ChecksPhase:
@@ -81,8 +85,6 @@ func FSMSpec(config install.FSMConfig) fsm.FSMSpecFunc {
 			return phases.NewDirectories(p, config.Operator)
 		case phases.PodsPhase:
 			return phases.NewPods(p, config.Operator)
-		case phases.TeleportPhase:
-			return phases.NewTeleport(p, config.Operator)
 		case phases.GravityPhase:
 			return phases.NewGravity(p, config.Operator)
 		case phases.ClusterPackagesPhase:

--- a/lib/install/reconfigure/phases/phases.go
+++ b/lib/install/reconfigure/phases/phases.go
@@ -37,6 +37,10 @@ const (
 	PodsPhase = "/pods"
 	// GravityPhase waits for gravity-site API to become available.
 	GravityPhase = "/gravity"
-	// TeleportPhase restarts teleport node.
+	// RestartPhase encapsulates Teleport/Planet restart subphases.
+	RestartPhase = "/restart"
+	// TeleportPhase restarts Teleport unit.
 	TeleportPhase = "/teleport"
+	// PlanetPhase restart Planet unit.
+	PlanetPhase = "/planet"
 )

--- a/lib/install/reconfigure/phases/state.go
+++ b/lib/install/reconfigure/phases/state.go
@@ -51,6 +51,7 @@ func NewState(p fsm.ExecutorParams, operator ops.Operator) (*stateExecutor, erro
 	return &stateExecutor{
 		FieldLogger:    logger,
 		ExecutorParams: p,
+		Operator:       operator,
 		Operation:      *operation,
 		Server:         *p.Phase.Data.Server,
 	}, nil
@@ -61,6 +62,8 @@ type stateExecutor struct {
 	logrus.FieldLogger
 	// ExecutorParams are common executor parameters.
 	fsm.ExecutorParams
+	// Operator is the installer operator.
+	Operator ops.Operator
 	// Operation is the current reconfigure operation.
 	Operation ops.SiteOperation
 	// Server is the server undergoing the reconfigure operation.
@@ -83,6 +86,9 @@ func (p *stateExecutor) Execute(ctx context.Context) error {
 	if err := p.removeAuthorities(clusterEnv.Backend); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := p.updateTokens(clusterEnv.Backend, clusterEnv.Operator); err != nil {
+		return trace.Wrap(err)
+	}
 	if err := p.updatePeers(clusterEnv.Backend); err != nil {
 		return trace.Wrap(err)
 	}
@@ -103,6 +109,27 @@ func (p *stateExecutor) updateNode(backend storage.Backend) error {
 		return trace.Wrap(err)
 	}
 	p.Debug("Updated node in the cluster state.")
+	return nil
+}
+
+func (p *stateExecutor) updateTokens(backend storage.Backend, operator ops.Operator) error {
+	existingToken, err := operator.GetExpandToken(p.Key().SiteKey())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = backend.DeleteProvisioningToken(existingToken.Token)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	token, err := p.Operator.GetExpandToken(p.Key().SiteKey())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = backend.CreateProvisioningToken(*token)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Debug("Updated provisioning tokens.")
 	return nil
 }
 

--- a/lib/install/reconfigure/plan.go
+++ b/lib/install/reconfigure/plan.go
@@ -91,7 +91,7 @@ func (p *Planner) GetOperationPlan(operator ops.Operator, cluster ops.Site, oper
 	builder.AddNodePhase(plan)
 	builder.AddDirectoriesPhase(plan)
 	builder.AddPodsPhase(plan)
-	builder.AddTeleportPhase(plan)
+	builder.AddRestartPhase(plan)
 	builder.AddGravityPhase(plan)
 	builder.AddClusterPackagesPhase(plan)
 

--- a/lib/install/reconfigure/planbuilder.go
+++ b/lib/install/reconfigure/planbuilder.go
@@ -138,7 +138,7 @@ func (b *PlanBuilder) AddTeleportPhase(plan *storage.OperationPlan) {
 		Description: "Restart Gravity services",
 		Phases: []storage.OperationPhase{
 			{
-				ID:          fmt.Sprintf("%v/%v", phases.RestartPhase, phases.TeleportPhase),
+				ID:          fmt.Sprintf("%v%v", phases.RestartPhase, phases.TeleportPhase),
 				Description: "Restart Teleport",
 				Data: &storage.OperationPhaseData{
 					Server:  &b.Master,
@@ -146,7 +146,7 @@ func (b *PlanBuilder) AddTeleportPhase(plan *storage.OperationPlan) {
 				},
 			},
 			{
-				ID:          fmt.Sprintf("%v/%v", phases.RestartPhase, phases.PlanetPhase),
+				ID:          fmt.Sprintf("%v%v", phases.RestartPhase, phases.PlanetPhase),
 				Description: "Restart Planet",
 				Data: &storage.OperationPhaseData{
 					Server:  &b.Master,

--- a/lib/install/reconfigure/planbuilder.go
+++ b/lib/install/reconfigure/planbuilder.go
@@ -132,7 +132,7 @@ func (b *PlanBuilder) AddPodsPhase(plan *storage.OperationPlan) {
 }
 
 // AddRestartPhase adds phase that restarts Teleport and Planet units.
-func (b *PlanBuilder) AddTeleportPhase(plan *storage.OperationPlan) {
+func (b *PlanBuilder) AddRestartPhase(plan *storage.OperationPlan) {
 	plan.Phases = append(plan.Phases, storage.OperationPhase{
 		ID:          phases.RestartPhase,
 		Description: "Restart Gravity services",

--- a/lib/install/reconfigure/planbuilder.go
+++ b/lib/install/reconfigure/planbuilder.go
@@ -17,9 +17,12 @@ limitations under the License.
 package reconfigure
 
 import (
+	"fmt"
+
 	"github.com/gravitational/gravity/lib/install"
 	installphases "github.com/gravitational/gravity/lib/install/phases"
 	"github.com/gravitational/gravity/lib/install/reconfigure/phases"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/storage"
 )
 
@@ -128,14 +131,28 @@ func (b *PlanBuilder) AddPodsPhase(plan *storage.OperationPlan) {
 	})
 }
 
-// AddTeleportPhase adds phase that restarts teleport service.
+// AddRestartPhase adds phase that restarts Teleport and Planet units.
 func (b *PlanBuilder) AddTeleportPhase(plan *storage.OperationPlan) {
 	plan.Phases = append(plan.Phases, storage.OperationPhase{
-		ID:          phases.TeleportPhase,
-		Description: "Restart Teleport service",
-		Data: &storage.OperationPhaseData{
-			Server:  &b.Master,
-			Package: &b.TeleportPackage,
+		ID:          phases.RestartPhase,
+		Description: "Restart Gravity services",
+		Phases: []storage.OperationPhase{
+			{
+				ID:          fmt.Sprintf("%v/%v", phases.RestartPhase, phases.TeleportPhase),
+				Description: "Restart Teleport",
+				Data: &storage.OperationPhaseData{
+					Server:  &b.Master,
+					Package: &loc.Teleport,
+				},
+			},
+			{
+				ID:          fmt.Sprintf("%v/%v", phases.RestartPhase, phases.PlanetPhase),
+				Description: "Restart Planet",
+				Data: &storage.OperationPhaseData{
+					Server:  &b.Master,
+					Package: &loc.Planet,
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR addresses a couple of discovered issues related to the "reconfigure" operation (the one that changes advertise IP of the node in a single-node cluster).

* Add a phase that restarts planet as a (almost) final step of the operation so all services can re-read their service account tokens. Without this, for example, kube-controller-manager keeps getting unauthorized errors until it's restarted.
* Fix an issue with Teleport node not being able to rejoin after reconfigure operation due to it using a join token generated by the installer which didn't get transferred to the cluster. I've updated it now to update the cluster's join token as well.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1535.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Before the change

Install a single-node cluster and perform reconfigure operation.

Teleport is offline:

```
Cluster nodes:
    Masters:
        * node-1 / 192.168.99.102 / node
            Status:		healthy
            Remote access:	offline
```

Trying to create a persistent volume, it stays pending:

```
ubuntu@node-1:~/resources/pv-test$ kubectl get pv,pvc -A
NAMESPACE   NAME                                   STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS       AGE
default     persistentvolumeclaim/claim-hostpath   Pending                                      openebs-hostpath   17s
```

And kube-controller-manager shows:

```
May 11 16:37:10 node-1 kube-controller-manager[569]: E0511 16:37:10.938336     569 goroutinemap.go:150] Operation for "provision-default/claim-hostpath[0ce8bedb-6325-4b2d-a150-7af63ee15a2a]" failed. No retries permitted until 2020-05-11 16:37:11.420226384 +0000 UTC m=+2911.389786830 (durationBeforeRetry 500ms). Error: "Unauthorized"
```

### After the change

Teleport is online:

```
Cluster nodes:
    Masters:
        * node-1 / 192.168.99.102 / node
            Status:		healthy
            Remote access:	online
```

Can create PV/PVC just fine:

```
ubuntu@node-1:~/resources/pv-test$ kubectl get pv,pvc -A
NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                    STORAGECLASS       REASON   AGE
persistentvolume/pvc-0912037d-764e-4039-af25-b15626565af1   1Gi        RWO            Delete           Bound    default/claim-hostpath   openebs-hostpath            91s

NAMESPACE   NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS       AGE
default     persistentvolumeclaim/claim-hostpath   Bound    pvc-0912037d-764e-4039-af25-b15626565af1   1Gi        RWO            openebs-hostpath   96s
```