### PR TITLE
[6.1.x] loosen same OS requirement

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -756,28 +756,58 @@ func checkRAM(info ServerInfo, ram schema.RAM) error {
 	return nil
 }
 
-// checkSameOS makes sure all servers have the same OS/version
+// checkSameOS verifies the OS distribution requirement for the specified set of servers.
+// The check will pass if all nodes in the cluster are based on the same OS distribution and major version.
+// Variance in minor/patch versions is acceptable.
 func checkSameOS(servers []Server) error {
-	osToNodes := make(map[string][]string)
+	// distros maps distribution name to list of versions
+	distros := make(map[string][]string)
 	for _, server := range servers {
-		os := systeminfo.OS(server.GetOS()).Name()
-		osToNodes[os] = append(osToNodes[os], fmt.Sprintf("%v (%v)",
-			server.ServerInfo.GetHostname(), server.AdvertiseAddr))
+		info := server.GetOS()
+		distros[info.ID] = append(distros[info.ID], info.Version)
 	}
-
-	if len(osToNodes) > 1 {
-		var formatted []string
-		for os, nodes := range osToNodes {
-			formatted = append(formatted, fmt.Sprintf(
-				"%v: %v", os, strings.Join(nodes, ", ")))
+	if len(distros) != 1 {
+		return trace.BadParameter("servers have different OS distributions: %v", formatKeysAsList(distros))
+	}
+	// Version verification is purposely simply and will compare the prefixes
+	// up to to either the first '.' or end of line
+	for _, versions := range distros {
+		if !verifyCommonVersionPrefix(versions...) {
+			return trace.BadParameter("servers have different OS versions: %v", formatAsList(distros))
 		}
-		return trace.BadParameter(
-			"servers have different OSes/versions:\n%v",
-			strings.Join(formatted, "\n"))
 	}
-
-	log.Infof("Servers passed check for the same OS: %v.", osToNodes)
+	log.Infof("Servers passed check for same OS: %v.", formatAsList(distros))
 	return nil
+}
+
+func verifyCommonVersionPrefix(versions ...string) bool {
+	if len(versions) <= 1 {
+		return true
+	}
+	for i := 0; i < len(versions)-1; i += 1 {
+		if !strings.EqualFold(
+			strings.Split(versions[i], ".")[0],
+			strings.Split(versions[i+1], ".")[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+func formatAsList(m map[string][]string) (result []string) {
+	result = make([]string, 0, len(m))
+	for k, v := range m {
+		result = append(result, fmt.Sprintf("%v (%v)", k, v))
+	}
+	return result
+}
+
+func formatKeysAsList(m map[string][]string) (result []string) {
+	result = make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	return result
 }
 
 // checkTime checks if time it out of sync between servers

--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -769,7 +769,7 @@ func checkSameOS(servers []Server) error {
 	if len(distros) != 1 {
 		return trace.BadParameter("servers have different OS distributions: %v", formatKeysAsList(distros))
 	}
-	// Version verification is purposely simply and will compare the prefixes
+	// Version verification is purposely simple and will compare the prefixes
 	// up to to either the first '.' or end of line
 	for _, versions := range distros {
 		if !verifyCommonVersionPrefix(versions...) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR loosens the same OS requirement preflight check with the following semantics:

  * OS distributions are the same if both name and versions are exact match
  * OS distributions are compatible (and check succeeds) if name is an exact match and versions match on the prefix up to the first '.'
  * otherwise, OS distributions are not compatible

Also, this has been brought up multiple times (frequently in the form of asking whether it's possible to suppress just the OS check).

## Type of change

* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
Backport of https://github.com/gravitational/gravity/pull/1484.

<!--This PR addresses the following issues.-->
Refs https://github.com/gravitational/gravity/issues/1112.

## TODOs

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Unit-tested change.
****