### PR TITLE
(5.5) Backport role_map fixes

### DIFF
--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1897,10 +1896,6 @@ func (p *Process) initAccount() error {
 		}
 	}
 
-	if err := p.fixOpsCenterRoles(*account); err != nil {
-		p.Errorf("Failed to migrate Ops Center: %v.", trace.DebugReport(err))
-	}
-
 	return nil
 }
 
@@ -1979,47 +1974,6 @@ func (p *Process) ensureClusterState() error {
 		return trace.Wrap(err)
 	}
 
-	return nil
-}
-
-// fixOpsCenterRoles fixes use case when cert authorities
-// for remote ops center did not have any roles set to them,
-// so user could not SSH into terminal
-func (p *Process) fixOpsCenterRoles(account users.Account) error {
-	clusters, err := p.backend.GetTrustedClusters()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	currentUser, err := user.Current()
-	if err != nil {
-		p.Warningf("Failed to query current user: %v.", trace.ConvertSystemError(err))
-	}
-	p.Debugf("Going to update certificate authorities for %v.", clusters)
-	for _, cluster := range clusters {
-		certAuthority, err := p.backend.GetCertAuthority(teleservices.CertAuthID{
-			Type:       teleservices.UserCA,
-			DomainName: cluster.GetName(),
-		}, true)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if len(certAuthority.GetRoles()) != 0 {
-			p.Debugf("CA %v has assigned roles.", certAuthority.GetClusterName())
-			continue
-		}
-		p.Debugf("Migrating CA %v.", certAuthority.GetClusterName())
-		role := teleservices.RoleForCertAuthority(certAuthority)
-		role.SetLogins(teleservices.Allow, storage.GetAllowedLogins(currentUser))
-		err = p.backend.UpsertRole(role, storage.Forever)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		certAuthority.SetRoles([]string{role.GetName()})
-		err = p.backend.UpsertCertAuthority(certAuthority)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
 	return nil
 }
 

--- a/lib/storage/trustedcluster.go
+++ b/lib/storage/trustedcluster.go
@@ -121,7 +121,7 @@ type TrustedClusterSpecV2 struct {
 	SNIHost string `json:"sni_host"`
 	// Roles is a list of roles that users will be assuming when connecting to
 	// this cluster
-	Roles []string `json:"roles"`
+	Roles []string `json:"roles,omitempty"`
 	// RoleMap specifies role mappings to remote roles
 	RoleMap teleservices.RoleMap `json:"role_map,omitempty"`
 	// PullUpdates indicates whether the trusted cluster should pull updates
@@ -316,13 +316,19 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 	if c.Spec.ReverseTunnelAddress == "" {
 		return trace.BadParameter("tunnel_addr can't be empty")
 	}
+	if len(c.Spec.Roles) != 0 && len(c.Spec.RoleMap) != 0 {
+		return trace.BadParameter("either roles or role_map should be set, not both")
+	}
 	if err := c.Spec.RoleMap.Check(); err != nil {
 		return trace.Wrap(err)
 	}
 	if c.Metadata.Labels == nil {
 		c.Metadata.Labels = map[string]string{}
 	}
-	if len(c.Spec.Roles) == 0 {
+	// Fields "roles" and "role_map" are mutually exclusive so only populate
+	// default mapping if neither of those is set, otherwise it will lead to
+	// incorrect trusted cluster configuration.
+	if len(c.Spec.Roles)+len(c.Spec.RoleMap) == 0 {
 		c.Spec.Roles = []string{constants.RoleAdmin}
 	}
 	return nil
@@ -369,8 +375,12 @@ func MarshalTrustedCluster(cluster teleservices.TrustedCluster) ([]byte, error) 
 
 // UnmarshalTrustedCluster unmarshals the trusted cluster resource from bytes
 func UnmarshalTrustedCluster(bytes []byte) (TrustedCluster, error) {
+	jsonBytes, err := teleutils.ToJSON(bytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	var header teleservices.ResourceHeader
-	if err := json.Unmarshal(bytes, &header); err != nil {
+	if err := json.Unmarshal(jsonBytes, &header); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if header.Kind != teleservices.KindTrustedCluster {

--- a/lib/storage/trustedcluster.go
+++ b/lib/storage/trustedcluster.go
@@ -329,7 +329,12 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 	// default mapping if neither of those is set, otherwise it will lead to
 	// incorrect trusted cluster configuration.
 	if len(c.Spec.Roles)+len(c.Spec.RoleMap) == 0 {
-		c.Spec.Roles = []string{constants.RoleAdmin}
+		c.Spec.RoleMap = teleservices.RoleMap{
+			{
+				Remote: constants.RoleAdmin,
+				Local:  []string{constants.RoleAdmin},
+			},
+		}
 	}
 	return nil
 }

--- a/lib/storage/trustedcluster_test.go
+++ b/lib/storage/trustedcluster_test.go
@@ -48,7 +48,9 @@ spec:
 		Token:                "trusted_cluster_token",
 		ProxyAddress:         "hub.example.com:32009",
 		ReverseTunnelAddress: "hub.example.com:3024",
-		Roles:                []string{constants.RoleAdmin},
+		RoleMap: services.RoleMap{
+			{Remote: constants.RoleAdmin, Local: []string{constants.RoleAdmin}},
+		},
 	}))
 }
 

--- a/lib/storage/trustedcluster_test.go
+++ b/lib/storage/trustedcluster_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/constants"
+
+	"github.com/gravitational/teleport/lib/services"
+	"gopkg.in/check.v1"
+)
+
+type TrustedClusterSuite struct{}
+
+var _ = check.Suite(&TrustedClusterSuite{})
+
+// TestTrustedClusterDefaults verifies basic trusted cluster resource parsing and
+// default field values.
+func (s *TrustedClusterSuite) TestTrustedClusterDefaults(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		Roles:                []string{constants.RoleAdmin},
+	}))
+}
+
+// TestTrustedClusterRoles makes sure roles field can be set.
+func (s *TrustedClusterSuite) TestTrustedClusterRoles(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  roles: ["admin", "developer"]
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		Roles:                []string{"admin", "developer"},
+	}))
+}
+
+// TestTrustedClusterRoleMap makes sure roles are not populated when role_map
+// is set.
+func (s *TrustedClusterSuite) TestTrustedClusterRoleMap(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  role_map:
+  - remote: "admin"
+    local: ["admin"]
+  - remote: "developer"
+    local: ["developer", "viewer"]
+`
+	tc, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, tc, NewTrustedCluster("hub.example.com", TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                "trusted_cluster_token",
+		ProxyAddress:         "hub.example.com:32009",
+		ReverseTunnelAddress: "hub.example.com:3024",
+		RoleMap: services.RoleMap{
+			{
+				Remote: "admin",
+				Local:  []string{"admin"},
+			},
+			{
+				Remote: "developer",
+				Local:  []string{"developer", "viewer"},
+			},
+		},
+	}))
+}
+
+// TestTrustedClusterRolesAndRoleMaps makes sure roles and role_map can't be both set.
+func (s *TrustedClusterSuite) TestTrustedClusterRolesAndRoleMaps(c *check.C) {
+	spec := `kind: trusted_cluster
+version: v2
+metadata:
+  name: hub.example.com
+spec:
+  enabled: true
+  token: trusted_cluster_token
+  tunnel_addr: "hub.example.com:3024"
+  web_proxy_addr: "hub.example.com:32009"
+  roles: ["admin"]
+  role_map:
+  - remote: "admin"
+    local: ["admin"]
+  - remote: "developer"
+    local: ["developer", "viewer"]
+`
+	_, err := UnmarshalTrustedCluster([]byte(spec))
+	c.Assert(err, check.NotNil)
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Backport 3 changes related to trusted clusters and role mapping:

* The original fix for setting role_map property on trusted clusters: https://github.com/gravitational/gravity/pull/1504.
* Removed the old authorities migration: https://github.com/gravitational/gravity/pull/1510.
* A more secure role map default: https://github.com/gravitational/gravity/pull/1544.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Ports https://github.com/gravitational/gravity/pull/1504, https://github.com/gravitational/gravity/pull/1510 & https://github.com/gravitational/gravity/pull/1544.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback


## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

* Install a 6.3 hub and a 5.5 cluster (same setup as a customer who ran into this has).
* Connect cluster to hub using trusted cluster with role_map.
* Set up "viewer" role that maps onto "view" K8s group.

When logging as an admin:

```
➜  bin ./tele login --hub=hub.gravitational.io:32009 lovinghopper3790
Hub:		hub.gravitational.io
Username:	roman@gravitational.com
Cluster:	lovinghopper3790
Expires:	Wed May 13 15:24 UTC (19 hours from now)
➜  bin kubectl get nodes
NAME             STATUS   ROLES    AGE   VERSION
192.168.99.103   Ready    <none>   32m   v1.13.12
```

When logging as a viewer:

```
➜  bin ./tele login --hub=hub.gravitational.io:32009 lovinghopper3790 --token=viewer-token
Hub:		hub.gravitational.io
Username:	viewer
Cluster:	lovinghopper3790
Expires:	Never
➜  bin kubectl get nodes
Error from server (Forbidden): nodes is forbidden: User "remote-viewer-hub.gravitational.io" cannot list resource "nodes" in API group "" at the cluster scope
```