### PR TITLE
(5.5) Add gravity rollback command

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -653,6 +653,8 @@ const (
 	InProgressMark = "→"
 	// WarnMark is used in CLI to visually indicate a warning
 	WarnMark = "!"
+	// RollbackMark is used in CLI to visually indicate rollback
+	RollbackMark = "⤺"
 
 	// WireguardNetworkType is a network type that is used for wireguard/wormhole support
 	WireguardNetworkType = "wireguard"

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -72,8 +72,10 @@ func printPhase(w io.Writer, phase storage.OperationPhase, indent int) {
 		marker = constants.InProgressMark
 	} else if phase.GetState() == storage.OperationPhaseStateCompleted {
 		marker = constants.SuccessMark
-	} else if phase.GetState() == storage.OperationPhaseStateFailed || phase.GetState() == storage.OperationPhaseStateRolledBack {
+	} else if phase.GetState() == storage.OperationPhaseStateFailed {
 		marker = constants.FailureMark
+	} else if phase.GetState() == storage.OperationPhaseStateRolledBack {
+		marker = constants.RollbackMark
 	}
 	fmt.Fprintf(w, "%v%v %v\t%v\t%v\t%v\t%v\t%v\n",
 		strings.Repeat("  ", indent),

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -302,7 +302,7 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 		default:
 			return trace.BadParameter(
 				`Node %[1]v does not appear to have an upgrade agent running so phase %[2]q rollback cannot be performed remotely from this node.
-You can either try to redeploy upgrade agents on all cluster nodes using "./gravity agent deploy", or execute "./gravity plan rollback --phase=%[2]v" directly from %[1]v."`,
+You can redeploy upgrade agents on all cluster nodes using "./gravity agent deploy", or execute "./gravity plan rollback --phase=%[2]v" directly from %[1]v."`,
 				execServer.Hostname, p.PhaseID)
 		}
 

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -80,8 +80,12 @@ type Params struct {
 	// to be rerun - this is unexpected when the operation is resumed
 	// and only the unfinished/failed steps are re-executed
 	Resume bool
+	// Rollback indicates that the specified phase should be rolled back.
+	Rollback bool
 	// Progress is optional progress reporter
 	Progress utils.Progress
+	// DryRun allows to only print phases without executing/rolling back.
+	DryRun bool
 }
 
 // CheckAndSetDefaults makes sure all required parameters are set
@@ -153,7 +157,7 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 		return trace.Wrap(err)
 	}
 	for _, phase := range plan.Phases {
-		f.Debugf("Executing phase %q.", phase.ID)
+		f.WithField("phase", phase.ID).Debug("Executing phase.")
 		err := f.ExecutePhase(ctx, Params{
 			PhaseID:  phase.ID,
 			Progress: progress,
@@ -161,6 +165,34 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 		})
 		if err != nil {
 			return trace.Wrap(err, "failed to execute phase %q", phase.ID)
+		}
+	}
+	return nil
+}
+
+// RollbackPlan rolls back all phases of the plan that have been attempted so
+// far in the reverse order.
+func (f *FSM) RollbackPlan(ctx context.Context, progress utils.Progress, dryRun bool) error {
+	plan, err := f.GetPlan()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	allPhases := plan.GetLeafPhases()
+	for i := len(allPhases) - 1; i >= 0; i -= 1 {
+		phase := allPhases[i]
+		log := f.WithFields(logrus.Fields{"phase": phase.ID, "state": phase.GetState()})
+		if phase.IsUnstarted() || phase.IsRolledBack() {
+			log.Info("Skip rollback.")
+			continue
+		}
+		log.Info("Rollback.")
+		err := f.RollbackPhase(ctx, Params{
+			PhaseID:  phase.ID,
+			Progress: progress,
+			DryRun:   dryRun,
+		})
+		if err != nil {
+			return trace.Wrap(err)
 		}
 	}
 	return nil
@@ -223,17 +255,14 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 		if !p.Force {
 			return trace.Wrap(err)
 		}
-		f.Warnf("Forcing rollback: %v.", trace.DebugReport(err))
+		f.WithError(err).Warn("Forcing rollback.")
 	}
 	phase, err := FindPhase(plan, p.PhaseID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if !phase.HasSubphases() {
-		//
-		// Check whether this phase should be run on a local or remote server
-		// If it should be run on a remote server, throw an error
-		//
+		// Check whether this phase should be run on a local or remote server.
 		var execServer *storage.Server
 		if phase.Data != nil {
 			if phase.Data.ExecServer != nil {
@@ -243,21 +272,40 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 			}
 		}
 
+		execWhere := CanRunLocally
 		if execServer != nil {
-			execWhere, err := canExecuteOnServer(ctx, *execServer, f.Runner, f.FieldLogger)
+			execWhere, err = canExecuteOnServer(ctx, *execServer, f.Runner, f.FieldLogger)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if execWhere != CanRunLocally {
-				return trace.BadParameter("rollback phase %v must be run from server %v", p.PhaseID, execServer.Hostname)
-			}
 		}
 
-		p.Progress.NextStep("Rolling back %q", phase.ID)
-		err = f.rollbackPhase(ctx, p, *phase)
-		if err != nil {
-			return trace.Wrap(err)
+		switch execWhere {
+		case CanRunLocally:
+			message := fmt.Sprintf("Rolling back %q locally", phase.ID)
+			if p.DryRun {
+				p.Progress.NextStep("[DRY-RUN] %v", message)
+				return nil
+			}
+			p.Progress.NextStep(message)
+			return f.rollbackPhaseLocally(ctx, p, *phase)
+
+		case CanRunRemotely:
+			message := fmt.Sprintf("Rolling back %q on node %v", phase.ID, execServer.Hostname)
+			if p.DryRun {
+				p.Progress.NextStep("[DRY-RUN] %v", message)
+				return nil
+			}
+			p.Progress.NextStep(message)
+			return f.rollbackPhaseRemotely(ctx, p, *phase, *execServer)
+
+		default:
+			return trace.BadParameter(
+				`Node %[1]v does not appear to have an upgrade agent running so phase %[2]q rollback cannot be performed remotely from this node.
+You can either try to redeploy upgrade agents on all cluster nodes using "./gravity agent deploy", or execute "./gravity plan rollback --phase=%[2]v" directly from %[1]v."`,
+				execServer.Hostname, p.PhaseID)
 		}
+
 		return nil
 	}
 	for i := len(phase.Phases) - 1; i >= 0; i-- {
@@ -268,6 +316,16 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 		}
 	}
 	return nil
+}
+
+func (f *FSM) rollbackPhaseRemotely(ctx context.Context, p Params, phase storage.OperationPhase, server storage.Server) error {
+	return f.RunCommand(ctx, f.Runner, server, Params{
+		PhaseID:  p.PhaseID,
+		Force:    p.Force,
+		Resume:   p.Resume,
+		Rollback: true,
+		Progress: p.Progress,
+	})
 }
 
 // SetPreExec sets the hook that's called before phase execution
@@ -457,7 +515,7 @@ func (f *FSM) executeOnePhase(ctx context.Context, p Params, phase storage.Opera
 	return nil
 }
 
-func (f *FSM) rollbackPhase(ctx context.Context, p Params, phase storage.OperationPhase) error {
+func (f *FSM) rollbackPhaseLocally(ctx context.Context, p Params, phase storage.OperationPhase) error {
 	plan, err := f.GetPlan()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/fsm/fsm_test.go
+++ b/lib/fsm/fsm_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+func TestFSM(t *testing.T) { check.TestingT(t) }
+
+type FSMSuite struct {
+	planner *testPlanner
+}
+
+var _ = check.Suite(&FSMSuite{
+	planner: &testPlanner{},
+})
+
+// TestExecutePlan executes an unstarted plan and makes sure all phases have
+// been executed in correct order.
+func (s *FSMSuite) TestExecutePlan(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateUnstarted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateUnstarted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.ExecutePlan(context.TODO(), utils.NewNopProgress())
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is completed now.
+	c.Assert(IsCompleted(plan), check.Equals, true)
+	// Make sure phases were executed in correct order.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateCompleted),
+		s.planner.upgradeChange(storage.OperationPhaseStateInProgress),
+		s.planner.upgradeChange(storage.OperationPhaseStateCompleted),
+	))
+}
+
+// TestRollbackPlan rolls back a failed plan and make sure all phases have been
+// rolled back in correct order.
+func (s *FSMSuite) TestRollbackPlan(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateFailed))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.NewNopProgress(), false)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is rolled back now.
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+	// Make sure phases were rolled back in correct order.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.upgradeChange(storage.OperationPhaseStateInProgress),
+		s.planner.upgradeChange(storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateRolledBack),
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateRolledBack),
+	))
+}
+
+// TestRollbackPlanSkip rolls back a plan with some rolled back / unstarted phases
+// and makes sure such phases are being skipped during rollback.
+func (s *FSMSuite) TestRollbackPlanSkip(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateRolledBack),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.NewNopProgress(), false)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is rolled back now.
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+	// Make sure unstarted/rolled back phases were skipped over.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateRolledBack),
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateRolledBack),
+	))
+}
+
+// TestRollbackPlanDryRun make sure that rollback in dry-run mode does not
+// rollback any of the phases.
+func (s *FSMSuite) TestRollbackPlanDryRun(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.NewNopProgress(), true)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is still not rolled back.
+	c.Assert(IsRolledBack(plan), check.Equals, false)
+	// Make sure changelog is empty.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog())
+}
+
+func (s *FSMSuite) checkChangelog(c *check.C, actual, expected storage.PlanChangelog) {
+	c.Assert(len(actual), check.Equals, len(expected))
+	for i := 0; i < len(actual); i += 1 {
+		c.Assert(actual[i].PhaseID, check.Equals, expected[i].PhaseID)
+		c.Assert(actual[i].NewState, check.Equals, expected[i].NewState)
+	}
+}

--- a/lib/fsm/fsm_test.go
+++ b/lib/fsm/fsm_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -70,7 +71,7 @@ func (s *FSMSuite) TestExecutePlan(c *check.C) {
 	))
 }
 
-// TestRollbackPlan rolls back a failed plan and make sure all phases have been
+// TestRollbackPlan rolls back a failed plan and makes sure all phases have been
 // rolled back in correct order.
 func (s *FSMSuite) TestRollbackPlan(c *check.C) {
 	plan := s.planner.newPlan(
@@ -162,7 +163,7 @@ func (s *FSMSuite) TestRollbackPlanDryRun(c *check.C) {
 func (s *FSMSuite) checkChangelog(c *check.C, actual, expected storage.PlanChangelog) {
 	c.Assert(len(actual), check.Equals, len(expected))
 	for i := 0; i < len(actual); i += 1 {
-		c.Assert(actual[i].PhaseID, check.Equals, expected[i].PhaseID)
-		c.Assert(actual[i].NewState, check.Equals, expected[i].NewState)
+		actual[i].Created = expected[i].Created // Do not compare timestamps.
+		compare.DeepCompare(c, actual[i], expected[i])
 	}
 }

--- a/lib/fsm/testhelpers.go
+++ b/lib/fsm/testhelpers.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/rpc"
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/trace"
+	"github.com/pborman/uuid"
+)
+
+func newTestEngine(plan storage.OperationPlan) *testEngine {
+	return &testEngine{plan: plan}
+}
+
+// testEngine is fsm engine used in tests. Keeps its changelog in memory.
+type testEngine struct {
+	plan      storage.OperationPlan
+	changelog storage.PlanChangelog
+}
+
+// GetExecutor returns one of the test executors depending on the specified phase.
+func (t *testEngine) GetExecutor(p ExecutorParams, r Remote) (PhaseExecutor, error) {
+	if strings.HasPrefix(p.Phase.ID, "/init") {
+		return newInit(), nil
+	} else if strings.HasPrefix(p.Phase.ID, "/bootstrap") {
+		return newBootstrap(), nil
+	} else if strings.HasPrefix(p.Phase.ID, "/upgrade") {
+		return newUpgrade(), nil
+	}
+	return nil, trace.BadParameter("unknown phase %q", p.Phase.ID)
+}
+
+// ChangePhaseState records the provided phase state change in the test engine.
+func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error {
+	t.changelog = append(t.changelog, storage.PlanChange{
+		ID:       uuid.New(),
+		PhaseID:  ch.Phase,
+		NewState: ch.State,
+		Created:  time.Now().UTC(),
+	})
+	return nil
+}
+
+// GetPlan returns the test plan with the changelog applied.
+func (t *testEngine) GetPlan() (*storage.OperationPlan, error) {
+	return ResolvePlan(t.plan, t.changelog), nil
+}
+
+// RunCommand is not implemented by the test engine.
+func (t *testEngine) RunCommand(ctx context.Context, r rpc.RemoteRunner, s storage.Server, p Params) error {
+	return trace.NotImplemented("test engine cannot execute remote commands")
+}
+
+// Complete is not implemented by the test engine.
+func (t *testEngine) Complete(err error) error {
+	return trace.NotImplemented("test engine cannot complete operations")
+}
+
+func newInit() *initExecutor {
+	return &initExecutor{newTest()}
+}
+
+type initExecutor struct {
+	*testExecutor
+}
+
+func newBootstrap() *bootstrapExecutor {
+	return &bootstrapExecutor{newTest()}
+}
+
+type bootstrapExecutor struct {
+	*testExecutor
+}
+
+func newUpgrade() *upgradeExecutor {
+	return &upgradeExecutor{newTest()}
+}
+
+type upgradeExecutor struct {
+	*testExecutor
+}
+
+func newTest() *testExecutor {
+	return &testExecutor{FieldLogger: logrus.WithField(trace.Component, "test")}
+}
+
+// testExecutor serves as a base for executors used in tests.
+type testExecutor struct {
+	logrus.FieldLogger
+}
+
+func (e *testExecutor) Execute(ctx context.Context) error   { return nil }
+func (e *testExecutor) Rollback(ctx context.Context) error  { return nil }
+func (e *testExecutor) PreCheck(ctx context.Context) error  { return nil }
+func (e *testExecutor) PostCheck(ctx context.Context) error { return nil }
+
+// testPlanner knows how to generate plans and changelogs used in fsm tests.
+type testPlanner struct{}
+
+func (p *testPlanner) newPlan(phases ...storage.OperationPhase) *storage.OperationPlan {
+	return &storage.OperationPlan{Phases: phases}
+}
+
+func (p *testPlanner) newChangelog(changes ...storage.PlanChange) storage.PlanChangelog {
+	return storage.PlanChangelog(changes)
+}
+
+func (p *testPlanner) initPhase(state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/init", State: state}
+}
+
+func (p *testPlanner) initChange(state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: "/init", NewState: state}
+}
+
+func (p *testPlanner) bootstrapPhase(phases ...storage.OperationPhase) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/bootstrap", Phases: phases}
+}
+
+func (p *testPlanner) bootstrapSubPhase(node, state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: fmt.Sprintf("/bootstrap/%v", node), State: state}
+}
+
+func (p *testPlanner) bootstrapSubChange(node, state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: fmt.Sprintf("/bootstrap/%v", node), NewState: state}
+}
+
+func (p *testPlanner) upgradePhase(state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/upgrade", State: state}
+}
+
+func (p *testPlanner) upgradeChange(state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: "/upgrade", NewState: state}
+}

--- a/lib/fsm/testhelpers.go
+++ b/lib/fsm/testhelpers.go
@@ -24,14 +24,15 @@ import (
 
 	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
-	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/trace"
-	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 func newTestEngine(plan storage.OperationPlan) *testEngine {
-	return &testEngine{plan: plan}
+	return &testEngine{
+		plan: plan,
+	}
 }
 
 // testEngine is fsm engine used in tests. Keeps its changelog in memory.
@@ -55,10 +56,11 @@ func (t *testEngine) GetExecutor(p ExecutorParams, r Remote) (PhaseExecutor, err
 // ChangePhaseState records the provided phase state change in the test engine.
 func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error {
 	t.changelog = append(t.changelog, storage.PlanChange{
-		ID:       uuid.New(),
 		PhaseID:  ch.Phase,
 		NewState: ch.State,
-		Created:  time.Now().UTC(),
+		// Using real time on purpose, because the final state is determined
+		// by the most recent phase in the changelog.
+		Created: time.Now().UTC(),
 	})
 	return nil
 }

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -45,7 +45,7 @@ func CanRollback(plan *storage.OperationPlan, phaseID string) error {
 
 // IsCompleted returns true if all phases of the provided plan are completed
 func IsCompleted(plan *storage.OperationPlan) bool {
-	for _, phase := range FlattenPlan(plan) {
+	for _, phase := range plan.GetLeafPhases() {
 		if !phase.IsCompleted() {
 			return false
 		}
@@ -55,7 +55,7 @@ func IsCompleted(plan *storage.OperationPlan) bool {
 
 // IsRolledBack returns true if the provided plan is rolled back.
 func IsRolledBack(plan *storage.OperationPlan) bool {
-	for _, phase := range FlattenPlan(plan) {
+	for _, phase := range plan.GetLeafPhases() {
 		if !phase.IsRolledBack() && !phase.IsUnstarted() {
 			return false
 		}

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -53,6 +53,16 @@ func IsCompleted(plan *storage.OperationPlan) bool {
 	return true
 }
 
+// IsRolledBack returns true if the provided plan is rolled back.
+func IsRolledBack(plan *storage.OperationPlan) bool {
+	for _, phase := range FlattenPlan(plan) {
+		if !phase.IsRolledBack() && !phase.IsUnstarted() {
+			return false
+		}
+	}
+	return true
+}
+
 // MarkCompleted marks all phases of the plan as completed
 func MarkCompleted(plan *storage.OperationPlan) {
 	allPhases := FlattenPlan(plan)
@@ -238,9 +248,8 @@ func CompleteOrFailOperation(plan *storage.OperationPlan, operator ops.Operator,
 }
 
 func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {
-	// add the phase itself
+	// Add the phase itself and all its subphases recursively.
 	*result = append(*result, phase)
-	// as well as all its subphases and their subphases recursively
 	for i := range phase.Phases {
 		addPhases(&phase.Phases[i], result)
 	}

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"github.com/gravitational/gravity/lib/storage"
+
+	"gopkg.in/check.v1"
+)
+
+type FSMUtilsSuite struct {
+	planner *testPlanner
+}
+
+var _ = check.Suite(&FSMUtilsSuite{
+	planner: &testPlanner{},
+})
+
+func (s *FSMUtilsSuite) TestIsCompleted(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateCompleted))
+	c.Assert(IsCompleted(plan), check.Equals, true)
+}
+
+func (s *FSMUtilsSuite) TestIsRolledBack(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateRolledBack),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+}

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -63,7 +63,7 @@ func (p OperationPlan) Check() error {
 	return nil
 }
 
-// GetLeafPhases "unfolds" the plan and returns all phases that do not have
+// GetLeafPhases flattens the plan and returns all phases that do not have
 // any subphases in the order they appear in the plan.
 //
 // For instance, for the following plan

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -63,6 +63,35 @@ func (p OperationPlan) Check() error {
 	return nil
 }
 
+// GetLeafPhases "unfolds" the plan and returns all phases that do not have
+// any subphases in the order they appear in the plan.
+//
+// For instance, for the following plan
+//
+//  * /init
+//    * /node-1
+//    * /node-2
+//  * /checks
+//
+// it will return ["/init/node-1", "/init/node-2", "/checks"].
+func (p *OperationPlan) GetLeafPhases() (result []OperationPhase) {
+	for _, phase := range p.Phases {
+		result = append(result, getLeafPhases(phase)...)
+	}
+	return result
+}
+
+func getLeafPhases(phase OperationPhase) (result []OperationPhase) {
+	if len(phase.Phases) == 0 {
+		result = append(result, phase)
+	} else {
+		for _, sub := range phase.Phases {
+			result = append(result, getLeafPhases(sub)...)
+		}
+	}
+	return result
+}
+
 // OperationPhase represents a single operation plan phase
 type OperationPhase struct {
 	// ID is the ID of the phase within operation

--- a/lib/storage/plan_test.go
+++ b/lib/storage/plan_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/gravitational/gravity/lib/compare"
+
+	"gopkg.in/check.v1"
+)
+
+type PlanSuite struct{}
+
+var _ = check.Suite(&PlanSuite{})
+
+func (*PlanSuite) TestGetLeafPhases(c *check.C) {
+	initPhase := OperationPhase{ID: "/init"}
+	bootstrapPhase1 := OperationPhase{ID: "/bootstrap/node-1"}
+	bootstrapPhase2 := OperationPhase{ID: "/bootstrap/node-2"}
+	bootstrapPhase := OperationPhase{
+		ID:     "/bootstrap",
+		Phases: []OperationPhase{bootstrapPhase1, bootstrapPhase2},
+	}
+	upgradePhase := OperationPhase{ID: "/upgrade"}
+	plan := &OperationPlan{
+		Phases: []OperationPhase{initPhase, bootstrapPhase, upgradePhase},
+	}
+	compare.DeepCompare(c, plan.GetLeafPhases(), []OperationPhase{
+		initPhase, bootstrapPhase1, bootstrapPhase2, upgradePhase})
+}

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -157,7 +157,11 @@ func (r *Engine) ChangePhaseState(ctx context.Context, change fsm.StateChange) e
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
 func (r *Engine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, params fsm.Params) error {
-	args := []string{"plan", "execute",
+	command := "execute"
+	if params.Rollback {
+		command = "rollback"
+	}
+	args := []string{"plan", command,
 		"--phase", params.PhaseID,
 		"--operation-id", r.Operation.ID,
 	}

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -100,7 +100,11 @@ func (r *Updater) RunPhase(ctx context.Context, phase string, phaseTimeout time.
 }
 
 // RollbackPhase rolls back the specified phase.
-func (r *Updater) RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error {
+func (r *Updater) RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force, dryRun bool) error {
+	if phase == fsm.RootPhase {
+		return r.rollbackPlan(ctx, dryRun)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, phaseTimeout)
 	defer cancel()
 
@@ -138,6 +142,23 @@ func (r *Updater) GetPlan() (*storage.OperationPlan, error) {
 // Close closes the underlying FSM
 func (r *Updater) Close() error {
 	return r.machine.Close()
+}
+
+func (r *Updater) rollbackPlan(ctx context.Context, dryRun bool) error {
+	progress := utils.NewProgress(ctx, formatOperation(*r.Operation), -1, false)
+	defer progress.Stop()
+
+	if err := r.machine.RollbackPlan(ctx, progress, dryRun); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !dryRun {
+		if err := r.machine.Complete(trace.BadParameter("rolled back")); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
 }
 
 func (r *Updater) executePlan(ctx context.Context) error {

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -100,21 +100,21 @@ func (r *Updater) RunPhase(ctx context.Context, phase string, phaseTimeout time.
 }
 
 // RollbackPhase rolls back the specified phase.
-func (r *Updater) RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force, dryRun bool) error {
-	if phase == fsm.RootPhase {
-		return r.rollbackPlan(ctx, dryRun)
+func (r *Updater) RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error {
+	if params.PhaseID == fsm.RootPhase {
+		return r.rollbackPlan(ctx, params.DryRun)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, phaseTimeout)
 	defer cancel()
 
-	progress := utils.NewProgress(ctx, fmt.Sprintf("Rolling back phase %q", phase), -1, false)
+	progress := utils.NewProgress(ctx, fmt.Sprintf("Rolling back phase %q", params.PhaseID), -1, false)
 	defer progress.Stop()
 
 	return trace.Wrap(r.machine.RollbackPhase(ctx, fsm.Params{
-		PhaseID:  phase,
+		PhaseID:  params.PhaseID,
 		Progress: progress,
-		Force:    force,
+		Force:    params.Force,
 	}))
 }
 

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -109,7 +109,7 @@ func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -109,7 +110,11 @@ func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -135,7 +135,7 @@ func rollbackUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
@@ -135,7 +136,11 @@ func rollbackUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -80,6 +80,8 @@ type Application struct {
 	PlanResumeCmd PlanResumeCmd
 	// PlanCompleteCmd completes the operation plan
 	PlanCompleteCmd PlanCompleteCmd
+	// RollbackCmd performs operation rollback
+	RollbackCmd RollbackCmd
 	// UpdateCmd combines app update related commands
 	UpdateCmd UpdateCmd
 	// UpdateCheckCmd checks if a new app version is available
@@ -526,6 +528,21 @@ type PlanResumeCmd struct {
 // PlanCompleteCmd completes the operation plan
 type PlanCompleteCmd struct {
 	*kingpin.CmdClause
+}
+
+// RollbackCmd performs operation rollback
+type RollbackCmd struct {
+	*kingpin.CmdClause
+	// PhaseTimeout is the individual phase rollback timeout
+	PhaseTimeout *time.Duration
+	// OperationID is optional ID of operation to rollback
+	OperationID *string
+	// SkipVersionCheck suppresses version mismatch errors
+	SkipVersionCheck *bool
+	// Confirmed suppresses confirmation prompt
+	Confirmed *bool
+	// DryRun prints rollback phases without actually performing them
+	DryRun *bool
 }
 
 // InstallPlanCmd combines subcommands for install plan

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -98,7 +98,7 @@ func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ Lo
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -98,7 +99,11 @@ func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ Lo
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force, params.DryRun)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/input.go
+++ b/tool/gravity/cli/input.go
@@ -135,7 +135,7 @@ func enforceConfirmation(title string, args ...interface{}) error {
 		return trace.Wrap(err)
 	}
 	if !confirmed {
-		return trace.CompareFailed("cancelled")
+		return trace.CompareFailed("Operation has been canceled by user.")
 	}
 	return nil
 }

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -155,9 +155,12 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark operation as completed")
 
-	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback an operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use gravity plan rollback command to rollback phase by phase.")
+	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback currently ongoing operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use gravity plan rollback command to rollback phase by phase.")
 	g.RollbackCmd.PhaseTimeout = g.RollbackCmd.Flag("timeout", "Individual phase rollback timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
-	g.RollbackCmd.OperationID = g.RollbackCmd.Flag("operation-id", "ID of the operation to rollback. If not specified, the last operation will be used").String()
+	// TODO(r0mant): Hide operation id flag for now, only the current operation
+	//               rollback is currently allowed. We might unhide it when we
+	//               allow completed operation rollbacks.
+	g.RollbackCmd.OperationID = g.RollbackCmd.Flag("operation-id", "ID of the operation to rollback. If not specified, the last operation will be used").Hidden().String()
 	g.RollbackCmd.SkipVersionCheck = g.RollbackCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 	g.RollbackCmd.Confirmed = g.RollbackCmd.Flag("confirm", "Do not ask for confirmation").Bool()
 	g.RollbackCmd.DryRun = g.RollbackCmd.Flag("dry-run", "Print rollback phases without actually performing them").Bool()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -155,7 +155,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark operation as completed")
 
-	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback currently ongoing operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use gravity plan rollback command to rollback phase by phase.")
+	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback currently ongoing operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use 'gravity plan rollback' command to rollback phase by phase.")
 	g.RollbackCmd.PhaseTimeout = g.RollbackCmd.Flag("timeout", "Individual phase rollback timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 	// TODO(r0mant): Hide operation id flag for now, only the current operation
 	//               rollback is currently allowed. We might unhide it when we

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -134,7 +134,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.RemoveCmd.Confirm = g.RemoveCmd.Flag("confirm", "Do not ask for confirmation").Bool()
 
 	g.PlanCmd.CmdClause = g.Command("plan", "Manage operation plan")
-	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. It not specified, the last operation will be used").String()
+	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. If not specified, the last operation will be used").String()
 	g.PlanCmd.SkipVersionCheck = g.PlanCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation").Default()
@@ -146,7 +146,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanExecuteCmd.PhaseTimeout = g.PlanExecuteCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 
 	g.PlanRollbackCmd.CmdClause = g.PlanCmd.Command("rollback", "Rollback specified operation phase")
-	g.PlanRollbackCmd.Phase = g.PlanRollbackCmd.Flag("phase", "Phase ID to execute").String()
+	g.PlanRollbackCmd.Phase = g.PlanRollbackCmd.Flag("phase", "Phase ID to rollback").Required().String()
 	g.PlanRollbackCmd.Force = g.PlanRollbackCmd.Flag("force", "Force rollback of specified phase").Bool()
 	g.PlanRollbackCmd.PhaseTimeout = g.PlanRollbackCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 
@@ -154,6 +154,13 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanResumeCmd.PhaseTimeout = g.PlanResumeCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark operation as completed")
+
+	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback an operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use gravity plan rollback command to rollback phase by phase.")
+	g.RollbackCmd.PhaseTimeout = g.RollbackCmd.Flag("timeout", "Individual phase rollback timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
+	g.RollbackCmd.OperationID = g.RollbackCmd.Flag("operation-id", "ID of the operation to rollback. If not specified, the last operation will be used").String()
+	g.RollbackCmd.SkipVersionCheck = g.RollbackCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
+	g.RollbackCmd.Confirmed = g.RollbackCmd.Flag("confirm", "Do not ask for confirmation").Bool()
+	g.RollbackCmd.DryRun = g.RollbackCmd.Flag("dry-run", "Print rollback phases without actually performing them").Bool()
 
 	g.UpdateCmd.CmdClause = g.Command("update", "Update actions on cluster")
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -105,6 +105,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.PlanRollbackCmd.FullCommand(),
 		g.PlanResumeCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.ResourceCreateCmd.FullCommand():
 		if *g.Debug {
 			teleutils.InitLogger(teleutils.LoggingForDaemon, level)
@@ -171,6 +172,7 @@ func InitAndCheck(g *Application, cmd string) error {
 	switch cmd {
 	case g.SystemUpdateCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.SystemRollbackCmd.FullCommand(),
 		g.SystemUninstallCmd.FullCommand(),
 		g.UpdateSystemCmd.FullCommand(),
@@ -211,6 +213,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.SystemRollbackCmd.FullCommand(),
 		g.UpdateSystemCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.SystemGCRegistryCmd.FullCommand(),
 		g.SystemUninstallCmd.FullCommand(),
 		g.PlanetEnterCmd.FullCommand(),
@@ -417,6 +420,14 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.PlanCmd.OperationID, *g.PlanDisplayCmd.Output)
 	case g.PlanCompleteCmd.FullCommand():
 		return completeOperationPlan(localEnv, g, *g.PlanCmd.OperationID)
+	case g.RollbackCmd.FullCommand():
+		return rollbackPlan(localEnv, g,
+			PhaseParams{
+				Timeout:          *g.RollbackCmd.PhaseTimeout,
+				SkipVersionCheck: *g.RollbackCmd.SkipVersionCheck,
+				OperationID:      *g.RollbackCmd.OperationID,
+				DryRun:           *g.RollbackCmd.DryRun,
+			}, *g.RollbackCmd.Confirmed)
 	case g.LeaveCmd.FullCommand():
 		return leave(localEnv, leaveConfig{
 			force:     *g.LeaveCmd.Force,

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -166,7 +167,7 @@ type updater interface {
 	io.Closer
 	Run(ctx context.Context) error
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
-	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force, dryRun bool) error
+	RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error
 	Complete(error) error
 }
 

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -166,7 +166,7 @@ type updater interface {
 	io.Closer
 	Run(ctx context.Context) error
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
-	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
+	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force, dryRun bool) error
 	Complete(error) error
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR adds a top-level `gravity rollback` command that can rollback all phases of the operation plan that have been executed (or failed) so far, in reverse order.

It is meant as a more user-friendly alternative to rolling back the plan phase-by-phase using `gravity plan rollback --phase=` approach, which is still there when more granular control is needed.

_Note: With `gravity rollback` available, nothing really prevents us from allowing rollbacks of certain completed operations which has come up a few times before. I'm planning to do this as a next step._

Some details worth mentioning:

* Only "upgrade", "runtime environment" and "cluster configuration" are supported by this command.
* Added dry-run mode to the command so it's possible to see which phases will be rolled back.
* As a part of this change I also allowed running rollback on remote nodes which was disabled before for no good reason.

Finally, **the best** part of the change is a new glyph that marks rolled back phases :)

```
ubuntu@node-1:~/upgrade$ sudo ./gravity plan
Phase                         Description                                                State           Node               Requires                                Updated
-----                         -----------                                                -----           ----               --------                                -------
⤺ init                        Initialize update operation                                Rolled Back     -                  -                                       Tue May 12 17:27 UTC
  ⤺ node-1                    Initialize node "node-1"                                   Rolled Back     192.168.99.102     -                                       Tue May 12 17:27 UTC
```

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1067.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Setup

Did all tests in a 2-node cluster to make sure to cover remote phase rollback.

### Upgrade

Start operation in manual mode:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Tue May 12 16:52:11 UTC	Upgrading cluster from 5.5.38 to 5.5.44-dev.5
```

Execute several phases:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity plan execute --phase=/init
...
ubuntu@node-1:~/upgrade$ sudo ./gravity plan execute --phase=/masters
```

Test dry run:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity rollback --dry-run
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/enable-node-2" on node node-2
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/untaint" locally
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/endpoints" locally
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/uncordon" locally
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/taint" locally
Tue May 12 17:24:19 UTC	[DRY-RUN] Rolling back "/masters/node-2/system-upgrade" on 
...
```

Test rollback:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity rollback --confirm
Tue May 12 17:25:11 UTC	Rolling back "/masters/node-2/enable-node-2" on node node-2
Tue May 12 17:25:12 UTC	Rolling back "/masters/node-2/untaint" locally
Tue May 12 17:25:13 UTC	Rolling back "/masters/node-2/endpoints" locally
Tue May 12 17:25:14 UTC	Rolling back "/masters/node-2/uncordon" locally
Tue May 12 17:25:15 UTC	Rolling back "/masters/node-2/taint" locally
Tue May 12 17:25:16 UTC	Rolling back "/masters/node-2/system-upgrade" on node node-2
	Still rolling back "/masters/node-2/system-upgrade" on node node-2 (10 seconds elapsed)
	Still rolling back "/masters/node-2/system-upgrade" on node node-2 (20 seconds elapsed)
...
```

Make sure cluster is at the original version and active:

```
ubuntu@node-1:~/upgrade$ sudo gravity status
Cluster name:		quizzicalheyrovsky2513
Cluster status:		active
```

Make sure plan is rolled back:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity plan
Phase                         Description                                                State           Node               Requires                                Updated
-----                         -----------                                                -----           ----               --------                                -------
⤺ init                        Initialize update operation                                Rolled Back     -                  -                                       Tue May 12 17:27 UTC
  ⤺ node-1                    Initialize node "node-1"                                   Rolled Back     192.168.99.102     -                                       Tue May 12 17:27 UTC
  ⤺ node-2                    Initialize node "node-2"                                   Rolled Back     192.168.99.103     -                                       Tue May 12 17:27 UTC
...
```

### Runtime environment

Did similar test to upgrade, to make sure this operation also rolls back fine.

Start in manual mode:

```
ubuntu@node-1:~/resources$ sudo gravity resource create runtimeenv.yaml --manual
```

Execute all operation phases:

```
ubuntu@node-1:~/resources$ sudo gravity plan execute --phase=/update-config
ubuntu@node-1:~/resources$ sudo gravity plan execute --phase=/masters/node-1
ubuntu@node-1:~/resources$ sudo gravity plan execute --phase=/masters/node-2
```

Make sure env var was set:

```
node-2:/$ cat /etc/container-environment
TEST_VAR="hello-world"
```

Rollback:

```
ubuntu@node-1:~/resources$ sudo gravity rollback --confirm
Wed May  6 23:33:06 UTC	Rolling back "/masters/node-2/enable-elections" on node node-2
Wed May  6 23:33:08 UTC	Rolling back "/masters/node-2/untaint" on node node-2
Wed May  6 23:33:09 UTC	Rolling back "/masters/node-2/endpoints" on node node-2
...
```

Make sure env var is no longer set.

## Additional information
<!--Optional. Anything else that may be relevant.-->

As mentioned above, the next step (besides forward-ports) for this really is to allow to use this command to certain completed operations. As a part of this next step, also would be nice to add a robotest scenario for rollback.