### PR TITLE
Child directories for influxdb and kapacitor

### DIFF
--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -202,7 +202,8 @@ func (p *bootstrapExecutor) configureSystemDirectories() error {
 		filepath.Join(stateDir, "site", "packages", "tmp"),
 		filepath.Join(stateDir, "secrets"),
 		filepath.Join(stateDir, "backup"),
-		filepath.Join(stateDir, "monitoring"),
+		filepath.Join(stateDir, "monitoring", "influxdb"),
+		filepath.Join(stateDir, "monitoring", "kapacitor"),
 	}
 
 	for _, dir := range mkdirList {

--- a/lib/ops/opsservice/deploy.go
+++ b/lib/ops/opsservice/deploy.go
@@ -117,7 +117,8 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("planet", "state"),
 		server.InGravity("site"),
 		server.InGravity("backup"),
-		server.InGravity("monitoring"),
+		server.InGravity("monitoring", "influxdb"),
+		server.InGravity("monitoring", "kapacitor"),
 	}
 
 	chmodList := []string{

--- a/lib/ops/opsservice/deploy.go
+++ b/lib/ops/opsservice/deploy.go
@@ -104,7 +104,8 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("site", "packages", "tmp"),
 		server.InGravity("site", "teleport"),
 		server.InGravity("backup"),
-		server.InGravity("monitoring"),
+		server.InGravity("monitoring", "influxdb"),
+		server.InGravity("monitoring", "kapacitor"),
 	}
 
 	chownList := []string{
@@ -117,8 +118,7 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("planet", "state"),
 		server.InGravity("site"),
 		server.InGravity("backup"),
-		server.InGravity("monitoring", "influxdb"),
-		server.InGravity("monitoring", "kapacitor"),
+		server.InGravity("monitoring"),
 	}
 
 	chmodList := []string{


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Follow up for https://github.com/gravitational/gravity/pull/1560. I just realized we need subdirectories with service-uid permissions, otherwise for hostPath Kubelet will created them with root:root permissions.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->


## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

- [X] Self-review the change
- [ ] Write tests
- [X] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
## Additional information
<!--Optional. Anything else that may be relevant.-->
