### PR TITLE
Move Wordpress example to Gravity repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ the world without a massive DevOps team.
 |---|----
 | [Gravity Website](https://gravitational.com/gravity/)  | The official website of the enterprise edition of Gravity |
 | [Gravity Documentation](https://gravitational.com/gravity/docs/)  | Gravity Documentation |
+| [Gravity Examples](examples/) | Examples of applications packaged with Gravity |
 | [Blog](http://blog.gravitational.com) | Our blog, where we publish Gravity news |
 | [Security and Release Updates](https://community.gravitational.com/c/gravity-news) | Gravity Community Security and Release Updates |
 | [Community Forum](https://community.gravitational.com) | Gravity Community Forum|
@@ -88,6 +89,15 @@ A Cluster Image produced by Gravity includes:
 An image is all one needs to re-create the complete replica of the original
 Kubernetes cluster, with all deployed applications inside, even in an
 air-gapped server room.
+
+## Examples
+
+Take a look at the [examples](examples/) directory in this repository to find
+examples of how to package and deploy Kubernetes applications using Gravity.
+
+The following examples are currently available:
+
+* [Wordpress](examples/wordpress). Deploys Wordpress CMS with an OpenEBS-backed persistent storage.
 
 ## How do Initial Deployments work?
 
@@ -179,17 +189,6 @@ $ make install
 # To remove the build artifacts:
 $ make clean
 ```
-
-## Examples
-
-Take a look at our [quickstart](https://github.com/gravitational/quickstart)
-repository to find examples of how to package and deploy Kubernetes applications
-using Gravity.
-
-The following examples are available:
-
-* [Wordpress](https://github.com/gravitational/quickstart/tree/master/wordpress).
-  Deploys Wordpress CMS with an OpenEBS-backed persistent storage.
 
 ## Known Issues
 

--- a/docs/7.x/quickstart.md
+++ b/docs/7.x/quickstart.md
@@ -58,8 +58,8 @@ Clone the sample Git repository which contains the Kubernetes resources for
 [Wordpress](https://www.wordpress.org/), which we are using in this tutorial as a sample application:
 
 ```bsh
-$ git clone https://github.com/gravitational/quickstart.git
-$ cd quickstart
+$ git clone https://github.com/gravitational/gravity.git
+$ cd gravity/examples
 ```
 
 ## Building a Cluster Image
@@ -79,7 +79,7 @@ To build a Cluster Image we'll perform the following steps:
 
 ### Step 2: Creating the Kubernetes Resources
 
-Making Wordpress run on Kubernetes is easy. The quickstart repository you have
+Making Wordpress run on Kubernetes is easy. The Gravity examples repository you have
 cloned above includes the YAML definitions of Kubernetes objects. We'll use
 a Helm chart for this:
 
@@ -107,7 +107,7 @@ You are welcome to modify this file and you can use --set and --values in the te
 In this step, we create an Image Manifest which describes the system
 requirements for the Cluster.
 
-We have already prepared one for this guide in the cloned repo: `wordpress/resources/app.yaml`. You can [open it on Github](https://github.com/gravitational/quickstart/blob/master/wordpress/resources/app.yaml) for convenience. We have commented the most important fields
+We have already prepared one for this guide in the cloned repo: `wordpress/resources/app.yaml`. You can [open it on Github](https://github.com/gravitational/gravity/blob/master/examples/wordpress/resources/app.yaml) for convenience. We have commented the most important fields
 in the example manifest.
 
 ### Step 4: Building the Cluster Image
@@ -312,7 +312,7 @@ $ sudo ./gravity install \
         --flavor=medium
 ```
 
-Flavor details are in the Wordpress [Cluster Manifest](https://github.com/gravitational/quickstart/blob/master/wordpress/resources/app.yaml). Flavors provide for specifying the number and configuration of nodes for a deployment.
+Flavor details are in the Wordpress [Cluster Manifest](https://github.com/gravitational/gravity/blob/master/examples/wordpress/resources/app.yaml). Flavors provide for specifying the number and configuration of nodes for a deployment.
 
 ## Adding a User
 The next step is to create a new Kubernetes user:

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -1,6 +1,6 @@
-# Quick Start
+# Wordpress on Gravity
 
-This repository includes the necessary files to package and deploy [Wordpress](https://www.wordpress.org/), an open source content management system, into on-prem, public or private cloud environments using [Gravity](http://gravitational.com/gravity/).  
+This repository includes the necessary files to package and deploy [Wordpress](https://www.wordpress.org/), an open source content management system, into on-prem, public or private cloud environments using [Gravity](http://gravitational.com/gravity/).
 
 This manifest uses the Open Elastic Block Store [OpenEBS](https://openebs.io/) built into Gravity 7.X.
 
@@ -49,12 +49,12 @@ Clone the sample Git repository which contains the Kubernetes resources for
 [Wordpress](https://www.wordpress.org/), which we are using in this tutorial as a sample application:
 
 ```bsh
-$ git clone https://github.com/gravitational/quickstart.git
-$ cd quickstart
+$ git clone https://github.com/gravitational/gravity.git
+$ cd gravity/examples
 ```
 ### Step 2: Creating the Kubernetes Resources
 
-Making Wordpress run on Kubernetes is easy. The quickstart repository you have
+Making Wordpress run on Kubernetes is easy. The examples repository you have
 cloned above includes the YAML definitions of Kubernetes objects. We'll use
 a Helm chart for this:
 
@@ -108,7 +108,7 @@ Mon Apr 27 00:51:21 UTC Creating application
 Mon Apr 27 00:51:36 UTC Generating the cluster image
 Mon Apr 27 00:51:44 UTC Saving the image as wordpress.tar
         Still saving the image as wordpress.tar (10 seconds elapsed)
-Mon Apr 27 00:52:02 UTC Build finished in 3 minutes 
+Mon Apr 27 00:52:02 UTC Build finished in 3 minutes
 ```
 
 Let's review what just happened. `tele build` did the following:
@@ -171,7 +171,7 @@ Flag              | Description
 -------------------|---------------------------------
 `--token`          | A secret token of your choosing which will be used to add additional nodes to this Cluster in the future. We'll use word "secret" here.
 `--advertise-addr` | The IP address this host will be visible on by other nodes in this Cluster. We'll use `10.5.5.28`.
-`--cloud-provider` | Whether in a specific cloud environment or a no-cloud provider such as standalone VMs/bare-metal environment [generic aws gce] We'll use `generic` here.  
+`--cloud-provider` | Whether in a specific cloud environment or a no-cloud provider such as standalone VMs/bare-metal environment [generic aws gce] We'll use `generic` here.
 
 The command below will create a single-node Kubernetes cluster with Wordpress running inside:
 
@@ -184,15 +184,15 @@ $ sudo ./gravity install \
 # Output:
 Sun Apr 26 23:55:11 UTC Starting enterprise installer
 
-To abort the installation and clean up the system,                                                                                                                                                                                              
-press Ctrl+C two times in a row.                                                                                                                                                                                                                
+To abort the installation and clean up the system,
+press Ctrl+C two times in a row.
 
-If you get disconnected from the terminal, you can reconnect to the installer                                                                                                                                                                   
-agent by issuing 'gravity resume' command.                                                                                                                                                                                                      
+If you get disconnected from the terminal, you can reconnect to the installer
+agent by issuing 'gravity resume' command.
 
-If the installation fails, use 'gravity plan' to inspect the state and                                                                                                                                                                          
-'gravity resume' to continue the operation.                                                                                                                                                                                                     
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.                                                                                                                                                  
+If the installation fails, use 'gravity plan' to inspect the state and
+'gravity resume' to continue the operation.
+See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.
 
 Sun Apr 26 23:55:11 UTC Connecting to installer
 Sun Apr 26 23:55:32 UTC Connected to installer
@@ -249,7 +249,7 @@ Cluster endpoints:
         - https://10.150.15.236:32009
 ```
 Navigate to `http://<node ip>:30080` to access the application.
-  
+
   This is powered by the following service:
 ```
 $ sudo kubectl get service wordpress
@@ -257,7 +257,7 @@ NAME        TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
 wordpress   NodePort   100.100.204.73   <none>        80:30080/TCP   75m
 ```
 
-**Note** that this is a single node deployment example.  You have the option of [joining](https://gravitational.com/gravity/docs/cluster/#adding-a-node) or installing with a different flavor.  The default flavor for this Cluster Manifest is small (1 node).  Other flavors include medium (3 nodes) and large (5 nodes). 
+**Note** that this is a single node deployment example.  You have the option of [joining](https://gravitational.com/gravity/docs/cluster/#adding-a-node) or installing with a different flavor.  The default flavor for this Cluster Manifest is small (1 node).  Other flavors include medium (3 nodes) and large (5 nodes).
 ```
 #Ex:
 
@@ -268,6 +268,4 @@ $ sudo ./gravity install \
         --flavor=medium
 ```
 
-Flavor details are in the Wordpress [Cluster Manifest](./resources/app.yaml) . Flavors provide for specifying the number and configuration of nodes for a deployment. 
-
-
+Flavor details are in the Wordpress [Cluster Manifest](./resources/app.yaml) . Flavors provide for specifying the number and configuration of nodes for a deployment.

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -139,7 +139,7 @@ cluster with the application pre-loaded. This file is the only artifact
 one needs to create a Kubernetes cluster with Wordpress running inside.
 
 Copy `wordpress.tar` to a clean Linux machine. Let's call it `host`. This node
-will be used to bootstrap the cluster. Let's untar it and look inside:
+will be used to bootstrap the cluster. Let's extract it and look inside:
 
 ```bash
 $ tar -xf wordpress.tar

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -1,0 +1,273 @@
+# Quick Start
+
+This repository includes the necessary files to package and deploy [Wordpress](https://www.wordpress.org/), an open source content management system, into on-prem, public or private cloud environments using [Gravity](http://gravitational.com/gravity/).  
+
+This manifest uses the Open Elastic Block Store [OpenEBS](https://openebs.io/) built into Gravity 7.X.
+
+# System Requirements
+
+
+* A x86_64 Linux machine or a VM for building a Cluster Image that is running one of the [supported Linux distributions](requirements.md#linux-distributions).
+* Docker version 17 or newer. Run `docker info` before continuing to make sure
+  you have Docker up and running. We recommend following instructions on [installing Docker CE from Docker.com](https://docs.docker.com/install/)
+* You must be a member of the `docker` group. Run `groups` command to make sure
+  `docker` group is listed. If not, you can add yourself to the "docker" group via `sudo usermod -aG docker $USER`
+* You must have `git` installed to clone the example application repo.
+* At least one Linux node. . The nodes in a target cluster must have at least 2GB of RAM and 40GB of free disk space. They must **_not_** have Docker.
+* You must have `sudo` privileges on all nodes.
+
+
+## Step 1 Getting the Tools
+
+Start by [downloading Gravity](https://gravitational.com/gravity/download/) and
+unpacking the archive. You should see the following files:
+
+```
+$ ls -l
+-rwxr-xr-x 1 user user 108093824 Apr 22 11:43 gravity
+-rwxr-xr-x 1 user user       137 Apr 22 11:43 install.sh
+-rw-r--r-- 1 user user     11357 Apr 22 11:43 LICENSE
+-rw-r--r-- 1 user user      2880 Apr 22 11:43 README.md
+-rwxr-xr-x 1 user user  84764672 Apr 22 11:43 tele
+-rwxr-xr-x 1 user user  57863592 Apr 22 11:43 terraform-provider-gravity
+-rwxr-xr-x 1 user user  32488888 Apr 22 11:43 tsh
+-rw-r--r-- 1 user user         6 Apr 22 11:43 VERSION
+```
+
+Execute `install.sh` to copy `tele` and `tsh` binaries to
+`/usr/local/bin/`. Then you can type `tele version` to confirm that
+everything works:
+
+```
+$ tele version
+Edition:        open-source
+Version:        7.0.1
+Git Commit:     af393fcddf8c675f00cf322ec054125d5e239727
+Helm Version:   v2.15
+```
+Clone the sample Git repository which contains the Kubernetes resources for
+[Wordpress](https://www.wordpress.org/), which we are using in this tutorial as a sample application:
+
+```bsh
+$ git clone https://github.com/gravitational/quickstart.git
+$ cd quickstart
+```
+### Step 2: Creating the Kubernetes Resources
+
+Making Wordpress run on Kubernetes is easy. The quickstart repository you have
+cloned above includes the YAML definitions of Kubernetes objects. We'll use
+a Helm chart for this:
+
+```
+$ tree wordpress/resources/charts/wordpress/
+wordpress/resources/charts/wordpress/
+├── Chart.yaml
+├── templates
+│   ├── _helpers.tpl
+│   ├── mysql-deployment.yaml
+│   ├── secret.yaml
+│   └── wordpress-deployment.yaml
+└── values.yaml
+
+```
+
+The values.yaml specifies several important values including
+  - Using OpenEBS for storage
+  - Size of the Persistent Storage for Wordpress and MySQL
+  - Password for MySQL db.
+You are welcome to modify this file and you can use --set and --values in the tele build process to replace these values. In this tutorial, we are packaging a single Helm chart but it is possible to have several of them packaged into a single Cluster Image.
+
+
+### Step 3: Building the Cluster Image
+Let's build the cluster image which will consist of a Kubernetes
+cluster with Wordpress pre-installed inside:
+
+```bsh
+$ tele build -o wordpress.tar wordpress/resources/app.yaml
+Mon Apr 27 00:49:02 UTC Building cluster image wordpress 0.0.1
+Mon Apr 27 00:49:02 UTC Selecting base image version
+        Will use base image version 7.0.4
+Mon Apr 27 00:49:02 UTC Downloading dependencies from s3://hub.gravitational.io
+        Still downloading dependencies from s3://hub.gravitational.io (10 seconds elapsed)
+        Still downloading dependencies from s3://hub.gravitational.io (20 seconds elapsed)
+Mon Apr 27 00:50:31 UTC Embedding application container images
+        Pulling remote image quay.io/gravitational/debian-tall:0.0.1
+        Pulling remote image quay.io/gravitational/debian-tall:stretch
+        Pulling remote image quay.io/gravitational/provisioner:ci.82
+        Pulling remote image quay.io/gravitational/debian-tall:buster
+        Using local image mysql:5.6
+        Using local image wordpress:4.8-apache
+        Vendored image gravitational/debian-tall:0.0.1
+        Vendored image gravitational/debian-tall:stretch
+        Vendored image gravitational/debian-tall:buster
+        Vendored image gravitational/provisioner:ci.82
+        Vendored image mysql:5.6
+        Vendored image wordpress:4.8-apache
+Mon Apr 27 00:51:21 UTC Creating application
+        Still creating application (10 seconds elapsed)
+Mon Apr 27 00:51:36 UTC Generating the cluster image
+Mon Apr 27 00:51:44 UTC Saving the image as wordpress.tar
+        Still saving the image as wordpress.tar (10 seconds elapsed)
+Mon Apr 27 00:52:02 UTC Build finished in 3 minutes 
+```
+
+Let's review what just happened. `tele build` did the following:
+
+* Downloaded Kubernetes binaries and Gravity tooling from Gravitational distribution hub.
+* Scanned the current directory and the subdirectories for Kubernetes resources and Helm charts.
+* Downloaded external container images referenced in the resources discovered in the previous step.
+* Packaged (or vendored) Docker images into the Cluster Image.
+* Removed the duplicate container image layers, reducing the size of the Cluster Image.
+* Saved the Cluster Image as `wordpress.tar`.
+
+Note: Slow Operation Warning
+    `tele build` needs to download hundreds of megabytes of binary dependencies which
+    can take a considerable amount of time, depending on your Internet connection speed.
+
+The resulting `wordpress.tar` file is about 2.9GB and it is **entirely
+self-sufficient** and dependency-free. It contains everything: the Kubernetes
+binaries, the Docker engine, the Docker registry and the Wordpress application itself:
+everything one needs to get Wordpress up and running on any fleet of Linux
+servers (or into an AWS/GCE/Azure account).
+
+Congratulations! You have created your first **Kubernetes virtual appliance**!
+
+## Step 4 Installing
+
+Installing the `wordpress.tar` Cluster Image results in creating a Kubernetes
+cluster with the application pre-loaded. This file is the only artifact
+one needs to create a Kubernetes cluster with Wordpress running inside.
+
+Copy `wordpress.tar` to a clean Linux machine. Let's call it `host`. This node
+will be used to bootstrap the cluster. Let's untar it and look inside:
+
+```bash
+$ tar -xf wordpress.tar
+$ tree
+├── app.yaml
+├── gravity
+├── gravity.db
+├── install
+├── packages
+│   ├── blobs
+│   │   ├── 0e1
+│   │   ...
+│   │   └── ff1
+│   │       └── ff19bcf2dc62f037e0016d5d065150d195f714be3c97a301791365a4ec5a43f0
+│   ├── tmp
+│   └── unpacked
+├── README
+├── upgrade
+└── upload
+```
+
+
+### Installing via CLI
+
+To install a Cluster via CLI, you have to execute the `./gravity install` command and
+supply three flags:
+
+Flag              | Description
+-------------------|---------------------------------
+`--token`          | A secret token of your choosing which will be used to add additional nodes to this Cluster in the future. We'll use word "secret" here.
+`--advertise-addr` | The IP address this host will be visible on by other nodes in this Cluster. We'll use `10.5.5.28`.
+`--cloud-provider` | Whether in a specific cloud environment or a no-cloud provider such as standalone VMs/bare-metal environment [generic aws gce] We'll use `generic` here.  
+
+The command below will create a single-node Kubernetes cluster with Wordpress running inside:
+
+```
+# We are executing this on the node named 'host' with IP address of 10.5.5.28
+$ sudo ./gravity install \
+        --advertise-addr=10.5.5.28 \
+        --token=secret \
+        --cloud-provider=generic
+# Output:
+Sun Apr 26 23:55:11 UTC Starting enterprise installer
+
+To abort the installation and clean up the system,                                                                                                                                                                                              
+press Ctrl+C two times in a row.                                                                                                                                                                                                                
+
+If you get disconnected from the terminal, you can reconnect to the installer                                                                                                                                                                   
+agent by issuing 'gravity resume' command.                                                                                                                                                                                                      
+
+If the installation fails, use 'gravity plan' to inspect the state and                                                                                                                                                                          
+'gravity resume' to continue the operation.                                                                                                                                                                                                     
+See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.                                                                                                                                                  
+
+Sun Apr 26 23:55:11 UTC Connecting to installer
+Sun Apr 26 23:55:32 UTC Connected to installer
+Sun Apr 26 23:55:32 UTC Successfully added "master" node on 10.150.15.236
+...
+
+Mon Apr 27 00:03:05 UTC Install application wordpress:0.0.1
+Mon Apr 27 00:03:05 UTC Executing install hook for wordpress:0.0.1
+Mon Apr 27 00:03:15 UTC         Still executing install hook for wordpress:0.0.1 (10 seconds elapsed)
+Mon Apr 27 00:03:16 UTC Executing "/connect-installer" locally
+Mon Apr 27 00:03:17 UTC Connecting to installer
+Mon Apr 27 00:03:17 UTC Connect to installer
+Mon Apr 27 00:03:19 UTC Executing "/election" locally
+Mon Apr 27 00:03:19 UTC Enable leader elections
+Mon Apr 27 00:03:19 UTC Enable cluster leader elections
+Mon Apr 27 00:03:20 UTC Executing operation finished in 6 minutes
+Mon Apr 27 00:03:20 UTC The operation has finished successfully in 7m48s
+Mon Apr 27 00:03:21 UTC
+Cluster endpoints:
+    * Authentication gateway:
+        - 10.150.15.236:32009
+    * Cluster management URL:
+        - https://10.150.15.236:32009
+
+Application endpoints:
+    * wordpress:0.0.1:
+        - wordpress:
+            - http://10.150.15.236:30080
+
+```
+
+**Congratulations!** You have created a fully functional Kubernetes cluster
+with Wordpress running inside. To check the health and status of the Cluster,
+execute this command on the target node:
+
+```bash
+$ sudo gravity status
+Cluster name:           wordpress
+Cluster status:         active
+Cluster image:          wordpress, version 0.0.1
+Gravity version:        7.0.4 (client) / 7.0.4 (server)
+Join token:             c2d3757aec3e50d210e189dc16b1fb37
+Periodic updates:       Not Configured
+Remote support:         Not Configured
+Last completed operation:
+    * 1-node install
+      ID:               e5608f31-0d8e-4399-9987-00a96f0b41f8
+      Started:          Sun Apr 26 23:55 UTC (1 hour ago)
+      Completed:        Sun Apr 26 23:57 UTC (1 hour ago)
+Cluster endpoints:
+    * Authentication gateway:
+        - 10.150.15.236:32009
+    * Cluster management URL:
+        - https://10.150.15.236:32009
+```
+Navigate to `http://<node ip>:30080` to access the application.
+  
+  This is powered by the following service:
+```
+$ sudo kubectl get service wordpress
+NAME        TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
+wordpress   NodePort   100.100.204.73   <none>        80:30080/TCP   75m
+```
+
+**Note** that this is a single node deployment example.  You have the option of [joining](https://gravitational.com/gravity/docs/cluster/#adding-a-node) or installing with a different flavor.  The default flavor for this Cluster Manifest is small (1 node).  Other flavors include medium (3 nodes) and large (5 nodes). 
+```
+#Ex:
+
+$ sudo ./gravity install \
+        --advertise-addr=10.5.5.28 \
+        --token=secret \
+        --cloud-provider=generic \
+        --flavor=medium
+```
+
+Flavor details are in the Wordpress [Cluster Manifest](./resources/app.yaml) . Flavors provide for specifying the number and configuration of nodes for a deployment. 
+
+

--- a/examples/wordpress/resources/app.yaml
+++ b/examples/wordpress/resources/app.yaml
@@ -27,9 +27,9 @@ endpoints:
 # for the cluster.
 installer:
 
-  # if 'flavors' section is present, the installer will ask the end user what
-  # type of Kubernetes cluster to create. We are offering either a small
-  # single node, 3 node or 5 node configuration.
+  # If 'flavors' section is present, the installer will ask the end user what
+  # type of Kubernetes cluster to create. Here we are offering either a small
+  # single node, 3 node or 6 node configuration.
   flavors:
     prompt: "What size install do you want (small, medium, or large)?"
     # The default flavor
@@ -50,7 +50,7 @@ installer:
         count: 1
       - profile: db
         count: 1
-#HA Master nodes (3) configuration with a 2 fronts and a db
+    # HA Master nodes (3) configuration with a 2 fronts and a db
     - name: "large"
       description: "High Availability Master Node configuration with 2 Wordpress PHP nodes and 1 DB node"
       nodes:
@@ -62,17 +62,17 @@ installer:
         count: 3
 
 # This section allows to define what flavors of servers are required for
-# this cluster. This example uses a single flavor called "node" but you
-# can have flavors like "database" or "gpu", etc.
-#
-#
+# this cluster. This example defines 4 flavors: a "general" flavor used
+# to run all services in a single-node install, and 3 flavors dedicated
+# to different components (control plane, frontend, database) used in
+# multi-node configurations.
 nodeProfiles:
   - name: general
     description: "Master node with labels for running database and front-end facing containers"
     labels:
       front: "true"
       db: "true"
-    # gravity will validate that the nodes have the requested amounts
+    # Gravity will validate that the nodes have the requested amounts
     # of RAM/CPU
     requirements:
       cpu:
@@ -83,7 +83,7 @@ nodeProfiles:
     description: "master node"
     labels:
       node-role.kubernetes.io/master: "true"
-    # gravity will validate that the nodes have the requested amounts
+    # Gravity will validate that the nodes have the requested amounts
     # of RAM/CPU
     requirements:
       cpu:
@@ -95,7 +95,7 @@ nodeProfiles:
     labels:
       front: "true"
       node-role.kubernetes.io/node: "true"
-    # gravity will validate that the nodes have the requested amounts
+    # Gravity will validate that the nodes have the requested amounts
     # of RAM/CPU
     requirements:
       cpu:
@@ -107,7 +107,7 @@ nodeProfiles:
     labels:
       db: "true"
       node-role.kubernetes.io/node: "true"
-    # gravity will validate that the nodes have the requested amounts
+    # Gravity will validate that the nodes have the requested amounts
     # of RAM/CPU
     requirements:
       cpu:
@@ -118,11 +118,10 @@ nodeProfiles:
 # This section allows you to specify Kubernetes jobs that will be executed
 # inside the cluster when certain cluster lifecycle events happen
 hooks:
-# Will install the Wordpress application
+  # Will install the Wordpress application
   install:
     job: file://install.yaml
-#As new versions of wordpress are realized this upgrade hook will invoke
-# the helm call to upgrade.
+  # As new versions of wordpress are realized this upgrade hook will invoke
+  # the helm call to upgrade.
   update:
     job: file://upgrade.yaml
-

--- a/examples/wordpress/resources/app.yaml
+++ b/examples/wordpress/resources/app.yaml
@@ -1,0 +1,128 @@
+# Sample application manifest for Wordpress, the open source content management system
+
+apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+metadata:
+  name: wordpress
+  resourceVersion: "0.0.1"
+
+# Note the use of Elastic Blockstore now available for Persistent Volumes since 7.0
+storage:
+ openebs:
+   enabled: true
+
+# The logo can be used to white label Gravity web interface for Kubernetes/Wordpress
+# management
+logo: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
+
+# This section declares the endpoints Wordpress requires.
+endpoints:
+ - name: "wordpress"
+   description: "Wordpress Application"
+   selector:
+    name: wordpress
+   protocol: http
+
+# This section allows to customize the graphical (web UI) installer
+# for the cluster.
+installer:
+
+  # if 'flavors' section is present, the installer will ask the end user what
+  # type of Kubernetes cluster to create. We are offering either a small
+  # single node, 3 node or 5 node configuration.
+  flavors:
+    prompt: "What size install do you want (small, medium, or large)?"
+    # The default flavor
+    default: small
+    # List of flavors:
+    items:
+    - name: "small"
+      description: "Single node"
+      nodes:
+      - profile: general
+        count: 1
+    - name: "medium"
+      description: "Three node install with one Master, one DB worker node, and one Front worker node "
+      nodes:
+      - profile: master
+        count: 1
+      - profile: front
+        count: 1
+      - profile: db
+        count: 1
+#HA Master nodes (3) configuration with a 2 fronts and a db
+    - name: "large"
+      description: "High Availability Master Node configuration with 2 Wordpress PHP nodes and 1 DB node"
+      nodes:
+      - profile: front
+        count: 2
+      - profile: db
+        count: 1
+      - profile: master
+        count: 3
+
+# This section allows to define what flavors of servers are required for
+# this cluster. This example uses a single flavor called "node" but you
+# can have flavors like "database" or "gpu", etc.
+#
+#
+nodeProfiles:
+  - name: general
+    description: "Master node with labels for running database and front-end facing containers"
+    labels:
+      front: "true"
+      db: "true"
+    # gravity will validate that the nodes have the requested amounts
+    # of RAM/CPU
+    requirements:
+      cpu:
+        min: 2
+      ram:
+        min: "2GB"
+  - name: master
+    description: "master node"
+    labels:
+      node-role.kubernetes.io/master: "true"
+    # gravity will validate that the nodes have the requested amounts
+    # of RAM/CPU
+    requirements:
+      cpu:
+        min: 2
+      ram:
+        min: "2GB"
+  - name: front
+    description: "Worker node labeled for Web front-facing containers"
+    labels:
+      front: "true"
+      node-role.kubernetes.io/node: "true"
+    # gravity will validate that the nodes have the requested amounts
+    # of RAM/CPU
+    requirements:
+      cpu:
+        min: 2
+      ram:
+        min: "2GB"
+  - name: db
+    description: "Worker node labeled for Database containers"
+    labels:
+      db: "true"
+      node-role.kubernetes.io/node: "true"
+    # gravity will validate that the nodes have the requested amounts
+    # of RAM/CPU
+    requirements:
+      cpu:
+        min: 2
+      ram:
+        min: "2GB"
+
+# This section allows you to specify Kubernetes jobs that will be executed
+# inside the cluster when certain cluster lifecycle events happen
+hooks:
+# Will install the Wordpress application
+  install:
+    job: file://install.yaml
+#As new versions of wordpress are realized this upgrade hook will invoke
+# the helm call to upgrade.
+  update:
+    job: file://upgrade.yaml
+

--- a/examples/wordpress/resources/charts/wordpress/Chart.yaml
+++ b/examples/wordpress/resources/charts/wordpress/Chart.yaml
@@ -1,0 +1,6 @@
+name: wordpress
+version: 0.0.1 
+description: Wordpress
+keywords:
+  - Demo of Wordpress chart with Gravity
+tillerVersion: ">=2.8.0"

--- a/examples/wordpress/resources/charts/wordpress/templates/_helpers.tpl
+++ b/examples/wordpress/resources/charts/wordpress/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "wordpress.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/wordpress/resources/charts/wordpress/templates/mysql-deployment.yaml
+++ b/examples/wordpress/resources/charts/wordpress/templates/mysql-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-mysql
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wordpress
+    tier: mysql
+  clusterIP: None
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim3
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  storageClassName: {{.Values.storageClassType}}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.wordpressStorageSize}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: {{.Values.registry}}mysql:{{.Values.mysqlTag}}
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim3
+      nodeSelector:
+        db: "true" # runs on a node designated as a db 
+

--- a/examples/wordpress/resources/charts/wordpress/templates/secret.yaml
+++ b/examples/wordpress/resources/charts/wordpress/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-pass
+  namespace: {{.Values.wordpressNamespace}}
+type: Opaque
+data:
+  password: {{.Values.mysqlPassword}}

--- a/examples/wordpress/resources/charts/wordpress/templates/wordpress-deployment.yaml
+++ b/examples/wordpress/resources/charts/wordpress/templates/wordpress-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    name: wordpress
+spec:
+  type: {{.Values.wordpressServiceType}}
+  ports:
+    - targetPort: 80
+      port: 80
+      nodePort: 30080
+  selector:
+    app: wordpress
+    tier: frontend
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-pv-claim3
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  storageClassName: {{.Values.storageClassType}}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.mysqlStorageSize}}
+---
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: wordpress
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: {{.Values.registry}}wordpress:{{.Values.wordpressTag}}
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim3
+      nodeSelector:
+        front: "true" # uses this to determine which node to attach to
+

--- a/examples/wordpress/resources/charts/wordpress/values.yaml
+++ b/examples/wordpress/resources/charts/wordpress/values.yaml
@@ -1,0 +1,17 @@
+registry: ""
+wordpressNamespace: default
+wordpressServiceType: NodePort
+
+#Password for the mysql db
+mysqlPassword: YWRtaW4=
+
+#Storage sizes for the persistent claims
+wordpressStorageSize: 2Gi
+mysqlStorageSize: 3Gi
+
+#Storage type
+storageClassType: openebs-hostpath
+
+#Wordpress and Mysql Image tags
+wordpressTag: 5.4-apache
+mysqlTag: 5.7

--- a/examples/wordpress/resources/install.yaml
+++ b/examples/wordpress/resources/install.yaml
@@ -1,0 +1,21 @@
+ apiVersion: batch/v1
+ kind: Job
+ metadata:
+   name: install
+ spec:
+   template:
+     metadata:
+       name: install
+     spec:
+       restartPolicy: OnFailure
+       containers:
+         - name: install
+           image: quay.io/gravitational/debian-tall:buster
+           command:
+             - /usr/local/bin/helm
+             - install
+             - /var/lib/gravity/resources/charts/wordpress
+             - --set
+             - registry=leader.telekube.local:5000/
+             - --name
+             - wordpress

--- a/examples/wordpress/resources/upgrade.yaml
+++ b/examples/wordpress/resources/upgrade.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: upgrade
+spec:
+  template:
+    metadata:
+      name: upgrade
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: upgrade
+          image: quay.io/gravitational/debian-tall:buster
+          command:
+            - /usr/local/bin/helm
+            - upgrade
+            - --set
+            - registry=registry.local:5000/
+            - wordpress
+            - /var/lib/gravity/resources/charts/wordpress


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Move Steven's wordpress example from quickstart to this repo since we're going to keep all examples under examples/ directory here.

Also, update readme to better place the examples link.
