### PR TITLE
[5.5.x] Collect status history in gravity report (#1520)

### DIFF
--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -151,6 +151,9 @@ func (s *site) getReport(runner remoteRunner, servers []remoteServer, master rem
 		if err := s.collectDebugInfoFromServers(dir, servers, runner); err != nil {
 			log.WithError(err).Error("Failed to collect diagnostics from some nodes.")
 		}
+		if err := s.collectStatusTimeline(reportWriter, serverRunner); err != nil {
+			log.WithError(err).Error("Failed to collect status timeline.")
+		}
 	}
 
 	// use a pipe to avoid allocating a buffer
@@ -239,6 +242,20 @@ func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverR
 		"--filter=%v", report.FilterEtcd), "--compressed")...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect etcd backup: %s", stderr.String())
+	}
+	return nil
+}
+
+func (s *site) collectStatusTimeline(reportWriter report.FileWriter, runner *serverRunner) error {
+	w, err := reportWriter.NewWriter("status.tar.gz")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	err = runner.RunStream(w, s.gravityCommand("system", "report",
+		fmt.Sprintf("--filter=%v", report.FilterTimeline), "--compressed")...)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	return nil
 }

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -252,10 +252,11 @@ func (s *site) collectStatusTimeline(reportWriter report.FileWriter, runner *ser
 		return trace.Wrap(err)
 	}
 	defer w.Close()
-	err = runner.RunStream(w, s.gravityCommand("system", "report",
+	var stderr bytes.Buffer
+	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
 		fmt.Sprintf("--filter=%v", report.FilterTimeline), "--compressed")...)
 	if err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "failed to collect status timeline: %s", stderr.String())
 	}
 	return nil
 }

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -48,6 +48,8 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
+		case FilterTimeline:
+			collectors = append(collectors, NewTimelineCollector())
 		}
 	}
 
@@ -111,7 +113,10 @@ const (
 
 	// FilterEtcd defines a report collection filter to fetch etcd data
 	FilterEtcd = "etcd"
+
+	// FilterTimeline defines a report collection filter to fetch the status timeline
+	FilterTimeline = "timeline"
 )
 
 // AllFilters lists all available collector filters
-var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd}
+var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd, FilterTimeline}

--- a/lib/report/timeline.go
+++ b/lib/report/timeline.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"context"
+	"io"
+
+	statusapi "github.com/gravitational/gravity/lib/status"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// NewTimelineCollector returns a new timeline collector.
+func NewTimelineCollector() *TimelineCollector {
+	return &TimelineCollector{}
+}
+
+// Collect collects the cluster status timeline.
+func (r TimelineCollector) Collect(ctx context.Context, reportWriter FileWriter, runner utils.CommandRunner) error {
+	w, err := reportWriter.NewWriter(timelineFilename)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	return trace.Wrap(collectTimeline(ctx, w))
+}
+
+// collectTimeline collects the cluster status timeline and writes to the
+// provided writer.
+func collectTimeline(ctx context.Context, w io.Writer) error {
+	resp, err := statusapi.Timeline(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, event := range resp.GetEvents() {
+		statusapi.PrintEvent(w, event)
+	}
+	return nil
+}
+
+// TimelineCollector collects the cluster status timeline.
+type TimelineCollector struct{}
+
+const (
+	// timelineFilename is the name of the file that stores the status timeline output
+	timelineFilename = "timeline"
+)

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -18,9 +18,13 @@ package status
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"time"
 
 	"github.com/gravitational/gravity/lib/httplib"
 
+	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 )
@@ -32,4 +36,49 @@ func Timeline(ctx context.Context) (*pb.TimelineResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 	return client.Timeline(ctx, &pb.TimelineRequest{})
+}
+
+// PrintEvent prints the event to the provided writer.
+func PrintEvent(w io.Writer, event *pb.TimelineEvent) {
+	timestamp := event.GetTimestamp().ToTime().Format(time.RFC3339)
+	switch event.GetData().(type) {
+	case *pb.TimelineEvent_ClusterDegraded:
+		fmt.Fprintln(w, color.RedString("%s [Cluster Degraded]",
+			timestamp))
+	case *pb.TimelineEvent_ClusterHealthy:
+		fmt.Fprintln(w, color.GreenString("%s [Cluster Healthy]",
+			timestamp))
+	case *pb.TimelineEvent_NodeAdded:
+		fmt.Fprintln(w, color.YellowString("%s [Node Added]\tnode=%s",
+			timestamp, event.GetNodeAdded().GetNode()))
+	case *pb.TimelineEvent_NodeRemoved:
+		fmt.Fprintln(w, color.YellowString("%s [Node Removed]\tnode=%s",
+			timestamp, event.GetNodeRemoved().GetNode()))
+	case *pb.TimelineEvent_NodeDegraded:
+		fmt.Fprintln(w, color.RedString("%s [Node Degraded]\tnode=%s",
+			timestamp, event.GetNodeDegraded().GetNode()))
+	case *pb.TimelineEvent_NodeHealthy:
+		fmt.Fprintln(w, color.GreenString("%s [Node Healthy]\tnode=%s",
+			timestamp, event.GetNodeHealthy().GetNode()))
+	case *pb.TimelineEvent_ProbeFailed:
+		e := event.GetProbeFailed()
+		fmt.Fprintln(w, color.RedString("%s [Probe Failed]\tnode=%s\tchecker=%s",
+			timestamp, e.GetNode(), e.GetProbe()))
+	case *pb.TimelineEvent_ProbeSucceeded:
+		e := event.GetProbeSucceeded()
+		fmt.Fprintln(w, color.GreenString("%s [Probe Succeeded]\tnode=%s\tchecker=%s",
+			timestamp, e.GetNode(), e.GetProbe()))
+	case *pb.TimelineEvent_LeaderElected:
+		e := event.GetLeaderElected()
+		if e.GetPrev() == "" {
+			fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tnew leader %s",
+				timestamp, e.GetNew()))
+		} else {
+			fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tleader changed %s -> %s",
+				timestamp, e.GetPrev(), e.GetNew()))
+		}
+	default:
+		fmt.Fprintln(w, color.YellowString("%s [Unknown Event]\t%s", timestamp, event))
+		log.WithField("event", event).Warn("Received unknown event type.")
+	}
 }

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 )
 
 // Timeline queries the currently stored cluster timeline.

--- a/tool/gravity/cli/history.go
+++ b/tool/gravity/cli/history.go
@@ -19,15 +19,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"text/tabwriter"
-	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	statusapi "github.com/gravitational/gravity/lib/status"
 
-	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 )
@@ -53,47 +50,7 @@ func printEvents(events []*pb.TimelineEvent) error {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 	for _, event := range events {
-		printEvent(w, event)
+		statusapi.PrintEvent(w, event)
 	}
 	return w.Flush()
-}
-
-func printEvent(w io.Writer, event *pb.TimelineEvent) {
-	timestamp := event.GetTimestamp().ToTime().Format(time.RFC3339)
-	switch event.GetData().(type) {
-	case *pb.TimelineEvent_ClusterDegraded:
-		fmt.Fprintln(w, color.RedString("%s [Cluster Degraded]",
-			timestamp))
-	case *pb.TimelineEvent_ClusterHealthy:
-		fmt.Fprintln(w, color.GreenString("%s [Cluster Healthy]",
-			timestamp))
-	case *pb.TimelineEvent_NodeAdded:
-		fmt.Fprintln(w, color.YellowString("%s [Node Added]\tnode=%s",
-			timestamp, event.GetNodeAdded().GetNode()))
-	case *pb.TimelineEvent_NodeRemoved:
-		fmt.Fprintln(w, color.YellowString("%s [Node Removed]\tnode=%s",
-			timestamp, event.GetNodeRemoved().GetNode()))
-	case *pb.TimelineEvent_NodeDegraded:
-		fmt.Fprintln(w, color.RedString("%s [Node Degraded]\tnode=%s",
-			timestamp, event.GetNodeDegraded().GetNode()))
-	case *pb.TimelineEvent_NodeHealthy:
-		fmt.Fprintln(w, color.GreenString("%s [Node Healthy]\tnode=%s",
-			timestamp, event.GetNodeHealthy().GetNode()))
-	case *pb.TimelineEvent_ProbeFailed:
-		e := event.GetProbeFailed()
-		fmt.Fprintln(w, color.RedString("%s [Probe Failed]\tnode=%s\tchecker=%s",
-			timestamp, e.GetNode(), e.GetProbe()))
-	case *pb.TimelineEvent_ProbeSucceeded:
-		e := event.GetProbeSucceeded()
-		fmt.Fprintln(w, color.GreenString("%s [Probe Succeeded]\tnode=%s\tchecker=%s",
-			timestamp, e.GetNode(), e.GetProbe()))
-	case *pb.TimelineEvent_LeaderElected:
-		e := event.GetLeaderElected()
-		fmt.Fprintln(w, color.YellowString("%s [Leader Elected]\tprev=%s\tnew=%s",
-			timestamp, e.GetPrev(), e.GetNew()))
-
-	default:
-		fmt.Fprintln(w, color.YellowString("%s Unknown event", timestamp))
-		log.WithField("event", event).Warn("Received unknown event type.")
-	}
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Modifies the gravity report command to include the status history in the debug report.
- Edits output of leader elected events.
- Unknown events dump entire struct.

## Type of change
<!--Required. Keep only those that apply.-->
* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1520

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify `gravity status history` still functions the same.**
```
[vagrant@node-1 ~]$ sudo gravity status history
2020-05-12T21:31:04Z [Leader Elected]   new leader 172.28.128.103
2020-05-12T21:31:07Z [Leader Elected]   leader changed 172.28.128.103 -> 172.28.128.103
2020-05-12T21:31:32Z [Node Healthy]     node=172_28_128_102.dev.test
2020-05-12T21:31:33Z [Node Healthy]     node=172_28_128_101.dev.test
2020-05-12T21:31:35Z [Node Healthy]     node=172_28_128_103.dev.test
[...]
```

**Verify `gravity report` now includes status history and contents are correct.**
```
[vagrant@node-1 ~]$ sudo gravity report
report for cluster(name=dev.test) exported to report.tar.gz

[vagrant@node-1 ~]$ tar xf report.tar.gz
[vagrant@node-1 ~]$ ls *status*
node-2-status.tar.gz

[vagrant@node-1 ~]$ tar xf node-2-status.tar.gz
[vagrant@node-1 ~]$ ls
timeline

[vagrant@node-1 ~]$ cat timeline
2020-05-12T21:31:04Z [Leader Elected]   new leader 172.28.128.103
2020-05-12T21:31:07Z [Leader Elected]   leader changed 172.28.128.103 -> 172.28.128.103
2020-05-12T21:31:32Z [Node Healthy]     node=172_28_128_102.dev.test
2020-05-12T21:31:33Z [Node Healthy]     node=172_28_128_101.dev.test
2020-05-12T21:31:35Z [Node Healthy]     node=172_28_128_103.dev.test
[...]
```