### PR TITLE
(5.5) Backport teleport fix for trusted clusters regression

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -911,8 +911,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "branch/3.0-g"
-  digest = "1:4844cc1b82b1d9500007be50c601675f791238baa63e7455010b1704cd98894e"
+  branch = "roman/3.0-g/rolemap"
+  digest = "1:c0c6ff4735b98934e2585e3b7f0c88d156b9bd37f3bcedccf41e720c9fbd22a3"
   name = "github.com/gravitational/teleport"
   packages = [
     ".",
@@ -968,7 +968,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "50a1f1cab731ca2d5096166e36f45c12ecb1cbe3"
+  revision = "5458e4de960e0883bdce09f9505793c6ba0d3b9e"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -911,7 +911,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "roman/3.0-g/rolemap"
+  branch = "branch/3.0-g"
   digest = "1:c0c6ff4735b98934e2585e3b7f0c88d156b9bd37f3bcedccf41e720c9fbd22a3"
   name = "github.com/gravitational/teleport"
   packages = [
@@ -968,7 +968,7 @@
     "lib/wrappers",
   ]
   pruneopts = "UT"
-  revision = "5458e4de960e0883bdce09f9505793c6ba0d3b9e"
+  revision = "5b6732a298fb51593276ff4594390b5c800b767c"
 
 [[projects]]
   digest = "1:5639168299375c369a68748214586e3b25bbc17e7ec9c64564f43f4635097bfc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,7 +203,8 @@ ignored = [
   # use gravity-specific 3.0 branch of teleport which includes
   # new Kubernetes because it can't be revendored in regular
   # 3.0 branch due to some compability issues
-  branch = "branch/3.0-g"
+  # branch = "branch/3.0-g"
+  branch = "roman/3.0-g/rolemap"
 
 [[constraint]]
   version = "0.0.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -203,8 +203,7 @@ ignored = [
   # use gravity-specific 3.0 branch of teleport which includes
   # new Kubernetes because it can't be revendored in regular
   # 3.0 branch due to some compability issues
-  # branch = "branch/3.0-g"
-  branch = "roman/3.0-g/rolemap"
+  branch = "branch/3.0-g"
 
 [[constraint]]
   version = "0.0.1"

--- a/vendor/github.com/gravitational/teleport/lib/auth/auth_with_roles.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/auth_with_roles.go
@@ -356,12 +356,7 @@ func (a *AuthWithRoles) filterNodes(nodes []services.Server) ([]services.Server,
 		return nodes, nil
 	}
 
-	// Fetch services.RoleSet for the identity of the logged in user.
-	roles, traits, err := services.ExtractFromIdentity(a.authServer, &a.identity)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	roleset, err := services.FetchRoles(roles, a.authServer, traits)
+	roleset, err := services.FetchRoles(a.user.GetRoles(), a.authServer, a.user.GetTraits())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/vendor/github.com/gravitational/teleport/lib/auth/permissions.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/permissions.go
@@ -449,6 +449,7 @@ func contextForBuiltinRole(clusterName string, clusterConfig services.ClusterCon
 }
 
 func contextForLocalUser(u LocalUser, identity services.UserGetter, access services.Access) (*AuthContext, error) {
+	// User has to be fetched to check if it's a blocked username
 	user, err := identity.GetUser(u.Username)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -461,6 +462,15 @@ func contextForLocalUser(u LocalUser, identity services.UserGetter, access servi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// Override roles and traits from the local user based on the identity roles
+	// and traits, this is done to prevent potential conflict. Imagine a scenairo
+	// when SSO user has left the company, but local user entry remained with old
+	// privileged roles. New user with the same name has been onboarded and would
+	// have derived the roles from the stale user entry. This code prevents
+	// that by extracting up to date identity traits and roles from the user's
+	// certificate metadata.
+	user.SetRoles(roles)
+	user.SetTraits(traits)
 
 	return &AuthContext{
 		User:    user,

--- a/vendor/github.com/gravitational/teleport/lib/auth/testauthority/testauthority.go
+++ b/vendor/github.com/gravitational/teleport/lib/auth/testauthority/testauthority.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -110,12 +111,19 @@ func (n *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	if !c.PermitPortForwarding {
 		delete(cert.Permissions.Extensions, teleport.CertExtensionPermitPortForwarding)
 	}
-	if len(c.Roles) != 0 {
-		// only add roles to the certificate extensions if the standard format was
-		// requested. we allow the option to omit this to support older versions of
-		// OpenSSH due to a bug in <= OpenSSH 7.1
-		// https://bugzilla.mindrot.org/show_bug.cgi?id=2387
-		if c.CertificateFormat == teleport.CertificateFormatStandard {
+	// Add roles, traits, and route to cluster in the certificate extensions if
+	// the standard format was requested. Certificate extensions are not included
+	// legacy SSH certificates due to a bug in OpenSSH <= OpenSSH 7.1:
+	// https://bugzilla.mindrot.org/show_bug.cgi?id=2387
+	if c.CertificateFormat == teleport.CertificateFormatStandard {
+		traits, err := wrappers.MarshalTraits(&c.Traits)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if len(traits) > 0 {
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportTraits] = string(traits)
+		}
+		if len(c.Roles) != 0 {
 			roles, err := services.MarshalCertRoles(c.Roles)
 			if err != nil {
 				return nil, trace.Wrap(err)

--- a/vendor/github.com/gravitational/teleport/lib/client/client.go
+++ b/vendor/github.com/gravitational/teleport/lib/client/client.go
@@ -75,7 +75,7 @@ func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
+	defer proxySession.Close()
 	stdout := &bytes.Buffer{}
 	reader, err := proxySession.StdoutPipe()
 	if err != nil {

--- a/vendor/github.com/gravitational/teleport/lib/services/role.go
+++ b/vendor/github.com/gravitational/teleport/lib/services/role.go
@@ -1357,7 +1357,6 @@ func ExtractFromCertificate(access UserGetter, cert *ssh.Certificate) ([]string,
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-
 		log.Warnf("User %v using old style SSH certificate, fetching roles and traits "+
 			"from backend. If the identity provider allows username changes, this can "+
 			"potentially allow an attacker to change the role of the existing user. "+
@@ -1423,7 +1422,7 @@ func isFormatOld(cert *ssh.Certificate) bool {
 	_, hasRoles := cert.Extensions[teleport.CertExtensionTeleportRoles]
 	_, hasTraits := cert.Extensions[teleport.CertExtensionTeleportTraits]
 
-	if hasRoles && hasTraits {
+	if hasRoles || hasTraits {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Revendor Teleport fix (https://github.com/gravitational/teleport/pull/3726) that fixes a regression with trusted clusters back from January (https://github.com/gravitational/teleport/issues/3252). This was fixed in later versions but never backported to 5.5

The gist of the issue is that after connecting a leaf cluster to a root cluster, the leaf cluster would attempt to look up the role a user has in the root cluster (i.e. from the certificate) instead of using role mapping.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/teleport/issues/3252.
* Requires https://github.com/gravitational/teleport/pull/3726.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Setup

Role in the hub:

```yaml
kind: role
version: v3
metadata:
  name: viewer
spec:
  allow:
    kubernetes_groups:
    - view
    logins:
    - guest
```

 Trusted cluster role mapping:

```yaml
  role_map:
  - remote: "viewer"
    local: ["@teleadmin", "admin"]
```

### Before

```
➜  bin ./tele login --hub=hub.gravitational.io:32009 testcluster --token=viewer-token
Hub:		hub.gravitational.io
Username:	viewer
Cluster:	testcluster
Expires:	Never
➜  bin ./tsh ls
error: role "viewer" is not found
```

### After

```
➜  bin ./tsh ls
Node Name                  Address             Labels
-------------------------- ------------------- ---------------------------------------------------------------
192_168_99_103.testcluster 192.168.99.103:3022 advertise-ip=192.168.99.103, app-role=node
                                               display-role=Gravity Auto Node, fqdn=192_168_99_103.testcluster
                                               gravitational.io/k8s-role=master, hostname=node-2
                                               instance-type=, role=node
```