### PR TITLE
[6.3.x] expand resume

### DIFF
--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -76,15 +76,14 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 		server:     server,
 		dispatcher: dispatcher,
 		// Account for agent exit or agent reconnect failure
-		errC:      make(chan error, 3),
-		exitC:     make(chan error, 1),
-		execC:     make(chan *installpb.ExecuteRequest),
-		execDoneC: make(chan install.ExecResult, 1),
-		closeC:    make(chan closeResponse),
-		connectC:  make(chan connectResult, 1),
+		errC:        make(chan error, 3),
+		exitC:       make(chan error, 1),
+		execC:       make(chan *installpb.ExecuteRequest),
+		execDoneC:   make(chan install.ExecResult, 1),
+		closeC:      make(chan closeResponse),
+		connectC:    make(chan connectResult, 1),
+		connectingC: make(chan struct{}),
 	}
-	peer.startConnectLoop()
-	peer.startStatusLoop()
 	peer.startExecuteLoop()
 	peer.startReconnectWatchLoop()
 	return peer, nil
@@ -97,13 +96,10 @@ type Peer struct {
 	ctx context.Context
 	// cancel cancels internal operation
 	cancel context.CancelFunc
-	// errC is signaled when either the service or agent is aborted
+	// errC is signaled when agent aborts or exits
 	errC chan error
 	// exitC is signaled when the service exits
 	exitC chan error
-	// connectC receives the results of connecting to either wizard
-	// or cluster controller
-	connectC chan connectResult
 	// server is the gRPC installer server
 	server     *server.Server
 	dispatcher dispatcher.EventDispatcher
@@ -116,6 +112,14 @@ type Peer struct {
 	execDoneC chan install.ExecResult
 	// wg is a wait group used to ensure completion of internal processes
 	wg sync.WaitGroup
+	// connectC receives the results of connecting to either wizard
+	// or cluster controller
+	connectC chan connectResult
+	// connectingC is closed once the connect loop starts running
+	connectingC chan struct{}
+	// connectOnce enables the execute loop to start the connect loop
+	// only on the first execute request
+	connectOnce sync.Once
 }
 
 // Run runs the peer operation
@@ -129,17 +133,22 @@ func (p *Peer) Run(listener net.Listener) error {
 	case err = <-errC:
 	case err = <-p.exitC:
 	}
+	if err != nil {
+		p.sendClientErrorResponse(err)
+	}
 	// Stopping is on best-effort basis, the client will be trying to stop the service
 	// if notified
+	p.WithField("exit-error", err).Info("Exit with error.")
 	p.stop()
-	if installpb.IsAbortedError(err) {
-		if err := p.leave(); err != nil {
-			p.WithError(err).Warn("Failed to leave cluster.")
-		}
-	}
-	if err != nil && !installpb.IsCompletedError(err) {
-		if err2 := p.fail(err.Error()); err2 != nil {
-			p.WithError(err2).Warn("Failed to mark operation as failed.")
+	if err != nil {
+		if installpb.IsAbortedError(err) {
+			if err := p.leave(); err != nil {
+				p.WithError(err).Warn("Failed to leave cluster.")
+			}
+		} else if !installpb.IsCompletedError(err) {
+			if err := p.fail(err.Error()); err != nil {
+				p.WithError(err).Warn("Failed to mark operation as failed.")
+			}
 		}
 	}
 	return installpb.WrapServiceError(err)
@@ -148,9 +157,8 @@ func (p *Peer) Run(listener net.Listener) error {
 // Stop shuts down this RPC agent
 // Implements signals.Stopper
 func (p *Peer) Stop(ctx context.Context) error {
-	p.Info("Stop.")
-	p.server.ManualStop(ctx, false)
-	return nil
+	p.Info("Peer Stop.")
+	return p.server.ManualStop(ctx, false)
 }
 
 // Execute executes the peer operation (join or just serving an agent).
@@ -184,13 +192,12 @@ func (p *Peer) Execute(req *installpb.ExecuteRequest, stream installpb.Agent_Exe
 			if result.CompletionEvent != nil {
 				err := stream.Send(result.CompletionEvent.AsProgressResponse())
 				if err != nil {
-					return trace.Wrap(err)
+					return err
 				}
 			}
 			return nil
 		}
 	}
-	return nil
 }
 
 // SetPhase sets phase state without executing it.
@@ -229,7 +236,7 @@ func (p *Peer) Complete(ctx context.Context, opKey ops.SiteOperationKey) error {
 // Implements server.Completer
 func (p *Peer) HandleCompleted(ctx context.Context) error {
 	p.Debug("Completion signaled.")
-	if p.sendCloseResponse(installpb.CompleteEvent) {
+	if p.sendClientCloseResponse(installpb.CompleteEvent) {
 		p.Debug("Client notified about completion.")
 	}
 	p.exitWithError(installpb.ErrCompleted)
@@ -240,7 +247,7 @@ func (p *Peer) HandleCompleted(ctx context.Context) error {
 // Implements server.Completer
 func (p *Peer) HandleAborted(ctx context.Context) error {
 	p.Debug("Abort signaled.")
-	if p.sendCloseResponse(installpb.AbortEvent) {
+	if p.sendClientCloseResponse(installpb.AbortEvent) {
 		p.Debug("Client notified about abort.")
 	}
 	p.exitWithError(installpb.ErrAborted)
@@ -335,27 +342,30 @@ func (c *PeerConfig) CheckAndSetDefaults() (err error) {
 }
 
 func (p *Peer) startConnectLoop() {
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		ctx, err := p.connectLoop()
-		if err == nil {
-			ctx.agent, err = p.init(*ctx)
-		}
-		if err != nil {
-			// Consider failure to connect/init a terminal error.
-			// This will prevent the service from automatically restarting.
-			// It can be restarted manually though (i.e. after correcting the configuration)
-			err = status.Error(codes.FailedPrecondition, trace.UserMessage(err))
-		}
-		select {
-		case p.connectC <- connectResult{
-			operationContext: ctx,
-			err:              err,
-		}:
-		case <-p.ctx.Done():
-		}
-	}()
+	p.connectOnce.Do(func() {
+		close(p.connectingC)
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			ctx, err := p.connectLoop()
+			if err == nil {
+				ctx.agent, err = p.init(*ctx)
+			}
+			if err != nil {
+				// Consider failure to connect/init a terminal error.
+				// This will prevent the service from automatically restarting.
+				// It can be restarted manually though (i.e. after correcting the configuration)
+				err = status.Error(codes.FailedPrecondition, trace.UserMessage(err))
+			}
+			select {
+			case p.connectC <- connectResult{
+				operationContext: ctx,
+				err:              err,
+			}:
+			case <-p.ctx.Done():
+			}
+		}()
+	})
 }
 
 // startExecuteLoop starts a loop that services the channel to handle
@@ -383,7 +393,7 @@ func (p *Peer) startExecuteLoop() {
 					}).Warn("Failed to execute.")
 					p.execDoneC <- install.ExecResult{Error: err}
 					if installpb.IsFailedPreconditionError(err) {
-						p.errC <- err
+						p.exitWithError(err)
 						return
 					}
 				} else {
@@ -413,23 +423,6 @@ func (p *Peer) startReconnectWatchLoop() {
 	}()
 }
 
-func (p *Peer) startStatusLoop() {
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		for {
-			select {
-			case err := <-p.errC:
-				p.sendErrorResponse(err)
-				p.exitWithError(err)
-				return
-			case <-p.ctx.Done():
-				return
-			}
-		}
-	}()
-}
-
 // startProgressLoop starts a new progress watch and dispatch loop.
 // The loop exits once the completion progress message has been received.
 // The lifetime is bounded by the peer-internal context
@@ -437,12 +430,15 @@ func (p *Peer) startProgressLoop(ctx operationContext) {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		install.ProgressPoller{
+		err := install.ProgressPoller{
 			FieldLogger:  p.FieldLogger,
 			Operator:     ctx.Operator,
 			OperationKey: ctx.Operation.Key(),
 			Dispatcher:   p.dispatcher,
 		}.Run(p.ctx)
+		if err != nil {
+			p.Warnf("Failed to stop progress poller: %v.", err)
+		}
 	}()
 }
 
@@ -461,6 +457,7 @@ func (p *Peer) submit(req *installpb.ExecuteRequest) bool {
 // execute executes either the complete operation or a single phase specified with req
 func (p *Peer) execute(req *installpb.ExecuteRequest) (dispatcher.Status, error) {
 	p.WithField("req", req).Info("Execute.")
+	p.startConnectLoop()
 	opCtx, err := p.operationContext(p.ctx)
 	if err != nil {
 		return dispatcher.StatusUnknown, trace.Wrap(err)
@@ -502,7 +499,6 @@ func (p *Peer) executeConcurrentStep(req *installpb.ExecuteRequest, stream insta
 			return trace.Wrap(err)
 		}
 	}
-	return nil
 }
 
 func (p *Peer) executePhase(ctx context.Context, opCtx operationContext, phase installpb.Phase, disp dispatcher.EventDispatcher) (dispatcher.Status, error) {
@@ -806,11 +802,11 @@ func (p *Peer) stop() {
 }
 
 func (p *Peer) shutdownAgent(ctx context.Context) error {
-	opCtx, err := p.operationContext(ctx)
+	opCtx, err := p.maybeOperationContext(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if opCtx.agent == nil {
+	if opCtx == nil || opCtx.agent == nil {
 		return nil
 	}
 	p.Info("Stop peer agent.")
@@ -854,12 +850,7 @@ func (p *Peer) tryConnect(operationID string) (ctx *operationContext, err error)
 			return nil, utils.Abort(err)
 		}
 		if trace.IsCompareFailed(err) {
-			p.Warnf("Waiting for precondition to create expand operation: %v.", err)
-			if utils.IsClusterDegradedError(err) {
-				p.printStep("Cluster is degraded, waiting for it to become healthy")
-			} else {
-				p.printStep("Waiting for another operation to complete at %v", addr)
-			}
+			p.printStep("Waiting for another operation to finish at %v", addr)
 		}
 	}
 	return ctx, trace.Wrap(err)
@@ -1010,9 +1001,13 @@ func (p *Peer) fail(message string) error {
 }
 
 func (p *Peer) failOperation(ctx context.Context, message string) error {
-	opCtx, err := p.operationContext(ctx)
+	opCtx, err := p.maybeOperationContext(ctx)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+	if opCtx == nil {
+		// No operation to fail
+		return nil
 	}
 	return ops.FailOperation(ctx, opCtx.Operation.Key(), opCtx.Operator, message)
 }
@@ -1099,6 +1094,15 @@ func (p *Peer) emitAuditEvent(ctx operationContext) error {
 	events.Emit(p.ctx, ctx.Operator, events.OperationExpandStart,
 		events.FieldsForOperation(*operation))
 	return nil
+}
+
+func (p *Peer) maybeOperationContext(ctx context.Context) (*operationContext, error) {
+	select {
+	case <-p.connectingC:
+		return p.operationContext(ctx)
+	default:
+		return nil, nil
+	}
 }
 
 func (p *Peer) operationContext(ctx context.Context) (*operationContext, error) {
@@ -1215,18 +1219,18 @@ func (p *Peer) newCompletionEvent() *dispatcher.Event {
 	}
 }
 
-func (p *Peer) sendErrorResponse(err error) bool {
+func (p *Peer) sendClientErrorResponse(err error) bool {
 	message := err.Error()
 	s, ok := status.FromError(trace.Unwrap(err))
 	if ok {
 		message = s.Message()
 	}
-	return p.sendCloseResponse(&installpb.ProgressResponse{
+	return p.sendClientCloseResponse(&installpb.ProgressResponse{
 		Error: &installpb.Error{Message: message},
 	})
 }
 
-func (p *Peer) sendCloseResponse(resp *installpb.ProgressResponse) bool {
+func (p *Peer) sendClientCloseResponse(resp *installpb.ProgressResponse) bool {
 	doneC := make(chan struct{})
 	select {
 	case p.closeC <- closeResponse{doneC: doneC, resp: resp}:
@@ -1234,7 +1238,7 @@ func (p *Peer) sendCloseResponse(resp *installpb.ProgressResponse) bool {
 		<-doneC
 		return true
 	default:
-		// Do not block if otherwise
+		// Do not block otherwise
 		return false
 	}
 }

--- a/lib/expand/phases/etcd.go
+++ b/lib/expand/phases/etcd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
+	"github.com/cenkalti/backoff"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -78,6 +79,7 @@ func NewEtcd(p fsm.ExecutorParams, operator ops.Operator, runner rpc.AgentReposi
 		Runner:         runner,
 		Master:         *p.Phase.Data.Master,
 		ExecutorParams: p,
+		etcdPeerURL:    p.Phase.Data.Server.EtcdPeerURL(),
 	}, nil
 }
 
@@ -92,13 +94,14 @@ type etcdExecutor struct {
 	Master storage.Server
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
+	// etcdPeerURL specifies this node's etcd peer URL
+	etcdPeerURL string
 }
 
 // Execute adds the joining node to the cluster's etcd cluster
 func (p *etcdExecutor) Execute(ctx context.Context) error {
 	p.Progress.NextStep("Adding etcd member")
-	member, err := p.Etcd.Add(ctx, fmt.Sprintf("https://%v:%v",
-		p.Phase.Data.Server.AdvertiseIP, defaults.EtcdPeerPort))
+	member, err := p.addEtcdMember(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -136,6 +139,38 @@ func (p *etcdExecutor) Rollback(ctx context.Context) error {
 	}
 	p.Infof("Restored etcd data from %v.", backupPath)
 	return nil
+}
+
+func (p *etcdExecutor) addEtcdMember(ctx context.Context) (member *etcd.Member, err error) {
+	boff := backoff.NewExponentialBackOff()
+	boff.MaxElapsedTime = defaults.TransientErrorTimeout
+	err = utils.RetryTransient(ctx, boff, func() error {
+		peers, err := p.Etcd.List(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if p.hasSelfAsMember(peers) {
+			p.WithField("peerURL", p.etcdPeerURL).Info("Node is already etcd peer.")
+			return nil
+		}
+		member, err = p.Etcd.Add(ctx, p.etcdPeerURL)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return member, nil
+}
+
+func (p *etcdExecutor) hasSelfAsMember(peers []etcd.Member) bool {
+	for _, peer := range peers {
+		for _, peerURL := range peer.PeerURLs {
+			if peerURL == p.etcdPeerURL {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (p *etcdExecutor) checkBackup(ctx context.Context, agent rpcclient.Client, backupPath string) error {

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -52,9 +52,9 @@ func (r *InstallerStrategy) connect(ctx context.Context) (installpb.AgentClient,
 	ctx, cancel = context.WithTimeout(ctx, r.ConnectTimeout)
 	defer cancel()
 	client, err := installpb.NewClient(ctx, installpb.ClientConfig{
-		FieldLogger:     r.FieldLogger,
-		SocketPath:      r.SocketPath,
-		IsServiceFailed: isServiceFailed(serviceName(r.ServicePath)),
+		FieldLogger:            r.FieldLogger,
+		SocketPath:             r.SocketPath,
+		ShouldReconnectService: shouldReconnectService(serviceName(r.ServicePath)),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -72,8 +72,8 @@ func (r *InstallerStrategy) installSelfAsService() error {
 		ServiceSpec: systemservice.ServiceSpec{
 			StartCommand:             strings.Join(r.Args, " "),
 			User:                     constants.RootUIDString,
-			SuccessExitStatus:        successExitStatuses,
-			RestartPreventExitStatus: noRestartExitStatuses,
+			SuccessExitStatus:        successExitStatusList,
+			RestartPreventExitStatus: noRestartExitStatusList,
 			// Enable automatic restart of the service
 			Restart:          "always",
 			Timeout:          int(time.Duration(defaults.ServiceConnectTimeout).Seconds()),
@@ -146,32 +146,53 @@ type InstallerStrategy struct {
 	ConnectTimeout time.Duration
 }
 
-// isServiceFailed returns an error if the service has failed.
-func isServiceFailed(serviceName string) func() error {
+// shouldReconnectService returns a function that determines whether the client should continue
+// reconnecting to the service given with serviceName
+func shouldReconnectService(serviceName string) func() error {
 	return func() error {
-		err := service.IsFailed(serviceName)
+		err := service.IsStatus(serviceName,
+			systemservice.ServiceStatusFailed)
 		if err == nil {
 			return trace.Errorf("service %q has failed. Check journal log for details.",
 				serviceName)
 		}
 		if !trace.IsCompareFailed(err) {
-			return trace.Wrap(err)
+			// Continue reconnecting if unable to query service status
+			log.Warnf("Failed to query service status: %v.", err)
 		}
 		return nil
 	}
 }
 
+func isNoRestartExitCode(code int) bool {
+	for _, s := range noRestartExitStatuses {
+		if code == s {
+			return true
+		}
+	}
+	return false
+}
+
+func toWhitespaceSeparated(vs ...int) string {
+	result := make([]string, 0, len(vs))
+	for _, v := range vs {
+		result = append(result, strconv.Itoa(v))
+	}
+	return strings.Join(result, " ")
+}
+
 var (
-	// successExitStatuses lists exit statuses considered a successful exit for the service
-	successExitStatuses = strings.Join([]string{
-		strconv.Itoa(defaults.AbortedOperationExitCode),
-		strconv.Itoa(defaults.CompletedOperationExitCode),
-	}, " ")
-	// noRestartExitStatuses lists exit statuses that prevent service from getting automatically
+	noRestartExitStatuses = []int{
+		defaults.AbortedOperationExitCode,
+		defaults.CompletedOperationExitCode,
+		defaults.FailedPreconditionExitCode,
+	}
+	// successExitStatusList lists exit statuses considered a successful exit for the service
+	successExitStatusList = toWhitespaceSeparated([]int{
+		defaults.AbortedOperationExitCode,
+		defaults.CompletedOperationExitCode,
+	}...)
+	// noRestartExitStatusList lists exit statuses that prevent service from getting automatically
 	// restarted by systemd
-	noRestartExitStatuses = strings.Join([]string{
-		strconv.Itoa(defaults.AbortedOperationExitCode),
-		strconv.Itoa(defaults.CompletedOperationExitCode),
-		strconv.Itoa(defaults.FailedPreconditionExitCode),
-	}, " ")
+	noRestartExitStatusList = toWhitespaceSeparated(noRestartExitStatuses...)
 )

--- a/lib/install/client/resume.go
+++ b/lib/install/client/resume.go
@@ -40,9 +40,9 @@ func (r *ResumeStrategy) connect(ctx context.Context) (installpb.AgentClient, er
 	defer cancel()
 	serviceName := serviceNameFromPath(r.ServicePath)
 	client, err := installpb.NewClient(ctx, installpb.ClientConfig{
-		FieldLogger:     r.FieldLogger,
-		SocketPath:      r.SocketPath,
-		IsServiceFailed: isServiceFailed(serviceName),
+		FieldLogger:            r.FieldLogger,
+		SocketPath:             r.SocketPath,
+		ShouldReconnectService: shouldReconnectService(serviceName),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to connect to the installer service.\n"+
@@ -61,8 +61,8 @@ func (r *ResumeStrategy) checkAndSetDefaults() (err error) {
 		r.ServicePath, err = environ.GetServicePath(stateDir)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return trace.Wrap(err, "failed to find installer service. "+
-					"Use 'gravity install' to start new installation or 'gravity join' to join an existing cluster.")
+				return trace.Wrap(err,
+					"failed to find installer service. Start the installation with 'gravity install'")
 			}
 			return trace.Wrap(err)
 		}

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -17,7 +17,6 @@ package install
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -33,7 +32,6 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
-	"github.com/gravitational/gravity/lib/process"
 	"github.com/gravitational/gravity/lib/rpc"
 	pb "github.com/gravitational/gravity/lib/rpc/proto"
 	rpcserver "github.com/gravitational/gravity/lib/rpc/server"
@@ -382,19 +380,7 @@ type ExecResult struct {
 // FormatAbortError formats the specified error for output by the installer client.
 // Output will contain error message for err as well as any error it wraps.
 func FormatAbortError(err error) string {
-	switch err := err.(type) {
-	case trace.Error:
-		userMessage := trace.UserMessage(err)
-		if err.OrigError() != nil {
-			detail := trace.UserMessage(err.OrigError())
-			if detail != userMessage {
-				userMessage = fmt.Sprintf("%v (%v)", userMessage, detail)
-			}
-		}
-		return userMessage
-	default:
-		return trace.UserMessage(err)
-	}
+	return trace.UserMessage(err)
 }
 
 func isOperationSuccessful(progress ops.ProgressEntry) bool {
@@ -403,21 +389,6 @@ func isOperationSuccessful(progress ops.ProgressEntry) bool {
 
 type eventDispatcher interface {
 	Send(dispatcher.Event)
-}
-
-func wait(ctx context.Context, cancel context.CancelFunc, p process.GravityProcess) error {
-	errC := make(chan error, 1)
-	go func() {
-		err := p.Wait()
-		cancel()
-		errC <- err
-	}()
-	select {
-	case err := <-errC:
-		return trace.Wrap(err)
-	case <-ctx.Done():
-		return trace.Wrap(ctx.Err())
-	}
 }
 
 func tryInstallBinary(targetPath string, uid, gid int, logger log.FieldLogger) error {

--- a/lib/ops/opsservice/agents.go
+++ b/lib/ops/opsservice/agents.go
@@ -365,7 +365,7 @@ func (r *AgentPeerStore) NewPeer(ctx context.Context, req pb.PeerJoinRequest, pe
 	}
 
 	if req.Config.KeyValues[ops.AgentMode] != ops.AgentModeShrink {
-		errCheck := r.validatePeer(ctx, group, info, req, token.SiteDomain)
+		errCheck := r.validatePeer(ctx, group, info, req, *token)
 		if errCheck != nil {
 			return errCheck
 		}
@@ -428,47 +428,34 @@ func (r *AgentPeerStore) authenticatePeer(token string) (*storage.ProvisioningTo
 }
 
 func (r *AgentPeerStore) validatePeer(ctx context.Context, group *agentGroup, info storage.System,
-	req pb.PeerJoinRequest, clusterName string) error {
+	req pb.PeerJoinRequest, token storage.ProvisioningToken) error {
 	if group.hasPeer(req.Addr, info.GetHostname()) {
 		return nil
 	}
 
-	if err := r.checkHostname(ctx, group, req.Addr, info.GetHostname(), clusterName); err != nil {
+	if err := r.checkHostname(ctx, group, req.Addr, info.GetHostname(), token); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := r.checkLicense(ctx, int(group.NumPeers()), clusterName, info); err != nil {
+	if err := r.checkLicense(ctx, int(group.NumPeers()), token.SiteDomain, info); err != nil {
 		return trace.Wrap(err)
 	}
 
 	return nil
 }
 
-func (r *AgentPeerStore) checkHostname(ctx context.Context, group *agentGroup, addr, hostname, clusterName string) error {
-	// collect hostnames from existing servers (for expand)
-	servers, err := r.teleport.GetServers(ctx, clusterName, nil)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-
-	var existingServers []string
-	for _, server := range servers {
-		hostname := server.GetLabels()[ops.Hostname]
-		if hostname == "" {
-			log.Warnf("Server hostname is empty: %+v.", server)
-			continue
+func (r *AgentPeerStore) checkHostname(ctx context.Context, group *agentGroup, addr, hostname string, token storage.ProvisioningToken) error {
+	if err := r.isPartOfActiveOperation(addr, token); err != nil {
+		if !trace.IsNotFound(err) && !trace.IsCompareFailed(err) {
+			r.Warnf("Failed to check whether the server is part of the active operation: %v.", err)
 		}
-		existingServers = append(existingServers, hostname)
+		if err := r.isExistingServer(ctx, hostname, token.SiteDomain); err != nil {
+			return trace.Wrap(err)
+		}
 	}
-
-	if utils.StringInSlice(existingServers, hostname) {
-		return trace.AccessDenied("One of existing servers already has hostname %q: %q.", hostname, existingServers)
-	}
-
 	if group.hasConflictingPeer(addr, hostname) {
 		return trace.AccessDenied("One of existing peers already has hostname %q.", hostname)
 	}
-
 	r.Debugf("Verified hostname %q.", hostname)
 	return nil
 }
@@ -565,6 +552,52 @@ func (r *AgentPeerStore) addGroup(key ops.SiteOperationKey) (*agentGroup, error)
 	r.WithField("key", key).Debug("Added group.")
 	r.groups[key] = agentGroup
 	return agentGroup, nil
+}
+
+func (r *AgentPeerStore) isPartOfActiveOperation(addr string, token storage.ProvisioningToken) error {
+	op, err := r.backend.GetSiteOperation(token.SiteDomain, token.OperationID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if op.Type != ops.OperationInstall && op.Type != ops.OperationExpand {
+		// Only relevant for install/expand operation
+		return nil
+	}
+	operation := (ops.SiteOperation)(*op)
+	logger := r.WithField("operation", operation.String())
+	if operation.Type == ops.OperationExpand && operation.IsCompleted() {
+		// Always fall-through for install as we cannot reliably say if it's completed
+		logger.Warn("Operation is already completed.")
+		return trace.CompareFailed("operation is already completed")
+	}
+	serverAddr := utils.ExtractHost(addr)
+	if op.Servers.FindByIP(serverAddr) == nil {
+		r.WithField("server-addr", serverAddr).Warn("Server is not part of the active operation.")
+		return trace.NotFound("server is not part of the active operation")
+	}
+	return nil
+}
+
+func (r *AgentPeerStore) isExistingServer(ctx context.Context, hostname, clusterName string) error {
+	// collect hostnames from existing servers (for expand)
+	servers, err := r.teleport.GetServers(ctx, clusterName, nil)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	var existingServers []string
+	for _, server := range servers {
+		hostname := server.GetLabels()[ops.Hostname]
+		if hostname == "" {
+			log.WithField("server", server).Warn("Server hostname is empty, will ignore.")
+			continue
+		}
+		existingServers = append(existingServers, hostname)
+	}
+	if utils.StringInSlice(existingServers, hostname) {
+		return trace.AccessDenied("One of existing servers already has hostname %q: %q.",
+			hostname, existingServers)
+	}
+	return nil
 }
 
 // AgentPeerStore manages groups of agents based on operation context.

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -375,7 +375,7 @@ type Mount struct {
 	Name string `json:"name"`
 	// Source is the directory to mount
 	Source string `json:"source"`
-	// Destination is the mount destination dir
+	// Destination is the mount destination directory
 	Destination string `json:"destination"`
 	// CreateIfMissing is whether to create the source directory if it doesn't exist
 	CreateIfMissing bool `json:"create_if_missing"`
@@ -428,7 +428,7 @@ type SiteOperation struct {
 	// in case of 'install' or 'provision_servers' it will store the
 	// servers that will be added and configured, for 'deprovision_servers'
 	// it will store the servers that will be deleted
-	Servers []Server `json:"servers"`
+	Servers Servers `json:"servers"`
 	// Shrink is set when the operation type is shrink (removing nodes from the cluster)
 	Shrink *ShrinkOperationState `json:"shrink,omitempty"`
 	// InstallExpand is set when the operation is install or expand
@@ -587,6 +587,7 @@ type Site struct {
 	InstallToken string `json:"install_token"`
 }
 
+// Check validates the cluster object's fields.
 func (s *Site) Check() error {
 	if s.AccountID == "" {
 		return trace.BadParameter("missing parameter AccountID")
@@ -610,6 +611,7 @@ type ClusterState struct {
 	// Docker specifies current cluster Docker configuration
 	Docker DockerConfig `json:"docker"`
 }
+
 type nodeKey struct {
 	profile      string
 	instanceType string
@@ -1607,6 +1609,11 @@ func (s *Server) KubeNodeID() string {
 // ObjectPeerID returns the peer ID of this server
 func (s *Server) ObjectPeerID() string {
 	return s.AdvertiseIP
+}
+
+// EtcdPeerURL returns etcd peer advertise URL with the server's IP.
+func (s *Server) EtcdPeerURL() string {
+	return fmt.Sprintf("https://%v:%v", s.AdvertiseIP, defaults.EtcdPeerPort)
 }
 
 // IsMaster returns true if the server has a master role


### PR DESCRIPTION
## Description
This PR refines the logic of the controller to validate whether an agent represents a valid server in the context of an ongoing operation - otherwise, expanding breaks at various points into the operation. As the last example - immediately after failing to add an etcd member (due to a transient connection error), the agent was not able to rejoin on the grounds of there already being a server with the same hostname.
Instead, the controller will first check whether the server is part of the currently active operation (by comparing the server's advertise address against the operation server state).

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
* Backports https://github.com/gravitational/gravity/pull/1542
* Refs https://github.com/gravitational/gravity/issues/1539

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
 * Install a 3-node cluster.
 * Remove a node and re-add simulating a failure on `etcd` step. Make sure it can be resumed with a correct binary.

While testing, I ran into an issue with etcd and was wondering if it was just me or anyone else ran into it as well. Basically one of the test scenarios is removing and re-introducing a node into the cluster. If the issue is time-related at all - the remove/join would be several minutes apart tops. When joining the node, the etcd would frequently panic on data inconsistency. Here's a snippet from the etcd log that captures the panic:
```
ay 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: 3830d8d1ab5f5cd0 switched to configuration voters=()
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: 3830d8d1ab5f5cd0 became follower at term 0
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:52 INFO: newRaft 3830d8d1ab5f5cd0 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
May 14 11:02:52 dmitri-centos-node-2 etcd[235]: starting member 3830d8d1ab5f5cd0 in cluster 10c90c1dbfb0f41d
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: simple token is not cryptographically signed
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting peer 66d74b9b9be85064...
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: added peer 66d74b9b9be85064
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting peer 6c1ddcb80fda6234...
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started HTTP pipelining with peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 66d74b9b9be85064 (stream Message reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (writer)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: added peer 6c1ddcb80fda6234
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: starting server... [version: 3.4.7, cluster version: to_be_decided]
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: started streaming with peer 6c1ddcb80fda6234 (stream Message reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: peer 66d74b9b9be85064 became active
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: established a TCP streaming connection with peer 66d74b9b9be85064 (stream MsgApp v2 reader)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: ClientTLS: cert = /var/state/etcd.cert, key = /var/state/etcd.key, trusted-ca = /var/state/root.cert, client-cert-auth = true, crl-file = 
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 INFO: 3830d8d1ab5f5cd0 [term: 0] received a MsgHeartbeat message with higher term from 66d74b9b9be85064 [term: 101]
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 INFO: 3830d8d1ab5f5cd0 became follower at term 101
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: raft2020/05/14 11:02:53 tocommit(83262) is out of range [lastIndex(0)]. Was the raft log corrupted, truncated, or lost?
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: listening for peers on 10.128.0.104:2380
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: panic: tocommit(83262) is out of range [lastIndex(0)]. Was the raft log corrupted, truncated, or lost?
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: goroutine 162 [running]:
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: log.(*Logger).Panicf(0xc0001f6230, 0x10cbbbf, 0x5d, 0xc0012891a0, 0x2, 0x2)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /usr/local/go/src/log/log.go:219 +0xc1
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*DefaultLogger).Panicf(0x1aa7080, 0x10cbbbf, 0x5d, 0xc0012891a0, 0x2, 0x2)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/logger.go:127 +0x60
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raftLog).commitTo(0xc0002b8070, 0x1453e)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/log.go:203 +0x131
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raft).handleHeartbeat(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:1396 +0x54
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.stepFollower(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:1341 +0x480
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*raft).Step(0xc0000fa780, 0x8, 0x3830d8d1ab5f5cd0, 0x66d74b9b9be85064, 0x65, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/raft.go:984 +0x1113
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: go.etcd.io/etcd/raft.(*node).run(0xc000346840)
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/node.go:352 +0xab6
May 14 11:02:53 dmitri-centos-node-2 etcd[235]: created by go.etcd.io/etcd/raft.RestartNode
May 14 11:02:53 dmitri-centos-node-2 etcd[235]:         /tmp/etcd-release-3.4.7/etcd/release/etcd/raft/node.go:240 +0x33c
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: etcd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: etcd.service: Failed with result 'exit-code'.
May 14 11:02:53 dmitri-centos-node-2 systemd[1]: Failed to start Etcd Service.
```

The behavior with the change now is continuously retry the add etcd peer step which in this case would be failing with `cluster has not leader` until timeout.
To resolve, I had to manually remove the member from another node:
```
$ etcdctl member remove <failing-member-id>
```
remove the data directory on the joining node:
```
$ rm -r /var/lib/gravity/planet/etcd/v<etcd-version>
```
and rerun the step:
```
$ ./gravity resume
```