### PR TITLE
[5.5.x] improved operation handling

### DIFF
--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -628,7 +628,7 @@ func (s *site) removeNodeFromCluster(server storage.Server, runner *serverRunner
 			fmt.Sprintf("-l=%v=%v", defaults.KubernetesHostnameLabel, server.KubeNodeID())),
 		// Issue `serf force-leave` from the master node to transition
 		// failed nodes to `left` state in case the node itself failed shutting down
-		s.planetEnterCommand(defaults.SerfBin, "force-leave", provisionedServer.AgentName(s.domainName)),
+		s.planetEnterCommand(defaults.SerfBin, "force-leave", "-prune", provisionedServer.AgentName(s.domainName)),
 	}
 
 	err = utils.Retry(defaults.RetryInterval, defaults.RetryAttempts, func() error {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -98,6 +98,11 @@ func Join(env, joinEnv *localenv.LocalEnvironment, j JoinConfig) error {
 		return trace.Wrap(err)
 	}
 
+	err = uninstallExistingAgentService()
+	if err != nil {
+		log.Warn("Failed to stop agent service: %v.")
+	}
+
 	err = j.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -100,7 +100,7 @@ func Join(env, joinEnv *localenv.LocalEnvironment, j JoinConfig) error {
 
 	err = uninstallExistingAgentService()
 	if err != nil {
-		log.Warn("Failed to stop agent service: %v.")
+		log.Warnf("Failed to stop agent service: %v.", err)
 	}
 
 	err = j.CheckAndSetDefaults()

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -255,7 +255,7 @@ func getBackendOperations(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 	b := newBackendOperations()
 	b.List(localEnv, environ)
 	for _, op := range b.operations {
-		if (operationID == "" || operationID == op.ID) && op.hasPlan {
+		if operationID == "" || operationID == op.ID {
 			result = append(result, op)
 		}
 	}

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -179,7 +179,7 @@ func completeOperationPlanForOperation(localEnv *localenv.LocalEnvironment, envi
 	case ops.OperationUpdateConfig:
 		err = completeConfigPlanForOperation(localEnv, environ, op)
 	default:
-		return trace.BadParameter("operation type %q does not support plan completion", op.Type)
+		return completeClusterOperationPlan(localEnv, op)
 	}
 	if op.Type != ops.OperationInstall && trace.IsNotFound(err) {
 		log.WithError(err).Warn("Failed to complete operation locally, will fallback to cluster operation.")
@@ -194,10 +194,10 @@ func completeClusterOperationPlan(localEnv *localenv.LocalEnvironment, operation
 		return trace.Wrap(err)
 	}
 	plan, err := fsm.GetOperationPlan(clusterEnv.Backend, operation.SiteDomain, operation.ID)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	if fsm.IsCompleted(plan) {
+	if err == nil && fsm.IsCompleted(plan) {
 		return ops.CompleteOperation(operation.Key(), clusterEnv.Operator)
 	}
 	return ops.FailOperation(operation.Key(), clusterEnv.Operator, "completed manually")
@@ -308,24 +308,14 @@ func (r *backendOperations) init(clusterBackend storage.Backend) error {
 	if len(clusterOperations) == 0 {
 		return nil
 	}
-	// Initialize the operation state from the list of existing cluster operations.
-	// operationsByType groups the operations by type to avoid looking at multiple operations
-	// of the same type as we are only interested in the latest operation
-	operationsByType := make(map[string]clusterOperation)
 	for _, op := range clusterOperations {
-		if _, exists := operationsByType[op.Type]; exists {
-			continue
-		}
 		clusterOperation := clusterOperation{
 			SiteOperation: (ops.SiteOperation)(op),
 		}
 		if _, err := clusterBackend.GetOperationPlan(op.SiteDomain, op.ID); err == nil {
 			clusterOperation.hasPlan = true
 		}
-		operationsByType[op.Type] = clusterOperation
-	}
-	for _, op := range operationsByType {
-		r.operations[op.ID] = op
+		r.operations[op.ID] = clusterOperation
 	}
 	latestOperation := r.operations[clusterOperations[0].ID]
 	r.clusterOperation = &latestOperation

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -417,6 +417,15 @@ type backendOperations struct {
 	clusterOperation *clusterOperation
 }
 
+func isInvalidOperation(op clusterOperation) bool {
+	switch op.Type {
+	case ops.OperationShrink:
+		return false
+	default:
+		return !op.hasPlan
+	}
+}
+
 // formatTable formats this operation list as a table
 func (r operationList) formatTable() string {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -69,12 +69,15 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 	if err != nil {
 		if trace.IsNotFound(err) {
 			message := noOperationStateNoClusterStateBanner
-			if err2 := CheckLocalState(localEnv); err2 != nil {
+			if err := CheckLocalState(localEnv); err != nil {
 				message = NoOperationStateBanner
 			}
 			return trace.NotFound(message)
 		}
 		return trace.Wrap(err)
+	}
+	if !op.hasPlan {
+		return trace.BadParameter(noOperationPlanBanner, op.String(), op.ID)
 	}
 	if op.IsCompleted() {
 		return displayClusterOperationPlan(localEnv, op.Key(), format)
@@ -253,5 +256,9 @@ Clean up the node with 'gravity leave' and start the operation with either 'grav
 	noOperationStateNoClusterStateBanner = `no operation found.
 This usually means that the installation/join operation has failed to start or was not started.
 Start the operation with either 'gravity install' or 'gravity join'.
+`
+	noOperationPlanBanner = `%v is invalid and has no plan.
+This usually means that the operation has failed to initialize properly.
+You can mark this operation explicitly as failed with 'gravity plan complete --operation-id=%v' so it does not appear active and re-attempt it.
 `
 )

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -257,7 +257,7 @@ Clean up the node with 'gravity leave' and start the operation with either 'grav
 This usually means that the installation/join operation has failed to start or was not started.
 Start the operation with either 'gravity install' or 'gravity join'.
 `
-	noOperationPlanBanner = `%v is invalid and has no plan.
+	noOperationPlanBanner = `%v has no plan and is invalid.
 This usually means that the operation has failed to initialize properly.
 You can mark this operation explicitly as failed with 'gravity plan complete --operation-id=%v' so it does not appear active and re-attempt it.
 `

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -76,10 +76,10 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 		}
 		return trace.Wrap(err)
 	}
-	if !op.hasPlan {
-		return trace.BadParameter(noOperationPlanBanner, op.String(), op.ID)
+	if isInvalidOperation(*op) {
+		return trace.BadParameter(invalidOperationBanner, op.String(), op.ID)
 	}
-	if op.IsCompleted() {
+	if op.IsCompleted() && op.hasPlan {
 		return displayClusterOperationPlan(localEnv, op.Key(), format)
 	}
 	switch op.Type {
@@ -96,7 +96,7 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 	case ops.OperationGarbageCollect:
 		err = displayClusterOperationPlan(localEnv, op.Key(), format)
 	default:
-		return trace.BadParameter("unknown operation type %q", op.Type)
+		return trace.BadParameter("cannot display plan for %q operation as it does not support plans", op.TypeString())
 	}
 	if err != nil && trace.IsNotFound(err) {
 		// Fallback to cluster plan
@@ -257,7 +257,7 @@ Clean up the node with 'gravity leave' and start the operation with either 'grav
 This usually means that the installation/join operation has failed to start or was not started.
 Start the operation with either 'gravity install' or 'gravity join'.
 `
-	noOperationPlanBanner = `%v has no plan and is invalid.
+	invalidOperationBanner = `%v is invalid.
 This usually means that the operation has failed to initialize properly.
 You can mark this operation explicitly as failed with 'gravity plan complete --operation-id=%v' so it does not appear active and re-attempt it.
 `

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/tool/common"
 
 	"github.com/gravitational/trace"
@@ -151,4 +152,12 @@ func (g *Application) isJoinCommand(cmd string) bool {
 		return true
 	}
 	return false
+}
+
+func uninstallExistingAgentService() error {
+	svm, err := systemservice.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return svm.UninstallService(defaults.GravityRPCAgentServiceName)
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the operation handling to make it more user-friendly and expected.
It changes the following:
  * adds `-prune` to serf command line to remove a node as this ensures that the member is evicted immediately
  * reverts the listing of all operations (and not just the last of any specific type) - otherwise operation-id targeted queries might fail if the id refers to an operation further down in operation stack
  * `plan display` explicitly handles invalid operations
  * `plan complete` handles operations even without plan - in this case the operation is explicitly marked as failed
  * uninstall possibly active agent prior to triggering the expand operation. This is done after verifying the package state so it is obvious that the agent is a leftover from the previous unfinished cleanup.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->

Displaying plan for operation that does not support plan:
```
Cluster name:		dev.test
Cluster status:		active
Application:		telekube, version 5.5.46-dev.5
Gravity version:	5.5.46-dev.5 (client) / 5.5.46-dev.5 (server)
Join token:		schmoken
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_shrink (7347bda1-ba40-475e-b074-5b37bfbf8a6b)
      started:		Thu May 21 19:11 UTC (59 minutes ago)
      completed:	Thu May 21 19:13 UTC (57 minutes ago)
...
$ gravity plan --operation-id=7347bda1-ba40-475e-b074-5b37bfbf8a6b
[ERROR]: cannot display plan for "shrink" operation as it does not support plans
```
Display plan for operation that failed to initialize properly:
```
Cluster name:		dev.test
Cluster status:		expanding
Application:		telekube, version 5.5.46-dev.5
Gravity version:	5.5.46-dev.5 (client) / 5.5.46-dev.5 (server)
Join token:		schmoken
Periodic updates:	Not Configured
Remote support:		Not Configured
Active operations:
    * operation_expand (32c26b8d-08df-4709-ba56-f5ba024808ff)
      started:	Thu May 21 20:13 UTC (5 seconds ago)
      Operation has been created, 0% complete
...
$ gravity plan
[ERROR]: operation(expand(32c26b8d-08df-4709-ba56-f5ba024808ff), cluster=dev.test, state=ready, created=Thu May 21 20:13 UTC) has no plan and is invalid.
This usually means that the operation has failed to initialize properly.
You can mark this operation explicitly as failed with 'gravity plan complete --operation-id=32c26b8d-08df-4709-ba56-f5ba024808ff' so it does not appear active and re-attempt it.
```
Attempt to resume upgrade in this case:
```
$ gravity --debug upgrade --resume
[ERROR]: no active update operation found
```
Attempt to resume an expand from unrelated node:
```
$ gravity join --resume
[ERROR]: unable to connect to the cluster service. Is the command being run from the joining node?
```
Attempt to resume install:
```
$ gravity install --resume
[ERROR]: installation already completed
```