### PR TITLE
Remove web instructions for offline upgrades

### DIFF
--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -386,12 +386,7 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-An upgrade can be triggered either through Cluster Control Panel or using
-command line. To trigger the upgrade from the Control Panel, select an appropriate
-version on the "Updates" tab click `Update`.
-
-To trigger the operation from the command line, copy the Cluster Image into one
-of the Cluster nodes and untar it:
+First copy the Cluster Image onto one of the Cluster nodes and untar it:
 
 ```bash
 $ tar xf cluster-image.tar

--- a/docs/6.x/cluster.md
+++ b/docs/6.x/cluster.md
@@ -386,7 +386,7 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-First copy the Cluster Image onto one of the Cluster nodes and untar it:
+First, copy the Cluster Image onto one of the Cluster nodes and untar it:
 
 ```bash
 $ tar xf cluster-image.tar

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -386,8 +386,7 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-To trigger the upgrade first copy the Cluster Image into one
-of the Cluster nodes and untar it:
+First copy the Cluster Image onto one of the Cluster nodes and untar it:
 
 ```bash
 $ tar xf cluster-image.tar

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -386,11 +386,7 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-An upgrade can be triggered either through Cluster Control Panel or using
-command line. To trigger the upgrade from the Control Panel, select an appropriate
-version on the "Updates" tab click `Update`.
-
-To trigger the operation from the command line, copy the Cluster Image into one
+To trigger the upgrade first copy the Cluster Image into one
 of the Cluster nodes and untar it:
 
 ```bash

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -386,7 +386,7 @@ upgrade procedure.
 
 ### Performing an Upgrade
 
-First copy the Cluster Image onto one of the Cluster nodes and untar it:
+First, copy the Cluster Image onto one of the Cluster nodes and untar it:
 
 ```bash
 $ tar xf cluster-image.tar


### PR DESCRIPTION
## Description
Updated 6.X and 7.X cluster instructions for offline upgrades.  The language had references to using an update tab on the web cluster control panel that are no longer available.  That has been removed and just command line language remains.

## Type of change
Documentation


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write documentation
- [x] Address review feedback

