### PR TITLE
(7.1) Add gravity rollback command

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -1234,7 +1234,7 @@ to learn how to gain insight into how the cluster status changes over time.
 
 !!! note "Direct upgrades"
     You can now upgrade existing 5.0.x clusters directly to 5.5.x.
-    See [Direct Upgrades From Older LTS Versions](cluster.md#direct-upgrades-from-older-lts-versions) for details.
+    See [Direct Upgrades From Older LTS Versions](cluster.md#multi-hop-upgrades) for details.
 
 #### Improvements
 

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -470,7 +470,63 @@ root$ ./gravity plan resume
 root$ ./gravity agent shutdown
 ```
 
-## Direct Upgrades From Older LTS Versions
+### Rolling Back a Failed Upgrade
+
+When an automatic upgrade procedure encounters an error, it stops and lets the
+user decide on how to proceed: attempt to resolve the error and resume the
+upgrade, or rollback the operation and return the cluster to the original state.
+
+To rollback a failed upgrade operation, Gravity provides a `gravity rollback`
+command:
+
+```bsh
+$ sudo ./gravity rollback
+You are about to rollback the following operation:
+Type                 ID                                       State                  Created
+----                 --                                       -----                  -------
+operation_update     30c5d94c-1fbc-48eb-a952-a8632d519891     update_in_progress     2020-05-27 21:27
+
+Consider checking the operation plan and using --dry-run flag first to see which actions will be performed.
+You can suppress this warning in future by providing --confirm flag.
+Proceed? (yes/no):
+yes
+Rolling back "/masters/node-2/untaint" locally
+Rolling back "/masters/node-2/endpoints" locally
+Rolling back "/masters/node-2/uncordon" locally
+Rolling back "/masters/node-2/taint" locally
+Rolling back "/masters/node-2/health" on node node-2
+Rolling back "/masters/node-2/elect" on node node-2
+Rolling back "/masters/node-2/system-upgrade" on node node-2
+...
+```
+
+The command also supports dry-run mode that can be invoked prior to performing
+the actual rollback to see the actions that will be executed:
+
+```bsh
+$ sudo ./gravity rollback --dry-run
+[DRY-RUN] Rolling back "/masters/node-2/untaint" locally
+[DRY-RUN] Rolling back "/masters/node-2/endpoints" locally
+[DRY-RUN] Rolling back "/masters/node-2/uncordon" locally
+[DRY-RUN] Rolling back "/masters/node-2/taint" locally
+[DRY-RUN] Rolling back "/masters/node-2/health" on node node-2
+[DRY-RUN] Rolling back "/masters/node-2/elect" on node node-2
+[DRY-RUN] Rolling back "/masters/node-2/system-upgrade" on node node-2
+...
+```
+
+!!! note "Supported operations"
+    Currently, `gravity rollback` supports only the following operations:
+    upgrade, [runtime environment](config.md#runtime-environment-variables) update and
+    [cluster configuration](config.md#general-cluster-configuration) update.
+    Rollback of completed operation is not supported at the moment.
+
+For a more granular control over rollback/execution, Gravity provides a set of `gravity plan`
+subcommands for inspecting and interacting with the upgrade (or any other)
+operation plan. See the [Managing Operations](#managing-operations) section below
+for more details.
+
+## Multi-Hop Upgrades
 
 Gravity LTS releases are at most 8 months apart and are based on Kubernetes releases which are no more than 2 minor versions apart.
 This requirement is partially necessitated by the Kubernetes version skew [support policy](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-version-skew).

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -680,6 +680,8 @@ const (
 	InProgressMark = "→"
 	// WarnMark is used in CLI to visually indicate a warning
 	WarnMark = "!"
+	// RollbackMark is used in CLI to visually indicate rollback
+	RollbackMark = "⤺"
 
 	// WireguardNetworkType is a network type that is used for wireguard/wormhole support
 	WireguardNetworkType = "wireguard"

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -72,8 +72,10 @@ func printPhase(w io.Writer, phase storage.OperationPhase, indent int) {
 		marker = constants.InProgressMark
 	} else if phase.GetState() == storage.OperationPhaseStateCompleted {
 		marker = constants.SuccessMark
-	} else if phase.GetState() == storage.OperationPhaseStateFailed || phase.GetState() == storage.OperationPhaseStateRolledBack {
+	} else if phase.GetState() == storage.OperationPhaseStateFailed {
 		marker = constants.FailureMark
+	} else if phase.GetState() == storage.OperationPhaseStateRolledBack {
+		marker = constants.RollbackMark
 	}
 	fmt.Fprintf(w, "%v%v %v\t%v\t%v\t%v\t%v\t%v\n",
 		strings.Repeat("  ", indent),

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -82,8 +82,12 @@ type Params struct {
 	// to be rerun - this is unexpected when the operation is resumed
 	// and only the unfinished/failed steps are re-executed
 	Resume bool
+	// Rollback indicates that the specified phase should be rolled back.
+	Rollback bool
 	// Progress is optional progress reporter
 	Progress utils.Progress
+	// DryRun allows to only print phases without executing/rolling back.
+	DryRun bool
 }
 
 // CheckAndSetDefaults makes sure all required parameters are set
@@ -160,7 +164,7 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 		return trace.Wrap(err)
 	}
 	for _, phase := range plan.Phases {
-		f.Debugf("Executing phase %q.", phase.ID)
+		f.WithField("phase", phase.ID).Debug("Executing phase.")
 		err := f.ExecutePhase(ctx, Params{
 			PhaseID:  phase.ID,
 			Progress: progress,
@@ -168,6 +172,34 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 		})
 		if err != nil {
 			return trace.Wrap(err, "failed to execute phase %q", phase.ID)
+		}
+	}
+	return nil
+}
+
+// RollbackPlan rolls back all phases of the plan that have been attempted so
+// far in the reverse order.
+func (f *FSM) RollbackPlan(ctx context.Context, progress utils.Progress, dryRun bool) error {
+	plan, err := f.GetPlan()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	allPhases := plan.GetLeafPhases()
+	for i := len(allPhases) - 1; i >= 0; i -= 1 {
+		phase := allPhases[i]
+		log := f.WithFields(logrus.Fields{"phase": phase.ID, "state": phase.GetState()})
+		if phase.IsUnstarted() || phase.IsRolledBack() {
+			log.Info("Skip rollback.")
+			continue
+		}
+		log.Info("Rollback.")
+		err := f.RollbackPhase(ctx, Params{
+			PhaseID:  phase.ID,
+			Progress: progress,
+			DryRun:   dryRun,
+		})
+		if err != nil {
+			return trace.Wrap(err)
 		}
 	}
 	return nil
@@ -231,17 +263,14 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 		if !p.Force {
 			return trace.Wrap(err)
 		}
-		f.Warnf("Forcing rollback: %v.", trace.DebugReport(err))
+		f.WithError(err).Warn("Forcing rollback.")
 	}
 	phase, err := FindPhase(plan, p.PhaseID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if !phase.HasSubphases() {
-		//
-		// Check whether this phase should be run on a local or remote server
-		// If it should be run on a remote server, throw an error
-		//
+		// Check whether this phase should be run on a local or remote server.
 		var execServer *storage.Server
 		if phase.Data != nil {
 			if phase.Data.ExecServer != nil {
@@ -251,21 +280,40 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 			}
 		}
 
+		execWhere := CanRunLocally
 		if execServer != nil {
-			execWhere, err := canExecuteOnServer(ctx, *execServer, f.Runner, f.FieldLogger)
+			execWhere, err = canExecuteOnServer(ctx, *execServer, f.Runner, f.FieldLogger)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if execWhere != CanRunLocally {
-				return trace.BadParameter("rollback phase %v must be run from server %v", p.PhaseID, execServer.Hostname)
-			}
 		}
 
-		p.Progress.NextStep("Rolling back %q", phase.ID)
-		err = f.rollbackPhase(ctx, p, *phase)
-		if err != nil {
-			return trace.Wrap(err)
+		switch execWhere {
+		case CanRunLocally:
+			message := fmt.Sprintf("Rolling back %q locally", phase.ID)
+			if p.DryRun {
+				p.Progress.NextStep("[DRY-RUN] %v", message)
+				return nil
+			}
+			p.Progress.NextStep(message)
+			return f.rollbackPhaseLocally(ctx, p, *phase)
+
+		case CanRunRemotely:
+			message := fmt.Sprintf("Rolling back %q on node %v", phase.ID, execServer.Hostname)
+			if p.DryRun {
+				p.Progress.NextStep("[DRY-RUN] %v", message)
+				return nil
+			}
+			p.Progress.NextStep(message)
+			return f.rollbackPhaseRemotely(ctx, p, *phase, *execServer)
+
+		default:
+			return trace.BadParameter(
+				`Node %[1]v does not appear to have an upgrade agent running so phase %[2]q rollback cannot be performed remotely from this node.
+You can redeploy upgrade agents on all cluster nodes using "./gravity agent deploy", or execute "./gravity plan rollback --phase=%[2]v" directly from %[1]v."`,
+				execServer.Hostname, p.PhaseID)
 		}
+
 		return nil
 	}
 	for i := len(phase.Phases) - 1; i >= 0; i-- {
@@ -483,7 +531,7 @@ func (f *FSM) executeOnePhase(ctx context.Context, p Params, phase storage.Opera
 	return nil
 }
 
-func (f *FSM) rollbackPhase(ctx context.Context, p Params, phase storage.OperationPhase) error {
+func (f *FSM) rollbackPhaseLocally(ctx context.Context, p Params, phase storage.OperationPhase) error {
 	plan, err := f.GetPlan()
 	if err != nil {
 		return trace.Wrap(err)
@@ -530,6 +578,16 @@ func (f *FSM) rollbackPhase(ctx context.Context, p Params, phase storage.Operati
 	}
 
 	return nil
+}
+
+func (f *FSM) rollbackPhaseRemotely(ctx context.Context, p Params, phase storage.OperationPhase, server storage.Server) error {
+	return f.RunCommand(ctx, f.Runner, server, Params{
+		PhaseID:  p.PhaseID,
+		Force:    p.Force,
+		Resume:   p.Resume,
+		Rollback: true,
+		Progress: p.Progress,
+	})
 }
 
 // prerequisitesComplete checks if specified phase can be executed in the

--- a/lib/fsm/fsm_test.go
+++ b/lib/fsm/fsm_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+func TestFSM(t *testing.T) { check.TestingT(t) }
+
+type FSMSuite struct {
+	planner *testPlanner
+}
+
+var _ = check.Suite(&FSMSuite{
+	planner: &testPlanner{},
+})
+
+// TestExecutePlan executes an unstarted plan and makes sure all phases have
+// been executed in correct order.
+func (s *FSMSuite) TestExecutePlan(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateUnstarted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateUnstarted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.ExecutePlan(context.TODO(), utils.DiscardProgress)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is completed now.
+	c.Assert(IsCompleted(plan), check.Equals, true)
+	// Make sure phases were executed in correct order.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateCompleted),
+		s.planner.upgradeChange(storage.OperationPhaseStateInProgress),
+		s.planner.upgradeChange(storage.OperationPhaseStateCompleted),
+	))
+}
+
+// TestRollbackPlan rolls back a failed plan and makes sure all phases have been
+// rolled back in correct order.
+func (s *FSMSuite) TestRollbackPlan(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateFailed))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.DiscardProgress, false)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is rolled back now.
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+	// Make sure phases were rolled back in correct order.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.upgradeChange(storage.OperationPhaseStateInProgress),
+		s.planner.upgradeChange(storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-1", storage.OperationPhaseStateRolledBack),
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateRolledBack),
+	))
+}
+
+// TestRollbackPlanSkip rolls back a plan with some rolled back / unstarted phases
+// and makes sure such phases are being skipped during rollback.
+func (s *FSMSuite) TestRollbackPlanSkip(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateRolledBack),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.DiscardProgress, false)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is rolled back now.
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+	// Make sure unstarted/rolled back phases were skipped over.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog(
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateInProgress),
+		s.planner.bootstrapSubChange("node-2", storage.OperationPhaseStateRolledBack),
+		s.planner.initChange(storage.OperationPhaseStateInProgress),
+		s.planner.initChange(storage.OperationPhaseStateRolledBack),
+	))
+}
+
+// TestRollbackPlanDryRun make sure that rollback in dry-run mode does not
+// rollback any of the phases.
+func (s *FSMSuite) TestRollbackPlanDryRun(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	engine := newTestEngine(*plan)
+	fsm, err := New(Config{Engine: engine})
+	c.Assert(err, check.IsNil)
+
+	err = fsm.RollbackPlan(context.TODO(), utils.DiscardProgress, true)
+	c.Assert(err, check.IsNil)
+
+	plan, err = fsm.GetPlan()
+	c.Assert(err, check.IsNil)
+	// Make sure plan is still not rolled back.
+	c.Assert(IsRolledBack(plan), check.Equals, false)
+	// Make sure changelog is empty.
+	s.checkChangelog(c, engine.changelog, s.planner.newChangelog())
+}
+
+func (s *FSMSuite) checkChangelog(c *check.C, actual, expected storage.PlanChangelog) {
+	c.Assert(len(actual), check.Equals, len(expected))
+	for i := 0; i < len(actual); i += 1 {
+		actual[i].Created = expected[i].Created // Do not compare timestamps.
+		compare.DeepCompare(c, actual[i], expected[i])
+	}
+}

--- a/lib/fsm/helpers_test.go
+++ b/lib/fsm/helpers_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/gravity/lib/rpc"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+)
+
+func newTestEngine(plan storage.OperationPlan) *testEngine {
+	return &testEngine{
+		plan:  plan,
+		clock: clockwork.NewFakeClock(),
+	}
+}
+
+// testEngine is fsm engine used in tests. Keeps its changelog in memory.
+type testEngine struct {
+	plan      storage.OperationPlan
+	changelog storage.PlanChangelog
+	clock     clockwork.Clock
+}
+
+// GetExecutor returns one of the test executors depending on the specified phase.
+func (t *testEngine) GetExecutor(p ExecutorParams, r Remote) (PhaseExecutor, error) {
+	if strings.HasPrefix(p.Phase.ID, "/init") {
+		return newInit(), nil
+	} else if strings.HasPrefix(p.Phase.ID, "/bootstrap") {
+		return newBootstrap(), nil
+	} else if strings.HasPrefix(p.Phase.ID, "/upgrade") {
+		return newUpgrade(), nil
+	}
+	return nil, trace.BadParameter("unknown phase %q", p.Phase.ID)
+}
+
+// ChangePhaseState records the provided phase state change in the test engine.
+func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error {
+	// Make sure that new changelog entries get the most recent timestamp.
+	timestamp := t.clock.Now().Add(time.Duration(len(t.changelog)) * time.Minute)
+	t.changelog = append(t.changelog, storage.PlanChange{
+		PhaseID:  ch.Phase,
+		NewState: ch.State,
+		Created:  timestamp,
+	})
+	return nil
+}
+
+// GetPlan returns the test plan with the changelog applied.
+func (t *testEngine) GetPlan() (*storage.OperationPlan, error) {
+	return ResolvePlan(t.plan, t.changelog), nil
+}
+
+// RunCommand is not implemented by the test engine.
+func (t *testEngine) RunCommand(ctx context.Context, r rpc.RemoteRunner, s storage.Server, p Params) error {
+	return trace.NotImplemented("test engine cannot execute remote commands")
+}
+
+// Complete is not implemented by the test engine.
+func (t *testEngine) Complete(err error) error {
+	return trace.NotImplemented("test engine cannot complete operations")
+}
+
+func newInit() *initExecutor {
+	return &initExecutor{newTest()}
+}
+
+type initExecutor struct {
+	*testExecutor
+}
+
+func newBootstrap() *bootstrapExecutor {
+	return &bootstrapExecutor{newTest()}
+}
+
+type bootstrapExecutor struct {
+	*testExecutor
+}
+
+func newUpgrade() *upgradeExecutor {
+	return &upgradeExecutor{newTest()}
+}
+
+type upgradeExecutor struct {
+	*testExecutor
+}
+
+func newTest() *testExecutor {
+	return &testExecutor{FieldLogger: logrus.WithField(trace.Component, "test")}
+}
+
+// testExecutor serves as a base for executors used in tests.
+type testExecutor struct {
+	logrus.FieldLogger
+}
+
+func (e *testExecutor) Execute(ctx context.Context) error   { return nil }
+func (e *testExecutor) Rollback(ctx context.Context) error  { return nil }
+func (e *testExecutor) PreCheck(ctx context.Context) error  { return nil }
+func (e *testExecutor) PostCheck(ctx context.Context) error { return nil }
+
+// testPlanner knows how to generate plans and changelogs used in fsm tests.
+type testPlanner struct{}
+
+func (p *testPlanner) newPlan(phases ...storage.OperationPhase) *storage.OperationPlan {
+	return &storage.OperationPlan{Phases: phases}
+}
+
+func (p *testPlanner) newChangelog(changes ...storage.PlanChange) storage.PlanChangelog {
+	return storage.PlanChangelog(changes)
+}
+
+func (p *testPlanner) initPhase(state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/init", State: state}
+}
+
+func (p *testPlanner) initChange(state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: "/init", NewState: state}
+}
+
+func (p *testPlanner) bootstrapPhase(phases ...storage.OperationPhase) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/bootstrap", Phases: phases}
+}
+
+func (p *testPlanner) bootstrapSubPhase(node, state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: fmt.Sprintf("/bootstrap/%v", node), State: state}
+}
+
+func (p *testPlanner) bootstrapSubChange(node, state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: fmt.Sprintf("/bootstrap/%v", node), NewState: state}
+}
+
+func (p *testPlanner) upgradePhase(state string) storage.OperationPhase {
+	return storage.OperationPhase{ID: "/upgrade", State: state}
+}
+
+func (p *testPlanner) upgradeChange(state string) storage.PlanChange {
+	return storage.PlanChange{PhaseID: "/upgrade", NewState: state}
+}

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -43,8 +43,18 @@ func CanRollback(plan *storage.OperationPlan, phaseID string) error {
 
 // IsCompleted returns true if all phases of the provided plan are completed
 func IsCompleted(plan *storage.OperationPlan) bool {
-	for _, phase := range FlattenPlan(plan) {
+	for _, phase := range plan.GetLeafPhases() {
 		if !phase.IsCompleted() {
+			return false
+		}
+	}
+	return true
+}
+
+// IsRolledBack returns true if the provided plan is rolled back.
+func IsRolledBack(plan *storage.OperationPlan) bool {
+	for _, phase := range plan.GetLeafPhases() {
+		if !phase.IsRolledBack() && !phase.IsUnstarted() {
 			return false
 		}
 	}
@@ -209,9 +219,8 @@ func OperationKey(plan storage.OperationPlan) ops.SiteOperationKey {
 }
 
 func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase) {
-	// add the phase itself
+	// Add the phase itself and all its subphases recursively.
 	*result = append(*result, phase)
-	// as well as all its subphases and their subphases recursively
 	for i := range phase.Phases {
 		addPhases(&phase.Phases[i], result)
 	}

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"github.com/gravitational/gravity/lib/storage"
+
+	"gopkg.in/check.v1"
+)
+
+type FSMUtilsSuite struct {
+	planner *testPlanner
+}
+
+var _ = check.Suite(&FSMUtilsSuite{
+	planner: &testPlanner{},
+})
+
+func (s *FSMUtilsSuite) TestIsCompleted(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateCompleted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateCompleted))
+	c.Assert(IsCompleted(plan), check.Equals, true)
+}
+
+func (s *FSMUtilsSuite) TestIsRolledBack(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateRolledBack),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateRolledBack),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+	c.Assert(IsRolledBack(plan), check.Equals, true)
+}

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -62,6 +62,35 @@ func (p OperationPlan) Check() error {
 	return nil
 }
 
+// GetLeafPhases flattens the plan and returns all phases that do not have
+// any subphases in the order they appear in the plan.
+//
+// For instance, for the following plan
+//
+//  * /init
+//    * /node-1
+//    * /node-2
+//  * /checks
+//
+// it will return ["/init/node-1", "/init/node-2", "/checks"].
+func (p *OperationPlan) GetLeafPhases() (result []OperationPhase) {
+	for _, phase := range p.Phases {
+		result = append(result, getLeafPhases(phase)...)
+	}
+	return result
+}
+
+func getLeafPhases(phase OperationPhase) (result []OperationPhase) {
+	if len(phase.Phases) == 0 {
+		result = append(result, phase)
+	} else {
+		for _, sub := range phase.Phases {
+			result = append(result, getLeafPhases(sub)...)
+		}
+	}
+	return result
+}
+
 // OperationPhase represents a single operation plan phase
 type OperationPhase struct {
 	// ID is the ID of the phase within operation

--- a/lib/storage/plan_test.go
+++ b/lib/storage/plan_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"github.com/gravitational/gravity/lib/compare"
+
+	"gopkg.in/check.v1"
+)
+
+type PlanSuite struct{}
+
+var _ = check.Suite(&PlanSuite{})
+
+func (*PlanSuite) TestGetLeafPhases(c *check.C) {
+	initPhase := OperationPhase{ID: "/init"}
+	bootstrapPhase1 := OperationPhase{ID: "/bootstrap/node-1"}
+	bootstrapPhase2 := OperationPhase{ID: "/bootstrap/node-2"}
+	bootstrapPhase := OperationPhase{
+		ID:     "/bootstrap",
+		Phases: []OperationPhase{bootstrapPhase1, bootstrapPhase2},
+	}
+	upgradePhase := OperationPhase{ID: "/upgrade"}
+	plan := &OperationPlan{
+		Phases: []OperationPhase{initPhase, bootstrapPhase, upgradePhase},
+	}
+	compare.DeepCompare(c, plan.GetLeafPhases(), []OperationPhase{
+		initPhase, bootstrapPhase1, bootstrapPhase2, upgradePhase})
+}

--- a/lib/update/engine.go
+++ b/lib/update/engine.go
@@ -164,7 +164,11 @@ func (r *Engine) ChangePhaseState(ctx context.Context, change fsm.StateChange) e
 // RunCommand executes the phase specified by params on the specified server
 // using the provided runner
 func (r *Engine) RunCommand(ctx context.Context, runner rpc.RemoteRunner, server storage.Server, params fsm.Params) error {
-	args := []string{"plan", "execute",
+	command := "execute"
+	if params.Rollback {
+		command = "rollback"
+	}
+	args := []string{"plan", command,
 		"--phase", params.PhaseID,
 		"--operation-id", r.Operation.ID,
 	}

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -109,17 +109,21 @@ func (r *Updater) SetPhase(ctx context.Context, phase, state string) error {
 }
 
 // RollbackPhase rolls back the specified phase.
-func (r *Updater) RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error {
+func (r *Updater) RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error {
+	if params.PhaseID == fsm.RootPhase {
+		return r.rollbackPlan(ctx, params.DryRun)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, phaseTimeout)
 	defer cancel()
 
-	progress := utils.NewProgress(ctx, fmt.Sprintf("Rolling back phase %q", phase), -1, false)
+	progress := utils.NewProgress(ctx, fmt.Sprintf("Rolling back phase %q", params.PhaseID), -1, false)
 	defer progress.Stop()
 
 	return trace.Wrap(r.machine.RollbackPhase(ctx, fsm.Params{
-		PhaseID:  phase,
+		PhaseID:  params.PhaseID,
 		Progress: progress,
-		Force:    force,
+		Force:    params.Force,
 	}))
 }
 
@@ -169,6 +173,23 @@ func (r *Updater) GetPlan() (*storage.OperationPlan, error) {
 // Close closes the underlying FSM
 func (r *Updater) Close() error {
 	return r.machine.Close()
+}
+
+func (r *Updater) rollbackPlan(ctx context.Context, dryRun bool) error {
+	progress := utils.NewProgress(ctx, formatOperation(*r.Operation), -1, false)
+	defer progress.Stop()
+
+	if err := r.machine.RollbackPlan(ctx, progress, dryRun); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !dryRun {
+		if err := r.machine.Complete(trace.BadParameter("rolled back")); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
 }
 
 func (r *Updater) executePlan(ctx context.Context) error {

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -122,7 +123,11 @@ func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
@@ -169,7 +170,11 @@ func rollbackUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -88,6 +88,8 @@ type Application struct {
 	PlanResumeCmd PlanResumeCmd
 	// PlanCompleteCmd completes the operation plan
 	PlanCompleteCmd PlanCompleteCmd
+	// RollbackCmd performs operation rollback
+	RollbackCmd RollbackCmd
 	// UpdateCmd combines app update related commands
 	UpdateCmd UpdateCmd
 	// UpdateCheckCmd checks if a new app version is available
@@ -581,6 +583,21 @@ type PlanResumeCmd struct {
 // PlanCompleteCmd completes the operation plan
 type PlanCompleteCmd struct {
 	*kingpin.CmdClause
+}
+
+// RollbackCmd performs operation rollback
+type RollbackCmd struct {
+	*kingpin.CmdClause
+	// PhaseTimeout is the individual phase rollback timeout
+	PhaseTimeout *time.Duration
+	// OperationID is optional ID of operation to rollback
+	OperationID *string
+	// SkipVersionCheck suppresses version mismatch errors
+	SkipVersionCheck *bool
+	// Confirmed suppresses confirmation prompt
+	Confirmed *bool
+	// DryRun prints rollback phases without actually performing them
+	DryRun *bool
 }
 
 // InstallPlanCmd combines subcommands for install plan

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -112,7 +113,11 @@ func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ Lo
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RollbackPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
+	err = updater.RollbackPhase(context.TODO(), fsm.Params{
+		PhaseID: params.PhaseID,
+		Force:   params.Force,
+		DryRun:  params.DryRun,
+	}, params.Timeout)
 	return trace.Wrap(err)
 }
 

--- a/tool/gravity/cli/input.go
+++ b/tool/gravity/cli/input.go
@@ -72,7 +72,7 @@ func enforceConfirmation(title string, args ...interface{}) error {
 		return trace.Wrap(err)
 	}
 	if !confirmed {
-		return trace.CompareFailed("cancelled")
+		return trace.CompareFailed("Operation has been canceled by user.")
 	}
 	return nil
 }

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	installerclient "github.com/gravitational/gravity/lib/install/client"
@@ -30,7 +31,9 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/system/signals"
+	"github.com/gravitational/gravity/tool/common"
 
+	"github.com/buger/goterm"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -49,6 +52,8 @@ type PhaseParams struct {
 	Timeout time.Duration
 	// SkipVersionCheck overrides the verification of binary version compatibility
 	SkipVersionCheck bool
+	// DryRun allows to only print execute/rollback phases
+	DryRun bool
 }
 
 func (r PhaseParams) isResume() bool {
@@ -142,6 +147,59 @@ func setPhase(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, p
 	return nil
 }
 
+const (
+	// planRollbackWarning is shown when "gravity rollback" command is launched
+	// without --confirm flag.
+	planRollbackWarning = `You are about to rollback the following operation:
+%v
+Consider checking the operation plan and using --dry-run flag first to see which actions will be performed.
+You can suppress this warning in future by providing --confirm flag.
+`
+	// unsupportedRollbackWarning is shown for operations that "gravity rollback"
+	// command does not support.
+	unsupportedRollbackWarning = `Operation %q does not support automatic rollback.
+Please use "gravity plan rollback" command to rollback individual phases.`
+)
+
+func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, confirmed bool) error {
+	operation, err := getActiveOperation(localEnv, environ, params.OperationID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	op := operation.SiteOperation
+	switch op.Type {
+	case ops.OperationUpdate, ops.OperationUpdateRuntimeEnviron, ops.OperationUpdateConfig:
+	default:
+		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
+	}
+	if !confirmed && !params.DryRun {
+		localEnv.Printf(planRollbackWarning, operationList([]clusterOperation{*operation}).formatTable())
+		if err := enforceConfirmation("Proceed?"); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	params.PhaseID = fsm.RootPhase
+	switch op.Type {
+	case ops.OperationUpdate:
+		err = rollbackUpdatePhaseForOperation(localEnv, environ, params, op)
+	case ops.OperationUpdateRuntimeEnviron:
+		err = rollbackEnvironPhaseForOperation(localEnv, environ, params, op)
+	case ops.OperationUpdateConfig:
+		err = rollbackConfigPhaseForOperation(localEnv, environ, params, op)
+	default:
+		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Make sure to reset the cluster state after the operation has been
+	// fully rolled back.
+	if !params.DryRun {
+		return completeOperationPlanForOperation(localEnv, environ, op)
+	}
+	return nil
+}
+
 // rollbackPhase rolls back a phase for the operation specified with params
 func rollbackPhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {
 	operation, err := getActiveOperation(localEnv, environ, params.OperationID)
@@ -170,7 +228,14 @@ func completeOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnv
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	op := operation.SiteOperation
+	err = completeOperationPlanForOperation(localEnv, environ, operation.SiteOperation)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func completeOperationPlanForOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, op ops.SiteOperation) (err error) {
 	switch op.Type {
 	case ops.OperationInstall:
 		err = completeInstallPlanForOperation(localEnv, op)
@@ -412,6 +477,17 @@ type backendOperations struct {
 	operations map[string]clusterOperation
 	// clusterOperation stores the first operation found in cluster state store (if any)
 	clusterOperation *clusterOperation
+}
+
+// formatTable formats this operation list as a table
+func (r operationList) formatTable() string {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	common.PrintTableHeader(t, []string{"Type", "ID", "State", "Created"})
+	for _, op := range r {
+		fmt.Fprintf(t, "%v\t%v\t%v\t%v\n",
+			op.Type, op.ID, op.State, op.Created.Format(constants.ShortDateFormat))
+	}
+	return t.String()
 }
 
 func (r operationList) String() string {

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -155,7 +155,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.StartCmd.Confirmed = g.StartCmd.Flag("confirm", "Suppress confirmation prompt.").Bool()
 
 	g.PlanCmd.CmdClause = g.Command("plan", "Manage operation plan.")
-	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. It not specified, the last operation will be used.").Hidden().String()
+	g.PlanCmd.OperationID = g.PlanCmd.Flag("operation-id", "ID of the active operation. If not specified, the last operation will be used.").Hidden().String()
 	g.PlanCmd.SkipVersionCheck = g.PlanCmd.Flag("skip-version-check", "Bypass version compatibility check.").Hidden().Bool()
 
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation.").Default()
@@ -181,6 +181,16 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.PlanResumeCmd.PhaseTimeout = g.PlanResumeCmd.Flag("timeout", "Phase execution timeout.").Default(defaults.PhaseTimeout).Hidden().Duration()
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark the current operation as completed.")
+
+	g.RollbackCmd.CmdClause = g.Command("rollback", "Rollback currently ongoing operation. Currently supports only upgrade, runtime environment and cluster configuration operations. For other operations use 'gravity plan rollback' command to rollback phase by phase.")
+	g.RollbackCmd.PhaseTimeout = g.RollbackCmd.Flag("timeout", "Individual phase rollback timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
+	// TODO(r0mant): Hide operation id flag for now, only the current operation
+	//               rollback is currently allowed. We might unhide it when we
+	//               allow completed operation rollbacks.
+	g.RollbackCmd.OperationID = g.RollbackCmd.Flag("operation-id", "ID of the operation to rollback. If not specified, the last operation will be used").Hidden().String()
+	g.RollbackCmd.SkipVersionCheck = g.RollbackCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
+	g.RollbackCmd.Confirmed = g.RollbackCmd.Flag("confirm", "Do not ask for confirmation").Bool()
+	g.RollbackCmd.DryRun = g.RollbackCmd.Flag("dry-run", "Print rollback phases without actually performing them").Bool()
 
 	g.UpdateCmd.CmdClause = g.Command("update", "Update actions on cluster.")
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -104,6 +104,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.UpgradeCmd.FullCommand(),
 		g.StartCmd.FullCommand(),
 		g.StopCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.ResourceCreateCmd.FullCommand():
 		if *g.Debug {
 			teleutils.InitLogger(teleutils.LoggingForDaemon, level)
@@ -176,6 +177,7 @@ func InitAndCheck(g *Application, cmd string) error {
 	switch cmd {
 	case g.SystemUpdateCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.SystemRollbackCmd.FullCommand(),
 		g.StopCmd.FullCommand(),
 		g.StartCmd.FullCommand(),
@@ -219,6 +221,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.SystemRollbackCmd.FullCommand(),
 		g.UpdateSystemCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.RollbackCmd.FullCommand(),
 		g.SystemGCRegistryCmd.FullCommand(),
 		g.SystemUninstallCmd.FullCommand(),
 		g.PlanetEnterCmd.FullCommand(),
@@ -454,6 +457,14 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.PlanCmd.OperationID, outputFormat)
 	case g.PlanCompleteCmd.FullCommand():
 		return completeOperationPlan(localEnv, g, *g.PlanCmd.OperationID)
+	case g.RollbackCmd.FullCommand():
+		return rollbackPlan(localEnv, g,
+			PhaseParams{
+				Timeout:          *g.RollbackCmd.PhaseTimeout,
+				SkipVersionCheck: *g.RollbackCmd.SkipVersionCheck,
+				OperationID:      *g.RollbackCmd.OperationID,
+				DryRun:           *g.RollbackCmd.DryRun,
+			}, *g.RollbackCmd.Confirmed)
 	case g.LeaveCmd.FullCommand():
 		return leave(localEnv, leaveConfig{
 			force:     *g.LeaveCmd.Force,

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -169,7 +170,7 @@ type updater interface {
 	io.Closer
 	Run(ctx context.Context) error
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
-	RollbackPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
+	RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error
 	Complete(error) error
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Forward-port `gravity rollback` to 7.1. See https://github.com/gravitational/gravity/pull/1558 for more detailed description of the changes.

Also includes docs for the new command.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Refs https://github.com/gravitational/gravity/issues/1067.
* Ports https://github.com/gravitational/gravity/pull/1558.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Same as in all other ports.