### PR TITLE
Fixed syntax in cluster.tf

### DIFF
--- a/terraform-dev/cluster.tf
+++ b/terraform-dev/cluster.tf
@@ -62,7 +62,7 @@ resource "libvirt_cloudinit_disk" "commoninit" {
             ip_address = "172.28.128.${count.index+3}",
             hostname = "telekube${count.index}"
             })
-  count     = var.nodes_count
+  count = var.nodes_count
 }
 
 # Create the machine


### PR DESCRIPTION
## Description
Fixed syntax to address incompatibility with newer Terraform version.

## Type of change

* Internal change (not necessarily a bug fix or a new feature)

## TODOs

- [ ] Perform manual testing

## Testing done

Tested with Terraform :
```
$ terraform version
Terraform v0.12.24
+ provider.libvirt (unversioned)
```