### PR TITLE
Use local image's application version for upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
 # Current Kubernetes version
-K8S_VER := 1.17.4
+K8S_VER := 1.17.6
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
@@ -46,7 +46,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.2.14
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 7.1.1-$(K8S_VER_SUFFIX)
+PLANET_TAG := 7.1.2-$(K8S_VER_SUFFIX)-1-g0a285db
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -12,7 +12,7 @@ UPGRADE_MAP[6.1.28]="ubuntu:18"
 # latest patch release on supported non-LTS version, keep this up to date
 UPGRADE_MAP[6.3.18]="ubuntu:18"
 
-# latest patch release on supported LTS version, keep this up to date
+# latest patch release on 7.0.x branch, keep this up to date
 UPGRADE_MAP[7.0.6]="ubuntu:18"
 
 # important versions in the field, these are static

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -6,12 +6,17 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
 
+# latest patch release on compatible LTS, keep this up to date
+UPGRADE_MAP[6.1.28]="ubuntu:18"
+
 # latest patch release on supported non-LTS version, keep this up to date
 UPGRADE_MAP[6.3.18]="ubuntu:18"
 
 # latest patch release on supported LTS version, keep this up to date
 UPGRADE_MAP[7.0.6]="ubuntu:18"
 
+# important versions in the field, these are static
+UPGRADE_MAP[6.1.0]="ubuntu:16"
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -6,14 +6,12 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
 
-# latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.18]="ubuntu:18"
-
 # latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.6]="ubuntu:18"
+UPGRADE_MAP[6.3.18]="ubuntu:18"
 
-# important versions in the field, these are static
-UPGRADE_MAP[6.1.0]="ubuntu:16"
+# latest patch release on supported LTS version, keep this up to date
+UPGRADE_MAP[7.0.6]="ubuntu:18"
+
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -189,13 +189,13 @@ func (l Locator) WithLiteralVersion(version string) Locator {
 func ParseLocator(v string) (*Locator, error) {
 	parts := strings.Split(v, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return nil, trace.Errorf(
-			"package locator should be repository/name:semver, e.g. example.com/test:1.0.0, got %v", v)
+		return nil, trace.BadParameter(
+			"invalid package locator %q - should be repository/name:semver, e.g. example.com/test:1.0.0", v)
 	}
 	m := locRe.FindAllStringSubmatch(parts[1], -1)
 	if len(m) != 1 || len(m[0]) != 3 {
-		return nil, trace.Errorf(
-			"invalid package locator, should be repository/name:semver, e.g. example.com/test:1.0.0")
+		return nil, trace.BadParameter(
+			"invalid package locator %q - should be repository/name:semver, e.g. example.com/test:1.0.0", v)
 	}
 	return NewLocator(parts[0], m[0][1], m[0][2])
 }

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -59,6 +59,7 @@ var (
 	// For instance, if the version is 5.2.10, the current version can upgrade
 	// directly from 5.2.10, 5.2.11 and so on.
 	DirectUpgradeVersions = Versions{
+		semver.New("6.1.0"),
 		semver.New("6.2.0"),
 		semver.New("6.3.0"),
 		semver.New("7.0.0"),

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -59,7 +59,6 @@ var (
 	// For instance, if the version is 5.2.10, the current version can upgrade
 	// directly from 5.2.10, 5.2.11 and so on.
 	DirectUpgradeVersions = Versions{
-		semver.New("6.1.0"),
 		semver.New("6.2.0"),
 		semver.New("6.3.0"),
 		semver.New("7.0.0"),

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -367,13 +368,7 @@ func checkForUpdate(
 	installedPackage loc.Locator,
 	updatePackage string,
 ) (updateApp *app.Application, err error) {
-	// if app package was not provided, default to the latest version of
-	// the currently installed app
-	if updatePackage == "" {
-		updatePackage = installedPackage.Name
-	}
-
-	updateLoc, err := loc.MakeLocator(updatePackage)
+	updateLoc, err := getUpdatePackage(env, updatePackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -397,6 +392,31 @@ func checkForUpdate(
 		updateApp.Package.Version)
 
 	return updateApp, nil
+}
+
+func getUpdatePackage(env *localenv.LocalEnvironment, updatePackagePattern string) (*loc.Locator, error) {
+	if updatePackagePattern != "" {
+		return loc.MakeLocator(updatePackagePattern)
+	}
+	clusterOperator, err := env.SiteOperator()
+	if err != nil {
+		return nil, trace.Wrap(err, "unable to access cluster.\n"+
+			"Use 'gravity status' to check the cluster state and retry when healthy.")
+	}
+	cluster, err := clusterOperator.GetLocalSite()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var args localenv.TarballEnvironmentArgs
+	if cluster.License != nil {
+		args.License = cluster.License.Raw
+	}
+	tarballEnv, err := localenv.NewTarballEnvironment(args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer tarballEnv.Close()
+	return install.GetAppPackage(tarballEnv.Apps)
 }
 
 func supportsUpdate(gravityPackage loc.Locator) (supports bool, err error) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
* Default to the version of the application from local cluster image for upgrades.
* Update latest planet to include a version fix.
* Update versions of (non-)LTS base versions used in robotest.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/1642
* Requires https://github.com/gravitational/planet/pull/659.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->


## Additional information
<!--Optional. Anything else that may be relevant.-->
