### PR TITLE
Robotest 2.0.0 Nightly Staging

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -25,7 +25,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0-rc.1}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
@@ -47,6 +47,7 @@ function build_resize_suite {
   cat <<EOF
  resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
  resize={"to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
+ shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
 EOF
 }
 


### PR DESCRIPTION
## Description
This PR introduces 3 changes:

1) Robotest 2.0.0-rc.1 is added to nightly
2) With 2.0.0, a shrink test is added to nightly
3) I removed Gravity explicitly specifying storage_driver and state_dir as both have sane defaults.

I'm intentionally not adding these changes to the PR build yet because:

1) Robotest in PR builds has been suffering from other instability recently  (#1639 and related work, I believe).  I don't want to introduce possibly confounding factors there until things settle down.
2) I'd like to get https://github.com/gravitational/robotest/pull/233 into 2.0, but I also don't want to further delay some sort of vetting on master.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Introduces the work from https://github.com/gravitational/robotest/pull/229, amongst many others.

This will help catch issues like https://github.com/gravitational/gravity/issues/1445, as well as more general shrink related issues.

## TODOs
- [x] Perform manual testing
- [x] Write automated tests (N/A - this is automated testing)
- [x] Write documentation (N/A)
- [x] Self-review the change
- [ ] Address review feedback

## Testing done
These changes were individually vetted in Robotest PRs 206-234.  This PR itself is testing/staging before introducing robotest 2.0.0 more widely (PR builds, all active release branches).

I would have tested this as a try build, but https://github.com/gravitational/ops/issues/142 makes it tedious to run anything other than the root `Jenkinsfile`.
