### PR TITLE
[7.0.x] use local image's application version for upgrade

### DIFF
--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -7,13 +7,13 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 declare -A UPGRADE_MAP
 
 # latest patch release on this branch, keep this up to date
-UPGRADE_MAP[7.0.5]="ubuntu:18"
+UPGRADE_MAP[7.0.6]="ubuntu:18"
 
 # latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.24]="ubuntu:18"
+UPGRADE_MAP[6.1.28]="ubuntu:18"
 
 # latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.13]="ubuntu:18"
+UPGRADE_MAP[6.3.18]="ubuntu:18"
 
 # important versions in the field, these are static
 UPGRADE_MAP[6.1.0]="ubuntu:16"

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -189,13 +189,13 @@ func (l Locator) WithLiteralVersion(version string) Locator {
 func ParseLocator(v string) (*Locator, error) {
 	parts := strings.Split(v, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return nil, trace.Errorf(
-			"package locator should be repository/name:semver, e.g. example.com/test:1.0.0, got %v", v)
+		return nil, trace.BadParameter(
+			"invalid package locator %q - should be repository/name:semver, e.g. example.com/test:1.0.0", v)
 	}
 	m := locRe.FindAllStringSubmatch(parts[1], -1)
 	if len(m) != 1 || len(m[0]) != 3 {
-		return nil, trace.Errorf(
-			"invalid package locator, should be repository/name:semver, e.g. example.com/test:1.0.0")
+		return nil, trace.BadParameter(
+			"invalid package locator %q - should be repository/name:semver, e.g. example.com/test:1.0.0", v)
 	}
 	return NewLocator(parts[0], m[0][1], m[0][2])
 }

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -373,7 +373,7 @@ func checkForUpdate(
 	installedPackage loc.Locator,
 	updatePackage string,
 ) (updateApp *app.Application, err error) {
-	updateLoc, err := getUpdatePackage(env, updatePackage)
+	updateLoc, err := getUpdatePackage(env, installedPackage, updatePackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -399,10 +399,20 @@ func checkForUpdate(
 	return updateApp, nil
 }
 
-func getUpdatePackage(env *localenv.LocalEnvironment, updatePackagePattern string) (*loc.Locator, error) {
+func getUpdatePackage(env *localenv.LocalEnvironment, installedPackage loc.Locator, updatePackagePattern string) (*loc.Locator, error) {
 	if updatePackagePattern != "" {
 		return loc.MakeLocator(updatePackagePattern)
 	}
+	if loc, err := getAppPackageFromTarball(env); err == nil {
+		return loc, nil
+	} else if !trace.IsNotFound(err) {
+		log.WithError(err).Debug("Failed to query package from tarball environment.")
+	}
+	// default to the latest version of the currently installed application
+	return loc.MakeLocator(installedPackage.Name)
+}
+
+func getAppPackageFromTarball(env *localenv.LocalEnvironment) (*loc.Locator, error) {
 	clusterOperator, err := env.SiteOperator()
 	if err != nil {
 		return nil, trace.Wrap(err, "unable to access cluster.\n"+

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/install"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
@@ -372,13 +373,7 @@ func checkForUpdate(
 	installedPackage loc.Locator,
 	updatePackage string,
 ) (updateApp *app.Application, err error) {
-	// if app package was not provided, default to the latest version of
-	// the currently installed app
-	if updatePackage == "" {
-		updatePackage = installedPackage.Name
-	}
-
-	updateLoc, err := loc.MakeLocator(updatePackage)
+	updateLoc, err := getUpdatePackage(env, updatePackage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -402,6 +397,31 @@ func checkForUpdate(
 		updateApp.Package.Version)
 
 	return updateApp, nil
+}
+
+func getUpdatePackage(env *localenv.LocalEnvironment, updatePackagePattern string) (*loc.Locator, error) {
+	if updatePackagePattern != "" {
+		return loc.MakeLocator(updatePackagePattern)
+	}
+	clusterOperator, err := env.SiteOperator()
+	if err != nil {
+		return nil, trace.Wrap(err, "unable to access cluster.\n"+
+			"Use 'gravity status' to check the cluster state and retry when healthy.")
+	}
+	cluster, err := clusterOperator.GetLocalSite()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var args localenv.TarballEnvironmentArgs
+	if cluster.License != nil {
+		args.License = cluster.License.Raw
+	}
+	tarballEnv, err := localenv.NewTarballEnvironment(args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer tarballEnv.Close()
+	return install.GetAppPackage(tarballEnv.Apps)
 }
 
 func supportsUpdate(gravityPackage loc.Locator) (supports bool, err error) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
### Update search for upgrade package as following:
 * use the package pattern if specified on command line
 * attempt to query the application package version from the tarball environment at current working directory
 * use the latest version of the installed application
### Update versions of (non-)LTS base versions used in robotest.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/1642
* Requires https://github.com/gravitational/planet/pull/659.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->


## Additional information
<!--Optional. Anything else that may be relevant.-->
