### PR TITLE
[5.5.x] fix grpc build target

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -78,6 +78,12 @@ BINARIES ?= tele gravity terraform-provider-gravity
 RELEASE_TARBALL_NAME := gravity-$(GRAVITY_VERSION)-$(OS)-$(ARCH)-bin.tar.gz
 RELEASE_OUT := $(GRAVITY_BUILDDIR)/$(RELEASE_TARBALL_NAME)
 
+GRPC_PROTOS = \
+	$(TOP)/lib/rpc/proto/agent.proto \
+	$(TOP)/lib/rpc/proto/discovery.proto \
+	$(TOP)/lib/network/validation/proto/validation.proto
+GRPC_PROTO_OUTPUTS = $(GRPC_PROTOS:.proto=.pb.go)
+
 BASH ?= /bin/bash
 
 # Export variables for recursive make invocations
@@ -152,35 +158,27 @@ endef
 #
 # build gravity binaries
 #
+ifeq ($(OS),darwin)
 .PHONY: build
-build:
-	@if [ "$(OS)" = "darwin" ]; then \
-		$(MAKE) build-on-host; \
-		ln -sf $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR); \
-	else \
-		$(MAKE) build-in-container; \
-		ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR); \
-	fi;
+build: build-on-host
+	ln -sf $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+else
+.PHONY: build
+build: grpc build-in-container
+	ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+endif
 
 #
 # generate gRPC code
 #
 .PHONY: grpc
-grpc: buildbox grpc-agents grpc-validation
+grpc: buildbox $(GRPC_PROTO_OUTPUTS)
 
-.PHONY: grpc-agents
-grpc-agents:
+$(GRPC_PROTO_OUTPUTS): $(GRPC_PROTOS)
 	docker run --rm=true -u $$(id -u) \
 		   -v $(TOP):$(SRCDIR) \
 		   $(BBOX) \
-		   dumb-init make -C $(SRCDIR)/lib/rpc/proto
-
-.PHONY: grpc-validation
-grpc-validation:
-	docker run --rm=true -u $$(id -u) \
-		   -v $(TOP):$(SRCDIR) \
-		   $(BBOX) \
-		   dumb-init make -C $(SRCDIR)/lib/network/validation/proto
+		   dumb-init make -C $(subst $(TOP),$(SRCDIR),$(@D))
 
 #
 # this is a temporary target until we upgrade docker packages

--- a/lib/network/validation/proto/Makefile
+++ b/lib/network/validation/proto/Makefile
@@ -5,7 +5,9 @@ deps = $(google_deps),$(agent_deps)
 
 .PHONY: all
 all: $(IDL)
-	protoc -I=. -I=$$PROTO_INCLUDE \
+	protoc -I=. \
+		-I=$(PROTO_INCLUDE) \
 		-I=/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/satellite/agent/proto \
+		-I=/gopath/src/github.com/gravitational/gravity/vendor/github.com/gravitational/satellite/agent/proto/agentpb \
 		$^ \
 		--gogo_out=plugins=grpc,$(deps):.


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR fixes the grpc build target which went a bit stale.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1361 (only the Makefile portion)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Before the change:
```
$ make grpc
...
event.proto: File not found.
agentpb/agent.proto: Import "event.proto" was not found or had errors.
agentpb/agent.proto:171:5: "ClusterHealthy" is not defined.
agentpb/agent.proto:173:5: "ClusterDegraded" is not defined.
agentpb/agent.proto:175:5: "ClusterUpgrade" is not defined.
agentpb/agent.proto:177:5: "NodeAdded" is not defined.
agentpb/agent.proto:179:5: "NodeRemoved" is not defined.
agentpb/agent.proto:181:5: "NodeHealthy" is not defined.
agentpb/agent.proto:183:5: "NodeDegraded" is not defined.
agentpb/agent.proto:185:5: "ProbeSucceeded" is not defined.
agentpb/agent.proto:187:5: "ProbeFailed" is not defined.
agentpb/agent.proto:189:5: "LeaderElected" is not defined.
agentpb/agent.proto:191:5: "UnknownEvent" is not defined.
validation.proto: Import "agentpb/agent.proto" was not found or had errors.
validation.proto:92:14: "agentpb.Probe" is not defined.
make: *** [all] Error 1
Makefile:8: recipe for target 'all' failed
make: Leaving directory '/gopath/src/github.com/gravitational/gravity/lib/network/validation/proto'
Makefile:180: recipe for target 'grpc-validation' failed
make[1]: *** [grpc-validation] Error 2
make[1]: Leaving directory '/home/deemok/go/_/src/github.com/gravitational/gravity/build.assets'
Makefile:238: recipe for target 'grpc' failed
make: *** [grpc] Error 2
```
After the change:
```
$ make grpc
...
Successfully built 71dcf6e0b7a2
Successfully tagged gravity-buildbox:latest
make[1]: Leaving directory '/home/deemok/go/_/src/github.com/gravitational/gravity/build.assets'
```
