### PR TITLE
[5.5.x] do not delete the RPC backup package when updating credentials package

### DIFF
--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -235,11 +235,7 @@ func (p *updatePhaseInit) backupRPCCredentials() error {
 		return trace.Wrap(err)
 	}
 	defer rc.Close()
-	essential := map[string]string{
-		pack.OperationIDLabel: p.Operation.ID,
-	}
-	runtimeLabels := utils.CombineLabels(essential, env.RuntimeLabels)
-	_, err = p.Packages.UpsertPackage(rpcBackupPackage(p.Operation.SiteDomain), rc, pack.WithLabels(runtimeLabels))
+	_, err = p.Packages.UpsertPackage(rpcBackupPackage(p.Operation.SiteDomain), rc, pack.WithLabels(env.RuntimeLabels))
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
[5.5.0](https://github.com/gravitational/gravity/commit/48a62dc24e24fbeffdb53fc65877c47e3fcc9465#diff-0ca52e98354a1b9f7b2c832ec1f273c1R293) fixed a bug in package server that would previously remove the package blob even if there were still aliass to it (i.e. other packages with the same data).
This PR relaxes the constraint for RPC credendtials backup package and avoid deleting it to avoid running into a problem with checksum collisions which might remove the original package on  versions prior to `5.5.0`.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/1623

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
### `5.5.38`
1. Install `5.5.38`.
1. Upload upgrade from this branch.
1. Start the upgrade in manual mode
1. Execute and rollback `/init` phase a couple of times

### `5.2.0`
1. Install `5.2.0`.
1. Upload upgrade from this branch.
1. Start the upgrade in manual mode
1. Execute and rollback `/init` phase a couple of times

## Additional information
<!--Optional. Anything else that may be relevant.-->
