### PR TITLE
(7.0) Do not require home env var for gravity resource

### DIFF
--- a/lib/utils/fileutils.go
+++ b/lib/utils/fileutils.go
@@ -254,7 +254,7 @@ func GetLocalPath(customPath, defaultLocalDir, defaultLocalPath string) (string,
 	}
 	homeDir := os.Getenv(constants.EnvHome)
 	if homeDir == "" {
-		return "", trace.BadParameter("no path provided and environment variable %v is not set", constants.EnvHome)
+		return "", trace.NotFound("no path provided and environment variable %v is not set", constants.EnvHome)
 	}
 	return filepath.Join(homeDir, defaultLocalDir, defaultLocalPath), nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

After 7.0 changes to CLI auth (to use Teleport certs), some gravity commands started requiring HOME environment variable to be set. This change makes it optional instead since in some environments it may not be set (e.g. automation) and disables local key store if that's the case.

Also, bundle in the change that removes a tele login warning for now.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1647, closes https://github.com/gravitational/gravity/issues/1668.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Before the change

```
$ sudo su
# unset HOME
# gravity resource create resources/user.yaml
[ERROR]: no path provided and environment variable HOME is not set
# gravity resource get users
[ERROR]: no path provided and environment variable HOME is not set
```

### After the change

```
$ sudo su
# unset HOME
# ./gravity resource create resources/user.yaml
Created user "admin@example.com"
# ./gravity resource get users
Name                             Type      Roles
----                             ----      -----
admin@example.com                admin     [@teleadmin]
adminagent@strangepascal1380     agent     [@teleadmin]
agent@strangepascal1380          agent     [@reader agent@strangepascal1380]
```
