### PR TITLE
Add shrink scenario to PRs and bump robotest to 2.0.0.

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -25,7 +25,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0-rc.1}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -22,7 +22,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
@@ -43,6 +43,7 @@ export REPEAT_TESTS=${REPEAT_TESTS:-1}
 function build_resize_suite {
   cat <<EOF
  resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
+ shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
 EOF
 }
 


### PR DESCRIPTION
## Description
This change adds a shrink scenario to PR builds and updates to a more recent robotest.

Significant changes between uid-gid & 2.0.0 include:
 - shrink testing is supported
 - robotest has smarter assertions about gravity status
 - robotest now follows semver
 - version & commit information is logged
 - Many other internal bugfixes

## Type of change
<!--Required. Keep only those that apply.-->
* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
https://github.com/gravitational/gravity/pull/1646 introduced shrink to nighties last week.

For more information on shrink, see:
* https://github.com/gravitational/robotest/pull/229
* https://github.com/gravitational/robotest/issues/188

For more information about status assertions, see:
* https://github.com/gravitational/robotest/pull/233
* https://github.com/gravitational/robotest/pull/225

For more information on all 2.0.0 changes, and why this is 2.0.0 see:
* https://github.com/gravitational/robotest/releases/tag/v2.0.0
* https://github.com/gravitational/robotest/issues/200

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback

## Testing done
See the robotest PRs for pretty extensive testing related to each individual change.  For the composite, & gravity changes I ran this as a try build here:

https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/48/

Also, the last couple nighties have included 2.0.0-rc.1 and the shrink scenario, thanks to https://github.com/gravitational/gravity/pull/1646:

https://jenkins.gravitational.io/view/Robotest/job/Gravity-Nightly/399/
https://jenkins.gravitational.io/view/Robotest/job/Gravity-Nightly/398/

## Additional Information
Unfortunately, because of the ongoing upgrade issues in master caused by https://github.com/gravitational/gravity/issues/1640, none of my tests against master are clean.  I'm hesitant to merge with that investigation ongoing, as I would rather not add confounding variables until master is green again.