### PR TITLE
Add shrink scenario to PRs and bump robotest to 2.0.0.

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -35,7 +35,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
@@ -57,6 +57,7 @@ function build_resize_suite {
   cat <<EOF
  resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:16","storage_driver":"overlay2"}
  resize={"to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:16","storage_driver":"overlay2"}
+ shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
 EOF
 }
 

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -33,7 +33,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/master/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-uid-gid}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export WAIT_FOR_INSTALLER=true
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
@@ -54,6 +54,7 @@ export REPEAT_TESTS=${REPEAT_TESTS:-1}
 function build_resize_suite {
   cat <<EOF
  resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:16","storage_driver":"overlay2"}
+ shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
 EOF
 }
 


### PR DESCRIPTION
## Description
This change adds a shrink scenario to PR builds and updates to a more recent robotest.

Significant changes between uid-gid & 2.0.0 include:
 - shrink testing is supported
 - robotest has smarter assertions about gravity status
 - robotest now follows semver
 - version & commit information is logged
 - Many other internal bugfixes

## Type of change
<!--Required. Keep only those that apply.-->
* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
This is a port of https://github.com/gravitational/gravity/pull/1670 and #1646.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback

## Testing done
See the robotest PRs linked in https://github.com/gravitational/gravity/pull/1670 for pretty extensive testing related to each individual change.  I did not do any 5.5.x specific testing. The PR build here serves as validation for this work.
