### PR TITLE
[5.5.x] do not rely on package labels when searching for legacy teleport configuration package

### DIFF
--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -522,9 +522,7 @@ func updateTeleportConfigLabels(packages pack.PackageService, clusterName string
 		Packages:   packages,
 		Repository: clusterName,
 		Match: func(e pack.PackageEnvelope) bool {
-			return e.Locator.Name == constants.TeleportNodeConfigPackage &&
-				(e.HasLabels(pack.TeleportNodeConfigPackageLabels) ||
-					e.HasLabels(pack.TeleportLegacyNodeConfigPackageLabels))
+			return e.Locator.Name == constants.TeleportNodeConfigPackage
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR relaxes the search query when looking for legacy teleport configuration package - only uses the package name and does not expect any other labels.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1676.


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
TODO
 * Install `5.0.35`
 * Remove labels from `teleport-node-config` package in host-local package store
 * Start upgrade to 5.5.x
 * Make sure the upgrade works
