### PR TITLE
(5.5) Check cluster status after upload

### DIFF
--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -529,7 +529,7 @@ func probeErrorDetail(p pb.Probe) string {
 		if err == nil {
 			return detail
 		}
-		log.Warnf(trace.DebugReport(err))
+		log.WithError(err).Warn("Failed to compose disk space probe error.")
 	}
 	detail := p.Detail
 	if p.Detail == "" {

--- a/lib/status/timeline.go
+++ b/lib/status/timeline.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fatih/color"
 	pb "github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // Timeline queries the currently stored cluster timeline.

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -125,6 +125,7 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.UpdateTriggerCmd.FullCommand(),
 		g.UpdatePlanInitCmd.FullCommand(),
 		g.UpgradeCmd.FullCommand(),
+		g.UpdateUploadCmd.FullCommand(),
 		g.RPCAgentRunCmd.FullCommand(),
 		g.LeaveCmd.FullCommand(),
 		g.RemoveCmd.FullCommand(),
@@ -461,7 +462,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.StatusHistoryCmd.FullCommand():
 		return statusHistory()
 	case g.UpdateUploadCmd.FullCommand():
-		return uploadUpdate(localEnv, *g.UpdateUploadCmd.OpsCenterURL, *g.UpdateUploadCmd.DataDir)
+		return uploadUpdate(context.Background(), localEnv,
+			*g.UpdateUploadCmd.OpsCenterURL,
+			*g.UpdateUploadCmd.DataDir)
 	case g.AppPackageCmd.FullCommand():
 		return appPackage(localEnv)
 		// app commands


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR updates the "gravity update upload" command that uploads new version of cluster image to the local cluster so it checks cluster health after all uploading has been done.

This is to accommodate a scenario where immediately after upload the cluster may degrade due to increased i/o and the following upgrade command will fail.

Now the upload command will give cluster a few minutes to settle before exiting.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1659.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### When everything's fine

The "verifying" step completes immediately.

```
ubuntu@node-1:~/upgrade$ sudo ./upload
Thu Jun 11 00:33:34 UTC	Importing cluster image telekube v5.5.48-dev.8
Thu Jun 11 00:34:18 UTC	Synchronizing application with Docker registry 192.168.99.102:5000
Thu Jun 11 00:34:26 UTC	Verifying cluster health
Thu Jun 11 00:34:26 UTC	Cluster image has been uploaded
```

### When cluster is temporarily degraded after upload

By the timestamp you can tell it spent some time in "verifying" step, it is visible in the logs also.

```
ubuntu@node-1:~/upgrade$ sudo ./upload
Thu Jun 11 00:46:28 UTC	Importing cluster image telekube v5.5.48-dev.8
Thu Jun 11 00:47:10 UTC	Synchronizing application with Docker registry 192.168.99.102:5000
Thu Jun 11 00:47:18 UTC	Verifying cluster health
Thu Jun 11 00:48:52 UTC	Cluster image has been uploaded
ubuntu@node-1:~/upgrade$ echo $?
0
```