### PR TITLE
(6.1) Update to planet that includes etcd 3.3.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.2.13
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 6.1.25-$(K8S_VER_SUFFIX)
+PLANET_TAG := 6.1.26-$(K8S_VER_SUFFIX)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)
@@ -63,7 +63,7 @@ OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m)
 
 # Image Vulnerability Scanning
-# The following variables are used to copy all docker images from a cluster image to a docker repository 
+# The following variables are used to copy all docker images from a cluster image to a docker repository
 # that is able to scan and report on those images
 TELE_COPY_TO_REGISTRY ?= quay.io/gravitational
 TELE_COPY_TO_REPOSITORY ?= gravitational/gravity-scan

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -7,7 +7,7 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 declare -A UPGRADE_MAP
 
 # latest patch release on this branch, keep this up to date
-UPGRADE_MAP[6.1.24]="ubuntu:16"
+UPGRADE_MAP[6.1.25]="ubuntu:16"
 
 # latest patch release on previous compatible LTS, keep this up to date
 UPGRADE_MAP[5.5.41]="ubuntu:16"


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

In 6.1 planet is missing etcd v3.3.20 which means it can't upgrade from versions using etcd v3.3.20. This PR updates to planet that does have it.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/1691.
* Requires https://github.com/gravitational/planet/pull/679.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Robotest should pass.

