### PR TITLE
[5.5.x] Update default storage checker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -876,7 +876,7 @@
   revision = "2e451040dbe9def043beba737d92a6b773bbd3f2"
 
 [[projects]]
-  digest = "1:9c894f02ad5369a49c7ceb3d50d7d90ffe9f8112267b507d78385cacf74ca51e"
+  digest = "1:5c098610febfbd7a43861f907f0c9197a4fc07f998e1d2837b931ada89b489e6"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -895,8 +895,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "d8d2853ec49f580e14fa5fe62f98cddf49709875"
-  version = "5.5.18"
+  revision = "5ca82d95a147887fdff5896ea3e4f20be99d95a5"
+  version = "5.5.19"
 
 [[projects]]
   digest = "1:49f6abbce9ade5f43508429e4af1adcce55d27adcd62719fea049decc766a7c9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.18"
+  version = "=5.5.19"
 
 [[constraint]]
   name = "github.com/xtgo/set"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults.go
@@ -69,8 +69,8 @@ func GetStorageDriverBootConfigParams(drv string) health.Checker {
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
-	return noopChecker{}
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	return noopChecker{}, nil
 }
 
 // NewDNSChecker sends some default queries to monitor DNS / service discovery health


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the default storage checker. Fixes mac builds.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/satellite/pull/230