### PR TITLE
[6.1.x] Update default storage checker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -942,7 +942,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a48fd5a9e1bd8c635504b9a6b589ecc1b16a387dad035924f1780c96e7a193ef"
+  digest = "1:5933881e14c76d26798e0505e99594df4ab06e5e57465f2c101a6fb68e051d42"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -959,8 +959,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "7672dd22975e414b01879d4d2545f87072c91913"
-  version = "6.1.11"
+  revision = "b0ae4adb8f6f68aa1fc6992f4f27b4046b56633a"
+  version = "6.1.12"
 
 [[projects]]
   digest = "1:49f6abbce9ade5f43508429e4af1adcce55d27adcd62719fea049decc766a7c9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,7 +66,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=6.1.11"
+  version = "=6.1.12"
 
 [[constraint]]
   name = "github.com/miekg/dns"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults.go
@@ -69,8 +69,8 @@ func GetStorageDriverBootConfigParams(drv string) health.Checker {
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
-	return noopChecker{}
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	return noopChecker{}, nil
 }
 
 // NewDNSChecker sends some default queries to monitor DNS / service discovery health


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the default storage checker. Fixes mac builds.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/satellite/pull/231
