### PR TITLE
[7.0.x] Update default storage checker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1027,7 +1027,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:087883bb24bf27a7e4fedbec9f88eca7e15460666d88358dbad169fbc6c481fd"
+  digest = "1:9612b74a482b437236e2eab76cb3efde253379fcd4f27418428b56cd0ea292bb"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -1044,8 +1044,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "bcf5cf9b9e3a05a7f557e7cad0526175434912c9"
-  version = "7.0.13"
+  revision = "26aeca5c391c72864fa8d503d403003d82787db3"
+  version = "7.0.14"
 
 [[projects]]
   digest = "1:49f6abbce9ade5f43508429e4af1adcce55d27adcd62719fea049decc766a7c9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -77,7 +77,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=7.0.13"
+  version = "=7.0.14"
 
 [[constraint]]
   name = "github.com/gravitational/coordinate"

--- a/vendor/github.com/gravitational/satellite/monitoring/defaults.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/defaults.go
@@ -69,8 +69,8 @@ func GetStorageDriverBootConfigParams(drv string) health.Checker {
 
 // NewStorageChecker creates a new instance of the volume checker
 // using the specified checker as configuration
-func NewStorageChecker(config StorageConfig) health.Checker {
-	return noopChecker{}
+func NewStorageChecker(config StorageConfig) (health.Checker, error) {
+	return noopChecker{}, nil
 }
 
 // NewDNSChecker sends some default queries to monitor DNS / service discovery health


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the default storage checker. Fixes mac builds.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/satellite/pull/232
