### PR TITLE
[5.5.x] status improvements

### DIFF
--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -586,6 +586,8 @@ type Node struct {
 	PublicIP string `json:"public_ip"`
 	// Profile is the node profile
 	Profile string `json:"profile"`
+	// Role is the node service role
+	Role string `json:"role"`
 	// InstanceType is the node instance type
 	InstanceType string `json:"instance_type"`
 }

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1359,6 +1359,7 @@ func (o *Operator) GetClusterNodes(key ops.SiteKey) ([]ops.Node, error) {
 			PublicIP:     labels[defaults.TeleportPublicIPv4Label],
 			Profile:      labels[ops.AppRole],
 			InstanceType: labels[ops.InstanceType],
+			Role:         labels[schema.ServiceLabelRole],
 		})
 	}
 	return result, nil

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -55,9 +55,18 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		},
 	}
 
+	status.Agent, err = FromPlanetAgent(ctx, cluster.ClusterState.Servers)
+	if err != nil {
+		log.WithError(err).Warn("Failed to collect system status from agents.")
+	}
+
+	if err := updateClusterNodes(cluster.Key(), operator, status); err != nil {
+		log.WithError(err).Warn("Failed to query cluster nodes.")
+	}
+
 	token, err := operator.GetExpandToken(cluster.Key())
 	if err != nil && !trace.IsNotFound(err) {
-		return status, trace.Wrap(err)
+		log.WithError(err).Warn("Failed to fetch expand token.")
 	}
 	if token != nil {
 		status.Token = *token
@@ -94,52 +103,16 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 
 	// FIXME: have status extension accept the operator/environment
-	err = status.Cluster.Extension.Collect()
-	if err != nil {
-		return status, trace.Wrap(err)
+	if err := status.Cluster.Extension.Collect(); err != nil {
+		log.WithError(err).Warn("Failed to query extension metadata.")
 	}
 
-	activeOperations, err := ops.GetActiveOperations(cluster.Key(), operator)
-	if err != nil && !trace.IsNotFound(err) {
-		return status, trace.Wrap(err)
-	}
-	for _, op := range activeOperations {
-		progress, err := operator.GetSiteOperationProgress(op.Key())
-		if err != nil {
-			return status, trace.Wrap(err)
-		}
-		status.ActiveOperations = append(status.ActiveOperations,
-			fromOperationAndProgress(op, *progress))
+	if err := collectActiveOperations(cluster.Key(), operator, status); err != nil {
+		log.WithError(err).Warn("Failed to query active operations.")
 	}
 
-	var operation *ops.SiteOperation
-	var progress *ops.ProgressEntry
-	// if operation ID is provided, get info for that operation, otherwise
-	// get info for the most recent operation
-	if operationID != "" {
-		operation, progress, err = ops.GetOperationWithProgress(
-			cluster.OperationKey(operationID), operator)
-	} else {
-		operation, progress, err = ops.GetLastCompletedOperation(
-			cluster.Key(), operator)
-	}
-	if err != nil {
-		return status, trace.Wrap(err)
-	}
-	status.Operation = fromOperationAndProgress(*operation, *progress)
-
-	status.Agent, err = FromPlanetAgent(ctx, cluster.ClusterState.Servers)
-	if err != nil {
-		return status, trace.Wrap(err, "failed to collect system status from agents")
-	}
-
-	// Collect registered Teleport nodes.
-	teleportNodes, err := operator.GetClusterNodes(cluster.Key())
-	if err != nil {
-		return status, trace.Wrap(err, "failed to query teleport nodes")
-	}
-	for i, server := range status.Agent.Nodes {
-		status.Agent.Nodes[i].TeleportNode = ops.Nodes(teleportNodes).FindByIP(server.AdvertiseIP)
+	if err := fetchOperationByID(cluster.Key(), operationID, operator, status); err != nil {
+		log.WithError(err).WithField("operation-id", operationID).Warn("Failed to query operation.")
 	}
 
 	status.State = cluster.State
@@ -157,25 +130,6 @@ func FromPlanetAgent(ctx context.Context, servers []storage.Server) (*Agent, err
 // FromLocalPlanetAgent collects the node status from the local planet agent
 func FromLocalPlanetAgent(ctx context.Context) (*Agent, error) {
 	return fromPlanetAgent(ctx, true, nil)
-}
-
-func fromPlanetAgent(ctx context.Context, local bool, servers []storage.Server) (*Agent, error) {
-	status, err := planetAgentStatus(ctx, local)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to query cluster status from agent")
-	}
-
-	var nodes []ClusterServer
-	if len(servers) != 0 {
-		nodes = fromClusterState(*status, servers)
-	} else {
-		nodes = fromSystemStatus(*status)
-	}
-
-	return &Agent{
-		SystemStatus: SystemStatus(status.Status),
-		Nodes:        nodes,
-	}, nil
 }
 
 // IsDegraded returns whether the cluster is in degraded state
@@ -310,15 +264,6 @@ func (e ApplicationsEndpoints) WriteTo(w io.Writer) (n int64, err error) {
 	return n, trace.NewAggregate(errors...)
 }
 
-func fprintf(n *int64, w io.Writer, format string, a ...interface{}) error {
-	written, err := fmt.Fprintf(w, format, a...)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	*n += int64(written)
-	return nil
-}
-
 // Key returns key structure that identifies this operation
 func (r ClusterOperation) Key() ops.SiteOperationKey {
 	return ops.SiteOperationKey{
@@ -396,6 +341,132 @@ type ClusterServer struct {
 
 func (r ClusterOperation) isFailed() bool {
 	return r.State == ops.OperationStateFailed
+}
+
+// String returns a textual representation of this system status
+func (r SystemStatus) String() string {
+	switch pb.SystemStatus_Type(r) {
+	case pb.SystemStatus_Running:
+		return "running"
+	case pb.SystemStatus_Degraded:
+		return "degraded"
+	case pb.SystemStatus_Unknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// GoString returns a textual representation of this system status
+func (r SystemStatus) GoString() string {
+	return r.String()
+}
+
+// SystemStatus is an alias for system status type
+type SystemStatus pb.SystemStatus_Type
+
+const (
+	// NodeHealthy is the status of a healthy node
+	NodeHealthy = "healthy"
+	// NodeOffline is the status of an unreachable/unavailable node
+	NodeOffline = "offline"
+	// NodeDegraged is the status of a node with failed probes
+	NodeDegraded = "degraded"
+
+	// publicIPAddrTag is the name of the tag containing node IP
+	publicIPAddrTag = "publicip"
+	// roleTag is the name of the tag containing node role
+	roleTag = "role"
+)
+
+func collectActiveOperations(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {
+	activeOperations, err := ops.GetActiveOperations(clusterKey, operator)
+	if err != nil && !trace.IsNotFound(err) {
+		// log.WithError(err).Warn("Failed to query active operations.")
+		return trace.Wrap(err, "failed to query active operations")
+	}
+	for _, op := range activeOperations {
+		progress, err := operator.GetSiteOperationProgress(op.Key())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		status.ActiveOperations = append(status.ActiveOperations,
+			fromOperationAndProgress(op, *progress))
+	}
+	return nil
+}
+
+func fetchOperationByID(clusterKey ops.SiteKey, operationID string, operator ops.Operator, status *Status) error {
+	var (
+		operation *ops.SiteOperation
+		progress  *ops.ProgressEntry
+		err       error
+	)
+	// if operation ID is provided, get info for that operation, otherwise
+	// get info for the most recent operation
+	if operationID != "" {
+		opKey := ops.SiteOperationKey{
+			AccountID:   clusterKey.AccountID,
+			SiteDomain:  clusterKey.SiteDomain,
+			OperationID: operationID,
+		}
+		operation, progress, err = ops.GetOperationWithProgress(opKey, operator)
+	} else {
+		operation, progress, err = ops.GetLastCompletedOperation(clusterKey, operator)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	status.Operation = fromOperationAndProgress(*operation, *progress)
+	return nil
+}
+
+func updateClusterNodes(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {
+	// Collect registered Teleport nodes.
+	teleportNodes, err := operator.GetClusterNodes(clusterKey)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if status.Agent != nil {
+		for i, server := range status.Agent.Nodes {
+			status.Agent.Nodes[i].TeleportNode = ops.Nodes(teleportNodes).FindByIP(server.AdvertiseIP)
+		}
+		return nil
+	}
+	status.Agent = &Agent{
+		Nodes: make([]ClusterServer, 0, len(teleportNodes)),
+	}
+	// Recreate server state from teleport node metadata
+	for i, server := range teleportNodes {
+		status.Agent.Nodes = append(status.Agent.Nodes, ClusterServer{
+			Status:       NodeOffline,
+			Hostname:     server.Hostname,
+			AdvertiseIP:  server.AdvertiseIP,
+			Role:         server.Role,
+			Profile:      server.Profile,
+			TeleportNode: &teleportNodes[i],
+		})
+	}
+	return nil
+}
+
+func fromPlanetAgent(ctx context.Context, local bool, servers []storage.Server) (*Agent, error) {
+	status, err := planetAgentStatus(ctx, local)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to query cluster status from agent")
+	}
+
+	var nodes []ClusterServer
+	if len(servers) != 0 {
+		nodes = fromClusterState(*status, servers)
+	} else {
+		nodes = fromSystemStatus(*status)
+	}
+
+	return &Agent{
+		SystemStatus: SystemStatus(status.Status),
+		Nodes:        nodes,
+	}, nil
 }
 
 func fromOperationAndProgress(operation ops.SiteOperation, progress ops.ProgressEntry) *ClusterOperation {
@@ -578,38 +649,11 @@ func diskSpaceProbeErrorDetail(p pb.Probe) (string, error) {
 	return "", trace.BadParameter("probe does not have warning or critical severity")
 }
 
-// String returns a textual representation of this system status
-func (r SystemStatus) String() string {
-	switch pb.SystemStatus_Type(r) {
-	case pb.SystemStatus_Running:
-		return "running"
-	case pb.SystemStatus_Degraded:
-		return "degraded"
-	case pb.SystemStatus_Unknown:
-		return "unknown"
-	default:
-		return "unknown"
+func fprintf(n *int64, w io.Writer, format string, a ...interface{}) error {
+	written, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		return trace.ConvertSystemError(err)
 	}
+	*n += int64(written)
+	return nil
 }
-
-// GoString returns a textual representation of this system status
-func (r SystemStatus) GoString() string {
-	return r.String()
-}
-
-// SystemStatus is an alias for system status type
-type SystemStatus pb.SystemStatus_Type
-
-const (
-	// NodeHealthy is the status of a healthy node
-	NodeHealthy = "healthy"
-	// NodeOffline is the status of an unreachable/unavailable node
-	NodeOffline = "offline"
-	// NodeDegraged is the status of a node with failed probes
-	NodeDegraded = "degraded"
-
-	// publicIPAddrTag is the name of the tag containing node IP
-	publicIPAddrTag = "publicip"
-	// roleTag is the name of the tag containing node role
-	roleTag = "role"
-)

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -143,6 +143,9 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 
 	status.State = cluster.State
+	if status.IsDegraded() {
+		status.State = ops.SiteStateDegraded
+	}
 	return status, nil
 }
 

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -382,7 +382,6 @@ const (
 func collectActiveOperations(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {
 	activeOperations, err := ops.GetActiveOperations(clusterKey, operator)
 	if err != nil && !trace.IsNotFound(err) {
-		// log.WithError(err).Warn("Failed to query active operations.")
 		return trace.Wrap(err, "failed to query active operations")
 	}
 	for _, op := range activeOperations {

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -510,6 +510,8 @@ func (r *Reason) Description() string {
 		return "application status check failed"
 	case ReasonClusterDegraded:
 		return "one or more of cluster nodes are not healthy"
+	case "":
+		return ""
 	default:
 		return "unknown reason"
 	}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -62,7 +62,7 @@ func status(env *localenv.LocalEnvironment, printOptions printOptions) error {
 		err = printStatus(operator, clusterStatus{*status, nil}, printOptions)
 		return trace.Wrap(err)
 	} else {
-		log.Errorf(trace.DebugReport(err))
+		log.WithError(err).Error("Failed to query status.")
 	}
 
 	if printOptions.operationID != "" {
@@ -184,7 +184,7 @@ func printStatus(operator ops.Operator, status clusterStatus, printOptions print
 			fmt.Println("there is no operation in progress")
 			return nil
 		}
-		fmt.Printf("%v\n", status.Operation.State)
+		fmt.Println(status.Operation.State)
 		return nil
 
 	case printOptions.token:
@@ -268,7 +268,13 @@ func printStatusText(cluster clusterStatus) {
 	if cluster.Cluster != nil {
 		fmt.Fprintf(w, "Cluster name:\t%v\n", unknownFallback(cluster.Cluster.Domain))
 		if cluster.Status.IsDegraded() {
-			fmt.Fprintf(w, "Cluster status:\t%v\n", color.RedString("degraded"))
+			if cluster.Reason != "" {
+				fmt.Fprintf(w, "Cluster status:\t%v (%v)\n",
+					color.RedString(cluster.State),
+					color.RedString(string(cluster.Reason)))
+			} else {
+				fmt.Fprintf(w, "Cluster status:\t%v\n", color.RedString(cluster.State))
+			}
 		} else {
 			fmt.Fprintf(w, "Cluster status:\t%v\n", color.GreenString(cluster.State))
 		}

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -271,7 +271,7 @@ func printStatusText(cluster clusterStatus) {
 			if cluster.Reason != "" {
 				fmt.Fprintf(w, "Cluster status:\t%v (%v)\n",
 					color.RedString(cluster.State),
-					color.RedString(string(cluster.Reason)))
+					color.RedString(string(cluster.Reason.Description())))
 			} else {
 				fmt.Fprintf(w, "Cluster status:\t%v\n", color.RedString(cluster.State))
 			}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the status collection logic as follows:
  * status collection is on best-effort - maximizing the amount of collected data and igoring intermediate errors where appropriate
  * display reason for cluster degraded state if available. This improves the visibility into the implicit controller status loop that would otherwise make `gravity status` show degraded for no apparent reason (https://github.com/gravitational/gravity/issues/1521)
  * reconstruct server state from teleport node metadata - i.e. when the planet agent is not accessible but controller is
  * unify final cluster status computation for `gravity status` and `gravity status --output=json` (https://github.com/gravitational/gravity/issues/1641)

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1521, https://github.com/gravitational/gravity/issues/1641

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
 1. Install an arbitrary configuration multi-node cluster.
 1. flip agent on nodes to trigger cluster to degrade

### Status on the node with inactive planet agent:
Before
```
Cluster name:		<unknown>
Cluster status:		degraded
Gravity version:	5.5.48-dev.11 (client) / n/a (server)
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_expand (c51c6316-81e3-4ba3-870f-47f92557d7e7)
      started:		Mon Jun 15 20:46 UTC (15 hours ago)
      completed:	Mon Jun 15 20:48 UTC (15 hours ago)
Cluster endpoints:
    * Authentication gateway:
    * Cluster management URL:
```
After:
```
Cluster name:		dev.test
Cluster status:		degraded (one or more of cluster nodes are not healthy)
Application:		telekube, version 5.5.48-dev.11
Gravity version:	5.5.48-dev.11 (client) / 5.5.48-dev.11 (server)
Join token:		schmoken
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_expand (c51c6316-81e3-4ba3-870f-47f92557d7e7)
      started:		Mon Jun 15 20:46 UTC (15 hours ago)
      completed:	Mon Jun 15 20:48 UTC (15 hours ago)
Cluster endpoints:
    * Authentication gateway:
        - 10.128.0.18:32009
    * Cluster management URL:
        - https://10.128.0.18:32009
Cluster nodes:
    Masters:
        * dmitri-centos-node-0 (10.128.0.18, node)
            Status:		offline
            Remote access:	online
    Nodes:
        * dmitri-centos-node-1 (10.128.0.13, knode)
            Status:		offline
            Remote access:	online
```

## Additional information
<!--Optional. Anything else that may be relevant.-->
