### PR TITLE
Update example link to current wordpress

### DIFF
--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -816,7 +816,7 @@ local Docker registry so that when Helm renders resource templates, they contain
 correct image references.
 
 !!! tip
-    There is a sample application available on [GitHub](https://github.com/gravitational/gravity/tree/master/examples/wordpresshttps://github.com/gravitational/gravity/tree/master/examples/wordpress)
+    There is a sample application available on [GitHub](https://github.com/gravitational/gravity/tree/master/examples/wordpress)
     that demonstrates this workflow.
 
 ### Customizing Helm values

--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -816,7 +816,7 @@ local Docker registry so that when Helm renders resource templates, they contain
 correct image references.
 
 !!! tip
-    There is a sample application available on [GitHub](https://github.com/gravitational/gravity/tree/master/examples/wordpress)
+    There is a sample application available on [GitHub](https://github.com/gravitational/gravity/tree/6048f1e994a14fb9b1b7fad16fdf56db96eef212/examples/wordpress)
     that demonstrates this workflow.
 
 ### Customizing Helm values

--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -816,7 +816,7 @@ local Docker registry so that when Helm renders resource templates, they contain
 correct image references.
 
 !!! tip
-    There is a sample application available on [GitHub](https://github.com/gravitational/quickstart/tree/master/mattermost)
+    There is a sample application available on [GitHub](https://github.com/gravitational/gravity/tree/master/examples/wordpresshttps://github.com/gravitational/gravity/tree/master/examples/wordpress)
     that demonstrates this workflow.
 
 ### Customizing Helm values


### PR DESCRIPTION
## Description
Update example chart link to wordpress example from mattermost in Build Chart image doc.

## Type of change
Documentation

