### PR TITLE
Add SUSE 12 SP5 to supported releases.

### DIFF
--- a/docs/6.x/requirements.md
+++ b/docs/6.x/requirements.md
@@ -15,8 +15,8 @@ Gravity supports the following Linux distributions:
 | Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu                   | 16.04, 18.04     | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
-| openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
-| Suse Linux Enterprise    | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
+| Suse Linux Enterprise    | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
 | Amazon Linux             | 2                | `overlay`, `overlay2`                 |
 
 !!! note
@@ -40,11 +40,11 @@ specified in the manifest:
 | Debian                   | debian                     | 8-9              |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04     |
 | Ubuntu-Core              | ubuntu                     | 16.04            |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3   |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2 to 12-SP5 |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2 to 12-SP5 |
 | Amazon Linux             | amz                        | 2                |
 
-For example, to specify openSUSE as a dependency and support both services packs:
+For example, to specify openSUSE as a dependency and support all services packs:
 
 ```yaml
 nodeProfiles:
@@ -52,10 +52,10 @@ nodeProfiles:
    requirements:
      os:
       - name: suse # openSUSE
-        versions: ["12-SP2", "12-SP3"]
+        versions: ["12-SP2", "12-SP3", "12-SP4", "12-SP5"]
      os:
       - name: opensuse-tumbleweed # specific openSUSE distribution
-        versions: ["12-SP2", "12-SP3"]
+        versions: ["12-SP2", "12-SP3", "12-SP4", "12-SP5"]
 ```
 
 !!! note

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -14,8 +14,8 @@ Gravity officially supports the following Linux distributions:
 | Debian                   | 8-9              | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04     | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04            | `overlay`, `overlay2`                 |
-| openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
-| Suse Linux Enterprise    | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                 |
+| openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                 |
+| Suse Linux Enterprise    | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                 |
 | Amazon Linux             | 2                | `overlay`, `overlay2`                 |
 
 ### Identifying OS Distributions In Manifest
@@ -36,11 +36,11 @@ specified in the manifest:
 | Debian                   | debian                     | 8-9              |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04     |
 | Ubuntu-Core              | ubuntu                     | 16.04            |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2, 12-SP3   |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2 to 12-SP5 |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2 to 12-SP5 |
 | Amazon Linux             | amz                        | 2                |
 
-For example, to specify openSUSE as a dependency and support both services packs:
+For example, to specify openSUSE as a dependency and support all services packs:
 
 ```yaml
 nodeProfiles:
@@ -48,10 +48,10 @@ nodeProfiles:
    requirements:
      os:
       - name: suse # openSUSE
-        versions: ["12-SP2", "12-SP3"]
+        versions: ["12-SP2", "12-SP3", "12-SP4", "12-SP5"]
      os:
       - name: opensuse-tumbleweed # specific openSUSE distribution
-        versions: ["12-SP2", "12-SP3"]
+        versions: ["12-SP2", "12-SP3", "12-SP4", "12-SP5"]
 ```
 
 !!! note
@@ -258,7 +258,7 @@ Gravity requires that these modules are loaded prior to installation.
 | Debian | 8-9 | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu-Core | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
-| Suse Linux (openSUSE and Enterprise) | 12 SP2, 12 SP3 | br_netfilter, ebtable_filter, iptables, overlay |
+| Suse Linux (openSUSE and Enterprise) | 12-SP2 to 12-SP5 | br_netfilter, ebtable_filter, iptables, overlay |
 
 ### Inotify watches
 


### PR DESCRIPTION
## Description
Add SUSE 12 SP5 to supported releases. Transitively, SUSE 12 SP4 is included.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
* Reflects the verification work done in https://github.com/gravitational/robotest/issues/248

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback

## Testing done
`make run` & eyeballed the changes.