### PR TITLE
[5.5.x] Add since flag to gravity report

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -854,8 +854,6 @@ const (
 
 	// EtcdLocalAddr is the local etcd address
 	EtcdLocalAddr = "https://127.0.0.1:2379"
-	// EtcdLocalMetricsAddr is address where etcd metrics are exposed
-	EtcdLocalMetricsAddr = "https://127.0.0.1:4001"
 	// EtcdKey is the key under which gravity data is stored in etcd
 	EtcdKey = "/gravity/local"
 	// EtcdKeyFilename is the etcd private key filename

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -193,6 +193,9 @@ const (
 	// GravityUpdateDir specifies the directory used by the update process
 	GravityUpdateDir = "/var/lib/gravity/site/update"
 
+	// PlanetStateDir specifies the planet state directory
+	PlanetStateDir = "/var/state"
+
 	// GravityRPCAgentPort defines which port RPC agent is listening on
 	GravityRPCAgentPort = 3012
 
@@ -851,6 +854,8 @@ const (
 
 	// EtcdLocalAddr is the local etcd address
 	EtcdLocalAddr = "https://127.0.0.1:2379"
+	// EtcdLocalMetricsAddr is address where etcd metrics are exposed
+	EtcdLocalMetricsAddr = "https://127.0.0.1:4001"
 	// EtcdKey is the key under which gravity data is stored in etcd
 	EtcdKey = "/gravity/local"
 	// EtcdKeyFilename is the etcd private key filename

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -22,6 +22,7 @@ import (
 	"encoding/pem"
 	"io"
 	"net/url"
+	"time"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -571,11 +572,11 @@ func (o *OperatorACL) GetSiteOperationCrashReport(key SiteOperationKey) (io.Read
 	return o.operator.GetSiteOperationCrashReport(key)
 }
 
-func (o *OperatorACL) GetSiteReport(key SiteKey) (io.ReadCloser, error) {
+func (o *OperatorACL) GetSiteReport(key SiteKey, since time.Duration) (io.ReadCloser, error) {
 	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteReport(key)
+	return o.operator.GetSiteReport(key, since)
 }
 
 func (o *OperatorACL) ValidateDomainName(domainName string) error {

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -571,7 +571,7 @@ func (o *OperatorACL) GetSiteOperationCrashReport(key SiteOperationKey) (io.Read
 	return o.operator.GetSiteOperationCrashReport(key)
 }
 
-func (o *OperatorACL) GetSiteReport(req GetSiteReportRequest) (io.ReadCloser, error) {
+func (o *OperatorACL) GetSiteReport(req GetClusterReportRequest) (io.ReadCloser, error) {
 	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -22,7 +22,6 @@ import (
 	"encoding/pem"
 	"io"
 	"net/url"
-	"time"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
@@ -572,11 +571,11 @@ func (o *OperatorACL) GetSiteOperationCrashReport(key SiteOperationKey) (io.Read
 	return o.operator.GetSiteOperationCrashReport(key)
 }
 
-func (o *OperatorACL) GetSiteReport(key SiteKey, since time.Duration) (io.ReadCloser, error) {
-	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+func (o *OperatorACL) GetSiteReport(req GetSiteReportRequest) (io.ReadCloser, error) {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteReport(key, since)
+	return o.operator.GetSiteReport(req)
 }
 
 func (o *OperatorACL) ValidateDomainName(domainName string) error {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -303,7 +303,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(SiteKey) (io.ReadCloser, error)
+	GetSiteReport(key SiteKey, since time.Duration) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -303,7 +303,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(GetSiteReportRequest) (io.ReadCloser, error)
+	GetSiteReport(GetClusterReportRequest) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)
@@ -1904,10 +1904,10 @@ type Identity interface {
 	GetAuthGateway(SiteKey) (storage.AuthGateway, error)
 }
 
-// GetSiteReportRequest specifies the request to get the site report
-type GetSiteReportRequest struct {
+// GetClusterReportRequest specifies the request to get the cluster report
+type GetClusterReportRequest struct {
 	// SiteKey is a key used to identify site
 	SiteKey
-	// Since is used to filter the collected report by time
-	Since time.Duration `json:"since"`
+	// Since is used to filter collected logs by time
+	Since time.Duration `json:"since,omitempty"`
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -303,7 +303,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(key SiteKey, since time.Duration) (io.ReadCloser, error)
+	GetSiteReport(GetSiteReportRequest) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)
@@ -1902,4 +1902,12 @@ type Identity interface {
 	UpsertAuthGateway(SiteKey, storage.AuthGateway) error
 	// GetAuthGateway returns auth gateway configuration
 	GetAuthGateway(SiteKey) (storage.AuthGateway, error)
+}
+
+// GetSiteReportRequest specifies the request to get the site report
+type GetSiteReportRequest struct {
+	// SiteKey is a key used to identify site
+	SiteKey
+	// Since is used to filter the collected report by time
+	Since time.Duration `json:"since"`
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -676,8 +676,11 @@ func (c *Client) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return file.Body(), nil
 }
 
-func (c *Client) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
-	file, err := c.GetFile(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), url.Values{})
+func (c *Client) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
+	params := url.Values{
+		"since": []string{since.String()},
+	}
+	file, err := c.GetFile(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -676,7 +676,7 @@ func (c *Client) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return file.Body(), nil
 }
 
-func (c *Client) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
+func (c *Client) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
 	params := url.Values{
 		"since": []string{req.Since.String()},
 	}

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -676,11 +676,11 @@ func (c *Client) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return file.Body(), nil
 }
 
-func (c *Client) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
+func (c *Client) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
 	params := url.Values{
-		"since": []string{since.String()},
+		"since": []string{req.Since.String()},
 	}
-	file, err := c.GetFile(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), params)
+	file, err := c.GetFile(c.Endpoint("accounts", req.AccountID, "sites", req.SiteDomain, "report"), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -958,7 +958,7 @@ func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p htt
 		}
 	}
 
-	report, err := context.Operator.GetSiteReport(ops.GetSiteReportRequest{
+	report, err := context.Operator.GetSiteReport(ops.GetClusterReportRequest{
 		SiteKey: siteKey(p),
 		Since:   since,
 	})

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -950,7 +950,15 @@ func (h *WebHandler) activateSite(w http.ResponseWriter, r *http.Request, p http
    GET /portal/v1/accounts/:account_id/sites/:site_domain/report
 */
 func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(siteKey(p))
+	var since time.Duration
+	if keys, ok := r.URL.Query()["since"]; ok && len(keys[0]) > 0 {
+		var err error
+		if since, err = time.ParseDuration(keys[0]); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	report, err := context.Operator.GetSiteReport(siteKey(p), since)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -951,9 +951,9 @@ func (h *WebHandler) activateSite(w http.ResponseWriter, r *http.Request, p http
 */
 func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
 	var since time.Duration
-	if keys, ok := r.URL.Query()["since"]; ok && len(keys[0]) > 0 {
+	if val := r.URL.Query().Get("since"); val != "" {
 		var err error
-		if since, err = time.ParseDuration(keys[0]); err != nil {
+		if since, err = time.ParseDuration(val); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -958,7 +958,10 @@ func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p htt
 		}
 	}
 
-	report, err := context.Operator.GetSiteReport(siteKey(p), since)
+	report, err := context.Operator.GetSiteReport(ops.GetSiteReportRequest{
+		SiteKey: siteKey(p),
+		Since:   since,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -417,7 +417,7 @@ func (r *Router) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return client.GetSiteOperationCrashReport(key)
 }
 
-func (r *Router) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
+func (r *Router) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
 	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"time"
 
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
@@ -418,12 +417,12 @@ func (r *Router) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return client.GetSiteOperationCrashReport(key)
 }
 
-func (r *Router) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
-	client, err := r.PickClient(key.SiteDomain)
+func (r *Router) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
+	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteReport(key, since)
+	return client.GetSiteReport(req)
 }
 
 // ValidateServers runs pre-installation checks

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"time"
 
 	"github.com/gravitational/gravity/lib/clients"
 	"github.com/gravitational/gravity/lib/constants"
@@ -417,12 +418,12 @@ func (r *Router) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return client.GetSiteOperationCrashReport(key)
 }
 
-func (r *Router) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
+func (r *Router) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
 	client, err := r.PickClient(key.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteReport(key)
+	return client.GetSiteReport(key, since)
 }
 
 // ValidateServers runs pre-installation checks

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -212,7 +212,7 @@ func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRu
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
 		fmt.Sprintf("--filter=%v", report.FilterSystem),
 		"--compressed",
-		fmt.Sprintf(`--since="%v"`, since.String()))...)
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect diagnostics: %s", stderr.String())
 	}
@@ -230,7 +230,7 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
 		fmt.Sprintf("--filter=%v", report.FilterKubernetes),
 		"--compressed",
-		fmt.Sprintf(`--since="%v"`, since.String()))...)
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect kubernetes diagnostics: %s", stderr.String())
 	}

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -208,11 +208,13 @@ func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRu
 	}
 	defer w.Close()
 
+	args := []string{"system", "report", "--filter", report.FilterSystem, "--compressed"}
+	if since != 0 {
+		args = append(args, "--since", since.String())
+	}
+
 	var stderr bytes.Buffer
-	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterSystem),
-		"--compressed",
-		"--since", since.String())...)
+	err = runner.RunStream(w, &stderr, s.gravityCommand(args...)...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect diagnostics: %s", stderr.String())
 	}
@@ -226,11 +228,13 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 	}
 	defer w.Close()
 
+	args := []string{"system", "report", "--filter", report.FilterKubernetes, "--compressed"}
+	if since != 0 {
+		args = append(args, "--since", since.String())
+	}
+
 	var stderr bytes.Buffer
-	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterKubernetes),
-		"--compressed",
-		"--since", since.String())...)
+	err = runner.RunStream(w, &stderr, s.gravityCommand(args...)...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect kubernetes diagnostics: %s", stderr.String())
 	}

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -69,17 +69,17 @@ func (s *site) getClusterInstallReport(op ops.SiteOperation, since time.Duration
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(ctx.provisionedServers))
 	for _, server := range servers {
 		remoteServers = append(remoteServers, server)
-		if server.IsMaster() && master == nil {
-			master = server
+		if server.IsMaster() {
+			masterServers = append(masterServers, server)
 		}
 	}
 
 	runner := s.agentRunner(ctx)
-	return s.getReport(runner, remoteServers, master, since)
+	return s.getReport(runner, remoteServers, masterServers, since)
 }
 
 func (s *site) getClusterGenericReport(since time.Duration) (io.ReadCloser, error) {
@@ -94,12 +94,13 @@ func (s *site) getClusterGenericReport(since time.Duration) (io.ReadCloser, erro
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
 	teleportRunner := &teleportRunner{
 		FieldLogger:          log.WithField(trace.Component, "teleport-runner"),
 		TeleportProxyService: s.teleport(),
 		domainName:           s.domainName,
 	}
+
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(servers))
 	for _, server := range servers {
 		teleportServer, err := newTeleportServer(server)
@@ -107,16 +108,15 @@ func (s *site) getClusterGenericReport(since time.Duration) (io.ReadCloser, erro
 			return nil, trace.Wrap(err)
 		}
 		role := schema.ServiceRole(teleportServer.Labels[schema.ServiceLabelRole])
-		if role == schema.ServiceRoleMaster && master == nil {
-			master = teleportServer
+		if role == schema.ServiceRoleMaster {
+			masterServers = append(masterServers, teleportServer)
 		}
 		remoteServers = append(remoteServers, teleportServer)
 	}
-
-	return s.getReport(teleportRunner, remoteServers, master, since)
+	return s.getReport(teleportRunner, remoteServers, masterServers, since)
 }
 
-func (s *site) getReport(runner remoteRunner, servers []remoteServer, master remoteServer,
+func (s *site) getReport(runner remoteRunner, servers []remoteServer, masters []remoteServer,
 	since time.Duration) (io.ReadCloser, error) {
 	dir, err := ioutil.TempDir("", "report")
 	if err != nil {
@@ -136,8 +136,10 @@ func (s *site) getReport(runner remoteRunner, servers []remoteServer, master rem
 
 	if len(servers) > 0 {
 		// Use the first master server to collect kubernetes diagnostics
-		server := master
-		if server == nil {
+		var server remoteServer
+		if len(masters) > 0 {
+			server = masters[0]
+		} else {
 			server = servers[0]
 			log.Warningf("No master servers, collecting Kubernetes diagnostics from %v.", server)
 		}
@@ -147,14 +149,14 @@ func (s *site) getReport(runner remoteRunner, servers []remoteServer, master rem
 		if err := s.collectKubernetesInfo(reportWriter, serverRunner, since); err != nil {
 			logger.WithError(err).Error("Failed to collect Kubernetes info.")
 		}
-		if err := s.collectEtcdBackup(reportWriter, serverRunner); err != nil {
-			logger.WithError(err).Error("Failed to collect etcd backup.")
+		if err := s.collectEtcdInfoFromMasters(dir, masters, runner); err != nil {
+			log.WithError(err).Error("Failed to collect etcd info.")
 		}
 		if err := s.collectDebugInfoFromServers(dir, servers, runner, since); err != nil {
 			log.WithError(err).Error("Failed to collect diagnostics from some nodes.")
 		}
 		if err := s.collectStatusTimeline(reportWriter, serverRunner); err != nil {
-			log.WithError(err).Error("Failed to collect status timeline.")
+			logger.WithError(err).Error("Failed to collect status timeline.")
 		}
 	}
 
@@ -241,7 +243,25 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 	return nil
 }
 
-func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverRunner) error {
+func (s *site) collectEtcdInfoFromMasters(dir string, masters []remoteServer, runner remoteRunner) error {
+	err := s.executeOnServers(context.TODO(), masters, func(c context.Context, master remoteServer) error {
+		log.Debugf("collectEtcdInfo for %v", master)
+		r := &serverRunner{
+			server: master,
+			runner: runner,
+		}
+		reportWriter := getReportWriterForServer(dir, master)
+		err := s.collectEtcdInfo(reportWriter, r)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// collectEtcdInfo collects etcd backup and metrics.
+func (s *site) collectEtcdInfo(reportWriter report.FileWriter, runner *serverRunner) error {
 	w, err := reportWriter.NewWriter("etcd.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
@@ -251,7 +271,7 @@ func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverR
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report", fmt.Sprintf(
 		"--filter=%v", report.FilterEtcd), "--compressed")...)
 	if err != nil {
-		return trace.Wrap(err, "failed to collect etcd backup: %s", stderr.String())
+		return trace.Wrap(err, "failed to collect etcd info: %s", stderr.String())
 	}
 	return nil
 }

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -242,7 +242,7 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 }
 
 func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverRunner) error {
-	w, err := reportWriter.NewWriter("etcd-backup.json.tar.gz")
+	w, err := reportWriter.NewWriter("etcd.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1085,16 +1085,16 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 }
 
 func (o *Operator) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadCloser, error) {
-	return o.GetSiteReport(key.SiteKey())
+	return o.GetSiteReport(key.SiteKey(), time.Duration(0))
 }
 
-func (o *Operator) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
+func (o *Operator) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
 	cluster, err := o.openSite(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return cluster.getClusterReport()
+	return cluster.getClusterReport(since)
 }
 
 func (o *Operator) GetSiteOperationProgress(key ops.SiteOperationKey) (*ops.ProgressEntry, error) {

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1085,13 +1085,13 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 }
 
 func (o *Operator) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadCloser, error) {
-	return o.GetSiteReport(ops.GetSiteReportRequest{
+	return o.GetSiteReport(ops.GetClusterReportRequest{
 		SiteKey: key.SiteKey(),
 		Since:   time.Duration(0),
 	})
 }
 
-func (o *Operator) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
+func (o *Operator) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
 	cluster, err := o.openSite(req.SiteKey)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1085,16 +1085,19 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 }
 
 func (o *Operator) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadCloser, error) {
-	return o.GetSiteReport(key.SiteKey(), time.Duration(0))
+	return o.GetSiteReport(ops.GetSiteReportRequest{
+		SiteKey: key.SiteKey(),
+		Since:   time.Duration(0),
+	})
 }
 
-func (o *Operator) GetSiteReport(key ops.SiteKey, since time.Duration) (io.ReadCloser, error) {
-	cluster, err := o.openSite(key)
+func (o *Operator) GetSiteReport(req ops.GetSiteReportRequest) (io.ReadCloser, error) {
+	cluster, err := o.openSite(req.SiteKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return cluster.getClusterReport(since)
+	return cluster.getClusterReport(req.Since)
 }
 
 func (o *Operator) GetSiteOperationProgress(key ops.SiteOperationKey) (*ops.ProgressEntry, error) {

--- a/lib/report/k8s.go
+++ b/lib/report/k8s.go
@@ -59,7 +59,7 @@ func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner, sin
 	commands = append(commands, capturePreviousContainerLogs(ctx, namespaces, runner, since)...)
 
 	// collect current container logs
-	if since == time.Duration(0) {
+	if since == 0 {
 		return append(commands, Cmd("k8s-cluster-info-dump.tgz", constants.GravityBin, "system", "cluster-info"))
 	}
 	// kubectl cluster-info dump does not provide a --since flag, so collect

--- a/lib/report/k8s.go
+++ b/lib/report/k8s.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/gravitational/gravity/lib/constants"
@@ -34,12 +35,10 @@ import (
 // diagnostics.
 func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner, since time.Duration) Collectors {
 	runner = planetContextRunner{runner}
-	// general kubernetes info
+	// collect general kubernetes info
 	commands := Collectors{
 		Cmd("k8s-nodes", utils.PlanetCommand(kubectl.Command("get", "nodes", "--output", "wide"))...),
 		Cmd("k8s-describe-nodes", utils.PlanetCommand(kubectl.Command("describe", "nodes"))...),
-		Cmd("k8s-cluster-info-dump.tgz",
-			constants.GravityBin, "system", "cluster-info"),
 	}
 	for _, resourceType := range defaults.KubernetesReportResourceTypes {
 		commands = append(commands,
@@ -51,15 +50,39 @@ func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner, sin
 					"get", resourceType, "--all-namespaces", "--output", "wide"))...),
 		)
 	}
+
+	// collect previous container logs
 	namespaces, err := kubectl.GetNamespaces(ctx, runner)
 	if err != nil || len(namespaces) == 0 {
 		namespaces = defaults.UsedNamespaces
 	}
-	return append(commands, capturePreviousContainerLogs(ctx, namespaces, runner, since)...)
+	commands = append(commands, capturePreviousContainerLogs(ctx, namespaces, runner, since)...)
+
+	// collect current container logs
+	if since == time.Duration(0) {
+		return append(commands, Cmd("k8s-cluster-info-dump.tgz", constants.GravityBin, "system", "cluster-info"))
+	}
+	// kubectl cluster-info dump does not provide a --since flag, so collect
+	// current container logs individually with kubectl logs.
+	return append(commands, captureCurrentContainerLogs(ctx, namespaces, runner, since)...)
 }
 
+// capturePreviousContainerLogs collects logs for previously running container
+// instances.
 func capturePreviousContainerLogs(ctx context.Context, namespaces []string, runner utils.CommandRunner,
 	since time.Duration) (collectors Collectors) {
+	return captureContainerLogs(ctx, namespaces, runner, since, true)
+}
+
+// captureCurrentContainerLogs collects logs for currently running container
+// instances.
+func captureCurrentContainerLogs(ctx context.Context, namespaces []string, runner utils.CommandRunner,
+	since time.Duration) (collectors Collectors) {
+	return captureContainerLogs(ctx, namespaces, runner, since, false)
+}
+
+func captureContainerLogs(ctx context.Context, namespaces []string, runner utils.CommandRunner,
+	since time.Duration, previous bool) (collectors Collectors) {
 	for _, namespace := range namespaces {
 		logger := log.WithField("namespace", namespace)
 		pods, err := kubectl.GetPods(ctx, namespace, runner)
@@ -77,15 +100,26 @@ func capturePreviousContainerLogs(ctx context.Context, namespaces []string, runn
 				continue
 			}
 			for _, container := range containers {
-				// Collect logs for the previous instance of the container if there's any.
-				name := fmt.Sprintf("k8s-logs-%v-%v-%v-prev", namespace, pod, container)
-				collectors = append(collectors, Cmd(name, kubectl.Command("logs", pod,
-					"--namespace", namespace, "-p", "--since", since.String(),
-					fmt.Sprintf("-c=%v", container)).Args()...))
+				collectors = append(collectors, containerLogCollector(namespace, pod, container, since, previous))
 			}
 		}
 	}
 	return collectors
+}
+
+// containerLogCollector returns a k8s log collector with the provided values
+// and configuration. If previous is true, only collect logs for previously
+// running instances of the container.
+func containerLogCollector(namespace, pod, container string, since time.Duration, previous bool) (cmd Command) {
+	name := fmt.Sprintf("k8s-logs-%v-%v-%v", namespace, pod, container)
+	if previous {
+		name += "-prev"
+	}
+	return Cmd(name, kubectl.Command("logs", pod,
+		"--namespace", namespace,
+		"--since", since.String(),
+		fmt.Sprintf("-p=%v", strconv.FormatBool(previous)),
+		fmt.Sprintf("-c=%v", container)).Args()...)
 }
 
 // RunStream executes the command specified with args in the context of the planet container

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -105,7 +105,7 @@ type Config struct {
 	// diagnostics collector
 	Packages pack.PackageService
 	// Since specifies the start of the time filter. A value of 1h will report
-	// log entries starting from one ago up till the end of the time filter.
+	// log entries starting from one hour ago up till the end of the time filter.
 	Since time.Duration
 }
 

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -49,6 +49,7 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner, config.Since)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
+			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
 		}

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/pack"
@@ -42,10 +43,10 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 	for _, filter := range teleutils.Deduplicate(config.Filters) {
 		switch filter {
 		case FilterSystem:
-			collectors = append(collectors, NewSystemCollector()...)
+			collectors = append(collectors, NewSystemCollector(config.Since)...)
 			collectors = append(collectors, NewPackageCollector(config.Packages))
 		case FilterKubernetes:
-			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner)...)
+			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner, config.Since)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
 		case FilterTimeline:
@@ -102,9 +103,18 @@ type Config struct {
 	// Packages specifies the package service for the package
 	// diagnostics collector
 	Packages pack.PackageService
+	// Since specifies the start of the time filter. A value of 1h will report
+	// log entries starting from one ago up till the end of the time filter.
+	Since time.Duration
+	// Until specifies the end of the time filter. A value of 1h will report
+	// log entries from the start of the time filter up till one hour ago.
+	Until time.Duration
 }
 
 const (
+	// JournalDateFormat defines the timestamp format for journalctl since/until flags
+	JournalDateFormat = "2006-01-02 15:04:05"
+
 	// FilterSystem defines a report collection filter to fetch system diagnostics
 	FilterSystem = "system"
 

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -106,9 +106,6 @@ type Config struct {
 	// Since specifies the start of the time filter. A value of 1h will report
 	// log entries starting from one ago up till the end of the time filter.
 	Since time.Duration
-	// Until specifies the end of the time filter. A value of 1h will report
-	// log entries from the start of the time filter up till one hour ago.
-	Until time.Duration
 }
 
 const (

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -113,7 +113,7 @@ func syslogExportLogs(since time.Duration) Collector {
 		script = script + fmt.Sprintf(`--since="%s" `, time.Now().Add(-since).Format(JournalDateFormat))
 	}
 	script = script + "| /bin/gzip -f"
-	return Script("gravity-system.log.gz", script)
+	return Script("gravity-journal.log.gz", script)
 }
 
 // systemFileLogs fetches gravity platform-related logs

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -76,6 +76,8 @@ func basicSystemInfo() Collectors {
 		Cmd("host-system-failed", "/bin/systemctl", "--failed", "--full"),
 		Cmd("host-system-jobs", "/bin/systemctl", "list-jobs", "--full"),
 		Cmd("dmesg", "/bin/dmesg", "--raw"),
+		Cmd("reboot-history", "last", "-x"),
+		Cmd("uname", "uname", "-a"),
 		// Fetch world-readable parts of /etc/
 		fetchEtc("etc-logs.tar.gz"),
 		// memory
@@ -83,6 +85,7 @@ func basicSystemInfo() Collectors {
 		Cmd("slabtop", "slabtop", "--once"),
 		Cmd("vmstat", "vmstat", "--stats"),
 		Cmd("slabinfo", "cat", "/proc/slabinfo"),
+		Cmd("swapon", "swapon", "-s"),
 	}
 }
 
@@ -96,6 +99,8 @@ func systemStatus() Collectors {
 		Cmd("planet-system-status", utils.PlanetCommandArgs("/bin/systemctl", "status", "--full")...),
 		Cmd("planet-system-failed", utils.PlanetCommandArgs("/bin/systemctl", "--failed", "--full")...),
 		Cmd("planet-system-jobs", utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")...),
+		// serf status
+		Cmd("serf-members", utils.PlanetCommandArgs(defaults.SerfBin, "members")...),
 	}
 }
 
@@ -143,6 +148,17 @@ func etcdBackup() Collectors {
 		Cmd("etcd-backup.json", utils.PlanetCommandArgs(defaults.PlanetBin, "etcd", "backup",
 			"--prefix", defaults.EtcdPlanetPrefix,
 			"--prefix", defaults.EtcdGravityPrefix)...),
+	}
+}
+
+// etcdMetrics fetches etcd metrics
+func etcdMetrics() Collectors {
+	return Collectors{
+		Cmd("etcd-metrics.json", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--insecure", "--tlsv1.2",
+			"--cacert", filepath.Join(defaults.PlanetStateDir, defaults.RootCertFilename),
+			"--cert", filepath.Join(defaults.PlanetStateDir, defaults.EtcdCertFilename),
+			"--key", filepath.Join(defaults.PlanetStateDir, defaults.EtcdKeyFilename),
+			filepath.Join(defaults.EtcdLocalMetricsAddr, "metrics"))...),
 	}
 }
 

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -154,7 +154,7 @@ func etcdBackup() Collectors {
 // etcdMetrics fetches etcd metrics
 func etcdMetrics() Collectors {
 	return Collectors{
-		Cmd("etcd-metrics.json", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--insecure", "--tlsv1.2",
+		Cmd("etcd-metrics", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--insecure", "--tlsv1.2",
 			"--cacert", filepath.Join(defaults.PlanetStateDir, defaults.RootCertFilename),
 			"--cert", filepath.Join(defaults.PlanetStateDir, defaults.EtcdCertFilename),
 			"--key", filepath.Join(defaults.PlanetStateDir, defaults.EtcdKeyFilename),

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -154,11 +154,11 @@ func etcdBackup() Collectors {
 // etcdMetrics fetches etcd metrics
 func etcdMetrics() Collectors {
 	return Collectors{
-		Cmd("etcd-metrics", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--insecure", "--tlsv1.2",
+		Cmd("etcd-metrics", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--tlsv1.2",
 			"--cacert", filepath.Join(defaults.PlanetStateDir, defaults.RootCertFilename),
 			"--cert", filepath.Join(defaults.PlanetStateDir, defaults.EtcdCertFilename),
 			"--key", filepath.Join(defaults.PlanetStateDir, defaults.EtcdKeyFilename),
-			filepath.Join(defaults.EtcdLocalMetricsAddr, "metrics"))...),
+			filepath.Join(defaults.EtcdLocalAddr, "metrics"))...),
 	}
 }
 

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -104,7 +104,7 @@ func syslogExportLogs(since time.Duration) Collector {
 	var script = `
 #!/bin/bash
 /bin/journalctl --no-pager --output=export `
-	if since != time.Duration(0) {
+	if since != 0 {
 		script = script + fmt.Sprintf(`--since="%s" `, time.Now().Add(-since).Format(JournalDateFormat))
 	}
 	script = script + "| /bin/gzip -f"

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1704,10 +1704,13 @@ func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httpro
 		}
 	}
 
-	reader, err := context.Operator.GetSiteReport(ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
-	}, since)
+	reader, err := context.Operator.GetSiteReport(ops.GetSiteReportRequest{
+		SiteKey: ops.SiteKey{
+			AccountID:  context.User.GetAccountID(),
+			SiteDomain: p.ByName("domain"),
+		},
+		Since: since,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1704,7 +1704,7 @@ func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httpro
 		}
 	}
 
-	reader, err := context.Operator.GetSiteReport(ops.GetSiteReportRequest{
+	reader, err := context.Operator.GetSiteReport(ops.GetClusterReportRequest{
 		SiteKey: ops.SiteKey{
 			AccountID:  context.User.GetAccountID(),
 			SiteDomain: p.ByName("domain"),

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1696,10 +1696,18 @@ func (m *Handler) getSiteEndpoints(w http.ResponseWriter, r *http.Request, p htt
 //
 //   report.tar
 func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
+	var since time.Duration
+	if keys, ok := r.URL.Query()["since"]; ok && len(keys[0]) > 0 {
+		var err error
+		if since, err = time.ParseDuration(keys[0]); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	reader, err := context.Operator.GetSiteReport(ops.SiteKey{
 		AccountID:  context.User.GetAccountID(),
 		SiteDomain: p.ByName("domain"),
-	})
+	}, since)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1697,9 +1697,9 @@ func (m *Handler) getSiteEndpoints(w http.ResponseWriter, r *http.Request, p htt
 //   report.tar
 func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
 	var since time.Duration
-	if keys, ok := r.URL.Query()["since"]; ok && len(keys[0]) > 0 {
+	if val := r.URL.Query().Get("since"); val != "" {
 		var err error
-		if since, err = time.ParseDuration(keys[0]); err != nil {
+		if since, err = time.ParseDuration(val); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1272,6 +1272,10 @@ type ReportCmd struct {
 	*kingpin.CmdClause
 	// FilePath is the report tarball path
 	FilePath *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SiteCmd combines cluster related subcommands
@@ -1565,6 +1569,10 @@ type SystemReportCmd struct {
 	// File optionally specifies the output file.
 	// If unspecified, stdout is used
 	File *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStateDirCmd shows local state directory

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -535,6 +535,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Generate cluster diagnostics report")
 	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "target report file name").Default("report.tar.gz").String()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")
@@ -674,6 +675,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()
 	g.SystemReportCmd.File = g.SystemReportCmd.Arg("file", "optional output path").String()
+	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
 
 	g.SystemStateDirCmd.CmdClause = g.SystemCmd.Command("state-dir", "show where all gravity data is stored on the node").Hidden()
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -534,8 +534,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Generate cluster diagnostics report")
-	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "target report file name").Default("report.tar.gz").String()
-	g.ReportCmd.Since = g.ReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
+	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "Target report file name").Default("report.tar.gz").String()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -535,7 +535,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Generate cluster diagnostics report")
 	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "Target report file name").Default("report.tar.gz").String()
-	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")
@@ -675,7 +675,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()
 	g.SystemReportCmd.File = g.SystemReportCmd.Arg("file", "optional output path").String()
-	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h").Duration()
+	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStateDirCmd.CmdClause = g.SystemCmd.Command("state-dir", "show where all gravity data is stored on the node").Hidden()
 

--- a/tool/gravity/cli/report.go
+++ b/tool/gravity/cli/report.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/report"
@@ -29,7 +30,8 @@ import (
 // systemReport collects system diagnostics and outputs them as a (optionally compressed) tarball
 // to the specified writer w.
 // filters defines the specific diagnostics to collect, if unspecified - all diagnostics will be collected.
-func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, outputPath string) error {
+func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, outputPath string,
+	since time.Duration) error {
 	var w io.Writer = os.Stdout
 	if outputPath != "" {
 		f, err := os.Create(outputPath)
@@ -43,6 +45,7 @@ func systemReport(env *localenv.LocalEnvironment, filters []string, compressed b
 		Filters:    filters,
 		Compressed: compressed,
 		Packages:   env.Packages,
+		Since:      since,
 	}
 	return report.Collect(context.TODO(), config, w)
 }

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -722,7 +722,9 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 			*g.APIKeyDeleteCmd.Email,
 			*g.APIKeyDeleteCmd.Token)
 	case g.ReportCmd.FullCommand():
-		return getClusterReport(localEnv, *g.ReportCmd.FilePath)
+		return getClusterReport(localEnv,
+			*g.ReportCmd.FilePath,
+			*g.ReportCmd.Since)
 	// cluster commands
 	case g.SiteListCmd.FullCommand():
 		return listSites(localEnv, *g.SiteListCmd.OpsCenterURL)
@@ -842,7 +844,8 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return systemReport(localEnv,
 			*g.SystemReportCmd.Filter,
 			*g.SystemReportCmd.Compressed,
-			*g.SystemReportCmd.File)
+			*g.SystemReportCmd.File,
+			*g.SystemReportCmd.Since)
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -139,7 +139,7 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since t
 		return trace.Wrap(err)
 	}
 
-	report, err := operator.GetSiteReport(ops.GetSiteReportRequest{
+	report, err := operator.GetSiteReport(ops.GetClusterReportRequest{
 		SiteKey: ops.SiteKey{
 			AccountID:  site.AccountID,
 			SiteDomain: site.Domain,

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -139,10 +139,13 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since t
 		return trace.Wrap(err)
 	}
 
-	report, err := operator.GetSiteReport(ops.SiteKey{
-		AccountID:  site.AccountID,
-		SiteDomain: site.Domain,
-	}, since)
+	report, err := operator.GetSiteReport(ops.GetSiteReportRequest{
+		SiteKey: ops.SiteKey{
+			AccountID:  site.AccountID,
+			SiteDomain: site.Domain,
+		},
+		Since: since,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -122,7 +122,7 @@ func listSites(env *localenv.LocalEnvironment, opsCenterURL string) error {
 	return nil
 }
 
-func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
+func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since time.Duration) error {
 	f, err := os.Create(targetFile)
 	if err != nil {
 		return trace.Wrap(err)
@@ -142,7 +142,7 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
 	report, err := operator.GetSiteReport(ops.SiteKey{
 		AccountID:  site.AccountID,
 		SiteDomain: site.Domain,
-	})
+	}, since)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds the `since` flag to `gravity report` command. This flag is used to filter the log entries by time. The current implementation only affects the log entries collected from `kubectl logs` and `journalctl`.

Add a few more system collectors that have come up recently:
* Reboots history: `last -x`
* Kernel information: `uname -a`
* Serf cluster: `serf members`
* Swap status: `swapon -s (we have vmstat but wouldn't hurt)`
* Etcd metrics: `curl -s --insecure --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https://localhost:4001/metrics`

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/1273

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify additional collectors**
```
[gravity-report] tree report                                                                                                                   bernard/5.5.x/time-filter  ✭ ✱
report
├── cluster.json
├── node-1-debug-logs
│   ├── bridge-fdb
│   ├── cluster-status
│   ├── df
│   ├── df-inodes
│   ├── dmesg
│   ├── dmsetup
│   ├── etcd-status
│   ├── etc-logs.tar.gz
│   ├── fdisk
│   ├── free
│   ├── gravity-install.log
│   ├── gravity-packages.yaml
│   ├── gravity-system.log
│   ├── gravity-system.log.gz
│   ├── host-system-failed
│   ├── host-system-jobs
│   ├── host-system-status
│   ├── ifconfig
│   ├── ip-addr
│   ├── ip-link
│   ├── ip-maddress
│   ├── ip-neighbor
│   ├── ip-netconf
│   ├── ip-ntable
│   ├── ip-route
│   ├── ip-rule
│   ├── iptables
│   ├── ip-tcp_metrics
│   ├── lsblk
│   ├── lscpu
│   ├── lsmod
│   ├── planet-journal-export.log.gz
│   ├── planet-status
│   ├── planet-system-failed
│   ├── planet-system-jobs
│   ├── planet-system-status
│   ├── reboot-history  <---
│   ├── route
│   ├── running-processes
│   ├── serf-members  <---
│   ├── slabinfo
│   ├── slabtop
│   ├── swapon <---
│   ├── uname  <---
│   └── vmstat
├── node-1-debug-logs.tar.gz
├── node-2-etcd
│   ├── etcd-backup.json
│   └── etcd-metrics  <---
├── node-2-etcd.tar.gz
[...]
```

**Verify kubectl logs are filtered by time**

* `--since 1m`
```
[vagrant@node-1 node-2-k8s-logs]$ cat k8s-logs-kube-system-gravity-site-kn59t-gravity-site
2020-06-13T09:36:30Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
2020-06-13T09:36:30Z INFO             2020/06/13 09:36:30 http: TLS handshake error from 127.0.0.1:32834: tls: internal error: failed to clone hash runtime/asm_amd64.s:1373
2020-06-13T09:36:40Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
2020-06-13T09:36:40Z INFO             2020/06/13 09:36:40 http: TLS handshake error from 127.0.0.1:32900: tls: internal error: failed to clone hash runtime/asm_amd64.s:1373
2020-06-13T09:36:40Z WARN [TELEPROXY] "Failed to renew certificate for opscenter@gravitational.io: \nERROR REPORT:\nOriginal Error: *trace.ConnectionProblemError remote error: tls: internal error\nStack Trace:\n\t/home/bernard/go/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/httplib/httplib.go:110 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/httplib.ConvertResponse\n\t/home/bernard/go/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth/clt.go:211 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth.(*Client).PostJSON\n\t/home/bernard/go/src/github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth/clt.go:1169 github.com/gravitational/gravity/vendor/github.com/gravitational/teleport/lib/auth.(*Client).GenerateUserCert\n\t/home/bernard/go/src/github.com/gravitational/gravity/lib/process/proxy.go:125 github.com/gravitational/gravity/lib/process.(*teleportProxyService).initAuthMethods.func1\n\t/home/bernard/go/src/github.com/gravitational/gravity/lib/process/proxy.go:154 github.com/gravitational/gravity/lib/process.(*teleportProxyService).initAuthMethods\n\t/usr/lib/go-1.14/src/runtime/asm_amd64.s:1373 runtime.goexit\nUser Message: remote error: tls: internal error." process/proxy.go:155
2020-06-13T09:36:50Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
2020-06-13T09:36:58Z INFO [RBAC]      Access to create user in namespace default denied to roles Node,default-implicit-role: no allow rule matched. services/role.go:1838
2020-06-13T09:37:00Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
2020-06-13T09:37:10Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
2020-06-13T09:37:20Z WARN [PROXY:AGE] Failed to create remote tunnel: dial tcp 172.28.128.101:61024: connect: connection refused, conn: <nil>. target:172.28.128.101:61024 reversetunnel/agent.go:447
```

**Verify journal logs are filtered by time**
* `--since 1m`
* Not entirely sure how to read these timestamps, but there are much fewer log entries compared to the report without a time filter provided.
```
[vagrant@node-1 node-1-debug-logs]$ cat gravity-system.log
__CURSOR=s=05ed0a8050e54d6eb25b26ebd98fd6d3;i=1d5d;b=7a3504e73fcc4cb186958464f737b949;m=1ea97c5500;t=5a7f3eea4dbd4;x=bfdc13f631df90fd
__REALTIME_TIMESTAMP=1592041006226388
__MONOTONIC_TIMESTAMP=131692516608
_BOOT_ID=7a3504e73fcc4cb186958464f737b949
_UID=0
_MACHINE_ID=ee32f6c4a34e4799afc544610c083982
PRIORITY=5
_CAP_EFFECTIVE=1fffffffff
_TRANSPORT=syslog
SYSLOG_FACILITY=10
_AUDIT_LOGINUID=1000
_SYSTEMD_OWNER_UID=1000
_SYSTEMD_SLICE=user-1000.slice
SYSLOG_IDENTIFIER=sudo
_GID=1000
_COMM=sudo
_EXE=/usr/bin/sudo
_SELINUX_CONTEXT=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
_HOSTNAME=node-1
MESSAGE= vagrant : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/gravity report --help
_CMDLINE=sudo gravity report --help
_AUDIT_SESSION=105
_SYSTEMD_CGROUP=/user.slice/user-1000.slice/session-105.scope
_SYSTEMD_SESSION=105
_SYSTEMD_UNIT=session-105.scope
_PID=17162
_SOURCE_REALTIME_TIMESTAMP=1592041006223422

__CURSOR=s=05ed0a8050e54d6eb25b26ebd98fd6d3;i=1d5e;b=7a3504e73fcc4cb186958464f737b949;m=1ea97c80c1;t=5a7f3eea50796;x=6c580e6969270a4f
__REALTIME_TIMESTAMP=1592041006237590
__MONOTONIC_TIMESTAMP=131692527809
_BOOT_ID=7a3504e73fcc4cb186958464f737b949
PRIORITY=6
_UID=0
_GID=0
_MACHINE_ID=ee32f6c4a34e4799afc544610c083982
_CAP_EFFECTIVE=1fffffffff
_TRANSPORT=syslog
SYSLOG_FACILITY=10
_AUDIT_LOGINUID=1000
_SYSTEMD_OWNER_UID=1000
_SYSTEMD_SLICE=user-1000.slice
SYSLOG_IDENTIFIER=sudo
_COMM=sudo
_EXE=/usr/bin/sudo
_SELINUX_CONTEXT=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
_HOSTNAME=node-1
MESSAGE=pam_unix(sudo:session): session opened for user root by vagrant(uid=0)
_CMDLINE=sudo gravity report --help
_AUDIT_SESSION=105
_SYSTEMD_CGROUP=/user.slice/user-1000.slice/session-105.scope
_SYSTEMD_SESSION=105
_SYSTEMD_UNIT=session-105.scope
_PID=17162
_SOURCE_REALTIME_TIMESTAMP=1592041006236963

__CURSOR=s=05ed0a8050e54d6eb25b26ebd98fd6d3;i=1d5f;b=7a3504e73fcc4cb186958464f737b949;m=1ea97d9723;t=5a7f3eea61df7;x=db7124e0e9f6124
__REALTIME_TIMESTAMP=1592041006308855
__MONOTONIC_TIMESTAMP=131692599075
_BOOT_ID=7a3504e73fcc4cb186958464f737b949
PRIORITY=6
_UID=0
_GID=0
_MACHINE_ID=ee32f6c4a34e4799afc544610c083982
_CAP_EFFECTIVE=1fffffffff
_TRANSPORT=syslog
SYSLOG_FACILITY=10
_AUDIT_LOGINUID=1000
_SYSTEMD_OWNER_UID=1000
_SYSTEMD_SLICE=user-1000.slice
SYSLOG_IDENTIFIER=sudo
_COMM=sudo
_EXE=/usr/bin/sudo
_SELINUX_CONTEXT=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
_HOSTNAME=node-1
MESSAGE=pam_unix(sudo:session): session closed for user root
_CMDLINE=sudo gravity report --help
_AUDIT_SESSION=105
_SYSTEMD_CGROUP=/user.slice/user-1000.slice/session-105.scope
_SYSTEMD_SESSION=105
_SYSTEMD_UNIT=session-105.scope
_PID=17162
_SOURCE_REALTIME_TIMESTAMP=1592041006308612

__CURSOR=s=05ed0a8050e54d6eb25b26ebd98fd6d3;i=1d60;b=7a3504e73fcc4cb186958464f737b949;m=1eac0643e1;t=5a7f3f12ecab5;x=8661f252df6da835
__REALTIME_TIMESTAMP=1592041048820405
__MONOTONIC_TIMESTAMP=131735110625
_BOOT_ID=7a3504e73fcc4cb186958464f737b949
PRIORITY=6
_UID=0
_GID=0
_SYSTEMD_SLICE=system.slice
_MACHINE_ID=ee32f6c4a34e4799afc544610c083982
SYSLOG_FACILITY=3
_CAP_EFFECTIVE=1fffffffff
_TRANSPORT=stdout
_SELINUX_CONTEXT=system_u:system_r:init_t:s0
_HOSTNAME=node-1
SYSLOG_IDENTIFIER=gravity
_COMM=teleport
_CMDLINE=rootfs/usr/bin/teleport start
_STREAM_ID=a4ff5bb0a2e34ea39c31b31ec84dbc20
_PID=1412
_EXE=/var/lib/gravity/local/packages/unpacked/gravitational.io/teleport/3.0.5/rootfs/usr/bin/teleport
_SYSTEMD_CGROUP=/system.slice/gravity__gravitational.io__teleport__3.0.5.service
_SYSTEMD_UNIT=gravity__gravitational.io__teleport__3.0.5.service
MESSAGE=INFO [NODE]      [LOCAL EXEC] Started command: "gravity --insecure system report --filter system --compressed --since 1m0s" id:9 local:172.28.128.101:3022 login:root remote:127.0.0.1:56576 teleportUser:opscenter@gravitational.io srv/exec.go:171

```