### PR TITLE
[6.1.x] status improvements

### DIFF
--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -698,6 +698,8 @@ type Node struct {
 	PublicIP string `json:"public_ip"`
 	// Profile is the node profile
 	Profile string `json:"profile"`
+	// Role is the node service role
+	Role string `json:"role"`
 	// InstanceType is the node instance type
 	InstanceType string `json:"instance_type"`
 }

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1415,6 +1415,7 @@ func (o *Operator) GetClusterNodes(key ops.SiteKey) ([]ops.Node, error) {
 			PublicIP:     labels[defaults.TeleportPublicIPv4Label],
 			Profile:      labels[ops.AppRole],
 			InstanceType: labels[ops.InstanceType],
+			Role:         labels[schema.ServiceLabelRole],
 		})
 	}
 	return result, nil

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -58,9 +58,18 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		},
 	}
 
+	status.Agent, err = FromPlanetAgent(ctx, cluster.ClusterState.Servers)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to collect system status from agents.")
+	}
+
+	if err := updateClusterNodes(cluster.Key(), operator, status); err != nil {
+		logrus.WithError(err).Warn("Failed to query cluster nodes.")
+	}
+
 	token, err := operator.GetExpandToken(cluster.Key())
 	if err != nil && !trace.IsNotFound(err) {
-		return status, trace.Wrap(err)
+		logrus.WithError(err).Warn("Failed to fetch expand token.")
 	}
 	if token != nil {
 		status.Token = *token
@@ -98,61 +107,22 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 	}
 
 	// FIXME: have status extension accept the operator/environment
-	err = status.Cluster.Extension.Collect()
-	if err != nil {
-		return status, trace.Wrap(err)
+	if err := status.Cluster.Extension.Collect(); err != nil {
+		logrus.WithError(err).Warn("Failed to query extension metadata.")
 	}
 
-	activeOperations, err := ops.GetActiveOperations(cluster.Key(), operator)
-	if err != nil && !trace.IsNotFound(err) {
-		return status, trace.Wrap(err)
-	}
-	for _, op := range activeOperations {
-		progress, err := operator.GetSiteOperationProgress(op.Key())
-		if err != nil {
-			return status, trace.Wrap(err)
-		}
-		operation, err := fromOperationAndProgress(op, *progress)
-		if err != nil {
-			return status, trace.Wrap(err)
-		}
-		status.ActiveOperations = append(status.ActiveOperations, operation)
+	if err := collectActiveOperations(cluster.Key(), operator, status); err != nil {
+		logrus.WithError(err).Warn("Failed to query active operations.")
 	}
 
-	var operation *ops.SiteOperation
-	var progress *ops.ProgressEntry
-	// if operation ID is provided, get info for that operation, otherwise
-	// get info for the most recent operation
-	if operationID != "" {
-		operation, progress, err = ops.GetOperationWithProgress(
-			cluster.OperationKey(operationID), operator)
-	} else {
-		operation, progress, err = ops.GetLastCompletedOperation(
-			cluster.Key(), operator)
-	}
-	if err != nil {
-		return status, trace.Wrap(err)
-	}
-	status.Operation, err = fromOperationAndProgress(*operation, *progress)
-	if err != nil {
-		return status, trace.Wrap(err)
-	}
-
-	status.Agent, err = FromPlanetAgent(ctx, cluster.ClusterState.Servers)
-	if err != nil {
-		return status, trace.Wrap(err, "failed to collect system status from agents")
-	}
-
-	// Collect registered Teleport nodes.
-	teleportNodes, err := operator.GetClusterNodes(cluster.Key())
-	if err != nil {
-		return status, trace.Wrap(err, "failed to query teleport nodes")
-	}
-	for i, server := range status.Agent.Nodes {
-		status.Agent.Nodes[i].TeleportNode = ops.Nodes(teleportNodes).FindByIP(server.AdvertiseIP)
+	if err := fetchOperationByID(cluster.Key(), operationID, operator, status); err != nil {
+		logrus.WithError(err).WithField("operation-id", operationID).Warn("Failed to query operation.")
 	}
 
 	status.State = cluster.State
+	if status.IsDegraded() {
+		status.State = ops.SiteStateDegraded
+	}
 	return status, nil
 }
 
@@ -164,25 +134,6 @@ func FromPlanetAgent(ctx context.Context, servers []storage.Server) (*Agent, err
 // FromLocalPlanetAgent collects the node status from the local planet agent
 func FromLocalPlanetAgent(ctx context.Context) (*Agent, error) {
 	return fromPlanetAgent(ctx, true, nil)
-}
-
-func fromPlanetAgent(ctx context.Context, local bool, servers []storage.Server) (*Agent, error) {
-	status, err := planetAgentStatus(ctx, local)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to query cluster status from agent")
-	}
-
-	var nodes []ClusterServer
-	if len(servers) != 0 {
-		nodes = fromClusterState(*status, servers)
-	} else {
-		nodes = fromSystemStatus(*status)
-	}
-
-	return &Agent{
-		SystemStatus: SystemStatus(status.Status),
-		Nodes:        nodes,
-	}, nil
 }
 
 // WaitForAgent blocks until able to retrieve status from planet-agent on local node (ignoring the result)
@@ -336,15 +287,6 @@ func (e ApplicationsEndpoints) WriteTo(w io.Writer) (n int64, err error) {
 	return n, trace.NewAggregate(errors...)
 }
 
-func fprintf(n *int64, w io.Writer, format string, a ...interface{}) error {
-	written, err := fmt.Fprintf(w, format, a...)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	*n += int64(written)
-	return nil
-}
-
 // Key returns key structure that identifies this operation
 func (r ClusterOperation) Key() ops.SiteOperationKey {
 	return ops.SiteOperationKey{
@@ -424,6 +366,137 @@ type ClusterServer struct {
 
 func (r ClusterOperation) isFailed() bool {
 	return r.State == ops.OperationStateFailed
+}
+
+// String returns a textual representation of this system status
+func (r SystemStatus) String() string {
+	switch pb.SystemStatus_Type(r) {
+	case pb.SystemStatus_Running:
+		return "running"
+	case pb.SystemStatus_Degraded:
+		return "degraded"
+	case pb.SystemStatus_Unknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// GoString returns a textual representation of this system status
+func (r SystemStatus) GoString() string {
+	return r.String()
+}
+
+// SystemStatus is an alias for system status type
+type SystemStatus pb.SystemStatus_Type
+
+const (
+	// NodeHealthy is the status of a healthy node
+	NodeHealthy = "healthy"
+	// NodeOffline is the status of an unreachable/unavailable node
+	NodeOffline = "offline"
+	// NodeDegraged is the status of a node with failed probes
+	NodeDegraded = "degraded"
+
+	// publicIPAddrTag is the name of the tag containing node IP
+	publicIPAddrTag = "publicip"
+	// roleTag is the name of the tag containing node role
+	roleTag = "role"
+)
+
+func collectActiveOperations(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {
+	activeOperations, err := ops.GetActiveOperations(clusterKey, operator)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err, "failed to query active operations")
+	}
+	for _, op := range activeOperations {
+		progress, err := operator.GetSiteOperationProgress(op.Key())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		operation, err := fromOperationAndProgress(op, *progress)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		status.ActiveOperations = append(status.ActiveOperations, operation)
+	}
+	return nil
+}
+
+func fetchOperationByID(clusterKey ops.SiteKey, operationID string, operator ops.Operator, status *Status) error {
+	var (
+		operation *ops.SiteOperation
+		progress  *ops.ProgressEntry
+		err       error
+	)
+	// if operation ID is provided, get info for that operation, otherwise
+	// get info for the most recent operation
+	if operationID != "" {
+		opKey := ops.SiteOperationKey{
+			AccountID:   clusterKey.AccountID,
+			SiteDomain:  clusterKey.SiteDomain,
+			OperationID: operationID,
+		}
+		operation, progress, err = ops.GetOperationWithProgress(opKey, operator)
+	} else {
+		operation, progress, err = ops.GetLastCompletedOperation(clusterKey, operator)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	status.Operation, err = fromOperationAndProgress(*operation, *progress)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func updateClusterNodes(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {
+	// Collect registered Teleport nodes.
+	teleportNodes, err := operator.GetClusterNodes(clusterKey)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if status.Agent != nil {
+		for i, server := range status.Agent.Nodes {
+			status.Agent.Nodes[i].TeleportNode = ops.Nodes(teleportNodes).FindByIP(server.AdvertiseIP)
+		}
+		return nil
+	}
+	status.Agent = &Agent{
+		Nodes: make([]ClusterServer, 0, len(teleportNodes)),
+	}
+	// Recreate server state from teleport node metadata
+	for i, server := range teleportNodes {
+		status.Agent.Nodes = append(status.Agent.Nodes, ClusterServer{
+			Status:       NodeOffline,
+			Hostname:     server.Hostname,
+			AdvertiseIP:  server.AdvertiseIP,
+			Role:         server.Role,
+			Profile:      server.Profile,
+			TeleportNode: &teleportNodes[i],
+		})
+	}
+	return nil
+}
+
+func fromPlanetAgent(ctx context.Context, local bool, servers []storage.Server) (*Agent, error) {
+	status, err := planetAgentStatus(ctx, local)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to query cluster status from agent")
+	}
+
+	var nodes []ClusterServer
+	if len(servers) != 0 {
+		nodes = fromClusterState(*status, servers)
+	} else {
+		nodes = fromSystemStatus(*status)
+	}
+
+	return &Agent{
+		SystemStatus: SystemStatus(status.Status),
+		Nodes:        nodes,
+	}, nil
 }
 
 func fromOperationAndProgress(operation ops.SiteOperation, progress ops.ProgressEntry) (*ClusterOperation, error) {
@@ -565,7 +638,7 @@ func probeErrorDetail(p pb.Probe) string {
 		if err == nil {
 			return detail
 		}
-		logrus.Warnf(trace.DebugReport(err))
+		logrus.WithError(err).Warn("Failed to compose disk space probe error.")
 	}
 	detail := p.Detail
 	if p.Detail == "" {
@@ -614,38 +687,11 @@ func diskSpaceProbeErrorDetail(p pb.Probe) (string, error) {
 	return "", trace.BadParameter("probe does not have warning or critical severity")
 }
 
-// String returns a textual representation of this system status
-func (r SystemStatus) String() string {
-	switch pb.SystemStatus_Type(r) {
-	case pb.SystemStatus_Running:
-		return "running"
-	case pb.SystemStatus_Degraded:
-		return "degraded"
-	case pb.SystemStatus_Unknown:
-		return "unknown"
-	default:
-		return "unknown"
+func fprintf(n *int64, w io.Writer, format string, a ...interface{}) error {
+	written, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		return trace.ConvertSystemError(err)
 	}
+	*n += int64(written)
+	return nil
 }
-
-// GoString returns a textual representation of this system status
-func (r SystemStatus) GoString() string {
-	return r.String()
-}
-
-// SystemStatus is an alias for system status type
-type SystemStatus pb.SystemStatus_Type
-
-const (
-	// NodeHealthy is the status of a healthy node
-	NodeHealthy = "healthy"
-	// NodeOffline is the status of an unreachable/unavailable node
-	NodeOffline = "offline"
-	// NodeDegraged is the status of a node with failed probes
-	NodeDegraded = "degraded"
-
-	// publicIPAddrTag is the name of the tag containing node IP
-	publicIPAddrTag = "publicip"
-	// roleTag is the name of the tag containing node role
-	roleTag = "role"
-)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -513,6 +513,8 @@ func (r *Reason) Description() string {
 		return "application status check failed"
 	case ReasonClusterDegraded:
 		return "one or more of cluster nodes are not healthy"
+	case "":
+		return ""
 	default:
 		return "unknown reason"
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Backport of https://github.com/gravitational/gravity/pull/1707.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
* Refs https://github.com/gravitational/gravity/issues/1521, https://github.com/gravitational/gravity/issues/1641

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
 1. Install an arbitrary configuration multi-node cluster.
 1. flip agent on nodes to trigger cluster to degrade

### Status on the node with inactive planet agent:
Before
```
Cluster name:		<unknown>
Cluster status:		degraded
Gravity version:	5.5.48-dev.11 (client) / n/a (server)
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_expand (c51c6316-81e3-4ba3-870f-47f92557d7e7)
      started:		Mon Jun 15 20:46 UTC (15 hours ago)
      completed:	Mon Jun 15 20:48 UTC (15 hours ago)
Cluster endpoints:
    * Authentication gateway:
    * Cluster management URL:
```
After:
```
Cluster name:		dev.test
Cluster status:		degraded (one or more of cluster nodes are not healthy)
Application:		telekube, version 5.5.48-dev.11
Gravity version:	5.5.48-dev.11 (client) / 5.5.48-dev.11 (server)
Join token:		schmoken
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_expand (c51c6316-81e3-4ba3-870f-47f92557d7e7)
      started:		Mon Jun 15 20:46 UTC (15 hours ago)
      completed:	Mon Jun 15 20:48 UTC (15 hours ago)
Cluster endpoints:
    * Authentication gateway:
        - 10.128.0.18:32009
    * Cluster management URL:
        - https://10.128.0.18:32009
Cluster nodes:
    Masters:
        * dmitri-centos-node-0 (10.128.0.18, node)
            Status:		offline
            Remote access:	online
    Nodes:
        * dmitri-centos-node-1 (10.128.0.13, knode)
            Status:		offline
            Remote access:	online
```

## Additional information
<!--Optional. Anything else that may be relevant.-->
