### PR TITLE
Refactor release table.

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -1,42 +1,42 @@
 # Releases
 
-## Supported Releases
+## Supported Branches
 
-| Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
-| --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 7.0.9         | No  | June 16th, 2020      | 7.1 is released      | 1.17.6             | 3.2.13           |
-| 6.1.29        | Yes | June 12th, 2020      | November 10th, 2021  | 1.15.12            | 3.2.12           |
-| 5.5.48        | Yes | June 15th, 2020      | March 7th, 2021      | 1.13.11            | 3.0.6-gravity    |
+| Branch | LTS | Latest Release | Latest Release Date | Initial Release Date | End of Support          | Kubernetes Version   | Teleport Version |
+| ------ | --- | -------------- | ------------------- | -------------------- | ----------------------- | -------------------- | ---------------- |
+| 7.0    | No  | 7.0.9          | June 16, 2020       | April 3, 2020        | 7.1 is released         | 1.17.6               | 3.2.13           |
+| 6.1    | Yes | 6.1.29         | June 12, 2020       | August 2, 2019       | November 10, 2021       | 1.15.12              | 3.2.12           |
+| 5.5    | Yes | 5.5.48         | June 15, 2020       | March 8, 2019        | March 8, 2021           | 1.13.11              | 3.0.6-gravity    |
 
-Gravity offers one Long Term Support (LTS) release for every 2nd Kubernetes
+Gravity offers one Long Term Support (LTS) branch for every 2nd Kubernetes
 minor version, allowing for seamless upgrades per Kubernetes
 [supported version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-version-skew).
-LTS Gravity versions are supported with security and bug fixes for two years
-after the x.x.0 release date.
+Gravity LTS branches are supported with security and bug fixes for two years.
 
-Non-LTS (regular) versions of Gravity have the latest features and offer
-more current versions of Kubernetes. Regular versions of Gravity are supported
-with security and bug fixes until the subsequent Gravity release is published.
+Non-LTS (regular) branches of Gravity offer the latest features and include
+more current versions of Kubernetes. Regular branches of Gravity are supported
+with security and bug fixes until first release of the subsequent Gravity
+branch is published.
 
-## Unsupported Releases
+## Unsupported Branches
 
-These releases are past their End of Life date, and no longer receive security
+These branches are past their End of Support date, and no longer receive security
 and bug fixes. [Gravity customers](https://gravitational.com/gravity/demo/) can
-extend updates past EOL through customer agreements if required.
+extend updates past End of Support through customer agreements if required.
 
-| Release       | LTS | Release Date         | Supported Until      | Kubernetes Version | Teleport Version |
-| --------------|-----| -------------------- | -------------------- | ------------------ |------------------|
-| 6.3.18        | No  | June 1st, 2020       | April 3rd, 2020      | 1.17.6             | 3.2.13           |
-| 6.2.5         | No  | December 3rd, 2019   | December 18th, 2019  | 1.16.3             | 3.2.13           |
-| 6.0.10        | No  | October 17th, 2019   | August 2nd, 2019     | 1.14.7             | 3.2.12           |
-| 5.6.8         | No  | September 18th, 2019 | July 17th, 2019      | 1.14.7             | 3.0.6-gravity    |
-| 5.4.10        | No  | March 26th, 2019     | March 8th, 2019      | 1.13.5             | 2.4.10           |
-| 5.3.9         | No  | March 7th, 2019      | December 14, 2018    | 1.12.3             | 2.4.7            |
-| 5.2.17        | Yes | June 11th, 2020      | October 15th, 2019   | 1.11.9             | 2.4.10           |
-| 5.0.36        | Yes | June 8th, 2020       | April 13th, 2019     | 1.9.13-gravitational | 2.4.10         |
-| 4.68.0        | Yes | January 17th, 2019   | November 16th, 2018  | 1.7.18-gravitational | 2.3.5          |
-| 3.64.0        | Yes | December 21st, 2017  | June 2nd, 2018       | 1.5.7              | 2.0.6            |
-| 1.30.0        | Yes | March 21st, 2017     | March 21st, 2018     | 1.3.8              | 1.2.0            |
+| Branch | LTS | Latest Release | Latest Release Date | Initial Release Date | End of Support          | Kubernetes Version   | Teleport Version |
+| ------ | --- | -------------- | ------------------- | -------------------- | ----------------------- |--------------------- |------------------|
+| 6.3    | No  | 6.3.18         | June 1, 2020        | December 18, 2019    | April 3, 2020 (7.0)     | 1.17.6               | 3.2.13           |
+| 6.2    | No  | 6.2.5          | December 3, 2019    | September 24, 2019   | December 18, 2019 (6.3) | 1.16.3               | 3.2.13           |
+| 6.0    | No  | 6.0.10         | October 17, 2019    | July 17, 2019        | August 2, 2019 (6.1)    | 1.14.7               | 3.2.12           |
+| 5.6    | No  | 5.6.8          | September 18, 2019  | April 19, 2019       | July 17, 2019 (6.0)     | 1.14.7               | 3.0.6-gravity    |
+| 5.4    | No  | 5.4.10         | March 26, 2019      | December 14, 2018    | March 8, 2019 (5.5)     | 1.13.5               | 2.4.10           |
+| 5.3    | No  | 5.3.9          | March 7, 2019       | October 19, 2018     | December 14, 2018 (5.4) | 1.12.3               | 2.4.7            |
+| 5.2    | Yes | 5.2.17         | June 11, 2020       | October 15, 2018     | October 15, 2019        | 1.11.9               | 2.4.10           |
+| 5.0    | Yes | 5.0.36         | June 8, 2020        | April 18, 2018       | April 13, 2019          | 1.9.13-gravitational | 2.4.10           |
+| 4.x    | Yes | 4.68.0         | January 17, 2019    | June 1, 2017         | November 16, 2018       | 1.7.18-gravitational | 2.3.5            |
+| 3.x    | Yes | 3.64.0         | December 21, 2017   | February 16, 2017    | June 2, 2018            | 1.5.7                | 2.0.6            |
+| 1.x    | Yes | 1.30.0         | March 21, 2017      | November 2nd, 2016   | March 21, 2018          | 1.3.8                | 1.2.0            |
 
 # Release Notes
 


### PR DESCRIPTION
## Description
Drawing from the discussion at #352, this patch tries to clarify a couple
confusing things about our release table:

 1) Releases that had a release date after their "Supported Until"
    didn't make any sense. Now they have the context of a distinction
    between a branch and a release, and when the first release on
    on the branch came out (which will always be before "End of
    Support").

 2) I tried to formalize language around "branch" vs "release".
    Previously we used release to mean both an individual tagged
    release, and the line of development it was associated with.
    This was confusing as 7.0 will be "a LTS Release" but 7.0.9 is
    not "a LTS release" because it is pre-LTS-ification of 7.0.
    Honestly, this is still pretty confusing (7.0 probably should have
    been LTS all along), but at least the branch metaphor aligns with
    what is happening behind the scenes.

## Type of change
<!--Required. Keep only those that apply.-->
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
Contributes to #352.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
`make run-docs` and captured the following screenshot:

![image](https://user-images.githubusercontent.com/187314/85073064-fac5b000-b16e-11ea-9436-5d97d09ef212.png)

