### PR TITLE
[7.0.x] sort inputs before computing the difference

### DIFF
--- a/lib/schema/diff.go
+++ b/lib/schema/diff.go
@@ -35,6 +35,8 @@ func DiffPorts(old, new Manifest, profileName string) (tcp, udp []int, err error
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+	sort.Sort(sort.IntSlice(oldTCP))
+	sort.Sort(sort.IntSlice(oldUDP))
 
 	newProfile, err := new.NodeProfiles.ByName(profileName)
 	if err != nil {
@@ -45,6 +47,8 @@ func DiffPorts(old, new Manifest, profileName string) (tcp, udp []int, err error
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+	sort.Sort(sort.IntSlice(tcp))
+	sort.Sort(sort.IntSlice(udp))
 
 	commonTCP := append(oldTCP, tcp...)
 	commonUDP := append(oldUDP, udp...)

--- a/lib/schema/diff_test.go
+++ b/lib/schema/diff_test.go
@@ -40,7 +40,7 @@ func (_ *DiffSuite) TestDiffsPorts(c *C) {
 			new: Requirements{
 				Network: Network{Ports: []Port{
 					{Protocol: "tcp", Ranges: []string{"3000-3199"}},
-					{Protocol: "udp", Ranges: []string{"3200", "3202"}},
+					{Protocol: "udp", Ranges: []string{"3202", "3200"}},
 				}}},
 			tcp:     newArray(3100, 3199),
 			udp:     []int{3202},
@@ -49,16 +49,16 @@ func (_ *DiffSuite) TestDiffsPorts(c *C) {
 		{
 			old: Requirements{
 				Network: Network{Ports: []Port{
-					{Protocol: "tcp", Ranges: []string{"3000-3009", "2099"}},
-					{Protocol: "udp", Ranges: []string{"3200", "1099"}},
+					{Protocol: "tcp", Ranges: []string{"2099", "3000-3009", "1098"}},
+					{Protocol: "udp", Ranges: []string{"1099", "3200", "2002"}},
 				}}},
 			new: Requirements{
 				Network: Network{Ports: []Port{
-					{Protocol: "tcp", Ranges: []string{"3000-3009", "3199"}},
-					{Protocol: "udp", Ranges: []string{"3200", "3201"}},
+					{Protocol: "tcp", Ranges: []string{"3000-3009", "3199", "1098"}},
+					{Protocol: "udp", Ranges: []string{"3200", "3201", "1098"}},
 				}}},
 			tcp:     []int{3199},
-			udp:     []int{3201},
+			udp:     []int{1098, 3201},
 			comment: "do not account for ports found only in old",
 		},
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Update the difference compute function to take unordered sequences into account.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1655
* Ports https://github.com/gravitational/gravity/pull/1656

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
So far, I've rearranged the unit test data to be unorderd.
Before:
```
$ go test ./lib/schema/...
----------------------------------------------------------------------
FAIL: diff_test.go:27: DiffSuite.TestDiffsPorts

diff_test.go:77:
    c.Assert(udp, DeepEquals, testCase.udp, Commentf(testCase.comment))
... obtained []int = []int{3200, 3202}
... expected []int = []int{3202}
... compute difference
... Difference:
...     []int[2] != []int[1]


OOPS: 21 passed, 1 FAILED
--- FAIL: TestSchema (0.01s)
FAIL
FAIL	github.com/gravitational/gravity/lib/schema	0.031s
?   	github.com/gravitational/gravity/lib/schema/defaults	[no test files]
?   	github.com/gravitational/gravity/lib/schema/unversioned	[no test files]
?   	github.com/gravitational/gravity/lib/schema/v1	[no test files]
```
After:
```
$ go test ./lib/schema/...
ok  	github.com/gravitational/gravity/lib/schema	0.033s
?   	github.com/gravitational/gravity/lib/schema/defaults	[no test files]
?   	github.com/gravitational/gravity/lib/schema/unversioned	[no test files]
?   	github.com/gravitational/gravity/lib/schema/v1	[no test files]
```

## Additional information
<!--Optional. Anything else that may be relevant.-->
