### PR TITLE
[6.1.x] backport RPC credentials rotation from 5.5.x

### DIFF
--- a/lib/app/docker/imageservice.go
+++ b/lib/app/docker/imageservice.go
@@ -138,14 +138,9 @@ func newImageService(req RegistryConnectionRequest) (*imageService, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Strip the scheme prefix if specified in the address as we manipulate
-	// the registry address without the URL scheme when wrapping/unwrapping image references
-	registryPrefix := strings.TrimPrefix(req.RegistryAddress, "http://")
-	registryPrefix = strings.TrimPrefix(registryPrefix, "https://")
 	return &imageService{
 		RegistryConnectionRequest: req,
 		FieldLogger:               log.WithField("registry", req.RegistryAddress),
-		registryPrefix:            registryPrefix,
 	}, nil
 }
 
@@ -171,8 +166,7 @@ type imageService struct {
 	RegistryConnectionRequest
 	log.FieldLogger
 
-	remoteStore    *remoteStore
-	registryPrefix string
+	remoteStore *remoteStore
 }
 
 // Sync synchronizes the contents of the local directory specified with dir
@@ -284,7 +278,7 @@ func (r *imageService) Wrap(image string) string {
 	if err != nil {
 		return image
 	}
-	parsed.Registry = r.registryPrefix
+	parsed.Registry = r.RegistryAddress
 	return parsed.String()
 }
 
@@ -292,7 +286,7 @@ func (r *imageService) Wrap(image string) string {
 // Its function is the inverse of Wrap.
 func (r *imageService) Unwrap(image string) (unwrapped string) {
 	unwrapped = TagFromString(image).String()
-	return strings.TrimPrefix(unwrapped, fmt.Sprintf("%v/", r.registryPrefix))
+	return strings.TrimPrefix(unwrapped, fmt.Sprintf("%v/", r.RegistryAddress))
 }
 
 func (r *imageService) connect(ctx context.Context) (err error) {

--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -498,15 +497,6 @@ func (h *WebHandler) exportApp(w http.ResponseWriter, req *http.Request,
 	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		return trace.Wrap(err)
 	}
-	_, _, err = net.SplitHostPort(config.RegistryHostPort)
-	if config.RegistryHostPort == "" || err != nil {
-		message := "invalid host:port value"
-		if err != nil {
-			message = err.Error()
-		}
-		return trace.BadParameter("registryHostPort: %v", message)
-	}
-
 	if err = context.applications.ExportApp(app.ExportAppRequest{
 		Package:         *locator,
 		RegistryAddress: config.RegistryHostPort,

--- a/lib/app/handler/handler_test.go
+++ b/lib/app/handler/handler_test.go
@@ -72,7 +72,7 @@ func (r *HandlerSuite) SetUpTest(c *C) {
 	r.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(r.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(r.dir)
+	objects, err := fs.New(fs.Config{Path: r.dir})
 	c.Assert(err, IsNil)
 
 	clock := &timetools.FreezedTime{

--- a/lib/app/handler/handler_test.go
+++ b/lib/app/handler/handler_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package handler
 
 import (
-	"crypto/tls"
-	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
@@ -133,16 +131,13 @@ func (r *HandlerSuite) SetUpTest(c *C) {
 		})
 		c.Assert(err, IsNil)
 
-		r.server = httptest.NewServer(handler)
+		// It is important that we launch TLS server as authentication
+		// middleware on the handler expects TLS connections.
+		r.server = httptest.NewTLSServer(handler)
 
 		apps, err := client.NewAuthenticatedClient(
 			r.server.URL, r.user.GetName(), "admin-password",
-			client.HTTPClient(&http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					}}}),
-		)
+			client.HTTPClient(r.server.Client()))
 		c.Assert(err, IsNil)
 		return apps
 	}

--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -35,7 +35,12 @@ import (
 
 // exportLayers exports the layers of the specified set of images into
 // the specified local directory
-func exportLayers(ctx context.Context, dir string, images []string, dockerClient docker.DockerInterface, log log.FieldLogger,
+func exportLayers(
+	ctx context.Context,
+	dir string,
+	images []string,
+	dockerClient docker.DockerInterface,
+	log log.FieldLogger,
 	parallel int, progress utils.Progress) error {
 	layerExporter, err := newLayerExporter(dir, dockerClient, log, progress)
 	if err != nil {

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -92,7 +92,6 @@ func (r *applications) getClusterInstaller(
 //  * import {web-assets,gravity,dns,teleport,planet-master,planet-node,application}
 //    packages from application package service into local package service running
 //    in ./packages
-//
 func (r *applications) GetAppInstaller(req appservice.InstallerRequest) (installer io.ReadCloser, err error) {
 	if err := req.Check(); err != nil {
 		return nil, trace.Wrap(err)
@@ -118,7 +117,9 @@ func (r *applications) GetAppInstaller(req appservice.InstallerRequest) (install
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(filepath.Join(tempDir, defaults.PackagesDir))
+	objects, err := fs.New(fs.Config{
+		Path: filepath.Join(tempDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/service/pull_test.go
+++ b/lib/app/service/pull_test.go
@@ -165,7 +165,7 @@ func setupServices(c *C) (storage.Backend, pack.PackageService, *applications) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/app/suite/suite.go
+++ b/lib/app/suite/suite.go
@@ -206,7 +206,7 @@ spec:
 	c.Assert(err, IsNil)
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: dockerRegistryAddr,
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -266,7 +266,7 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: dockerRegistryAddr,
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 	apps := r.NewService(c, dockerClient, imageService)
@@ -275,10 +275,9 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	c.Assert(err, IsNil)
 	application := r.importApplication(apps, vendorer, c)
 
-	registryAddr := fmt.Sprintf("http://%v", registry.Addr())
+	registryAddr := registryAddr(registry.Addr())
 	c.Assert(apps.ExportApp(app.ExportAppRequest{
-		Package: application.Package,
-		// For tests, registry runs in insecure mode
+		Package:         application.Package,
 		RegistryAddress: registryAddr,
 	}), IsNil)
 
@@ -621,7 +620,7 @@ func (r *AppsSuite) Charts(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: dockerRegistryAddr,
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -686,7 +685,7 @@ registry:
 	c.Assert(files["resources/charts/mattermost/values.yaml"], Equals, valuesBytes)
 	c.Assert(files["resources/charts/mattermost/templates/pod.yaml"], Equals, templateBytes)
 
-	registryAddr := fmt.Sprintf("http://%v", registry.Addr())
+	registryAddr := registryAddr(registry.Addr())
 	// alpine was referenced as a part of helm template,
 	// but make sure helm template has captured it
 	// and added to the list of vendored apps
@@ -886,5 +885,6 @@ spec:
 	return importedApplication
 }
 
-// dockerRegistryAddr specifies the address of local registry for tests
-var dockerRegistryAddr = fmt.Sprintf("http://%v", constants.DockerRegistry)
+func registryAddr(addr string) string {
+	return fmt.Sprintf("http://%v", addr)
+}

--- a/lib/blob/fs/fs.go
+++ b/lib/blob/fs/fs.go
@@ -27,17 +27,19 @@ import (
 
 	"github.com/gravitational/gravity/lib/blob"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/systeminfo"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
 
-func New(path string) (blob.Objects, error) {
-	if path == "" {
-		return nil, trace.BadParameter("missing Path parameter")
+// New creates a new instance of the local fs blob service
+func New(config Config) (blob.Objects, error) {
+	if err := config.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	o := &objects{dir: path}
-	for _, d := range []string{o.tempDir(), o.blobDir()} {
+	o := &objects{config: config}
+	for _, d := range []string{config.tempDir(), config.blobDir()} {
 		if err := os.MkdirAll(d, defaults.SharedDirMask); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -45,16 +47,31 @@ func New(path string) (blob.Objects, error) {
 	return o, nil
 }
 
+// Config defines the blob service configuration
+type Config struct {
+	// Path specifies the directory for blobs
+	Path string
+	// User optionally specifies the user context for file operations
+	User *systeminfo.User
+}
+
+func (r *Config) checkAndSetDefaults() error {
+	if r.Path == "" {
+		return trace.BadParameter("missing Path parameter")
+	}
+	return nil
+}
+
+func (r Config) tempDir() string {
+	return filepath.Join(r.Path, "tmp")
+}
+
+func (r Config) blobDir() string {
+	return filepath.Join(r.Path, "blobs")
+}
+
 type objects struct {
-	dir string
-}
-
-func (o *objects) tempDir() string {
-	return filepath.Join(o.dir, "tmp")
-}
-
-func (o *objects) blobDir() string {
-	return filepath.Join(o.dir, "blobs")
+	config Config
 }
 
 // hashDir helps us to organize the blobs in the folder -
@@ -63,7 +80,7 @@ func (o *objects) blobDir() string {
 // of the sha512 hash - this will allow to scale in cases
 // when there are too many files in one directory
 func (o *objects) hashDir(h string) string {
-	return filepath.Join(o.blobDir(), h[0:3])
+	return filepath.Join(o.config.blobDir(), h[0:3])
 }
 
 func (o *objects) Close() error {
@@ -73,7 +90,7 @@ func (o *objects) Close() error {
 // GetBLOBs returns a list of BLOBs in the storage
 func (o *objects) GetBLOBs() ([]string, error) {
 	var out []string
-	blobDir := o.blobDir()
+	blobDir := o.config.blobDir()
 	err := filepath.Walk(blobDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Warningf("error while traversing %v: %v", blobDir, err)
@@ -97,12 +114,14 @@ func (o *objects) GetBLOBs() ([]string, error) {
 func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	// step1 : write data and compute it's hash to the temporary file,
 	// then move it to the proper location based on it's hash
-	f, err := ioutil.TempFile(o.tempDir(), "blob")
+	f, err := ioutil.TempFile(o.config.tempDir(), "blob")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer f.Close()
 
+	// if true, sets proper directory/file ownership.
+	hasUser := o.config.User != nil && os.Geteuid() != o.config.User.UID
 	hasher := sha512.New()
 	w := io.MultiWriter(f, hasher)
 	size, err := io.Copy(w, data)
@@ -119,14 +138,28 @@ func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	hash := fmt.Sprintf("%x", hasher.Sum(nil)[:sha512.Size/2])
 	targetDir := o.hashDir(hash)
 	if err := os.MkdirAll(targetDir, defaults.SharedDirMask); err != nil {
+		// This will fail as expected if the command is not run as root or
+		// under a different user context
 		defer os.Remove(f.Name())
 		return nil, trace.Wrap(err)
+	}
+	if hasUser {
+		if err := os.Chown(targetDir, o.config.User.UID, o.config.User.GID); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	// now place it to the right place in the filesystem
 	targetPath := filepath.Join(targetDir, hash)
 	if err := os.Rename(f.Name(), targetPath); err != nil {
 		defer os.Remove(f.Name())
 		return nil, trace.Wrap(err)
+	}
+	if hasUser {
+		// This will fail as expected if the command is not run as root or
+		// under a different user context
+		if err := os.Chown(targetPath, o.config.User.UID, o.config.User.GID); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	fileInfo, err := os.Stat(targetPath)
 	if err != nil {

--- a/lib/blob/fs/fs_test.go
+++ b/lib/blob/fs/fs_test.go
@@ -39,7 +39,7 @@ func (s *FSSuite) SetUpTest(c *C) {
 	log.SetOutput(os.Stderr)
 	s.dir = c.MkDir()
 
-	obj, err := New(s.dir)
+	obj, err := New(Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.suite.Objects = obj

--- a/lib/blob/handler/blobhandler_test.go
+++ b/lib/blob/handler/blobhandler_test.go
@@ -69,7 +69,7 @@ func (s *HandlerSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -381,7 +381,7 @@ func (b *Builder) initServices() (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	objects, err := blobfs.New(filepath.Join(b.Dir, defaults.PackagesDir))
+	objects, err := blobfs.New(blobfs.Config{Path: filepath.Join(b.Dir, defaults.PackagesDir)})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1156,6 +1156,9 @@ var (
 	// TeleportVersion specifies the version of the bundled teleport package as a semver
 	TeleportVersion = semver.New(TeleportVersionString)
 
+	// DockerRegistry is a default name for private docker registry
+	DockerRegistry = DockerRegistryAddr("leader.telekube.local")
+
 	// MetricsInterval is the default interval cluster metrics are displayed for.
 	MetricsInterval = time.Hour
 	// MetricsStep is the default interval b/w cluster metrics data points.

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -130,7 +130,7 @@ func NewAgentStop(p fsm.ExecutorParams, operator ops.Operator, packages pack.Pac
 		Key:      opKey(p.Plan),
 		Operator: operator,
 	}
-	credentials, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	credentials, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/fsm/rpc.go
+++ b/lib/fsm/rpc.go
@@ -246,13 +246,18 @@ func IsMasterServer(server storage.Server) bool {
 	return server.ClusterRole == string(schema.ServiceRoleMaster)
 }
 
-// GetClientCredentials returns the RPC credentials for an update operation
+// GetClientCredentials reads the RPC credentials for an update operation from a predefined directory.
+//
+// The reason credentials are not read from the cluster package service is that
+// during certain operations (cluster upgrades, cluster or environment configuration updates), the etcd backend
+// might be temporarily inaccessible between commands hence in this mode, the credentials
+// are cached on disk.
 func GetClientCredentials() (credentials.TransportCredentials, error) {
 	secretsDir, err := AgentSecretsDir()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	creds, err := rpc.ClientCredentials(secretsDir)
+	creds, err := rpc.ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/phases/app.go
+++ b/lib/install/phases/app.go
@@ -48,7 +48,7 @@ func NewHook(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications,
 		return nil, trace.BadParameter("service user is required")
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -51,7 +51,7 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		return nil, trace.BadParameter("application package is required: %#v", p.Phase.Data)
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -91,7 +91,6 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		ExecutorParams:   p,
 		ServiceUser:      *serviceUser,
 		remote:           remote,
-		dnsConfig:        p.Plan.DNSConfig,
 	}, nil
 }
 
@@ -108,8 +107,6 @@ type bootstrapExecutor struct {
 	ServiceUser systeminfo.User
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
-	// dnsConfig specifies local cluster DNS configuration to set
-	dnsConfig storage.DNSConfig
 	// remote specifies the server remote control interface
 	remote fsm.Remote
 }
@@ -138,7 +135,7 @@ func (p *bootstrapExecutor) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.configureDNS()
+	err = p.configureSystemMetadata()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -236,7 +233,7 @@ func (p *bootstrapExecutor) configureSystemDirectories() error {
 		out, err := exec.Command("chown", "-R", fmt.Sprintf("%v:%v",
 			p.ServiceUser.UID, p.ServiceUser.GID), dir).CombinedOutput()
 		if err != nil {
-			return trace.Wrap(err, "failed to chmod %v: %s", dir, out)
+			return trace.Wrap(err, "failed to chown %v: %s", dir, out)
 		}
 	}
 	chmodList := []string{
@@ -281,10 +278,10 @@ func (p *bootstrapExecutor) configureApplicationVolumes() error {
 		uid, gid := mount.UID, mount.GID
 		if !existingDir {
 			if uid == nil {
-				uid = utils.IntPtr(defaults.ServiceUID)
+				uid = utils.IntPtr(p.ServiceUser.UID)
 			}
 			if gid == nil {
-				gid = utils.IntPtr(defaults.ServiceGID)
+				gid = utils.IntPtr(p.ServiceUser.GID)
 			}
 		}
 		// Only chown directories/files if necessary
@@ -322,13 +319,47 @@ func (p *bootstrapExecutor) logIntoCluster() error {
 	return nil
 }
 
-// configureDNS creates local cluster DNS configuration
+func (p *bootstrapExecutor) configureSystemMetadata() error {
+	if err := p.configureDNS(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.configureNodeAddr(); err != nil {
+		return trace.Wrap(err)
+	}
+	return p.configureServiceUser()
+}
+
+// configureDNS creates local cluster DNS configuration in local state database
 func (p *bootstrapExecutor) configureDNS() error {
-	err := p.LocalBackend.SetDNSConfig(p.dnsConfig)
+	err := p.LocalBackend.SetDNSConfig(p.Plan.DNSConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	p.Infof("Created DNS configuration: %v.", p.dnsConfig)
+	p.Infof("Created DNS configuration: %v.", p.Plan.DNSConfig)
+	return nil
+}
+
+// configureNodeAddr persists the node advertise IP in local state database
+func (p *bootstrapExecutor) configureNodeAddr() error {
+	err := p.LocalBackend.SetNodeAddr(p.Phase.Data.Server.AdvertiseIP)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Set node address: %v.", p.Phase.Data.Server.AdvertiseIP)
+	return nil
+}
+
+// configureServiceUser persists the service user in local state database
+func (p *bootstrapExecutor) configureServiceUser() error {
+	err := p.LocalBackend.SetServiceUser(storage.OSUser{
+		Name: p.ServiceUser.Name,
+		UID:  strconv.Itoa(p.ServiceUser.UID),
+		GID:  strconv.Itoa(p.ServiceUser.GID),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Set service user: %v.", p.ServiceUser)
 	return nil
 }
 
@@ -357,22 +388,4 @@ func opKey(plan storage.OperationPlan) ops.SiteOperationKey {
 		SiteDomain:  plan.ClusterName,
 		OperationID: plan.OperationID,
 	}
-}
-
-func userFromOSUser(user storage.OSUser) (*systeminfo.User, error) {
-	uid, err := strconv.Atoi(user.UID)
-	if err != nil {
-		return nil, trace.BadParameter("expected a numeric UID but got %v", user.UID)
-	}
-
-	gid, err := strconv.Atoi(user.GID)
-	if err != nil {
-		return nil, trace.BadParameter("expected a numeric GID but got %v", user.GID)
-	}
-
-	return &systeminfo.User{
-		Name: user.Name,
-		UID:  uid,
-		GID:  gid,
-	}, nil
 }

--- a/lib/install/phases/pull.go
+++ b/lib/install/phases/pull.go
@@ -47,7 +47,7 @@ func NewPull(p fsm.ExecutorParams, operator ops.Operator, wizardPack, localPack 
 		return nil, trace.BadParameter("service user is required")
 	}
 
-	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
+	serviceUser, err := systeminfo.FromOSUser(*p.Phase.Data.ServiceUser)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -216,7 +216,7 @@ func LoadRPCCredentials(ctx context.Context, packages pack.PackageService) (*rpc
 
 // ClientCredentials returns the contents of the default RPC credentials package
 func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
-	clientCreds, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	clientCreds, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch RPC credentials")
 	}

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -18,10 +18,13 @@ package localenv
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/blob"
+	libcluster "github.com/gravitational/gravity/lib/blob/cluster"
 	"github.com/gravitational/gravity/lib/blob/fs"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/ops/opsservice"
@@ -29,10 +32,11 @@ import (
 	"github.com/gravitational/gravity/lib/pack/localpack"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
+	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/users/usersservice"
-	"github.com/gravitational/teleport/lib/events"
 
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/kubernetes"
 )
@@ -42,17 +46,32 @@ import (
 func (r *LocalEnvironment) NewClusterEnvironment(opts ...ClusterEnvironmentOption) (*ClusterEnvironment, error) {
 	client, _, err := httplib.GetClusterKubeClient(r.DNS.Addr())
 	if err != nil {
-		log.Errorf("Failed to create Kubernetes client: %v.",
-			trace.DebugReport(err))
+		log.WithError(err).Warn("Failed to create Kubernetes client.")
+	}
+	user, err := r.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.FromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := r.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
 	}
 	auditLog, err := r.AuditLog(context.TODO())
 	if err != nil {
-		log.Warnf("Failed to create audit log: %v.",
-			trace.DebugReport(err))
+		log.WithError(err).Warn("Failed to create audit log.")
 	}
 	config := clusterEnvironmentConfig{
-		client:   client,
-		auditLog: auditLog,
+		client:      client,
+		auditLog:    auditLog,
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
 	}
 	for _, opt := range opts {
 		opt(&config)
@@ -82,7 +101,33 @@ type ClusterEnvironment struct {
 // returns a new instance of cluster environment.
 // The resulting environment will not have a kubernetes client
 func NewClusterEnvironment() (*ClusterEnvironment, error) {
-	return newClusterEnvironment(clusterEnvironmentConfig{})
+	stateDir, err := LocalGravityDir()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := New(stateDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := env.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.FromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := env.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	return newClusterEnvironment(clusterEnvironmentConfig{
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
+	})
 }
 
 // WithClient is an option to override the kubernetes client to use
@@ -120,9 +165,37 @@ func newClusterEnvironment(config clusterEnvironmentConfig) (*ClusterEnvironment
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(packagesDir)
+	localObjects, err := fs.New(fs.Config{
+		Path: packagesDir,
+		User: config.serviceUser,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	var objects blob.Objects
+	if config.nodeAddr == "" {
+		objects, err = fs.New(fs.Config{Path: packagesDir})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// To be able to use cluster-level package service,
+		// a node address is required. This is not available on nodes prior to upgrade
+		// with an version that did not support the necessary system metadata (node address
+		// and service user).
+		// This is normally not a problem as the cluster-level package service is not required
+		// during the upgrade.
+		objects, err = libcluster.New(libcluster.Config{
+			Local:         localObjects,
+			WriteFactor:   1,
+			Backend:       backend,
+			ID:            config.nodeAddr,
+			AdvertiseAddr: fmt.Sprintf("https://%v", config.nodeAddr),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unpackedDir, err := SiteUnpackedDir()
@@ -197,5 +270,7 @@ type clusterEnvironmentConfig struct {
 	// Falls back to defaults.EtcdRetryInterval if unspecified
 	etcdTimeout time.Duration
 	// auditLog provides API to the cluster audit log
-	auditLog events.IAuditLog
+	auditLog    events.IAuditLog
+	serviceUser *systeminfo.User
+	nodeAddr    string
 }

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -189,7 +189,9 @@ func (env *LocalEnvironment) init() error {
 		env.DNS = DNSConfig(*dns)
 	}
 
-	env.Objects, err = fs.New(filepath.Join(env.StateDir, defaults.PackagesDir))
+	env.Objects, err = fs.New(fs.Config{
+		Path: filepath.Join(env.StateDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/testhelpers.go
+++ b/lib/ops/opsservice/testhelpers.go
@@ -74,7 +74,7 @@ func SetupTestServices(c *check.C) TestServices {
 	backend, err := keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(dir, "bolt.db")})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, check.IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/pack/layerpack/layer_test.go
+++ b/lib/pack/layerpack/layer_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/timetools"
+	log "github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -63,9 +63,9 @@ func (s *LayerSuite) SetUpTest(c *C) {
 	s.outerBackend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(outerDir, "storage.db")})
 	c.Assert(err, IsNil)
 
-	innerObjects, err := fs.New(innerDir)
+	innerObjects, err := fs.New(fs.Config{Path: innerDir})
 	c.Assert(err, IsNil)
-	outerObjects, err := fs.New(outerDir)
+	outerObjects, err := fs.New(fs.Config{Path: outerDir})
 	c.Assert(err, IsNil)
 
 	inner, err := localpack.New(localpack.Config{

--- a/lib/pack/localpack/local_test.go
+++ b/lib/pack/localpack/local_test.go
@@ -64,7 +64,7 @@ func (s *LocalSuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.server, err = New(Config{

--- a/lib/pack/webpack/webpack_test.go
+++ b/lib/pack/webpack/webpack_test.go
@@ -78,7 +78,7 @@ func (s *WebpackSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -70,7 +70,9 @@ func newImporter(dir string) (*importer, error) {
 		}),
 	}
 	err = func() error {
-		objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
+		objects, err := fs.New(fs.Config{
+			Path: filepath.Join(dir, defaults.PackagesDir),
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -216,7 +216,9 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := blobfs.New(filepath.Join(cfg.DataDir, defaults.PackagesDir))
+	objects, err := blobfs.New(blobfs.Config{
+		Path: filepath.Join(cfg.DataDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -250,6 +252,7 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	clusterObjects.Start()
 
 	packages, err := localpack.New(localpack.Config{
 		Backend:     backend,
@@ -479,7 +482,7 @@ func (p *Process) ImportState(importDir string) (err error) {
 
 // InitRPCCredentials initializes the package with RPC secrets
 func (p *Process) InitRPCCredentials() error {
-	pkg, err := rpc.InitRPCCredentials(p.packages)
+	pkg, err := rpc.InitCredentials(p.packages)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err, "failed to init RPC credentials")
 	}
@@ -1196,7 +1199,9 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		objects, err := blobfs.New(filepath.Join(p.cfg.Pack.ReadDir, defaults.PackagesDir))
+		objects, err := blobfs.New(blobfs.Config{
+			Path: filepath.Join(p.cfg.Pack.ReadDir, defaults.PackagesDir),
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/process/process_test.go
+++ b/lib/process/process_test.go
@@ -299,7 +299,7 @@ func (s *importerSuite) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, check.IsNil)
 
 	s.pack, err = localpack.New(localpack.Config{

--- a/lib/rpc/tls.go
+++ b/lib/rpc/tls.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
@@ -35,11 +36,22 @@ import (
 	"github.com/gravitational/license/authority"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
 )
 
-// InitRPCCredentials creates a package with RPC secrets in the specified package service
-func InitRPCCredentials(packages pack.PackageService) (*loc.Locator, error) {
+// LoadCredentialsData returns an io.Reader into the credentials package.
+// Caller is responsible for closing the returned reader
+func LoadCredentialsData(packages pack.PackageService) (env *pack.PackageEnvelope, rc io.ReadCloser, err error) {
+	env, rc, err = packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return env, rc, nil
+}
+
+// InitCredentials creates a package with RPC secrets in the specified package service
+func InitCredentials(packages pack.PackageService) (*loc.Locator, error) {
 	longLivedClient := true
 	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
 	if err != nil {
@@ -87,8 +99,11 @@ func CredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Loc
 
 // GenerateAgentCredentialsPackage creates or updates a package in packages with client/server credentials.
 // pkgTemplate specifies the naming template for the resulting package
-func GenerateAgentCredentialsPackage(packages pack.PackageService, pkgTemplate loc.Locator,
-	archive utils.TLSArchive) (secretsLocator *loc.Locator, err error) {
+func GenerateAgentCredentialsPackage(
+	packages pack.PackageService,
+	pkgTemplate loc.Locator,
+	archive utils.TLSArchive,
+) (secretsLocator *loc.Locator, err error) {
 	secretsLocator, err = loc.NewLocator(
 		pkgTemplate.Repository,
 		defaults.RPCAgentSecretsPackage,
@@ -100,7 +115,6 @@ func GenerateAgentCredentialsPackage(packages pack.PackageService, pkgTemplate l
 	if err != nil {
 		return secretsLocator, trace.Wrap(err)
 	}
-
 	return secretsLocator, nil
 }
 
@@ -159,22 +173,47 @@ func GenerateAgentCredentials(hosts []string, commonName string, longLivedClient
 	return archive, nil
 }
 
-// Credentials returns both server and client credentials read from the
-// specified directory
-func Credentials(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
-	server, err = ServerCredentials(secretsDir)
+// CredentialsFromDir returns both server and client credentials read from the
+// specified secrets dir
+func CredentialsFromDir(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	server, err = ServerCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	client, err = ClientCredentials(secretsDir)
+	client, err = ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	return server, client, nil
 }
 
-// ClientCredentials loads the client agent credentials from the specified location
-func ClientCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// Credentials returns both server and client credentials read from the
+// specified package service
+func Credentials(packages pack.PackageService) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	tlsArchive, err := utils.ReadTLSArchive(reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	server, err = ServerCredentialsFromKeyPairs(*tlsArchive[pb.Server],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	client, err = ClientCredentialsFromKeyPairs(*tlsArchive[pb.Client],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return server, client, nil
+}
+
+// ClientCredentialsFromDir loads the client agent credentials from the specified location
+func ClientCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	clientCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Cert))
 	clientKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -202,9 +241,9 @@ func ClientCredentials(secretsDir string) (credentials.TransportCredentials, err
 	return creds, nil
 }
 
-// ClientCredentialsFromPackage reads client credentials from the specified package
-func ClientCredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Locator) (credentials.TransportCredentials, error) {
-	_, reader, err := packages.ReadPackage(secretsPackage)
+// ClientCredentials reads client credentials from specified package service
+func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -238,8 +277,8 @@ func ClientCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
-// ServerCredentials loads server agent credentials from the specified location
-func ServerCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// ServerCredentialsFromDir loads server agent credentials from the specified location
+func ServerCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	serverCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Cert))
 	serverKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -269,9 +308,9 @@ func ServerCredentials(secretsDir string) (credentials.TransportCredentials, err
 	return creds, nil
 }
 
-// ServerCredentialsFromPackage reads server credentials from the specified package
-func ServerCredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Locator) (credentials.TransportCredentials, error) {
-	_, reader, err := packages.ReadPackage(secretsPackage)
+// ServerCredentials reads server credentials from the specified package service
+func ServerCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -306,6 +345,41 @@ func ServerCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
+// DeleteCredentials deletes the package with RPC credentials from the specified package service
+func DeleteCredentials(packages pack.PackageService) error {
+	return packages.DeletePackage(loc.RPCSecrets)
+}
+
+// UpsertCredentials creates or updates RPC secrets package in the specified package service
+func UpsertCredentials(packages pack.PackageService) (*loc.Locator, error) {
+	longLivedClient := true
+	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = upsertPackage(packages, loc.RPCSecrets, keys)
+	if err != nil {
+		return &loc.RPCSecrets, trace.Wrap(err)
+	}
+
+	return &loc.RPCSecrets, nil
+}
+
+// UpsertCredentialsFromData creates or updates RPC credentials from the specified data
+func UpsertCredentialsFromData(packages pack.PackageService, r io.Reader, labels map[string]string) error {
+	err := packages.UpsertRepository(defaults.SystemAccountOrg, time.Time{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	essential := map[string]string{
+		pack.PurposeLabel: pack.PurposeRPCCredentials,
+	}
+	runtimeLabels := utils.CombineLabels(essential, labels)
+	_, err = packages.UpsertPackage(loc.RPCSecrets, r, pack.WithLabels(runtimeLabels))
+	return trace.Wrap(err)
+}
+
 // AgentAddr returns a complete agent address for specified address addr.
 // If addr already contains a port, the address is returned unaltered,
 // otherwise, a default RPC agent port is added
@@ -321,7 +395,6 @@ func createPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 		return trace.Wrap(err)
 	}
 	defer reader.Close()
-
 	err = packages.UpsertRepository(pkg.Repository, time.Time{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -355,21 +428,23 @@ func upsertPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 }
 
 func validateCertificateExpiration(pemBytes []byte, now time.Time) error {
-	const tolerance = 30 * time.Second
 	cert, err := tlsca.ParseCertificatePEM(pemBytes)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if now.Add(-tolerance).Before(cert.NotBefore) {
-		// return newCertError("certificate is valid in the future")
+	logrus.WithFields(logrus.Fields{
+		"now":        now,
+		"not-before": cert.NotBefore.String(),
+		"not-after":  cert.NotAfter.String(),
+	}).Info("Validate certificate.")
+	if now.Before(cert.NotBefore) {
 		return trace.BadParameter("certificate is valid in the future").
 			AddFields(trace.Fields{
 				"now":        now,
 				"not-before": cert.NotBefore,
 			})
 	}
-	if now.Add(tolerance).After(cert.NotAfter) {
-		// return newCertError("certificate is valid in the past")
+	if now.After(cert.NotAfter) {
 		return trace.BadParameter("certificate is valid in the past").
 			AddFields(trace.Fields{
 				"now":       now,

--- a/lib/rpc/tls.go
+++ b/lib/rpc/tls.go
@@ -345,11 +345,6 @@ func ServerCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
-// DeleteCredentials deletes the package with RPC credentials from the specified package service
-func DeleteCredentials(packages pack.PackageService) error {
-	return packages.DeletePackage(loc.RPCSecrets)
-}
-
 // UpsertCredentials creates or updates RPC secrets package in the specified package service
 func UpsertCredentials(packages pack.PackageService) (*loc.Locator, error) {
 	longLivedClient := true

--- a/lib/storage/keyval/constants.go
+++ b/lib/storage/keyval/constants.go
@@ -75,6 +75,8 @@ const (
 	remoteClustersP             = "remoteclusters"
 	systemP                     = "system"
 	dnsP                        = "dns"
+	nodeAddrP                   = "nodeaddress"
+	serviceUserP                = "serviceuser"
 	chartsP                     = "charts"
 	indexP                      = "index"
 

--- a/lib/storage/keyval/system.go
+++ b/lib/storage/keyval/system.go
@@ -37,3 +37,33 @@ func (b *backend) SetDNSConfig(config storage.DNSConfig) error {
 	err := b.upsertVal(b.key(systemP, dnsP), &config, forever)
 	return trace.Wrap(err)
 }
+
+// GetNodeAddr returns the current node advertise IP
+func (b *backend) GetNodeAddr() (addr string, err error) {
+	var nodeAddr string
+	err = b.getVal(b.key(systemP, nodeAddrP), &nodeAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return nodeAddr, nil
+}
+
+// SetNodeAddr sets current node advertise IP
+func (b *backend) SetNodeAddr(addr string) error {
+	return b.upsertVal(b.key(systemP, nodeAddrP), addr, forever)
+}
+
+// GetServiceUser returns the current serviceo user
+func (b *backend) GetServiceUser() (*storage.OSUser, error) {
+	var user storage.OSUser
+	err := b.getVal(b.key(systemP, serviceUserP), &user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &user, nil
+}
+
+// SetServiceUser sets current service user
+func (b *backend) SetServiceUser(user storage.OSUser) error {
+	return b.upsertVal(b.key(systemP, serviceUserP), &user, forever)
+}

--- a/lib/storage/keyval/tokens.go
+++ b/lib/storage/keyval/tokens.go
@@ -81,7 +81,7 @@ func (b *backend) GetOperationProvisioningToken(clusterName, operationID string)
 			return t, nil
 		}
 	}
-	return nil, trace.Wrap(err)
+	return nil, trace.NotFound("no provisioning token for cluster %v and operation %v", clusterName, operationID)
 }
 
 // GetSiteProvisioningTokens returns install token for site

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1070,6 +1070,14 @@ type SystemMetadata interface {
 	GetDNSConfig() (*DNSConfig, error)
 	// SetDNSConfig sets current DNS configuration
 	SetDNSConfig(DNSConfig) error
+	// GetNodeAddr returns the current node advertise IP
+	GetNodeAddr() (addr string, err error)
+	// SetNodeAddr sets current node advertise IP
+	SetNodeAddr(addr string) error
+	// GetServiceUser returns the current service user
+	GetServiceUser() (*OSUser, error)
+	// SetServiceUser sets current service user
+	SetServiceUser(OSUser) error
 }
 
 // DefaultDNSConfig defines the default cluster local DNS configuration

--- a/lib/systeminfo/user.go
+++ b/lib/systeminfo/user.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -104,6 +105,23 @@ func LookupUserByUID(uid int) (*User, error) {
 	}
 	return &User{
 		Name: usr.Username,
+		UID:  uid,
+		GID:  gid,
+	}, nil
+}
+
+// FromOSUser converts the user to this package format
+func FromOSUser(user storage.OSUser) (*User, error) {
+	uid, err := strconv.Atoi(user.UID)
+	if err != nil {
+		return nil, trace.BadParameter("expected a numeric UID but got %v", user.UID)
+	}
+	gid, err := strconv.Atoi(user.GID)
+	if err != nil {
+		return nil, trace.BadParameter("expected a numeric GID but got %v", user.GID)
+	}
+	return &User{
+		Name: user.Name,
 		UID:  uid,
 		GID:  gid,
 	}, nil

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -145,7 +145,7 @@ func (p *updatePhaseBootstrap) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.updateDNSConfig()
+	err = p.updateSystemMetadata()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -196,6 +196,16 @@ func (p *updatePhaseBootstrap) exportGravity(ctx context.Context) error {
 	return trace.Wrap(err)
 }
 
+func (p *updatePhaseBootstrap) updateSystemMetadata() error {
+	if err := p.updateDNSConfig(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.updateNodeAddr(); err != nil {
+		return trace.Wrap(err)
+	}
+	return p.updateServiceUser()
+}
+
 // updateDNSConfig persists the DNS configuration in the local backend if it has not been set
 func (p *updatePhaseBootstrap) updateDNSConfig() error {
 	p.Infof("Update cluster DNS configuration as %v.", p.Plan.DNSConfig)
@@ -204,6 +214,18 @@ func (p *updatePhaseBootstrap) updateDNSConfig() error {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+// updateNodeAddr persists the node advertise IP in the local state database
+func (p *updatePhaseBootstrap) updateNodeAddr() error {
+	p.Infof("Update node address as %v.", p.Server.AdvertiseIP)
+	return p.HostLocalBackend.SetNodeAddr(p.Server.AdvertiseIP)
+}
+
+// updateServiceUser persists the service user in the local state database
+func (p *updatePhaseBootstrap) updateServiceUser() error {
+	p.Infof("Update service user as %v.", p.ServiceUser)
+	return p.HostLocalBackend.SetServiceUser(p.ServiceUser)
 }
 
 func (p *updatePhaseBootstrap) pullSystemUpdates(ctx context.Context) error {

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/install"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
@@ -170,7 +171,7 @@ func (p *updatePhaseInit) PostCheck(context.Context) error {
 func (p *updatePhaseInit) Execute(context.Context) error {
 	err := removeLegacyUpdateDirectory(p.FieldLogger)
 	if err != nil {
-		return trace.Wrap(err, "failed to remove legacy update directory")
+		p.WithError(err).Warn("Failed to remove legacy update directory.")
 	}
 	if err := p.createAdminAgent(); err != nil {
 		return trace.Wrap(err, "failed to create cluster admin agent")
@@ -178,7 +179,7 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	if err := p.upsertServiceUser(); err != nil {
 		return trace.Wrap(err, "failed to upsert service user")
 	}
-	if err := p.initRPCCredentials(); err != nil {
+	if err := p.updateRPCCredentials(); err != nil {
 		return trace.Wrap(err, "failed to update RPC credentials")
 	}
 	if err := p.updateClusterRoles(); err != nil {
@@ -211,28 +212,68 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	return nil
 }
 
-func (p *updatePhaseInit) initRPCCredentials() error {
-	// FIXME: the secrets package is currently only generated once.
-	// Even though the package is generated with some time buffer in advance,
-	// we need to make sure if the existing package needs to be rotated (i.e.
-	// as expiring soon).
-	// This will ether need to generate a new package version and then the
-	// problem becomes how the agents will know the name of the package.
-	// Or, the package version is recycled and then we need to make sure
-	// to restart the cluster controller (gravity-site) to make sure it has
-	// reloaded its copy of the credentials.
-	// See: https://github.com/gravitational/gravity/issues/3607.
-	pkg, err := rpc.InitRPCCredentials(p.Packages)
-	if err != nil && !trace.IsAlreadyExists(err) {
+// Rollback rolls back the init phase
+func (p *updatePhaseInit) Rollback(ctx context.Context) error {
+	err := p.restoreRPCCredentials()
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-
-	if trace.IsAlreadyExists(err) {
-		p.Info("RPC credentials already initialized.")
-	} else {
-		p.Infof("Initialized RPC credentials: %v.", pkg)
+	if err := p.removeConfiguredPackages(); err != nil {
+		return trace.Wrap(err)
 	}
+	return nil
+}
 
+// updateRPCCredentials rotates the RPC credentials used for install/expand/leave operations.
+func (p *updatePhaseInit) updateRPCCredentials() error {
+	// This assumes that the cluster controller Pods are eventually restarted
+	// by the upcoming phase for these changes to take effect.
+	//
+	// Currently the upgrade short-circuits the application-only upgrades by not
+	// including the init phase so this is safe.
+	//
+	// Keep it in mind for future changes.
+	// See https://github.com/gravitational/gravity/issues/3607 for more details when we had
+	// to be careful about it previously.
+	p.Info("Update RPC credentials")
+	err := p.backupRPCCredentials()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	loc, err := rpc.UpsertCredentials(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.WithField("package", loc.String()).Info("Update RPC credentials.")
+	return nil
+}
+
+func (p *updatePhaseInit) backupRPCCredentials() error {
+	p.Info("Backup RPC credentials")
+	env, rc, err := rpc.LoadCredentialsData(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	_, err = p.Packages.UpsertPackage(rpcBackupPackage(p.Operation.SiteDomain), rc, pack.WithLabels(env.RuntimeLabels))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (p *updatePhaseInit) restoreRPCCredentials() error {
+	p.Info("Restore RPC credentials from backup")
+	env, rc, err := p.Packages.ReadPackage(rpcBackupPackage(p.Operation.SiteDomain))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	delete(env.RuntimeLabels, pack.OperationIDLabel)
+	err = rpc.UpsertCredentialsFromData(p.Packages, rc, env.RuntimeLabels)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -438,6 +479,21 @@ func (p *updatePhaseInit) rotateTeleportConfig(server storage.UpdateServer) erro
 	return nil
 }
 
+// removeConfiguredPackages removes packages configured during init phase
+func (p *updatePhaseInit) removeConfiguredPackages() error {
+	// all packages created during this operation were marked
+	// with corresponding operation-id label
+	p.Info("Removing configured packages.")
+	return pack.ForeachPackageInRepo(p.Packages, p.Operation.SiteDomain,
+		func(e pack.PackageEnvelope) error {
+			if e.HasLabel(pack.OperationIDLabel, p.Operation.ID) {
+				p.Infof("Removing package %q.", e.Locator)
+				return p.Packages.DeletePackage(e.Locator)
+			}
+			return nil
+		})
+}
+
 func masterIPs(servers []storage.UpdateServer) (addrs []string) {
 	for _, server := range servers {
 		if server.IsMaster() {
@@ -469,25 +525,10 @@ func removeLegacyUpdateDirectory(log log.FieldLogger) error {
 	return trace.ConvertSystemError(err)
 }
 
-// Rollback rolls back the init phase
-func (p *updatePhaseInit) Rollback(context.Context) error {
-	if err := p.removeConfiguredPackages(); err != nil {
-		return trace.Wrap(err)
+func rpcBackupPackage(repository string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       "rpcagent-secrets-backup",
+		Version:    loc.FirstVersion,
 	}
-	return nil
-}
-
-// removeConfiguredPackages removes packages configured during init phase
-func (p *updatePhaseInit) removeConfiguredPackages() error {
-	// all packages created during this operation were marked
-	// with corresponding operation-id label
-	p.Info("Removing configured packages.")
-	return pack.ForeachPackageInRepo(p.Packages, p.Operation.SiteDomain,
-		func(e pack.PackageEnvelope) error {
-			if e.HasLabel(pack.OperationIDLabel, p.Operation.ID) {
-				p.Infof("Removing package %q.", e.Locator)
-				return p.Packages.DeletePackage(e.Locator)
-			}
-			return nil
-		})
 }

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -123,7 +123,7 @@ func newAgent() (rpcserver.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	serverCreds, clientCreds, err := rpc.Credentials(secretsDir)
+	serverCreds, clientCreds, err := rpc.CredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -131,7 +131,7 @@ func newAgent() (rpcserver.Server, error) {
 	serverAddr := fmt.Sprintf(":%v", defaults.GravityRPCAgentPort)
 	listener, err := net.Listen("tcp4", serverAddr)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to bind to %v")
+		return nil, trace.Wrap(err, "failed to bind to %v", serverAddr)
 	}
 
 	config := rpcserver.Config{
@@ -145,7 +145,7 @@ func newAgent() (rpcserver.Server, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Infof("Starting RPC agent on %v.", listener.Addr().String())
+	log.WithField("addr", listener.Addr().String()).Info("Starting RPC agent.")
 
 	return server, nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
The PR does not port the RPC `rotate` sub-command as the taken approach is to refresh the RPC credentials on each cluster upgrade operation.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1740.
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1629, https://github.com/gravitational/gravity/pull/1363.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
