### PR TITLE
[7.0.x] backport RPC credentials rotation from 5.5.x

### DIFF
--- a/lib/app/handler/handler_test.go
+++ b/lib/app/handler/handler_test.go
@@ -70,7 +70,7 @@ func (r *HandlerSuite) SetUpTest(c *C) {
 	r.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(r.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(r.dir)
+	objects, err := fs.New(fs.Config{Path: r.dir})
 	c.Assert(err, IsNil)
 
 	clock := &timetools.FreezedTime{

--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -35,7 +35,12 @@ import (
 
 // exportLayers exports the layers of the specified set of images into
 // the specified local directory
-func exportLayers(ctx context.Context, dir string, images []string, dockerClient docker.DockerInterface, log log.FieldLogger,
+func exportLayers(
+	ctx context.Context,
+	dir string,
+	images []string,
+	dockerClient docker.DockerInterface,
+	log log.FieldLogger,
 	parallel int, progress utils.Progress) error {
 	layerExporter, err := newLayerExporter(dir, dockerClient, log, progress)
 	if err != nil {

--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -92,7 +92,6 @@ func (r *applications) getClusterInstaller(
 //  * import {web-assets,gravity,dns,teleport,planet-master,planet-node,application}
 //    packages from application package service into local package service running
 //    in ./packages
-//
 func (r *applications) GetAppInstaller(req appservice.InstallerRequest) (installer io.ReadCloser, err error) {
 	if err := req.Check(); err != nil {
 		return nil, trace.Wrap(err)
@@ -118,7 +117,9 @@ func (r *applications) GetAppInstaller(req appservice.InstallerRequest) (install
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(filepath.Join(tempDir, defaults.PackagesDir))
+	objects, err := fs.New(fs.Config{
+		Path: filepath.Join(tempDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/app/service/pull_test.go
+++ b/lib/app/service/pull_test.go
@@ -165,7 +165,7 @@ func setupServices(c *C) (storage.Backend, pack.PackageService, *applications) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/blob/cluster/cluster.go
+++ b/lib/blob/cluster/cluster.go
@@ -157,7 +157,7 @@ func (c *Cluster) periodically(name string, fn func() error) {
 	for {
 		select {
 		case <-c.close.Done():
-			c.Infof("Returning, cluster is closing.")
+			c.Info("Returning, cluster is closing.")
 			return
 		case <-ticker.C:
 			if err := fn(); err != nil {

--- a/lib/blob/cluster/cluster.go
+++ b/lib/blob/cluster/cluster.go
@@ -84,13 +84,16 @@ func New(config Config) (*Cluster, error) {
 }
 
 func (r *Config) checkAndSetDefaults() error {
+	if r.WriteFactor < 1 {
+		r.WriteFactor = defaults.WriteFactor
+	}
 	if r.Local == nil {
 		return trace.BadParameter("missing parameter Local")
 	}
 	if r.Backend == nil {
 		return trace.BadParameter("missing parameter Backend")
 	}
-	if r.GetPeer == nil {
+	if r.GetPeer == nil && r.WriteFactor != 1 {
 		return trace.BadParameter("missing parameter GetPeer")
 	}
 	if r.ID == "" {
@@ -98,9 +101,6 @@ func (r *Config) checkAndSetDefaults() error {
 	}
 	if r.AdvertiseAddr == "" {
 		return trace.BadParameter("missing parameter AdvertiseAddr")
-	}
-	if r.WriteFactor < 1 {
-		r.WriteFactor = defaults.WriteFactor
 	}
 	if r.Clock == nil {
 		r.Clock = clockwork.NewRealClock()

--- a/lib/blob/cluster/cluster_test.go
+++ b/lib/blob/cluster/cluster_test.go
@@ -73,7 +73,7 @@ func (s *ClusterSinglePeer) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	local, err := fs.New(s.dir)
+	local, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	obj, err := New(Config{
@@ -151,7 +151,7 @@ func (s *ClusterMultiPeers) SetUpTest(c *C) {
 	}
 
 	for i := 0; i < peersCount; i++ {
-		local, err := fs.New(c.MkDir())
+		local, err := fs.New(fs.Config{Path: c.MkDir()})
 		c.Assert(err, IsNil)
 		peers[i] = local
 		obj, err := New(Config{
@@ -249,7 +249,7 @@ func (s *RPCSuite) SetUpTest(c *C) {
 	fakeClock := clockwork.NewFakeClockAt(time.Now().UTC())
 
 	for i := 0; i < 3; i++ {
-		local, err := fs.New(c.MkDir())
+		local, err := fs.New(fs.Config{Path: c.MkDir()})
 		c.Assert(err, IsNil)
 		peers[i] = local
 

--- a/lib/blob/fs/fs_test.go
+++ b/lib/blob/fs/fs_test.go
@@ -39,7 +39,7 @@ func (s *FSSuite) SetUpTest(c *C) {
 	log.SetOutput(os.Stderr)
 	s.dir = c.MkDir()
 
-	obj, err := New(s.dir)
+	obj, err := New(Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.suite.Objects = obj

--- a/lib/blob/handler/blobhandler_test.go
+++ b/lib/blob/handler/blobhandler_test.go
@@ -67,7 +67,7 @@ func (s *HandlerSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/builder/builder.go
+++ b/lib/builder/builder.go
@@ -404,7 +404,7 @@ func (b *Builder) initServices() (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	objects, err := blobfs.New(filepath.Join(b.Dir, defaults.PackagesDir))
+	objects, err := blobfs.New(blobfs.Config{Path: filepath.Join(b.Dir, defaults.PackagesDir)})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/docker/imageservice.go
+++ b/lib/docker/imageservice.go
@@ -156,13 +156,13 @@ func newImageService(req RegistryConnectionRequest) (*imageService, error) {
 
 // NewClusterImageService returns an in-cluster image service for the
 // specified registry address.
-func NewClusterImageService(registry string) (ImageService, error) {
+func NewClusterImageService(registryAddr string) (ImageService, error) {
 	stateDir, err := state.GetStateDir()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return NewImageService(RegistryConnectionRequest{
-		RegistryAddress: registry,
+		RegistryAddress: registryAddr,
 		CertName:        defaults.DockerRegistry,
 		CACertPath:      state.Secret(stateDir, defaults.RegistryCAFilename),
 		ClientCertPath:  state.Secret(stateDir, defaults.RegistryCertFilename),

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -130,7 +130,7 @@ func NewAgentStop(p fsm.ExecutorParams, operator ops.Operator, packages pack.Pac
 		Key:      opKey(p.Plan),
 		Operator: operator,
 	}
-	credentials, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	credentials, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/fsm/rpc.go
+++ b/lib/fsm/rpc.go
@@ -247,13 +247,18 @@ func IsMasterServer(server storage.Server) bool {
 	return server.ClusterRole == string(schema.ServiceRoleMaster)
 }
 
-// GetClientCredentials returns the RPC credentials for an update operation
+// GetClientCredentials reads the RPC credentials for an update operation from a predefined directory.
+//
+// The reason credentials are not read from the cluster package service is that
+// during certain operations (cluster upgrades, cluster or environment configuration updates), the etcd backend
+// might be temporarily inaccessible between commands hence in this mode, the credentials
+// are cached on disk.
 func GetClientCredentials() (credentials.TransportCredentials, error) {
 	secretsDir, err := AgentSecretsDir()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	creds, err := rpc.ClientCredentials(secretsDir)
+	creds, err := rpc.ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/httplib/client.go
+++ b/lib/httplib/client.go
@@ -173,12 +173,18 @@ func WithIdleConnTimeout(timeout time.Duration) ClientOption {
 
 // GetClient returns secure or insecure client based on settings
 func GetClient(insecure bool, options ...ClientOption) *http.Client {
+	if insecure {
+		options = append(options, WithInsecure())
+	}
+	return NewClient(options...)
+}
+
+// NewClient creates a new HTTP client with the specified list of configuration
+// options
+func NewClient(options ...ClientOption) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{},
 		DialContext:     (&net.Dialer{Timeout: defaults.DialTimeout}).DialContext,
-	}
-	if insecure {
-		options = append(options, WithInsecure())
 	}
 	client := &http.Client{Transport: transport}
 	for _, o := range options {

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -215,7 +215,7 @@ func LoadRPCCredentials(ctx context.Context, packages pack.PackageService) (*rpc
 
 // ClientCredentials returns the contents of the default RPC credentials package
 func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
-	clientCreds, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	clientCreds, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch RPC credentials")
 	}

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -18,10 +18,13 @@ package localenv
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/blob"
+	libcluster "github.com/gravitational/gravity/lib/blob/cluster"
 	"github.com/gravitational/gravity/lib/blob/fs"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
@@ -30,10 +33,11 @@ import (
 	"github.com/gravitational/gravity/lib/pack/localpack"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
+	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/users/usersservice"
-	"github.com/gravitational/teleport/lib/events"
 
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/kubernetes"
 )
@@ -52,9 +56,26 @@ func (r *LocalEnvironment) NewClusterEnvironment(opts ...ClusterEnvironmentOptio
 	if err != nil && !trace.IsNotFound(err) {
 		log.WithError(err).Warn("Failed to create audit log.")
 	}
+	user, err := r.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.UserFromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := r.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
 	config := clusterEnvironmentConfig{
-		client:   client,
-		auditLog: auditLog,
+		client:      client,
+		auditLog:    auditLog,
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
 	}
 	for _, opt := range opts {
 		opt(&config)
@@ -84,7 +105,33 @@ type ClusterEnvironment struct {
 // returns a new instance of cluster environment.
 // The resulting environment will not have a kubernetes client
 func NewClusterEnvironment() (*ClusterEnvironment, error) {
-	return newClusterEnvironment(clusterEnvironmentConfig{})
+	stateDir, err := LocalGravityDir()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := New(stateDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := env.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.UserFromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := env.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	return newClusterEnvironment(clusterEnvironmentConfig{
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
+	})
 }
 
 // WithClient is an option to override the kubernetes client to use
@@ -122,9 +169,37 @@ func newClusterEnvironment(config clusterEnvironmentConfig) (*ClusterEnvironment
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(packagesDir)
+	localObjects, err := fs.New(fs.Config{
+		Path: packagesDir,
+		User: config.serviceUser,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	var objects blob.Objects
+	if config.nodeAddr == "" {
+		objects, err = fs.New(fs.Config{Path: packagesDir})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// To be able to use cluster-level package service,
+		// a node address is required. This is not available on nodes prior to upgrade
+		// with an version that did not support the necessary system metadata (node address
+		// and service user).
+		// This is normally not a problem as the cluster-level package service is not required
+		// during the upgrade.
+		objects, err = libcluster.New(libcluster.Config{
+			Local:         localObjects,
+			WriteFactor:   1,
+			Backend:       backend,
+			ID:            config.nodeAddr,
+			AdvertiseAddr: fmt.Sprintf("https://%v", config.nodeAddr),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unpackedDir, err := SiteUnpackedDir()
@@ -199,5 +274,7 @@ type clusterEnvironmentConfig struct {
 	// Falls back to defaults.EtcdRetryInterval if unspecified
 	etcdTimeout time.Duration
 	// auditLog provides API to the cluster audit log
-	auditLog events.IAuditLog
+	auditLog    events.IAuditLog
+	serviceUser *systeminfo.User
+	nodeAddr    string
 }

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -182,7 +182,9 @@ func (env *LocalEnvironment) init() error {
 		env.DNS = DNSConfig(*dns)
 	}
 
-	env.Objects, err = fs.New(filepath.Join(env.StateDir, defaults.PackagesDir))
+	env.Objects, err = fs.New(fs.Config{
+		Path: filepath.Join(env.StateDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/testhelpers.go
+++ b/lib/ops/opsservice/testhelpers.go
@@ -74,7 +74,7 @@ func SetupTestServices(c *check.C) TestServices {
 	backend, err := keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(dir, "bolt.db")})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(dir)
+	objects, err := fs.New(fs.Config{Path: dir})
 	c.Assert(err, check.IsNil)
 
 	packService, err := localpack.New(localpack.Config{

--- a/lib/pack/layerpack/layer_test.go
+++ b/lib/pack/layerpack/layer_test.go
@@ -63,9 +63,9 @@ func (s *LayerSuite) SetUpTest(c *C) {
 	s.outerBackend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(outerDir, "storage.db")})
 	c.Assert(err, IsNil)
 
-	innerObjects, err := fs.New(innerDir)
+	innerObjects, err := fs.New(fs.Config{Path: innerDir})
 	c.Assert(err, IsNil)
-	outerObjects, err := fs.New(outerDir)
+	outerObjects, err := fs.New(fs.Config{Path: outerDir})
 	c.Assert(err, IsNil)
 
 	inner, err := localpack.New(localpack.Config{

--- a/lib/pack/localpack/local_test.go
+++ b/lib/pack/localpack/local_test.go
@@ -62,7 +62,7 @@ func (s *LocalSuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.server, err = New(Config{

--- a/lib/pack/webpack/webpack_test.go
+++ b/lib/pack/webpack/webpack_test.go
@@ -77,7 +77,7 @@ func (s *WebpackSuite) SetUpTest(c *C) {
 	s.backend, err = keyval.NewBolt(keyval.BoltConfig{Path: filepath.Join(s.dir, "bolt.db")})
 	c.Assert(err, IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, IsNil)
 
 	s.users, err = usersservice.New(

--- a/lib/process/import.go
+++ b/lib/process/import.go
@@ -70,7 +70,9 @@ func newImporter(dir string) (*importer, error) {
 		}),
 	}
 	err = func() error {
-		objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
+		objects, err := fs.New(fs.Config{
+			Path: filepath.Join(dir, defaults.PackagesDir),
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -212,7 +212,9 @@ func New(ctx context.Context, cfg processconfig.Config, tcfg telecfg.FileConfig)
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := blobfs.New(filepath.Join(cfg.DataDir, defaults.PackagesDir))
+	objects, err := blobfs.New(blobfs.Config{
+		Path: filepath.Join(cfg.DataDir, defaults.PackagesDir),
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -492,7 +494,7 @@ func (p *Process) ImportState(importDir string) (err error) {
 
 // InitRPCCredentials initializes the package with RPC secrets
 func (p *Process) InitRPCCredentials() error {
-	pkg, err := rpc.InitRPCCredentials(p.packages)
+	pkg, err := rpc.InitCredentials(p.packages)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err, "failed to init RPC credentials")
 	}
@@ -1267,7 +1269,9 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		objects, err := blobfs.New(filepath.Join(p.cfg.Pack.ReadDir, defaults.PackagesDir))
+		objects, err := blobfs.New(blobfs.Config{
+			Path: filepath.Join(p.cfg.Pack.ReadDir, defaults.PackagesDir),
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/process/process_test.go
+++ b/lib/process/process_test.go
@@ -295,7 +295,7 @@ func (s *importerSuite) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	objects, err := fs.New(s.dir)
+	objects, err := fs.New(fs.Config{Path: s.dir})
 	c.Assert(err, check.IsNil)
 
 	s.pack, err = localpack.New(localpack.Config{

--- a/lib/storage/keyval/constants.go
+++ b/lib/storage/keyval/constants.go
@@ -72,6 +72,8 @@ const (
 	systemP                     = "system"
 	dnsP                        = "dns"
 	seLinuxP                    = "seLinux"
+	nodeAddrP                   = "nodeaddress"
+	serviceUserP                = "serviceuser"
 	chartsP                     = "charts"
 	indexP                      = "index"
 

--- a/lib/storage/keyval/system.go
+++ b/lib/storage/keyval/system.go
@@ -50,3 +50,33 @@ func (b *backend) GetSELinux() (enabled bool, err error) {
 func (b *backend) SetSELinux(enabled bool) error {
 	return b.upsertVal(b.key(systemP, seLinuxP), &enabled, forever)
 }
+
+// GetNodeAddr returns the current node advertise IP
+func (b *backend) GetNodeAddr() (addr string, err error) {
+	var nodeAddr string
+	err = b.getVal(b.key(systemP, nodeAddrP), &nodeAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return nodeAddr, nil
+}
+
+// SetNodeAddr sets current node advertise IP
+func (b *backend) SetNodeAddr(addr string) error {
+	return b.upsertVal(b.key(systemP, nodeAddrP), addr, forever)
+}
+
+// GetServiceUser returns the current serviceo user
+func (b *backend) GetServiceUser() (*storage.OSUser, error) {
+	var user storage.OSUser
+	err := b.getVal(b.key(systemP, serviceUserP), &user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &user, nil
+}
+
+// SetServiceUser sets current service user
+func (b *backend) SetServiceUser(user storage.OSUser) error {
+	return b.upsertVal(b.key(systemP, serviceUserP), &user, forever)
+}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1085,6 +1085,14 @@ type SystemMetadata interface {
 	GetSELinux() (enabled bool, err error)
 	// SetSELinux sets SELinux support
 	SetSELinux(enabled bool) error
+	// GetNodeAddr returns the current node advertise IP
+	GetNodeAddr() (addr string, err error)
+	// SetNodeAddr sets current node advertise IP
+	SetNodeAddr(addr string) error
+	// GetServiceUser returns the current service user
+	GetServiceUser() (*OSUser, error)
+	// SetServiceUser sets current service user
+	SetServiceUser(OSUser) error
 }
 
 // DefaultDNSConfig defines the default cluster local DNS configuration

--- a/lib/systeminfo/user.go
+++ b/lib/systeminfo/user.go
@@ -197,6 +197,15 @@ func DefaultServiceUser() *User {
 	}
 }
 
+// OSUser returns a new storage user from this user
+func (r User) OSUser() storage.OSUser {
+	return storage.OSUser{
+		Name: r.Name,
+		UID:  strconv.Itoa(r.UID),
+		GID:  strconv.Itoa(r.GID),
+	}
+}
+
 // UserFromOSUser returns a new user from the specified storage user
 func UserFromOSUser(user storage.OSUser) (*User, error) {
 	uid, err := strconv.Atoi(user.UID)

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/install"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
@@ -170,7 +171,7 @@ func (p *updatePhaseInit) PostCheck(context.Context) error {
 func (p *updatePhaseInit) Execute(context.Context) error {
 	err := removeLegacyUpdateDirectory(p.FieldLogger)
 	if err != nil {
-		return trace.Wrap(err, "failed to remove legacy update directory")
+		p.WithError(err).Warn("Failed to remove legacy update directory.")
 	}
 	if err := p.createAdminAgent(); err != nil {
 		return trace.Wrap(err, "failed to create cluster admin agent")
@@ -178,7 +179,7 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	if err := p.upsertServiceUser(); err != nil {
 		return trace.Wrap(err, "failed to upsert service user")
 	}
-	if err := p.initRPCCredentials(); err != nil {
+	if err := p.updateRPCCredentials(); err != nil {
 		return trace.Wrap(err, "failed to update RPC credentials")
 	}
 	if err := p.updateClusterRoles(); err != nil {
@@ -211,28 +212,68 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	return nil
 }
 
-func (p *updatePhaseInit) initRPCCredentials() error {
-	// FIXME: the secrets package is currently only generated once.
-	// Even though the package is generated with some time buffer in advance,
-	// we need to make sure if the existing package needs to be rotated (i.e.
-	// as expiring soon).
-	// This will ether need to generate a new package version and then the
-	// problem becomes how the agents will know the name of the package.
-	// Or, the package version is recycled and then we need to make sure
-	// to restart the cluster controller (gravity-site) to make sure it has
-	// reloaded its copy of the credentials.
-	// See: https://github.com/gravitational/gravity/issues/3607.
-	pkg, err := rpc.InitRPCCredentials(p.Packages)
-	if err != nil && !trace.IsAlreadyExists(err) {
+// Rollback rolls back the init phase
+func (p *updatePhaseInit) Rollback(ctx context.Context) error {
+	err := p.restoreRPCCredentials()
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-
-	if trace.IsAlreadyExists(err) {
-		p.Info("RPC credentials already initialized.")
-	} else {
-		p.Infof("Initialized RPC credentials: %v.", pkg)
+	if err := p.removeConfiguredPackages(); err != nil {
+		return trace.Wrap(err)
 	}
+	return nil
+}
 
+// updateRPCCredentials rotates the RPC credentials used for install/expand/leave operations.
+func (p *updatePhaseInit) updateRPCCredentials() error {
+	// This assumes that the cluster controller Pods are eventually restarted
+	// by the upcoming phase for these changes to take effect.
+	//
+	// Currently the upgrade short-circuits the application-only upgrades by not
+	// including the init phase so this is safe.
+	//
+	// Keep it in mind for future changes.
+	// See https://github.com/gravitational/gravity/issues/3607 for more details when we had
+	// to be careful about it previously.
+	p.Info("Update RPC credentials")
+	err := p.backupRPCCredentials()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	loc, err := rpc.UpsertCredentials(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.WithField("package", loc.String()).Info("Update RPC credentials.")
+	return nil
+}
+
+func (p *updatePhaseInit) backupRPCCredentials() error {
+	p.Info("Backup RPC credentials")
+	env, rc, err := rpc.LoadCredentialsData(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	_, err = p.Packages.UpsertPackage(rpcBackupPackage(p.Operation.SiteDomain), rc, pack.WithLabels(env.RuntimeLabels))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (p *updatePhaseInit) restoreRPCCredentials() error {
+	p.Info("Restore RPC credentials from backup")
+	env, rc, err := p.Packages.ReadPackage(rpcBackupPackage(p.Operation.SiteDomain))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	delete(env.RuntimeLabels, pack.OperationIDLabel)
+	err = rpc.UpsertCredentialsFromData(p.Packages, rc, env.RuntimeLabels)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -438,6 +479,21 @@ func (p *updatePhaseInit) rotateTeleportConfig(server storage.UpdateServer) erro
 	return nil
 }
 
+// removeConfiguredPackages removes packages configured during init phase
+func (p *updatePhaseInit) removeConfiguredPackages() error {
+	// all packages created during this operation were marked
+	// with corresponding operation-id label
+	p.Info("Removing configured packages.")
+	return pack.ForeachPackageInRepo(p.Packages, p.Operation.SiteDomain,
+		func(e pack.PackageEnvelope) error {
+			if e.HasLabel(pack.OperationIDLabel, p.Operation.ID) {
+				p.Infof("Removing package %q.", e.Locator)
+				return p.Packages.DeletePackage(e.Locator)
+			}
+			return nil
+		})
+}
+
 func masterIPs(servers []storage.UpdateServer) (addrs []string) {
 	for _, server := range servers {
 		if server.IsMaster() {
@@ -469,25 +525,10 @@ func removeLegacyUpdateDirectory(log log.FieldLogger) error {
 	return trace.ConvertSystemError(err)
 }
 
-// Rollback rolls back the init phase
-func (p *updatePhaseInit) Rollback(context.Context) error {
-	if err := p.removeConfiguredPackages(); err != nil {
-		return trace.Wrap(err)
+func rpcBackupPackage(repository string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       "rpcagent-secrets-backup",
+		Version:    loc.FirstVersion,
 	}
-	return nil
-}
-
-// removeConfiguredPackages removes packages configured during init phase
-func (p *updatePhaseInit) removeConfiguredPackages() error {
-	// all packages created during this operation were marked
-	// with corresponding operation-id label
-	p.Info("Removing configured packages.")
-	return pack.ForeachPackageInRepo(p.Packages, p.Operation.SiteDomain,
-		func(e pack.PackageEnvelope) error {
-			if e.HasLabel(pack.OperationIDLabel, p.Operation.ID) {
-				p.Infof("Removing package %q.", e.Locator)
-				return p.Packages.DeletePackage(e.Locator)
-			}
-			return nil
-		})
 }

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -122,7 +122,7 @@ func newAgent() (rpcserver.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	serverCreds, clientCreds, err := rpc.Credentials(secretsDir)
+	serverCreds, clientCreds, err := rpc.CredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -130,7 +130,7 @@ func newAgent() (rpcserver.Server, error) {
 	serverAddr := fmt.Sprintf(":%v", defaults.GravityRPCAgentPort)
 	listener, err := net.Listen("tcp4", serverAddr)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to bind to %v")
+		return nil, trace.Wrap(err, "failed to bind to %v", serverAddr)
 	}
 
 	config := rpcserver.Config{
@@ -144,7 +144,7 @@ func newAgent() (rpcserver.Server, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Infof("Starting RPC agent on %v.", listener.Addr().String())
+	log.WithField("addr", listener.Addr().String()).Info("Starting RPC agent.")
 
 	return server, nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
The PR does not port the RPC `rotate` sub-command as the taken approach is to refresh the RPC credentials on each cluster upgrade operation.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1740.
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1747.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

#### Install `6.1.30`
#### Start upgrade to `7.0.14-dev.2` (from this branch)
```sh
$ ./gravity upgrade -m
```
#### Export credentials package to test pre-upgrade state
```sh
$ gravity package unpack --insecure --ops-url=https://gravity-site.kube-system.svc.cluster.local:3009 gravitational.io/rpcagent-secrets:0.0.1 creds
$ openssl x509 -noout -text -in creds/client.cert |grep -iE 'not before|not after'
            Not Before: Jul 17 14:24:09 2020 GMT
            Not After : Jul 15 15:24:09 2030 GMT
``` 
#### Run `/init` step to update RPC credentials and make sure credentials have been updated
```
$ $ ./gravity plan execute --phase=/init
$ gravity package unpack --insecure --ops-url=https://gravity-site.kube-system.svc.cluster.local:3009 gravitational.io/rpcagent-secrets:0.0.1 creds2
$ openssl x509 -noout -text -in creds2/client.cert |grep -iE 'not before|not after'
            Not Before: Jul 17 14:29:12 2020 GMT
            Not After : Jul 15 15:29:12 2030 GMT
```
#### Roll back `/init` step to restore credentials
```
$ ./gravity plan rollback --phase=/init
$ gravity package unpack --insecure --ops-url=https://gravity-site.kube-system.svc.cluster.local:3009 gravitational.io/rpcagent-secrets:0.0.1 creds3
$ openssl x509 -noout -text -in creds3/client.cert |grep -iE 'not before|not after'
            Not Before: Jul 17 14:24:09 2020 GMT
            Not After : Jul 15 15:24:09 2030 GMT
```
#### Complete upgrade and make sure it's successful
```sh
$ gravity package unpack --insecure --ops-url=https://gravity-site.kube-system.svc.cluster.local:3009 gravitational.io/rpcagent-secrets:0.0.1 creds4
$ openssl x509 -noout -text -in creds4/client.cert |grep -iE 'not before|not after'
            Not Before: Jul 17 14:30:49 2020 GMT
            Not After : Jul 15 15:30:49 2030 GMT
```

## Additional information
<!--Optional. Anything else that may be relevant.-->
