### PR TITLE
[7.0.x] System pods check

### DIFF
--- a/assets/dns-app/resources/dns.yaml
+++ b/assets/dns-app/resources/dns.yaml
@@ -93,6 +93,7 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
+        gravitational.io/critical-pod: ''
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: docker/default

--- a/assets/site-app/resources/site.yaml
+++ b/assets/site-app/resources/site.yaml
@@ -114,6 +114,7 @@ spec:
     metadata:
       labels:
         app: gravity-site
+        gravitational.io/critical-pod: ''
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: docker/default

--- a/assets/tiller-app/resources/resources.yaml
+++ b/assets/tiller-app/resources/resources.yaml
@@ -36,6 +36,7 @@ spec:
       labels:
         app: helm
         name: tiller
+        gravitational.io/critical-pod: ''
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds a system pods checker. This checker verifies that all pods with the `gravitational.io/critical-pod` label is healthy.

Added `gravitational.io/critial-pod` label to `gravity-site`, `coredns`, `tiller` apps.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/satellite/pull/236, https://github.com/gravitational/planet/pull/691
* Updates https://github.com/gravitational/gravity/issues/1740

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
**Test gravity-site CrashLoopBackOff**

* Change /var/lib/gravity/site permissions
```
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.10-dev.4
Gravity version:        7.0.10-dev.4 (client) / 7.0.10-dev.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-1 / 172.28.128.101 / node
            Status:             healthy
            [!]                 pod kube-system/gravity-site-wtprm is not running (gravity-site waiting: CrashLoopBackOff)
            Remote access:      online
        * node-3 / 172.28.128.103 / node
            Status:             healthy
            Remote access:      online
        * node-2 / 172.28.128.102 / node
            Status:             healthy
            Remote access:      online
```

**Test coredns CrashLoopBackOff**

* Update coredns configmap
```
[vagrant@node-1 installer]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         active
Cluster image:          telekube, version 7.0.10-dev.4
Gravity version:        7.0.10-dev.4 (client) / 7.0.10-dev.4 (server)
[...]
Cluster nodes:
    Masters:
        * node-1 / 172.28.128.101 / node
            Status:             healthy
            [!]                 pod kube-system/coredns-rqm6d is not running (coredns waiting: CrashLoopBackOff)
            Remote access:      online
        * node-3 / 172.28.128.103 / node
            Status:             healthy
            [!]                 pod kube-system/coredns-5nhpx is not running (coredns waiting: CrashLoopBackOff)
            Remote access:      online
        * node-2 / 172.28.128.102 / node
            Status:             healthy
            Remote access:      online
```