### PR TITLE
Update robotest upgrade targets.

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -9,15 +9,17 @@ DOCKER_STORAGE_DRIVERS="overlay2"
 declare -A UPGRADE_MAP
 
 # latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.18]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[7.0.10]="centos:7 debian:9 ubuntu:18"
 
-# latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.6]="centos:7 debian:9 ubuntu:18"
+# latest patch release on compatible non-LTS versions
+UPGRADE_MAP[6.3.18]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[6.2.5]="centos:7 debian:9 ubuntu:18"
 
 # important versions in the field, these are static
-UPGRADE_MAP[6.1.0]="ubuntu:16"
-UPGRADE_MAP[6.2.5]="ubuntu:16"
+UPGRADE_MAP[7.0.0]="ubuntu:16"
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
+# UPGRADE_MAP[6.2.0]="ubuntu:16"  # pretty close to 6.2.5, no need to test both
+
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -7,14 +7,16 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 declare -A UPGRADE_MAP
 
 # latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.18]="ubuntu:18"
+UPGRADE_MAP[7.0.10]="ubuntu:18"
 
-# latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.6]="ubuntu:18"
+# latest patch release on compatible non-LTS versions
+UPGRADE_MAP[6.3.18]="ubuntu:18"
+UPGRADE_MAP[6.2.5]="ubuntu:18"
 
 # important versions in the field, these are static
-UPGRADE_MAP[6.1.0]="ubuntu:16"
+UPGRADE_MAP[7.0.0]="ubuntu:16"
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
+# UPGRADE_MAP[6.2.0]="ubuntu:16"  # pretty close to 6.2.5, no need to test both
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -10,13 +10,12 @@ declare -A UPGRADE_MAP
 UPGRADE_MAP[7.0.10]="ubuntu:18"
 
 # latest patch release on compatible non-LTS versions
-UPGRADE_MAP[6.3.18]="ubuntu:18"
-UPGRADE_MAP[6.2.5]="ubuntu:18"
+# 6.2 and 6.3 ignored in PR builds per https://github.com/gravitational/gravity/pull/1760#pullrequestreview-437838773
+# UPGRADE_MAP[6.3.18]="ubuntu:18"
+# UPGRADE_MAP[6.2.5]="ubuntu:18"
 
 # important versions in the field, these are static
 UPGRADE_MAP[7.0.0]="ubuntu:16"
-# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
-# UPGRADE_MAP[6.2.0]="ubuntu:16"  # pretty close to 6.2.5, no need to test both
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}


### PR DESCRIPTION
## Description
This patch drops validation of 6.1 to 7.1.0-alpha upgrades.
These are replaced with validation from 7.0. Furthermore 6.2 and 6.3
are included per our <=2 minor kubernetes version skew policy and some
recent discussion with @knisbet about whether we support non-LTS to
non-LTS upgrades.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform testing
- [x] Address review feedback

## Testing done
The PR build is sufficient testing.
