### PR TITLE
Add logic to test upgrade from previous release.

### DIFF
--- a/build.assets/robotest_run_nightly.sh
+++ b/build.assets/robotest_run_nightly.sh
@@ -5,21 +5,35 @@ readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
 DOCKER_STORAGE_DRIVERS="overlay2"
 
+# decrement_patch returns x.y.(z-1) given valid x.y.z semver.
+decrement_patch() {
+    major=$(echo $1 | cut -d'.' -f1)
+    minor=$(echo $1 | cut -d'.' -f2)
+    patch=$(echo $1 | cut -d'.' -f3)
+    patch=$((patch - 1))
+    echo "${major}.${minor}.${patch}"
+}
+
+readonly GRAVITY_VERSION=${GRAVITY_VERSION:?Set GRAVITY_VERSION to the current SemVer}
+readonly THIS_RELEASE=$(echo $GRAVITY_VERSION | cut -f1 -d'+' | cut -f1 -d'-')
+readonly PREVIOUS_RELEASE=$(decrement_patch $THIS_RELEASE)
+unset -f decrement_patch THIS_RELEASE
+
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
 
-# latest patch release on this branch, keep this up to date
-UPGRADE_MAP[7.0.3]="ubuntu:18"
+# latest patch release on this branch
+UPGRADE_MAP[$PREVIOUS_RELEASE]="centos:7 debian:9 ubuntu:18"
 
 # latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.24]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[6.1.29]="centos:7 debian:9 ubuntu:18"
 
-# latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.13]="centos:7 debian:9 ubuntu:18"
+# latest patch release on compatible non-LTS versions
+UPGRADE_MAP[6.3.18]="centos:7 debian:9 ubuntu:18"
+UPGRADE_MAP[6.2.5]="ubuntu:16"
 
 # important versions in the field, these are static
 UPGRADE_MAP[6.1.0]="ubuntu:16"
-UPGRADE_MAP[6.2.5]="ubuntu:16"
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}

--- a/build.assets/robotest_run_suite.sh
+++ b/build.assets/robotest_run_suite.sh
@@ -3,17 +3,32 @@ set -eu -o pipefail
 
 readonly UPGRADE_FROM_DIR=${1:-$(pwd)/../upgrade_from}
 
+# decrement_patch returns x.y.(z-1) given valid x.y.z semver.
+decrement_patch() {
+    major=$(echo $1 | cut -d'.' -f1)
+    minor=$(echo $1 | cut -d'.' -f2)
+    patch=$(echo $1 | cut -d'.' -f3)
+    patch=$((patch - 1))
+    echo "${major}.${minor}.${patch}"
+}
+
+readonly GRAVITY_VERSION=${GRAVITY_VERSION:?Set GRAVITY_VERSION to the current SemVer}
+readonly THIS_RELEASE=$(echo $GRAVITY_VERSION | cut -f1 -d'+' | cut -f1 -d'-')
+readonly PREVIOUS_RELEASE=$(decrement_patch $THIS_RELEASE)
+unset -f decrement_patch THIS_RELEASE
+
 # UPGRADE_MAP maps gravity version -> list of OS releases to upgrade from
 declare -A UPGRADE_MAP
 
-# latest patch release on this branch, keep this up to date
-UPGRADE_MAP[7.0.5]="ubuntu:18"
+# latest patch release on this branch
+UPGRADE_MAP[$PREVIOUS_RELEASE]="ubuntu:18"
 
 # latest patch release on compatible LTS, keep this up to date
-UPGRADE_MAP[6.1.24]="ubuntu:18"
+UPGRADE_MAP[6.1.29]="ubuntu:18"
 
-# latest patch release on supported non-LTS version, keep this up to date
-UPGRADE_MAP[6.3.13]="ubuntu:18"
+# latest patch release on compatible non-LTS versions
+UPGRADE_MAP[6.3.18]="ubuntu:18"
+UPGRADE_MAP[6.2.5]="ubuntu:16"
 
 # important versions in the field, these are static
 UPGRADE_MAP[6.1.0]="ubuntu:16"


### PR DESCRIPTION
## Description
This changeset seeks to catch issues like #1691 by ensuring we always test upgrade from the most current previous release.  This is definitely a halfway measure as it only covers intra-branch upgrade issues, and not inter-branch ones. Still, intra would have caught #1691.

 Also bump latest releases on other branches.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to #1199.
* Intended to catch issues like #1691.

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
I put an exit in the script before it ran and gathered the following output:

```
walt@work:~/git/gravity$ make robotest-run-suite GET_GRAVITATIONAL_IO_APIKEY=a | tr " " "\n"                                                                                                  
./build.assets/robotest_run_suite.sh
/home/walt/git/gravity/upgrade_from
resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
upgrade={"flavor":"three","nodes":3,"role":"node","service_uid":997,"service_gid":994,"os":"ubuntu:18","storage_driver":"overlay2","from":"/telekube_6.1.29.tar"}
upgrade={"flavor":"three","nodes":3,"role":"node","service_uid":997,"service_gid":994,"os":"ubuntu:18","storage_driver":"overlay2","from":"/telekube_7.0.9.tar"}
upgrade={"flavor":"three","nodes":3,"role":"node","service_uid":997,"service_gid":994,"os":"ubuntu:16","storage_driver":"overlay2","from":"/telekube_6.1.0.tar"}
upgrade={"flavor":"three","nodes":3,"role":"node","service_uid":997,"service_gid":994,"os":"ubuntu:16","storage_driver":"overlay2","from":"/telekube_6.2.5.tar"}
upgrade={"flavor":"three","nodes":3,"role":"node","service_uid":997,"service_gid":994,"os":"ubuntu:18","storage_driver":"overlay2","from":"/telekube_6.3.18.tar"}
install={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","storage_driver":"overlay2"}
install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
walt@work:~/git/gravity$ ./build.assets/robotest_run_suite.sh 
./build.assets/robotest_run_suite.sh: line 15: GRAVITY_VERSION: Set GRAVITY_VERSION to the current SemVer
```
The PR build should be everything else this needs.

## Implementation Details

I chose to put this 'calculate previous version' logic in our shell scripts because:
* the other versioning is handed in shell (though we'd like to move away from that -- doing so would be huge scope creep for this pretty small change)
* It keeps the impact localized, this doesn't bleed into the makefile at all (other than depending on the `GRAVITY_VERSION` in addtion to `GRAVITY_BUILDDIR`)

I'm not super happy with how it turned out.  However this will probably get entirely replaced with a proper solution to #1199 hits.  This is just a low hanging fruit to catch a known escape without investing more time in a proper refactoring.

## Additional info
I've got all the ports of this ready to go, but I wanted to incorporate any PR feedback before posting them, so I don't need to make the same change 4 times.