### PR TITLE
[5.5.x] Explicitly pass since value to gravity system report

### DIFF
--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -210,13 +210,11 @@ func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRu
 	}
 	defer w.Close()
 
-	args := []string{"system", "report", "--filter", report.FilterSystem, "--compressed"}
-	if since != 0 {
-		args = append(args, "--since", since.String())
-	}
-
 	var stderr bytes.Buffer
-	err = runner.RunStream(w, &stderr, s.gravityCommand(args...)...)
+	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
+		"--filter", report.FilterSystem,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect diagnostics: %s", stderr.String())
 	}
@@ -230,13 +228,11 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 	}
 	defer w.Close()
 
-	args := []string{"system", "report", "--filter", report.FilterKubernetes, "--compressed"}
-	if since != 0 {
-		args = append(args, "--since", since.String())
-	}
-
 	var stderr bytes.Buffer
-	err = runner.RunStream(w, &stderr, s.gravityCommand(args...)...)
+	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
+		"--filter", report.FilterKubernetes,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect kubernetes diagnostics: %s", stderr.String())
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Pass --since value to `gravity system report` even if the value is 0. The reason for this is so that k8s logs can be collected with `kubectl cluster-info dump` when `--since 0s` is specified.


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verfiy `gravity report --since 0s` collects `kubectl cluster-info dump`**
```
report
├── cluster.json
├── node-1-debug-logs.tar.gz 
├── node-1-etcd.tar.gz
├── node-1-k8s-logs
│   ├── k8s-cluster-info-dump.tgz  <---
│   ├── k8s-daemonsets
│   ├── k8s-deployments
│   ├── k8s-describe-daemonsets
│   ├── k8s-describe-deployments
│   ├── k8s-describe-endpoints
│   ├── k8s-describe-events
│   ├── k8s-describe-jobs
│   ├── k8s-describe-nodes
│   ├── k8s-describe-pods
│   ├── k8s-describe-replicasets
│   ├── k8s-describe-services
│   ├── k8s-endpoints
│   ├── k8s-events
│   ├── k8s-jobs
│   ├── k8s-logs-kube-system-site-app-post-install-4fe702-xwz6f-post-install-hook-prev
│   ├── k8s-logs-monitoring-influxdb-6b55955dfc-cx2mk-watcher-prev
│   ├── k8s-nodes
│   ├── k8s-pods
│   ├── k8s-replicasets
│   ├── k8s-replicationcontrollers
│   └── k8s-services
├── node-1-k8s-logs.tar.gz
├── node-1-status.tar.gz
└── operation_install.4932c557-68c4-4b90-979f-564aa3b62da4
```