### PR TITLE
(5.5) Fix issue with chown when only uid is specified

### DIFF
--- a/lib/ops/opsservice/utils.go
+++ b/lib/ops/opsservice/utils.go
@@ -145,11 +145,14 @@ func newMount(m schema.Volume) storage.Mount {
 // chownExpr generates chown expression in the form used by chown command
 // based on uid and gid parameters
 func chownExpr(uid, gid *int) string {
+	// When both uid and gid are specified, the syntax is "chown <uid>:<gid> <dir>"
 	if uid != nil && gid != nil {
 		return fmt.Sprintf("%v:%v", *uid, *gid)
 	}
+	// When only uid is specified, the syntax is "chown <uid> <dir>"
 	if uid != nil {
-		return fmt.Sprintf("%v:", *uid)
+		return fmt.Sprintf("%v", *uid)
 	}
+	// When only gid is specified, the syntax is "chown :<gid> <dir>"
 	return fmt.Sprintf(":%v", *gid)
 }

--- a/lib/ops/opsservice/utils_test.go
+++ b/lib/ops/opsservice/utils_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"github.com/gravitational/gravity/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type UtilsSuite struct {
+}
+
+var _ = check.Suite(&UtilsSuite{})
+
+func (s *UtilsSuite) TestChownExpr(c *check.C) {
+	tests := []struct {
+		uid     *int
+		gid     *int
+		result  string
+		comment string
+	}{
+		{
+			uid:     utils.IntPtr(1000),
+			result:  "1000",
+			comment: "only uid is specified",
+		},
+		{
+			gid:     utils.IntPtr(2000),
+			result:  ":2000",
+			comment: "only gid is specified",
+		},
+		{
+			uid:     utils.IntPtr(1000),
+			gid:     utils.IntPtr(2000),
+			result:  "1000:2000",
+			comment: "both uid and gid are specified",
+		},
+	}
+	for _, t := range tests {
+		c.Assert(chownExpr(t.uid, t.gid), check.Equals, t.result,
+			check.Commentf(t.comment))
+	}
+}

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -250,23 +250,37 @@ func DisableAccess(backend Backend, name string, delay time.Duration) error {
 		Type:       teleservices.UserCA,
 		DomainName: name,
 	}, true)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	ca.SetTTL(backend, delay)
-	if err := backend.UpsertCertAuthority(ca); err != nil {
-		return trace.Wrap(err)
+	// User authority may have already been deleted if one of the calls below
+	// failed and this is being retried.
+	if trace.IsNotFound(err) {
+		log.WithField("name", name).Warn("User authority not found.")
+	}
+	if ca != nil {
+		ca.SetTTL(backend, delay)
+		if err := backend.UpsertCertAuthority(ca); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	ca, err = backend.GetCertAuthority(teleservices.CertAuthID{
 		Type:       teleservices.HostCA,
 		DomainName: name,
 	}, true)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	ca.SetTTL(backend, delay)
-	if err := backend.UpsertCertAuthority(ca); err != nil {
-		return trace.Wrap(err)
+	// Host authority may have already been deleted if one of the calls below
+	// failed and this is being retried.
+	if trace.IsNotFound(err) {
+		log.WithField("name", name).Warn("Host authority not found.")
+	}
+	if ca != nil {
+		ca.SetTTL(backend, delay)
+		if err := backend.UpsertCertAuthority(ca); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	cluster, err := backend.GetTrustedCluster(name)
 	if err != nil {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR addresses the issue with upgrade failing to update permissions of a new volume if only uid is set due to an incorrect chown command (see linked ticket for more details).

I have also updated a piece of code responsible to disabling remote access (e.g. to a wizard) to tolerate "not found" errors for authorities to ensure reentrability - otherwise if a later call (e.g. deleting a trusted cluster) fails due to etcd error, the authorities won't be there and it'll fail with not found.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1788.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Install a cluster, then upgrade to a new version that has this volume:

```yaml
 nodeProfiles:
   - name: worker
     description: Worker
     requirements:
       volumes:
         - name: data
           path: /var/data
           targetPath: /data
           uid: 3000
```

Before the change, upgrade fails with:

```
User Message: failed to execute phase &#34;/bootstrap&#34;
	failed to run {[chown 3000: /var/data] setting ownership of /var/data to 3000: false}:
		exit status 1] handler:upgrade utils/logging.go:103
```

After the change, the upgrade passes and volume is chown'd:

```
ubuntu@node-1:~/upgrade$ ls -l /var | grep data
drwxr-xr-x  3 3000 root   4096 May 28 00:05 data
```
