### PR TITLE
[5.5] ensure resumption on upgrade leader

### DIFF
--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -156,6 +157,12 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	err = f.checkExecuteOnCoordinator(plan)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	for _, phase := range plan.Phases {
 		f.WithField("phase", phase.ID).Debug("Executing phase.")
 		err := f.ExecutePhase(ctx, Params{
@@ -168,6 +175,21 @@ func (f *FSM) ExecutePlan(ctx context.Context, progress utils.Progress) error {
 		}
 	}
 	return nil
+}
+
+// checkExecuteOnCoordinator ensures that resuming the plan is executed on the lead node for the particular plan.
+// This is mainly important for etcd upgrades, where state can only be kept in sync on the leadMaster node itself.
+func (f *FSM) checkExecuteOnCoordinator(plan *storage.OperationPlan) error {
+	if plan.OfflineCoordinator == nil {
+		return nil
+	}
+
+	err := systeminfo.HasInterface(plan.OfflineCoordinator.AdvertiseIP)
+	if err != nil && trace.IsNotFound(err) {
+		return trace.BadParameter("Plan must be resumed on node %v/%v", plan.OfflineCoordinator.Hostname, plan.OfflineCoordinator.AdvertiseIP)
+	}
+
+	return trace.Wrap(err)
 }
 
 // RollbackPlan rolls back all phases of the plan that have been attempted so

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -43,6 +43,9 @@ type OperationPlan struct {
 	Phases []OperationPhase `json:"phases"`
 	// Servers is the list of all cluster servers
 	Servers []Server `json:"servers"`
+	// OfflineCoordinator is the server leading/coordinating the upgrade across the cluster, and will have a local copy
+	// of completed plan phases if the underlying state sync (etcd) is offline
+	OfflineCoordinator *Server `json:"lead_master"`
 	// GravityPackage is updated gravity package locator
 	GravityPackage loc.Locator `json:"gravity_package"`
 	// CreatedAt is the plan creation timestamp

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -162,6 +162,8 @@ func (r phaseBuilder) newPlan() (*storage.OperationPlan, error) {
 
 	root.AddParallel(initPhase, checksPhase, preUpdatePhase)
 
+	r.planTemplate.OfflineCoordinator = &r.leadMaster
+
 	if len(r.steps) == 0 {
 		// Embed the target runtime step directly into root phase
 		r.targetStep.buildInline(&root, r.leadMaster, r.installedApp.Package, r.updateApp.Package,

--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -154,13 +154,14 @@ func (s *PlanSuite) TestPlanWithRuntimeAppsUpdate(c *check.C) {
 	leadMaster := updates[1]
 	rearrangedServers := []storage.UpdateServer{updates[1], updates[0], updates[2]}
 	c.Assert(*obtainedPlan, check.DeepEquals, storage.OperationPlan{
-		OperationID:    builder.operation.ID,
-		OperationType:  builder.operation.Type,
-		AccountID:      builder.operation.AccountID,
-		ClusterName:    builder.operation.SiteDomain,
-		Servers:        servers,
-		DNSConfig:      storage.DefaultDNSConfig,
-		GravityPackage: loc.MustParseLocator("gravitational.io/gravity:3.0.0"),
+		OperationID:        builder.operation.ID,
+		OperationType:      builder.operation.Type,
+		AccountID:          builder.operation.AccountID,
+		ClusterName:        builder.operation.SiteDomain,
+		Servers:            servers,
+		DNSConfig:          storage.DefaultDNSConfig,
+		GravityPackage:     loc.MustParseLocator("gravitational.io/gravity:3.0.0"),
+		OfflineCoordinator: &leadMaster.Server,
 		Phases: []storage.OperationPhase{
 			params.init(rearrangedServers),
 			params.checks("/init"),
@@ -372,13 +373,14 @@ func (s *PlanSuite) TestPlanWithIntermediateRuntimeUpdate(c *check.C) {
 	nodes := updates[2:]
 
 	c.Assert(*obtainedPlan, check.DeepEquals, storage.OperationPlan{
-		OperationID:    builder.operation.ID,
-		OperationType:  builder.operation.Type,
-		AccountID:      builder.operation.AccountID,
-		ClusterName:    builder.operation.SiteDomain,
-		Servers:        servers,
-		DNSConfig:      storage.DefaultDNSConfig,
-		GravityPackage: loc.MustParseLocator("gravitational.io/gravity:3.0.0"),
+		OperationID:        builder.operation.ID,
+		OperationType:      builder.operation.Type,
+		AccountID:          builder.operation.AccountID,
+		ClusterName:        builder.operation.SiteDomain,
+		Servers:            servers,
+		DNSConfig:          storage.DefaultDNSConfig,
+		GravityPackage:     loc.MustParseLocator("gravitational.io/gravity:3.0.0"),
+		OfflineCoordinator: &leadMaster.Server,
 		Phases: []storage.OperationPhase{
 			params.init(rearrangedIntermediateServers),
 			params.checks("/init"),


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Forces resumed upgrades that contain etcd upgrade phases to be run on the node coordinating the upgrades. This prevents unsynced plan phases from blocking the upgrade due to dependency resolution failures.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
https://github.com/gravitational/gravity/issues/1689
* Backports
  - #1737 

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Do a manual upgrade that contains an etcd upgrade, and then resume from a different node.

Node 1:
```
root@kevin-test1:~/build# ./upload
Thu Jun 18 20:12:20 UTC	Importing application telekube v7.1.0-alpha.1.91
Thu Jun 18 20:13:15 UTC	Synchronizing application with Docker registry 10.162.0.7:5000
Thu Jun 18 20:15:07 UTC	Synchronizing application with Docker registry 10.162.0.6:5000
Thu Jun 18 20:16:18 UTC	Application has been uploaded
root@kevin-test1:~/build# ./gravity upgrade --manual
Thu Jun 18 20:16:38 UTC	Upgrading cluster from 7.0.0 to 7.1.0-alpha.1.91
Thu Jun 18 20:16:39 UTC	Deploying agents on cluster nodes
Deployed agent on kevin-test2 (10.162.0.6)
Deployed agent on kevin-test1 (10.162.0.7)
The operation has been created in manual mode.

See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.
```

Node 2:
```
root@kevin-test1:~/build# ./gravity plan resume
Wed Jun 24 22:12:12 UTC	initializing the operation
[ERROR]: Plan must be resumed on node kevin-test2/10.162.0.6
```

## Additional information
<!--Optional. Anything else that may be relevant.-->

Please note, unlike #1737 this backport affects all runtime upgrades. This is due to structural differences in the upgrade code that haven't been ported, which shouldn't be ported as part of this PR.
