### PR TITLE
(5.5) Bump election timeout

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1006,7 +1006,9 @@ const (
 
 	// ElectionWaitTimeout specifies the maximum amount of time to wait to resume elections
 	// on a master node
-	ElectionWaitTimeout = 1 * time.Minute
+	ElectionWaitTimeout = 5 * time.Minute
+	// ElectionRetryInterval is the interval between resuming election attempts
+	ElectionRetryInterval = 10 * time.Second
 
 	// ImageRegistryVar is a local cluster registry variable that gets
 	// substituted in Helm templates.

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1007,8 +1007,8 @@ const (
 	// ElectionWaitTimeout specifies the maximum amount of time to wait to resume elections
 	// on a master node
 	ElectionWaitTimeout = 5 * time.Minute
-	// ElectionRetryInterval is the interval between resuming election attempts
-	ElectionRetryInterval = 10 * time.Second
+	// ElectionRetryMaxInterval is the max interval between resuming election attempts
+	ElectionRetryMaxInterval = 10 * time.Second
 
 	// ImageRegistryVar is a local cluster registry variable that gets
 	// substituted in Helm templates.

--- a/lib/ops/election.go
+++ b/lib/ops/election.go
@@ -38,7 +38,7 @@ func PauseLeaderElection(ctx context.Context, clusterName string, node storage.S
 
 func runLeaderCommandRetry(ctx context.Context, command string, clusterName string, node storage.Server, log logrus.FieldLogger) error {
 	b := backoff.NewExponentialBackOff()
-	b.MaxInterval = defaults.ElectionRetryInterval
+	b.MaxInterval = defaults.ElectionRetryMaxInterval
 	b.MaxElapsedTime = defaults.ElectionWaitTimeout
 	return utils.RetryTransient(ctx, b, func() error {
 		return runLeaderCommand(ctx, command, clusterName, node, log)

--- a/lib/ops/election.go
+++ b/lib/ops/election.go
@@ -38,6 +38,7 @@ func PauseLeaderElection(ctx context.Context, clusterName string, node storage.S
 
 func runLeaderCommandRetry(ctx context.Context, command string, clusterName string, node storage.Server, log logrus.FieldLogger) error {
 	b := backoff.NewExponentialBackOff()
+	b.MaxInterval = defaults.ElectionRetryInterval
 	b.MaxElapsedTime = defaults.ElectionWaitTimeout
 	return utils.RetryTransient(ctx, b, func() error {
 		return runLeaderCommand(ctx, command, clusterName, node, log)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Just had a failure on join due to 

```
failed to enable election for 10.128.0.20: [ERROR]: client: etcd cluster is unavailable or misconfigured; error #0: client: endpoint https://127.0.0.1:2379 exceeded header timeout
```

Looking at the logs, etcd was having some temporary issues on the new node, and the current leader election timeout is pretty short - 1m - esp. considering it uses exponential backoff, so there may be not a lot of attempts.

This PR increases the timeout to 5m and also makes sure that max retry interval is 10s so the phase gets plenty of attempts to account for temp. etcd issues.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

None, really. Just a simple constant bump.