### PR TITLE
[6.1.x] Gravity report improvements

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -188,6 +188,9 @@ const (
 	// GravityUpdateDir specifies the directory used by the update process
 	GravityUpdateDir = "/var/lib/gravity/site/update"
 
+	// PlanetStateDir specifies the planet state directory
+	PlanetStateDir = "/var/state"
+
 	// GravityRPCAgentPort defines which port RPC agent is listening on
 	GravityRPCAgentPort = 3012
 

--- a/lib/install/operation.go
+++ b/lib/install/operation.go
@@ -268,10 +268,7 @@ func (i *Installer) generateDebugReport(ctx context.Context, clusterKey ops.Site
 			os.Remove(f.Name())
 		}
 	}()
-	rc, err := i.config.Operator.GetSiteReport(ctx, ops.GetClusterReportRequest{
-		SiteKey: clusterKey,
-		Since:   time.Duration(0),
-	})
+	rc, err := i.config.Operator.GetSiteReport(ctx, ops.GetClusterReportRequest{SiteKey: clusterKey})
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/install/operation.go
+++ b/lib/install/operation.go
@@ -268,7 +268,10 @@ func (i *Installer) generateDebugReport(ctx context.Context, clusterKey ops.Site
 			os.Remove(f.Name())
 		}
 	}()
-	rc, err := i.config.Operator.GetSiteReport(ctx, clusterKey)
+	rc, err := i.config.Operator.GetSiteReport(ctx, ops.GetClusterReportRequest{
+		SiteKey: clusterKey,
+		Since:   time.Duration(0),
+	})
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -571,11 +571,11 @@ func (o *OperatorACL) CreateProgressEntry(key SiteOperationKey, entry ProgressEn
 	return o.operator.CreateProgressEntry(key, entry)
 }
 
-func (o *OperatorACL) GetSiteReport(ctx context.Context, key SiteKey) (io.ReadCloser, error) {
-	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+func (o *OperatorACL) GetSiteReport(ctx context.Context, req GetClusterReportRequest) (io.ReadCloser, error) {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteReport(ctx, key)
+	return o.operator.GetSiteReport(ctx, req)
 }
 
 func (o *OperatorACL) ValidateDomainName(domainName string) error {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -415,7 +415,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(context.Context, SiteKey) (io.ReadCloser, error)
+	GetSiteReport(context.Context, GetClusterReportRequest) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)
@@ -2125,4 +2125,12 @@ func (r AuditEventRequest) String() string {
 type Audit interface {
 	// EmitAuditEvent saves the provided event in the audit log.
 	EmitAuditEvent(context.Context, AuditEventRequest) error
+}
+
+// GetClusterReportRequest specifies the request to get the cluster report
+type GetClusterReportRequest struct {
+	// SiteKey is a key used to identify site
+	SiteKey
+	// Since is used to filter collected logs by time
+	Since time.Duration `json:"since,omitempty"`
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -685,8 +685,11 @@ func (c *Client) CreateProgressEntry(key ops.SiteOperationKey, entry ops.Progres
 	return nil
 }
 
-func (c *Client) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	file, err := c.GetFile(ctx, c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), url.Values{})
+func (c *Client) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	params := url.Values{
+		"since": []string{req.Since.String()},
+	}
+	file, err := c.GetFile(ctx, c.Endpoint("accounts", req.AccountID, "sites", req.SiteDomain, "report"), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1840,17 +1840,7 @@ func (h *WebHandler) streamOperationLogs(w http.ResponseWriter, r *http.Request,
 
 */
 func (h *WebHandler) getSiteOperationCrashReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	var since time.Duration
-	if val := r.URL.Query().Get("since"); val != "" {
-		var err error
-		if since, err = time.ParseDuration(val); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	report, err := context.Operator.GetSiteReport(r.Context(), ops.GetClusterReportRequest{
-		SiteKey: siteKey(p),
-		Since:   since,
-	})
+	report, err := context.Operator.GetSiteReport(r.Context(), ops.GetClusterReportRequest{SiteKey: siteKey(p)})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1840,7 +1840,17 @@ func (h *WebHandler) streamOperationLogs(w http.ResponseWriter, r *http.Request,
 
 */
 func (h *WebHandler) getSiteOperationCrashReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(r.Context(), siteKey(p))
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	report, err := context.Operator.GetSiteReport(r.Context(), ops.GetClusterReportRequest{
+		SiteKey: siteKey(p),
+		Since:   since,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1026,7 +1026,19 @@ func (h *WebHandler) activateSite(w http.ResponseWriter, r *http.Request, p http
    GET /portal/v1/accounts/:account_id/sites/:site_domain/report
 */
 func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(r.Context(), siteKey(p))
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	report, err := context.Operator.GetSiteReport(r.Context(),
+		ops.GetClusterReportRequest{
+			SiteKey: siteKey(p),
+			Since:   since,
+		})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -417,12 +417,12 @@ func (r *Router) CreateProgressEntry(key ops.SiteOperationKey, entry ops.Progres
 	return client.CreateProgressEntry(key, entry)
 }
 
-func (r *Router) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	client, err := r.PickClient(key.SiteDomain)
+func (r *Router) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteReport(ctx, key)
+	return client.GetSiteReport(ctx, req)
 }
 
 // ValidateServers runs pre-installation checks

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/archive"
@@ -41,7 +42,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *site) getClusterReport(ctx context.Context) (io.ReadCloser, error) {
+func (s *site) getClusterReport(ctx context.Context, since time.Duration) (io.ReadCloser, error) {
 	op, err := storage.GetLastOperationForCluster(s.backend(), s.domainName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -50,13 +51,13 @@ func (s *site) getClusterReport(ctx context.Context) (io.ReadCloser, error) {
 	s.WithField("op", op).Info("Capture debug report for operation.")
 	switch {
 	case isActiveInstallOperation((ops.SiteOperation)(*op)):
-		return s.getClusterInstallReport(ctx, (ops.SiteOperation)(*op))
+		return s.getClusterInstallReport(ctx, (ops.SiteOperation)(*op), since)
 	default:
-		return s.getClusterGenericReport(ctx)
+		return s.getClusterGenericReport(ctx, since)
 	}
 }
 
-func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation) (io.ReadCloser, error) {
+func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation, since time.Duration) (io.ReadCloser, error) {
 	opCtx, err := s.newOperationContext(op)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -68,20 +69,20 @@ func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(opCtx.provisionedServers))
 	for _, server := range servers {
 		remoteServers = append(remoteServers, server)
-		if server.IsMaster() && master == nil {
-			master = server
+		if server.IsMaster() {
+			masterServers = append(masterServers, server)
 		}
 	}
 
 	runner := s.agentRunner(opCtx)
-	return s.getReport(ctx, runner, remoteServers, master)
+	return s.getReport(ctx, runner, remoteServers, masterServers, since)
 }
 
-func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, error) {
+func (s *site) getClusterGenericReport(ctx context.Context, since time.Duration) (io.ReadCloser, error) {
 	const noRetry = 1
 	servers, err := s.getTeleportServersWithTimeout(
 		nil,
@@ -93,12 +94,13 @@ func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, erro
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
 	teleportRunner := &teleportRunner{
 		FieldLogger:          log.WithField(trace.Component, "teleport-runner"),
 		TeleportProxyService: s.teleport(),
 		domainName:           s.domainName,
 	}
+
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(servers))
 	for _, server := range servers {
 		teleportServer, err := newTeleportServer(server)
@@ -106,16 +108,17 @@ func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, erro
 			return nil, trace.Wrap(err)
 		}
 		role := schema.ServiceRole(teleportServer.Labels[schema.ServiceLabelRole])
-		if role == schema.ServiceRoleMaster && master == nil {
-			master = teleportServer
+		if role == schema.ServiceRoleMaster {
+			masterServers = append(masterServers, teleportServer)
 		}
 		remoteServers = append(remoteServers, teleportServer)
 	}
 
-	return s.getReport(ctx, teleportRunner, remoteServers, master)
+	return s.getReport(ctx, teleportRunner, remoteServers, masterServers, since)
 }
 
-func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []remoteServer, master remoteServer) (io.ReadCloser, error) {
+func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []remoteServer, masters []remoteServer,
+	since time.Duration) (io.ReadCloser, error) {
 	dir, err := ioutil.TempDir("", "report")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -134,18 +137,20 @@ func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []rem
 
 	if len(servers) > 0 {
 		// Use the first master server to collect kubernetes diagnostics
-		server := master
-		if server == nil {
+		var server remoteServer
+		if len(masters) > 0 {
+			server = masters[0]
+		} else {
 			server = servers[0]
 			log.Warningf("No master servers, collecting Kubernetes diagnostics from %v.", server)
 		}
 		serverRunner := &serverRunner{server: server, runner: runner}
 		reportWriter := getReportWriterForServer(dir, server)
 		logger := log.WithField("server", server.Address())
-		if err := s.collectKubernetesInfo(reportWriter, serverRunner); err != nil {
+		if err := s.collectKubernetesInfo(reportWriter, serverRunner, since); err != nil {
 			logger.WithError(err).Error("Failed to collect Kubernetes info.")
 		}
-		if err := s.collectDebugInfoFromServers(ctx, dir, servers, runner); err != nil {
+		if err := s.collectDebugInfoFromServers(ctx, dir, servers, runner, since); err != nil {
 			log.WithError(err).Error("Failed to collect diagnostics from some nodes.")
 		}
 		if err := s.collectStatusTimeline(reportWriter, serverRunner); err != nil {
@@ -178,7 +183,8 @@ func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []rem
 //
 //   <server-name>-<resource>
 //
-func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, servers []remoteServer, runner remoteRunner) error {
+func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, servers []remoteServer, runner remoteRunner,
+	since time.Duration) error {
 	err := s.executeOnServers(ctx, servers, func(c context.Context, server remoteServer) error {
 		log.WithField("server", server.Debug()).Debug("Collect debug info.")
 		r := &serverRunner{
@@ -186,7 +192,7 @@ func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, serv
 			runner: runner,
 		}
 		reportWriter := getReportWriterForServer(dir, server)
-		err := s.collectDebugInfo(reportWriter, r)
+		err := s.collectDebugInfo(reportWriter, r, since)
 		return trace.Wrap(err)
 	})
 	if err != nil {
@@ -195,7 +201,7 @@ func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, serv
 	return nil
 }
 
-func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRunner) error {
+func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRunner, since time.Duration) error {
 	w, err := reportWriter.NewWriter("debug-logs.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
@@ -203,15 +209,16 @@ func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRu
 	defer w.Close()
 
 	err = runner.RunStream(w, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterSystem),
-		"--compressed")...)
+		"--filter", report.FilterSystem,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect diagnostics")
 	}
 	return nil
 }
 
-func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *serverRunner) error {
+func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *serverRunner, since time.Duration) error {
 	w, err := reportWriter.NewWriter("k8s-logs.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
@@ -219,7 +226,9 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 	defer w.Close()
 
 	err = runner.RunStream(w, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterKubernetes), "--compressed")...)
+		"--filter", report.FilterKubernetes,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect kubernetes diagnostics")
 	}

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -256,7 +256,7 @@ func (s *site) collectEtcdInfoFromMasters(ctx context.Context, dir string, maste
 	return nil
 }
 
-// collectEtcdInfo collects etcd metrics.
+// collectEtcdInfo collects etcd metrics and captures a snapshot of the data.
 func (s *site) collectEtcdInfo(reportWriter report.FileWriter, runner *serverRunner) error {
 	w, err := reportWriter.NewWriter("etcd.tar.gz")
 	if err != nil {

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1144,13 +1144,13 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 	return site.createLogEntry(key, entry)
 }
 
-func (o *Operator) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	cluster, err := o.openSite(key)
+func (o *Operator) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	cluster, err := o.openSite(req.SiteKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return cluster.getClusterReport(ctx)
+	return cluster.getClusterReport(ctx, req.Since)
 }
 
 func (o *Operator) GetSiteOperationProgress(key ops.SiteOperationKey) (*ops.ProgressEntry, error) {

--- a/lib/ops/suite/opssuite.go
+++ b/lib/ops/suite/opssuite.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	apptest "github.com/gravitational/gravity/lib/app/service/test"
@@ -153,7 +154,10 @@ func (s *OpsSuite) SitesCRUD(c *C) {
 	c.Assert(logStream.Close(), IsNil)
 
 	// download crashreport
-	reportStream, err := s.O.GetSiteReport(context.TODO(), opKey.SiteKey())
+	reportStream, err := s.O.GetSiteReport(context.TODO(), ops.GetClusterReportRequest{
+		SiteKey: opKey.SiteKey(),
+		Since:   time.Duration(0),
+	})
 	c.Assert(err, IsNil)
 	_, err = io.Copy(ioutil.Discard, reportStream)
 	c.Assert(err, IsNil)

--- a/lib/ops/suite/opssuite.go
+++ b/lib/ops/suite/opssuite.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	apptest "github.com/gravitational/gravity/lib/app/service/test"
@@ -154,10 +153,7 @@ func (s *OpsSuite) SitesCRUD(c *C) {
 	c.Assert(logStream.Close(), IsNil)
 
 	// download crashreport
-	reportStream, err := s.O.GetSiteReport(context.TODO(), ops.GetClusterReportRequest{
-		SiteKey: opKey.SiteKey(),
-		Since:   time.Duration(0),
-	})
+	reportStream, err := s.O.GetSiteReport(context.TODO(), ops.GetClusterReportRequest{SiteKey: opKey.SiteKey()})
 	c.Assert(err, IsNil)
 	_, err = io.Copy(ioutil.Discard, reportStream)
 	c.Assert(err, IsNil)

--- a/lib/report/collector.go
+++ b/lib/report/collector.go
@@ -130,9 +130,10 @@ func Self(name string, args ...string) Command {
 
 // Command defines a generic command with a name and a list of arguments
 type Command struct {
-	name string
-	cmd  string
-	args []string
+	name             string
+	cmd              string
+	args             []string
+	successExitCodes []int
 }
 
 // Collect implements Collector for this Command
@@ -145,7 +146,18 @@ func (r Command) Collect(ctx context.Context, reportWriter FileWriter, runner ut
 
 	args := []string{r.cmd}
 	args = append(args, r.args...)
-	return runner.RunStream(ctx, w, args...)
+	if err := runner.RunStream(ctx, w, args...); err != nil && r.isExitCodeFailed(err) {
+		return trace.Wrap(err, "failed to execute %v", r)
+	}
+	return nil
+}
+
+func (r Command) isExitCodeFailed(err error) bool {
+	exitCode := utils.ExitStatusFromError(err)
+	if exitCode == nil {
+		return false
+	}
+	return *exitCode != 0 && !exitCodeOneOf(*exitCode, r.successExitCodes...)
 }
 
 // Script creates a new script collector
@@ -176,4 +188,16 @@ func tarball(pattern string) string {
 #!/bin/bash
 /bin/tar cz --ignore-failed-read --ignore-command-error -f /dev/stdout -C / $(readlink -e %v) -P 2> /dev/null
 `, pattern)
+}
+
+func exitCodeOneOf(exitCode int, exitCodes ...int) bool {
+	if len(exitCodes) == 0 {
+		return false
+	}
+	for _, code := range exitCodes {
+		if code == exitCode {
+			return true
+		}
+	}
+	return false
 }

--- a/lib/report/k8s.go
+++ b/lib/report/k8s.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/utils"
@@ -30,7 +31,7 @@ import (
 
 // NewKubernetesCollector returns a list of collectors to fetch kubernetes-specific
 // diagnostics.
-func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner) Collectors {
+func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner, since time.Duration) Collectors {
 	runner = planetContextRunner{runner}
 	// general kubernetes info
 	commands := Collectors{
@@ -76,12 +77,14 @@ func NewKubernetesCollector(ctx context.Context, runner utils.CommandRunner) Col
 				name := fmt.Sprintf("k8s-logs-%v-%v-%v", namespace, pod, container)
 				commands = append(commands, Cmd(name, utils.PlanetCommand(kubectl.Command("logs", pod,
 					"--namespace", namespace,
+					"--since", since.String(),
 					fmt.Sprintf("-c=%v", container)))...))
 				// Also collect logs for the previous instance
 				// of the container if there's any.
 				name = fmt.Sprintf("%v-prev", name)
 				commands = append(commands, Cmd(name, utils.PlanetCommand(kubectl.Command("logs", pod,
 					"--namespace", namespace, "-p",
+					"--since", since.String(),
 					fmt.Sprintf("-c=%v", container)))...))
 			}
 		}

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -47,6 +47,8 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, NewPackageCollector(config.Packages))
 		case FilterKubernetes:
 			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner, config.Since)...)
+		case FilterEtcd:
+			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
 		}
@@ -115,6 +117,9 @@ const (
 
 	// FilterKubernetes defines a report collection filter to fetch kubernetes diagnostics
 	FilterKubernetes = "kubernetes"
+
+	// FilterEtcd defines a report collection filter to fetch etcd data
+	FilterEtcd = "etcd"
 
 	// FilterTimeline defines a report collection filter to fetch the status timeline
 	FilterTimeline = "timeline"

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -33,10 +33,10 @@ func NewSystemCollector(since time.Duration) Collectors {
 	}
 
 	add(basicSystemInfo()...)
-	add(planetServices()...)
+	add(systemStatus()...)
 	add(syslogExportLogs(since))
 	add(systemFileLogs()...)
-	add(planetLogs()...)
+	add(planetLogs(since)...)
 
 	return collectors
 }
@@ -73,6 +73,12 @@ func basicSystemInfo() Collectors {
 		Cmd("host-system-status", "/bin/systemctl", "status", "--full"),
 		Cmd("host-system-failed", "/bin/systemctl", "--failed", "--full"),
 		Cmd("host-system-jobs", "/bin/systemctl", "list-jobs", "--full"),
+		Command{
+			name:             "host-system-jobs",
+			cmd:              "/bin/systemctl",
+			args:             []string{"list-jobs", "--full"},
+			successExitCodes: []int{1},
+		},
 		Cmd("dmesg", "/bin/dmesg", "--raw"),
 		Cmd("reboot-history", "last", "-x"),
 		Cmd("uname", "uname", "-a"),
@@ -87,7 +93,8 @@ func basicSystemInfo() Collectors {
 	}
 }
 
-func planetServices() Collectors {
+func systemStatus() Collectors {
+	listJobArgs := utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")
 	return Collectors{
 		// etcd cluster health
 		Cmd("etcd-status", utils.PlanetCommandArgs("/usr/bin/etcdctl", "cluster-health")...),
@@ -97,6 +104,12 @@ func planetServices() Collectors {
 		Cmd("planet-system-status", utils.PlanetCommandArgs("/bin/systemctl", "status", "--full")...),
 		Cmd("planet-system-failed", utils.PlanetCommandArgs("/bin/systemctl", "--failed", "--full")...),
 		Cmd("planet-system-jobs", utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")...),
+		Command{
+			name:             "planet-system-jobs",
+			cmd:              listJobArgs[0],
+			args:             listJobArgs[1:],
+			successExitCodes: []int{1},
+		},
 		// serf status
 		Cmd("serf-members", utils.PlanetCommandArgs(defaults.SerfBin, "members")...),
 	}
@@ -129,14 +142,14 @@ cat %v 2> /dev/null || true`
 }
 
 // planetLogs fetches planet syslog messages as well as the fresh journal entries
-func planetLogs() Collectors {
+func planetLogs(since time.Duration) Collectors {
 	return Collectors{
 		// Fetch planet journal entries for the last two days
 		// The log can be imported as a journal with systemd-journal-remote:
 		//
 		// $ cat ./node-1-planet-journal-export.log | /lib/systemd/systemd-journal-remote -o ./journal/system.journal -
 		Self("planet-journal-export.log.gz",
-			"system", "export-runtime-journal"),
+			"system", "export-runtime-journal", "--since", since.String()),
 	}
 }
 

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -18,6 +18,7 @@ package report
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
@@ -136,5 +137,16 @@ func planetLogs() Collectors {
 		// $ cat ./node-1-planet-journal-export.log | /lib/systemd/systemd-journal-remote -o ./journal/system.journal -
 		Self("planet-journal-export.log.gz",
 			"system", "export-runtime-journal"),
+	}
+}
+
+// etcdMetrics fetches etcd metrics
+func etcdMetrics() Collectors {
+	return Collectors{
+		Cmd("etcd-metrics", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--tlsv1.2",
+			"--cacert", filepath.Join(defaults.PlanetStateDir, defaults.RootCertFilename),
+			"--cert", filepath.Join(defaults.PlanetStateDir, defaults.EtcdCertFilename),
+			"--key", filepath.Join(defaults.PlanetStateDir, defaults.EtcdKeyFilename),
+			filepath.Join(defaults.EtcdLocalAddr, "metrics"))...),
 	}
 }

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1732,10 +1732,22 @@ func (m *Handler) getJoinToken(w http.ResponseWriter, r *http.Request, p httprou
 //
 //   report.tar
 func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	reader, err := context.Operator.GetSiteReport(r.Context(), ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
-	})
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	reader, err := context.Operator.GetSiteReport(r.Context(),
+		ops.GetClusterReportRequest{
+			SiteKey: ops.SiteKey{
+				AccountID:  context.User.GetAccountID(),
+				SiteDomain: p.ByName("domain"),
+			},
+			Since: since,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1307,6 +1307,10 @@ type ReportCmd struct {
 	*kingpin.CmdClause
 	// FilePath is the report tarball path
 	FilePath *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SiteCmd combines cluster related subcommands
@@ -1578,6 +1582,10 @@ type SystemReportCmd struct {
 	Filter *[]string
 	// Compressed allows to gzip the tarball
 	Compressed *bool
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStateDirCmd shows local state directory

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1620,11 +1620,19 @@ type SystemExportRuntimeJournalCmd struct {
 	*kingpin.CmdClause
 	// OutputFile specifies the path of the resulting tarball
 	OutputFile *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStreamRuntimeJournalCmd streams contents of the runtime journal
 type SystemStreamRuntimeJournalCmd struct {
 	*kingpin.CmdClause
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemGCJournalCmd manages cleanup of journal files

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -1132,7 +1132,7 @@ func InstallerGenerateLocalReport(env *localenv.LocalEnvironment) func(context.C
 				os.Remove(f.Name())
 			}
 		}()
-		err = systemReport(env, report.AllFilters, true, f)
+		err = systemReport(env, report.AllFilters, true, f, time.Duration(0))
 		if err != nil {
 			return trace.ConvertSystemError(err)
 		}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -549,6 +549,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Collect tarball with cluster's diagnostic information.")
 	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "File name with collected diagnostic information.").Default("report.tar.gz").String()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")
@@ -681,6 +682,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemReportCmd.CmdClause = g.SystemCmd.Command("report", "collect system diagnostics and output as gzipped tarball to terminal").Hidden()
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()
+	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStateDirCmd.CmdClause = g.SystemCmd.Command("state-dir", "show where all gravity data is stored on the node").Hidden()
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -696,8 +696,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// journal helpers
 	g.SystemExportRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("export-runtime-journal", "Export runtime journal logs to a file").Hidden()
 	g.SystemExportRuntimeJournalCmd.OutputFile = g.SystemExportRuntimeJournalCmd.Flag("output", "Name of resulting tarball. Output to stdout if unspecified").String()
+	g.SystemExportRuntimeJournalCmd.Since = g.SystemExportRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStreamRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("stream-runtime-journal", "Stream runtime journal to stdout").Hidden()
+	g.SystemStreamRuntimeJournalCmd.Since = g.SystemStreamRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	// pruning cluster resources
 	g.GarbageCollectCmd.CmdClause = g.Command("gc", "Prune cluster resources")

--- a/tool/gravity/cli/report.go
+++ b/tool/gravity/cli/report.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/report"
@@ -30,11 +31,13 @@ import (
 // to the stdout.
 // filters define the specific diagnostics to collect ('system', 'kubernetes'),
 // if empty all diagnostics are collected.
-func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, w io.Writer) error {
+func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, w io.Writer,
+	since time.Duration) error {
 	config := report.Config{
 		Filters:    filters,
 		Compressed: compressed,
 		Packages:   env.Packages,
+		Since:      since,
 	}
 	err := report.Collect(context.TODO(), config, w)
 	return trace.Wrap(err)

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -717,7 +717,9 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.APIKeyDeleteCmd.Email,
 			*g.APIKeyDeleteCmd.Token)
 	case g.ReportCmd.FullCommand():
-		return getClusterReport(localEnv, *g.ReportCmd.FilePath)
+		return getClusterReport(localEnv,
+			*g.ReportCmd.FilePath,
+			*g.ReportCmd.Since)
 	// cluster commands
 	case g.SiteListCmd.FullCommand():
 		return listSites(localEnv, *g.SiteListCmd.OpsCenterURL)
@@ -828,7 +830,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		return systemReport(localEnv,
 			*g.SystemReportCmd.Filter,
 			*g.SystemReportCmd.Compressed,
-			os.Stdout)
+			os.Stdout,
+			*g.SystemReportCmd.Since)
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -835,9 +835,11 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():
-		return exportRuntimeJournal(localEnv, *g.SystemExportRuntimeJournalCmd.OutputFile)
+		return exportRuntimeJournal(localEnv,
+			*g.SystemExportRuntimeJournalCmd.OutputFile,
+			*g.SystemExportRuntimeJournalCmd.Since)
 	case g.SystemStreamRuntimeJournalCmd.FullCommand():
-		return streamRuntimeJournal(localEnv)
+		return streamRuntimeJournal(localEnv, *g.SystemStreamRuntimeJournalCmd.Since)
 	case g.GarbageCollectCmd.FullCommand():
 		return garbageCollect(localEnv, *g.GarbageCollectCmd.Manual, *g.GarbageCollectCmd.Confirmed)
 	case g.SystemGCJournalCmd.FullCommand():

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -122,7 +122,7 @@ func listSites(env *localenv.LocalEnvironment, opsCenterURL string) error {
 	return nil
 }
 
-func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
+func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since time.Duration) error {
 	f, err := os.Create(targetFile)
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,10 +140,14 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
 	}
 
 	// TODO(dmitri): see comments on defaults.GenerateDebugReportTimeout
-	report, err := operator.GetSiteReport(context.TODO(), ops.SiteKey{
-		AccountID:  site.AccountID,
-		SiteDomain: site.Domain,
-	})
+	report, err := operator.GetSiteReport(context.TODO(),
+		ops.GetClusterReportRequest{
+			SiteKey: ops.SiteKey{
+				AccountID:  site.AccountID,
+				SiteDomain: site.Domain,
+			},
+			Since: since,
+		})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds a time filter to `gravity report` and adds a few more system collectors.

- Reboots history: `last -x`
- Kernel information: `uname -a`
- Serf cluster: `serf members`
- Swap status: `swapon -s` (we have vmstat but wouldn't hurt)
- Etcd metrics: `curl -s  --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https://localhost:2379/metrics`

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
* Ports https://github.com/gravitational/gravity/pull/1719, https://github.com/gravitational/gravity/pull/1755

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verified additional collectors**

**Verified k8s logs are filtered by time**

**Verified journal logs are filtered by time**
