### PR TITLE
(6.1) Forward-port upgrade prechecks and uid fix

### DIFF
--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1358,6 +1358,8 @@ type CreateSiteAppUpdateOperationRequest struct {
 	App string `json:"package"`
 	// StartAgents specifies whether the operation will automatically start the update agents
 	StartAgents bool `json:"start_agents"`
+	// Force allows to override the otherwise failed preconditions
+	Force bool `json:"force"`
 }
 
 // Check validates this request

--- a/lib/ops/opsservice/operationgroup.go
+++ b/lib/ops/opsservice/operationgroup.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/ops/events"
 	"github.com/gravitational/gravity/lib/schema"
@@ -65,10 +66,18 @@ func (s swap) Check() error {
 
 // createSiteOperation creates the provided operation if the checks allow it to be created
 func (g *operationGroup) createSiteOperation(operation ops.SiteOperation) (*ops.SiteOperationKey, error) {
+	return g.createSiteOperationWithOptions(operation, createOperationOptions{})
+}
+
+type createOperationOptions struct {
+	force bool
+}
+
+func (g *operationGroup) createSiteOperationWithOptions(operation ops.SiteOperation, options createOperationOptions) (*ops.SiteOperationKey, error) {
 	g.Lock()
 	defer g.Unlock()
 
-	err := g.canCreateOperation(operation)
+	err := g.canCreateOperation(operation, options.force)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -119,7 +128,7 @@ func (g *operationGroup) emitAuditEvent(ctx context.Context, operation ops.SiteO
 //
 // In case of failed checks returns trace.CompareFailed error to indicate that
 // the cluster is not in the appropriate state.
-func (g *operationGroup) canCreateOperation(operation ops.SiteOperation) error {
+func (g *operationGroup) canCreateOperation(operation ops.SiteOperation, force bool) error {
 	cluster, err := g.operator.GetSite(g.siteKey)
 	if err != nil {
 		return trace.Wrap(err)
@@ -131,6 +140,11 @@ func (g *operationGroup) canCreateOperation(operation ops.SiteOperation) error {
 	case ops.OperationExpand:
 		// expand has to undergo some checks
 		err := g.canCreateExpandOperation(*cluster, operation)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	case ops.OperationUpdate:
+		err := g.canCreateUpgradeOperation(*cluster, operation, force)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -150,6 +164,70 @@ func (g *operationGroup) canCreateOperation(operation ops.SiteOperation) error {
 		}
 	}
 
+	return nil
+}
+
+func (g *operationGroup) canCreateUpgradeOperation(cluster ops.Site, operation ops.SiteOperation, force bool) error {
+	// Upgrade is only allowed for active and healthy clusters.
+	if cluster.State != ops.SiteStateActive {
+		return trace.CompareFailed(
+			`Upgrade operation can only be triggered for active clusters. This cluster is currently %v.
+Use "gravity status" to see the cluster status and make sure that the cluster is active and healthy before retrying.`, cluster.State)
+	}
+	// Even if the cluster is active, run a few checks on the last upgrade
+	// operation to make sure it was completed/rolled back properly, to
+	// protect against cases when cluster state is force-reset midway.
+	lastUpgrade, err := ops.GetLastUpgradeOperation(cluster.Key(), g.operator)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	if trace.IsNotFound(err) {
+		return nil
+	}
+	err = g.checkLastOperation(*lastUpgrade)
+	if err != nil {
+		if force { // Last operation checks didn't pass but force flag was provided.
+			log.WithError(err).Warn("Force-creating upgrade operation.")
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+	// All last operation checks passed.
+	return nil
+}
+
+func (g *operationGroup) checkLastOperation(operation ops.SiteOperation) error {
+	// Check if the operation is in a terminal state.
+	if !operation.IsFinished() {
+		return trace.CompareFailed(
+			`The last %v operation (%v) is still in progress.
+Use "gravity plan" to view the operation plan, and either resume or rollback it before attempting to start another operation.
+You can provide --force flag to override this check.`,
+			operation.TypeString(),
+			operation.ID)
+	}
+	// Last upgrade completed fine.
+	if operation.IsCompleted() {
+		return nil
+	}
+	// Otherwise the operation is failed - check its plan and make sure it was
+	// fully rolled back.
+	plan, err := g.operator.GetOperationPlan(operation.Key())
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	if trace.IsNotFound(err) {
+		return nil
+	}
+	if !fsm.IsRolledBack(plan) {
+		return trace.CompareFailed(
+			`The last %v operation (%v) is in a %v state but its operation plan isn't fully rolled back.
+Use "gravity plan" to view the operation plan, and either resume it or roll it back before attempting to start another operation.
+You can provide --force flag to override this check.`,
+			operation.TypeString(),
+			operation.ID,
+			operation.State)
+	}
 	return nil
 }
 

--- a/lib/ops/opsservice/operationgroup_test.go
+++ b/lib/ops/opsservice/operationgroup_test.go
@@ -19,6 +19,7 @@ package opsservice
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/ops"
@@ -26,20 +27,27 @@ import (
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	"gopkg.in/check.v1"
 )
 
 type OperationGroupSuite struct {
 	operator *Operator
+	backend  storage.Backend
 	cluster  *ops.Site
+	clock    clockwork.Clock
 }
 
-var _ = check.Suite(&OperationGroupSuite{})
+var _ = check.Suite(&OperationGroupSuite{
+	clock: clockwork.NewFakeClock(),
+})
 
 func (s *OperationGroupSuite) SetUpTest(c *check.C) {
 	services := SetupTestServices(c)
 	s.operator = services.Operator
-
+	s.backend = services.Backend
 	suite := &suite.OpsSuite{}
 	app, err := suite.SetUpTestPackage(services.Apps, services.Packages, c)
 	c.Assert(err, check.IsNil)
@@ -286,6 +294,109 @@ func (s *OperationGroupSuite) TestClusterStateModifications(c *check.C) {
 	err = group.removeClusterStateServers([]string{"node-2"})
 	c.Assert(err, check.IsNil)
 	s.assertServerCount(c, 2)
+}
+
+func (s *OperationGroupSuite) TestCanCreateUpgradeOperation(c *check.C) {
+	// Can't create upgrade operation if cluster isn't active.
+	s.setClusterState(c, ops.SiteStateUpdating)
+	_, err := s.createUpgradeOperation(c, s.clock.Now(), false)
+	c.Assert(err, check.NotNil,
+		check.Commentf("Shouldn't be able to create upgrade operation for non-active cluster"))
+
+	// First upgrade operation should create fine.
+	s.setClusterState(c, ops.SiteStateActive)
+	key, err := s.createUpgradeOperation(c, s.clock.Now().Add(time.Second), false)
+	c.Assert(err, check.IsNil,
+		check.Commentf("Should be able to create first upgrade operation"))
+
+	// Reset the cluster state but the first operation is still in progress.
+	s.setClusterState(c, ops.SiteStateActive)
+	_, err = s.createUpgradeOperation(c, s.clock.Now().Add(2*time.Second), false)
+	c.Assert(err, check.NotNil,
+		check.Commentf("Shouldn't be able to create upgrade operation if another one in progress"))
+
+	// Simulate failed operation and force-reset cluster state.
+	s.setClusterState(c, ops.SiteStateActive)
+	s.setOperationState(c, *key, ops.OperationStateFailed)
+	_, err = s.backend.CreateOperationPlanChange(storage.PlanChange{
+		ID:          uuid.New(),
+		ClusterName: s.cluster.Domain,
+		OperationID: key.OperationID,
+		PhaseID:     "/init",
+		NewState:    storage.OperationPhaseStateFailed,
+		Created:     s.clock.Now(),
+	})
+	c.Assert(err, check.IsNil)
+	_, err = s.createUpgradeOperation(c, s.clock.Now().Add(3*time.Second), false)
+	c.Assert(err, check.NotNil,
+		check.Commentf("Shouldn't be able to create upgrade operation if last failed upgrade plan isn't rolled back"))
+
+	// Rollback the failed operation properly, should be able to create a new one then.
+	s.setOperationState(c, *key, ops.OperationStateFailed)
+	_, err = s.backend.CreateOperationPlanChange(storage.PlanChange{
+		ID:          uuid.New(),
+		ClusterName: s.cluster.Domain,
+		OperationID: key.OperationID,
+		PhaseID:     "/init",
+		NewState:    storage.OperationPhaseStateRolledBack,
+		Created:     s.clock.Now().Add(time.Second),
+	})
+	c.Assert(err, check.IsNil)
+	_, err = s.createUpgradeOperation(c, s.clock.Now().Add(4*time.Second), false)
+	c.Assert(err, check.IsNil,
+		check.Commentf("Should be able to create upgrade operation if last upgrade plan is fully rolled back"))
+
+	// Force flag should allow to create operation.
+	s.setClusterState(c, ops.SiteStateActive)
+	_, err = s.createUpgradeOperation(c, s.clock.Now().Add(5*time.Second), true)
+	c.Assert(err, check.IsNil,
+		check.Commentf("Should be able to create upgrade operation in force mode"))
+}
+
+func (s *OperationGroupSuite) setClusterState(c *check.C, state string) {
+	cluster, err := s.backend.GetSite(s.cluster.Domain)
+	c.Assert(err, check.IsNil)
+	cluster.State = state
+	_, err = s.backend.UpdateSite(*cluster)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *OperationGroupSuite) setOperationState(c *check.C, key ops.SiteOperationKey, state string) {
+	op, err := s.backend.GetSiteOperation(key.SiteDomain, key.OperationID)
+	c.Assert(err, check.IsNil)
+	op.State = state
+	_, err = s.backend.UpdateSiteOperation(*op)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *OperationGroupSuite) createUpgradeOperation(c *check.C, created time.Time, force bool) (*ops.SiteOperationKey, error) {
+	group := s.operator.getOperationGroup(s.cluster.Key())
+	key, err := group.createSiteOperationWithOptions(ops.SiteOperation{
+		AccountID:  s.cluster.AccountID,
+		SiteDomain: s.cluster.Domain,
+		Type:       ops.OperationUpdate,
+		State:      ops.OperationStateUpdateInProgress,
+		Created:    created,
+	}, createOperationOptions{force: force})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	_, err = s.backend.CreateOperationPlan(storage.OperationPlan{
+		OperationID:   key.OperationID,
+		OperationType: ops.OperationUpdate,
+		AccountID:     s.cluster.AccountID,
+		ClusterName:   s.cluster.Domain,
+		Phases: []storage.OperationPhase{
+			{
+				ID:    "/init",
+				State: storage.OperationPhaseStateUnstarted,
+			},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return key, nil
 }
 
 func (s *OperationGroupSuite) assertClusterState(c *check.C, state string) {

--- a/lib/ops/opsservice/shrink.go
+++ b/lib/ops/opsservice/shrink.go
@@ -101,7 +101,8 @@ func (s *site) createShrinkOperation(context context.Context, req ops.CreateSite
 		}
 	}
 
-	key, err := s.getOperationGroup().createSiteOperation(*op)
+	key, err := s.getOperationGroup().createSiteOperationWithOptions(*op,
+		createOperationOptions{force: req.Force})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/uninstall.go
+++ b/lib/ops/opsservice/uninstall.go
@@ -119,7 +119,8 @@ func (s *site) createUninstallOperation(context context.Context, req ops.CreateS
 		}
 	}
 
-	key, err := s.getOperationGroup().createSiteOperation(*op)
+	key, err := s.getOperationGroup().createSiteOperationWithOptions(*op,
+		createOperationOptions{force: req.Force})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opsservice/update.go
+++ b/lib/ops/opsservice/update.go
@@ -373,9 +373,10 @@ func (s *site) createUpdateOperation(context context.Context, req ops.CreateSite
 	}
 	defer ctx.Close()
 
-	key, err := s.getOperationGroup().createSiteOperation(op)
+	key, err := s.getOperationGroup().createSiteOperationWithOptions(op,
+		createOperationOptions{req.Force})
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to create update operation")
+		return nil, trace.Wrap(err)
 	}
 
 	resetClusterState := func() {

--- a/lib/ops/opsservice/utils.go
+++ b/lib/ops/opsservice/utils.go
@@ -145,11 +145,14 @@ func newMount(m schema.Volume) storage.Mount {
 // chownExpr generates chown expression in the form used by chown command
 // based on uid and gid parameters
 func chownExpr(uid, gid *int) string {
+	// When both uid and gid are specified, the syntax is "chown <uid>:<gid> <dir>"
 	if uid != nil && gid != nil {
 		return fmt.Sprintf("%v:%v", *uid, *gid)
 	}
+	// When only uid is specified, the syntax is "chown <uid> <dir>"
 	if uid != nil {
-		return fmt.Sprintf("%v:", *uid)
+		return fmt.Sprintf("%v", *uid)
 	}
+	// When only gid is specified, the syntax is "chown :<gid> <dir>"
 	return fmt.Sprintf(":%v", *gid)
 }

--- a/lib/ops/opsservice/utils_test.go
+++ b/lib/ops/opsservice/utils_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opsservice
+
+import (
+	"github.com/gravitational/gravity/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type UtilsSuite struct {
+}
+
+var _ = check.Suite(&UtilsSuite{})
+
+func (s *UtilsSuite) TestChownExpr(c *check.C) {
+	tests := []struct {
+		uid     *int
+		gid     *int
+		result  string
+		comment string
+	}{
+		{
+			uid:     utils.IntPtr(1000),
+			result:  "1000",
+			comment: "only uid is specified",
+		},
+		{
+			gid:     utils.IntPtr(2000),
+			result:  ":2000",
+			comment: "only gid is specified",
+		},
+		{
+			uid:     utils.IntPtr(1000),
+			gid:     utils.IntPtr(2000),
+			result:  "1000:2000",
+			comment: "both uid and gid are specified",
+		},
+	}
+	for _, t := range tests {
+		c.Assert(chownExpr(t.uid, t.gid), check.Equals, t.result,
+			check.Commentf(t.comment))
+	}
+}

--- a/lib/ops/utils.go
+++ b/lib/ops/utils.go
@@ -122,18 +122,16 @@ func GetLastCompletedOperation(key SiteKey, operator Operator) (*SiteOperation, 
 		key.SiteDomain)
 }
 
-// GetLastUpdateOperation returns the last update operation
-//
-// If there're no operations or the last operation is not of type 'update', returns NotFound error
-func GetLastUpdateOperation(siteKey SiteKey, operator Operator) (*SiteOperation, error) {
-	lastOperation, _, err := GetLastOperation(siteKey, operator)
+// GetLastUpgradeOperation returns the most recent upgrade operation or NotFound.
+func GetLastUpgradeOperation(key SiteKey, operator Operator) (*SiteOperation, error) {
+	op, _, err := MatchOperation(key, operator, MatchByType(OperationUpdate))
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("no upgrade operation for %v found", key)
+		}
 		return nil, trace.Wrap(err)
 	}
-	if lastOperation.Type != OperationUpdate {
-		return nil, trace.NotFound("the last operation is not update: %v", lastOperation)
-	}
-	return lastOperation, nil
+	return op, nil
 }
 
 // GetLastShrinkOperation returns the last shrink operation

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -250,23 +250,37 @@ func DisableAccess(backend Backend, name string, delay time.Duration) error {
 		Type:       teleservices.UserCA,
 		DomainName: name,
 	}, true)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	ca.SetTTL(backend, delay)
-	if err := backend.UpsertCertAuthority(ca); err != nil {
-		return trace.Wrap(err)
+	// User authority may have already been deleted if one of the calls below
+	// failed and this is being retried.
+	if trace.IsNotFound(err) {
+		log.WithField("name", name).Warn("User authority not found.")
+	}
+	if ca != nil {
+		ca.SetTTL(backend, delay)
+		if err := backend.UpsertCertAuthority(ca); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	ca, err = backend.GetCertAuthority(teleservices.CertAuthID{
 		Type:       teleservices.HostCA,
 		DomainName: name,
 	}, true)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	ca.SetTTL(backend, delay)
-	if err := backend.UpsertCertAuthority(ca); err != nil {
-		return trace.Wrap(err)
+	// Host authority may have already been deleted if one of the calls below
+	// failed and this is being retried.
+	if trace.IsNotFound(err) {
+		log.WithField("name", name).Warn("Host authority not found.")
+	}
+	if ca != nil {
+		ca.SetTTL(backend, delay)
+		if err := backend.UpsertCertAuthority(ca); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	cluster, err := backend.GetTrustedCluster(name)
 	if err != nil {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -87,6 +87,7 @@ func newClusterUpdater(
 	init := &clusterInitializer{
 		updatePackage: updatePackage,
 		unattended:    !manual,
+		force:         force,
 	}
 
 	if err := checkStatus(ctx, localEnv, force); err != nil {
@@ -284,8 +285,7 @@ func (r *clusterInitializer) validatePreconditions(localEnv *localenv.LocalEnvir
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = checkCanUpdate(cluster, operator, updateApp.Manifest)
-	if err != nil {
+	if err := checkCanUpdate(cluster, operator, updateApp.Manifest); err != nil {
 		return trace.Wrap(err)
 	}
 	r.updateLoc = updateApp.Package
@@ -297,6 +297,7 @@ func (r clusterInitializer) newOperation(operator ops.Operator, cluster ops.Site
 		AccountID:  cluster.AccountID,
 		SiteDomain: cluster.Domain,
 		App:        r.updateLoc.String(),
+		Force:      r.force,
 	})
 }
 
@@ -356,6 +357,7 @@ type clusterInitializer struct {
 	updateLoc     loc.Locator
 	updatePackage string
 	unattended    bool
+	force         bool
 }
 
 const (

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -701,6 +701,8 @@ type StatusHistoryCmd struct {
 // StatusResetCmd resets cluster to active state
 type StatusResetCmd struct {
 	*kingpin.CmdClause
+	// Confirmed suppresses confirmation prompt
+	Confirmed *bool
 }
 
 // BackupCmd launches app backup hook

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2019 Gravitational, Inc.
+Copyright 2018-2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -229,7 +229,8 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.StatusHistoryCmd.CmdClause = g.StatusCmd.Command("history", "Display cluster status history.")
 
 	// reset cluster state, for debugging/emergencies
-	g.StatusResetCmd.CmdClause = g.Command("status-reset", "Reset the cluster state to 'active'").Hidden()
+	g.StatusResetCmd.CmdClause = g.Command("status-reset", "Force-reset the cluster state to active. USE WITH CAUTION, the cluster may end up in an inconsistent state.").Hidden()
+	g.StatusResetCmd.Confirmed = g.StatusResetCmd.Flag("confirm", "Bypass confirmation prompt.").Bool()
 
 	// backup
 	g.BackupCmd.CmdClause = g.Command("backup", "Launch the cluster's backup hook.")

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -730,7 +730,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.SiteResetPasswordCmd.FullCommand():
 		return resetPassword(localEnv)
 	case g.StatusResetCmd.FullCommand():
-		return resetClusterState(localEnv)
+		return resetClusterState(localEnv,
+			*g.StatusResetCmd.Confirmed)
 	case g.LocalSiteCmd.FullCommand():
 		return getLocalSite(localEnv)
 	// system service commands

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
@@ -291,8 +292,32 @@ func getLocalSite(env *localenv.LocalEnvironment) error {
 	return nil
 }
 
-func resetClusterState(app *localenv.LocalEnvironment) error {
-	operator, err := app.SiteOperator()
+const stateResetWarning = `WARNING! This operation will force-set the cluster state to active without any
+extra checks.
+
+If used improperly, it may lead to inconsistent cluster state which may affect
+future operations, so only proceed if you're certain of what you're doing.
+
+Before resetting the cluster state consider doing the following:
+
+ * Inspect "gravity status" to understand which state the cluster is in.
+
+ * If there're unfinished operations, use "gravity plan" commands to properly
+   complete or roll them back.
+
+ * Refer to https://gravitational.com/gravity/docs/cluster/#managing-operations
+   for more information about operation management.
+`
+
+func resetClusterState(env *localenv.LocalEnvironment, confirmed bool) error {
+	if !confirmed {
+		env.Println(color.YellowString(stateResetWarning))
+		if err := enforceConfirmation("Proceed?"); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	operator, err := env.SiteOperator()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -310,7 +335,7 @@ func resetClusterState(app *localenv.LocalEnvironment) error {
 		return trace.Wrap(err)
 	}
 
-	app.Printf("cluster %s state has been set to active\n", site.Domain)
+	env.Printf("Cluster %s state has been set to active\n", site.Domain)
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR forward-ports a couple of recent updates from 5.5:

* Upgrade precheck that verifies previous upgrade was completed or rolled back.
* Upgrade failure when a new volume with only uid is specified.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Ports https://github.com/gravitational/gravity/pull/1731 and https://github.com/gravitational/gravity/pull/1789.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Same as in linked PRs.

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Fri Jun 26 01:28:52 UTC	Upgrading cluster from 0.0.1 to 0.0.2
[ERROR]: The last update operation (2de4a25c-348f-4452-8145-52929874d7eb) is still in progress.
Use "gravity plan" to view the operation plan, and either resume or rollback it before attempting to start another operation.
You can provide --force flag to override this check.
```