### PR TITLE
[7.0.x] Gravity report improvements

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -188,6 +188,9 @@ const (
 	// GravityUpdateDir specifies the directory used by the update process
 	GravityUpdateDir = "/var/lib/gravity/site/update"
 
+	// PlanetCredDir specifies the planet certs and keys directory
+	PlanetCredDir = "/var/state"
+
 	// GravityRPCAgentPort defines which port RPC agent is listening on
 	GravityRPCAgentPort = 3012
 

--- a/lib/install/operation.go
+++ b/lib/install/operation.go
@@ -268,7 +268,7 @@ func (i *Installer) generateDebugReport(ctx context.Context, clusterKey ops.Site
 			os.Remove(f.Name())
 		}
 	}()
-	rc, err := i.config.Operator.GetSiteReport(ctx, clusterKey)
+	rc, err := i.config.Operator.GetSiteReport(ctx, ops.GetClusterReportRequest{SiteKey: clusterKey})
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -577,11 +577,11 @@ func (o *OperatorACL) CreateProgressEntry(key SiteOperationKey, entry ProgressEn
 	return o.operator.CreateProgressEntry(key, entry)
 }
 
-func (o *OperatorACL) GetSiteReport(ctx context.Context, key SiteKey) (io.ReadCloser, error) {
-	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+func (o *OperatorACL) GetSiteReport(ctx context.Context, req GetClusterReportRequest) (io.ReadCloser, error) {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteReport(ctx, key)
+	return o.operator.GetSiteReport(ctx, req)
 }
 
 func (o *OperatorACL) ValidateDomainName(domainName string) error {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -417,7 +417,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(context.Context, SiteKey) (io.ReadCloser, error)
+	GetSiteReport(context.Context, GetClusterReportRequest) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)
@@ -2185,4 +2185,12 @@ func (r AuditEventRequest) String() string {
 type Audit interface {
 	// EmitAuditEvent saves the provided event in the audit log.
 	EmitAuditEvent(context.Context, AuditEventRequest) error
+}
+
+// GetClusterReportRequest specifies the request to get the cluster report
+type GetClusterReportRequest struct {
+	// SiteKey is a key used to identify site
+	SiteKey
+	// Since is used to filter collected logs by time
+	Since time.Duration `json:"since,omitempty"`
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -717,8 +717,11 @@ func (c *Client) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return file.Body(), nil
 }
 
-func (c *Client) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	file, err := c.GetFile(ctx, c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), url.Values{})
+func (c *Client) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	params := url.Values{
+		"since": []string{req.Since.String()},
+	}
+	file, err := c.GetFile(ctx, c.Endpoint("accounts", req.AccountID, "sites", req.SiteDomain, "report"), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1064,7 +1064,19 @@ func (h *WebHandler) activateSite(w http.ResponseWriter, r *http.Request, p http
    GET /portal/v1/accounts/:account_id/sites/:site_domain/report
 */
 func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(r.Context(), siteKey(p))
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	report, err := context.Operator.GetSiteReport(r.Context(),
+		ops.GetClusterReportRequest{
+			SiteKey: siteKey(p),
+			Since:   since,
+		})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1866,7 +1878,9 @@ func (h *WebHandler) streamOperationLogs(w http.ResponseWriter, r *http.Request,
 
 */
 func (h *WebHandler) getSiteOperationCrashReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(r.Context(), siteKey(p))
+	report, err := context.Operator.GetSiteReport(r.Context(), ops.GetClusterReportRequest{
+		SiteKey: siteKey(p),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -422,12 +422,12 @@ func (r *Router) CreateProgressEntry(key ops.SiteOperationKey, entry ops.Progres
 	return client.CreateProgressEntry(key, entry)
 }
 
-func (r *Router) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	client, err := r.PickClient(key.SiteDomain)
+func (r *Router) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteReport(ctx, key)
+	return client.GetSiteReport(ctx, req)
 }
 
 // ValidateServers runs pre-installation checks

--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/archive"
@@ -41,7 +42,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *site) getClusterReport(ctx context.Context) (io.ReadCloser, error) {
+func (s *site) getClusterReport(ctx context.Context, since time.Duration) (io.ReadCloser, error) {
 	op, err := storage.GetLastOperationForCluster(s.backend(), s.domainName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -50,13 +51,13 @@ func (s *site) getClusterReport(ctx context.Context) (io.ReadCloser, error) {
 	s.WithField("op", op).Info("Capture debug report for operation.")
 	switch {
 	case isActiveInstallOperation((ops.SiteOperation)(*op)):
-		return s.getClusterInstallReport(ctx, (ops.SiteOperation)(*op))
+		return s.getClusterInstallReport(ctx, (ops.SiteOperation)(*op), since)
 	default:
-		return s.getClusterGenericReport(ctx)
+		return s.getClusterGenericReport(ctx, since)
 	}
 }
 
-func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation) (io.ReadCloser, error) {
+func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation, since time.Duration) (io.ReadCloser, error) {
 	opCtx, err := s.newOperationContext(op)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -68,20 +69,20 @@ func (s *site) getClusterInstallReport(ctx context.Context, op ops.SiteOperation
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(opCtx.provisionedServers))
 	for _, server := range servers {
 		remoteServers = append(remoteServers, server)
-		if server.IsMaster() && master == nil {
-			master = server
+		if server.IsMaster() {
+			masterServers = append(masterServers, server)
 		}
 	}
 
 	runner := s.agentRunner(opCtx)
-	return s.getReport(ctx, runner, remoteServers, master)
+	return s.getReport(ctx, runner, remoteServers, masterServers, since)
 }
 
-func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, error) {
+func (s *site) getClusterGenericReport(ctx context.Context, since time.Duration) (io.ReadCloser, error) {
 	const noRetry = 1
 	servers, err := s.getTeleportServersWithTimeout(
 		nil,
@@ -93,12 +94,13 @@ func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, erro
 		return nil, trace.Wrap(err)
 	}
 
-	var master remoteServer
 	teleportRunner := &teleportRunner{
 		FieldLogger:          log.WithField(trace.Component, "teleport-runner"),
 		TeleportProxyService: s.teleport(),
 		domainName:           s.domainName,
 	}
+
+	var masterServers []remoteServer
 	remoteServers := make([]remoteServer, 0, len(servers))
 	for _, server := range servers {
 		teleportServer, err := newTeleportServer(server)
@@ -106,16 +108,17 @@ func (s *site) getClusterGenericReport(ctx context.Context) (io.ReadCloser, erro
 			return nil, trace.Wrap(err)
 		}
 		role := schema.ServiceRole(teleportServer.Labels[schema.ServiceLabelRole])
-		if role == schema.ServiceRoleMaster && master == nil {
-			master = teleportServer
+		if role == schema.ServiceRoleMaster {
+			masterServers = append(masterServers, teleportServer)
 		}
 		remoteServers = append(remoteServers, teleportServer)
 	}
 
-	return s.getReport(ctx, teleportRunner, remoteServers, master)
+	return s.getReport(ctx, teleportRunner, remoteServers, masterServers, since)
 }
 
-func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []remoteServer, master remoteServer) (io.ReadCloser, error) {
+func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []remoteServer, masters []remoteServer,
+	since time.Duration) (io.ReadCloser, error) {
 	dir, err := ioutil.TempDir("", "report")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -134,21 +137,23 @@ func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []rem
 
 	if len(servers) > 0 {
 		// Use the first master server to collect kubernetes diagnostics
-		server := master
-		if server == nil {
+		var server remoteServer
+		if len(masters) > 0 {
+			server = masters[0]
+		} else {
 			server = servers[0]
 			log.Warningf("No master servers, collecting Kubernetes diagnostics from %v.", server)
 		}
 		serverRunner := &serverRunner{server: server, runner: runner}
 		reportWriter := getReportWriterForServer(dir, server)
 		logger := log.WithField("server", server.Address())
-		if err := s.collectKubernetesInfo(reportWriter, serverRunner); err != nil {
+		if err := s.collectKubernetesInfo(reportWriter, serverRunner, since); err != nil {
 			logger.WithError(err).Error("Failed to collect Kubernetes info.")
 		}
-		if err := s.collectEtcdBackup(reportWriter, serverRunner); err != nil {
-			logger.WithError(err).Error("Failed to collect etcd backup.")
+		if err := s.collectEtcdInfoFromMasters(dir, masters, runner); err != nil {
+			log.WithError(err).Error("Failed to collect etcd info.")
 		}
-		if err := s.collectDebugInfoFromServers(ctx, dir, servers, runner); err != nil {
+		if err := s.collectDebugInfoFromServers(ctx, dir, servers, runner, since); err != nil {
 			log.WithError(err).Error("Failed to collect diagnostics from some nodes.")
 		}
 		if err := s.collectStatusTimeline(reportWriter, serverRunner); err != nil {
@@ -181,7 +186,8 @@ func (s *site) getReport(ctx context.Context, runner remoteRunner, servers []rem
 //
 //   <server-name>-<resource>
 //
-func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, servers []remoteServer, runner remoteRunner) error {
+func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, servers []remoteServer, runner remoteRunner,
+	since time.Duration) error {
 	err := s.executeOnServers(ctx, servers, func(c context.Context, server remoteServer) error {
 		log.WithField("server", server.Debug()).Debug("Collect debug info.")
 		r := &serverRunner{
@@ -189,7 +195,7 @@ func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, serv
 			runner: runner,
 		}
 		reportWriter := getReportWriterForServer(dir, server)
-		err := s.collectDebugInfo(reportWriter, r)
+		err := s.collectDebugInfo(reportWriter, r, since)
 		return trace.Wrap(err)
 	})
 	if err != nil {
@@ -198,7 +204,7 @@ func (s *site) collectDebugInfoFromServers(ctx context.Context, dir string, serv
 	return nil
 }
 
-func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRunner) error {
+func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRunner, since time.Duration) error {
 	w, err := reportWriter.NewWriter("debug-logs.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
@@ -207,15 +213,16 @@ func (s *site) collectDebugInfo(reportWriter report.FileWriter, runner *serverRu
 
 	var stderr bytes.Buffer
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterSystem),
-		"--compressed")...)
+		"--filter", report.FilterSystem,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect diagnostics: %s", stderr.String())
 	}
 	return nil
 }
 
-func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *serverRunner) error {
+func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *serverRunner, since time.Duration) error {
 	w, err := reportWriter.NewWriter("k8s-logs.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
@@ -224,15 +231,35 @@ func (s *site) collectKubernetesInfo(reportWriter report.FileWriter, runner *ser
 
 	var stderr bytes.Buffer
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
-		fmt.Sprintf("--filter=%v", report.FilterKubernetes), "--compressed")...)
+		"--filter", report.FilterKubernetes,
+		"--compressed",
+		"--since", since.String())...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect kubernetes diagnostics: %s", stderr.String())
 	}
 	return nil
 }
 
-func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverRunner) error {
-	w, err := reportWriter.NewWriter("etcd-backup.json.tar.gz")
+func (s *site) collectEtcdInfoFromMasters(dir string, masters []remoteServer, runner remoteRunner) error {
+	err := s.executeOnServers(context.TODO(), masters, func(c context.Context, master remoteServer) error {
+		log.Debugf("collectEtcdInfo for %v", master)
+		r := &serverRunner{
+			server: master,
+			runner: runner,
+		}
+		reportWriter := getReportWriterForServer(dir, master)
+		err := s.collectEtcdInfo(reportWriter, r)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// collectEtcdInfo collects etcd metrics and captures a snapshot of the data.
+func (s *site) collectEtcdInfo(reportWriter report.FileWriter, runner *serverRunner) error {
+	w, err := reportWriter.NewWriter("etcd.json.tar.gz")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -241,7 +268,7 @@ func (s *site) collectEtcdBackup(reportWriter report.FileWriter, runner *serverR
 	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report", fmt.Sprintf(
 		"--filter=%v", report.FilterEtcd), "--compressed")...)
 	if err != nil {
-		return trace.Wrap(err, "failed to collect etcd backup: %s", stderr.String())
+		return trace.Wrap(err, "failed to collect etcd info: %s", stderr.String())
 	}
 	return nil
 }

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1140,13 +1140,13 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 	return site.createLogEntry(key, entry)
 }
 
-func (o *Operator) GetSiteReport(ctx context.Context, key ops.SiteKey) (io.ReadCloser, error) {
-	cluster, err := o.openSite(key)
+func (o *Operator) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	cluster, err := o.openSite(req.SiteKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return cluster.getClusterReport(ctx)
+	return cluster.getClusterReport(ctx, req.Since)
 }
 
 func (o *Operator) GetSiteOperationProgress(key ops.SiteOperationKey) (*ops.ProgressEntry, error) {

--- a/lib/ops/suite/opssuite.go
+++ b/lib/ops/suite/opssuite.go
@@ -143,7 +143,7 @@ func (s *OpsSuite) SitesCRUD(c *C) {
 	c.Assert(logStream.Close(), IsNil)
 
 	// download crashreport
-	reportStream, err := s.O.GetSiteReport(context.TODO(), opKey.SiteKey())
+	reportStream, err := s.O.GetSiteReport(context.TODO(), ops.GetClusterReportRequest{SiteKey: opKey.SiteKey()})
 	c.Assert(err, IsNil)
 	_, err = io.Copy(ioutil.Discard, reportStream)
 	c.Assert(err, IsNil)

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/pack"
@@ -42,12 +43,13 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 	for _, filter := range teleutils.Deduplicate(config.Filters) {
 		switch filter {
 		case FilterSystem:
-			collectors = append(collectors, NewSystemCollector()...)
+			collectors = append(collectors, NewSystemCollector(config.Since)...)
 			collectors = append(collectors, NewPackageCollector(config.Packages))
 		case FilterKubernetes:
-			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner)...)
+			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner, config.Since)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
+			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
 		}
@@ -102,9 +104,15 @@ type Config struct {
 	// Packages specifies the package service for the package
 	// diagnostics collector
 	Packages pack.PackageService
+	// Since specifies the start of the time filter. A value of 1h will report
+	// log entries starting from one hour ago up till the end of the time filter.
+	Since time.Duration
 }
 
 const (
+	// JournalDateFormat defines the timestamp format for journalctl since flag
+	JournalDateFormat = "2006-01-02 15:04:05"
+
 	// FilterSystem defines a report collection filter to fetch system diagnostics
 	FilterSystem = "system"
 

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -38,9 +38,9 @@ func NewSystemCollector(since time.Duration) Collectors {
 	}
 
 	add(basicSystemInfo()...)
-	add(planetServices()...)
+	add(systemStatus()...)
 	add(systemFileLogs()...)
-	add(planetLogs()...)
+	add(planetLogs(since)...)
 	add(syslogExportLogs(since))
 	add(auditLog())
 
@@ -77,6 +77,12 @@ func basicSystemInfo() Collectors {
 		Cmd("host-system-status", "/bin/systemctl", "status", "--full"),
 		Cmd("host-system-failed", "/bin/systemctl", "--failed", "--full"),
 		Cmd("host-system-jobs", "/bin/systemctl", "list-jobs", "--full"),
+		Command{
+			name:             "host-system-jobs",
+			cmd:              "/bin/systemctl",
+			args:             []string{"list-jobs", "--full"},
+			successExitCodes: []int{1},
+		},
 		Cmd("dmesg", "/bin/dmesg", "--raw"),
 		Cmd("reboot-history", "last", "-x"),
 		Cmd("uname", "uname", "-a"),
@@ -91,7 +97,8 @@ func basicSystemInfo() Collectors {
 	}
 }
 
-func planetServices() Collectors {
+func systemStatus() Collectors {
+	listJobArgs := utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")
 	return Collectors{
 		Cmd("cluster-status", "/usr/bin/gravity", "status", "--output=json"),
 		// etcd cluster health
@@ -102,6 +109,12 @@ func planetServices() Collectors {
 		Cmd("planet-system-status", utils.PlanetCommandArgs("/bin/systemctl", "status", "--full")...),
 		Cmd("planet-system-failed", utils.PlanetCommandArgs("/bin/systemctl", "--failed", "--full")...),
 		Cmd("planet-system-jobs", utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")...),
+		Command{
+			name:             "planet-system-jobs",
+			cmd:              listJobArgs[0],
+			args:             listJobArgs[1:],
+			successExitCodes: []int{1},
+		},
 		// serf status
 		Cmd("serf-members", utils.PlanetCommandArgs(defaults.SerfBin, "members")...),
 	}
@@ -135,14 +148,14 @@ cat %v 2> /dev/null || true`
 }
 
 // planetLogs fetches planet syslog messages as well as the fresh journal entries
-func planetLogs() Collectors {
+func planetLogs(since time.Duration) Collectors {
 	return Collectors{
 		// Fetch planet journal entries for the last two days
 		// The log can be imported as a journal with systemd-journal-remote:
 		//
 		// $ cat ./node-1-planet-journal-export.log | /lib/systemd/systemd-journal-remote -o ./journal/system.journal -
 		Self("planet-journal-export.log.gz",
-			"system", "export-runtime-journal"),
+			"system", "export-runtime-journal", "--since", since.String()),
 	}
 }
 

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1731,10 +1731,22 @@ func (m *Handler) getJoinToken(w http.ResponseWriter, r *http.Request, p httprou
 //
 //   report.tar
 func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	reader, err := context.Operator.GetSiteReport(r.Context(), ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
-	})
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	reader, err := context.Operator.GetSiteReport(r.Context(),
+		ops.GetClusterReportRequest{
+			SiteKey: ops.SiteKey{
+				AccountID:  context.User.GetAccountID(),
+				SiteDomain: p.ByName("domain"),
+			},
+			Since: since,
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1675,11 +1675,19 @@ type SystemExportRuntimeJournalCmd struct {
 	*kingpin.CmdClause
 	// OutputFile specifies the path of the resulting tarball
 	OutputFile *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStreamRuntimeJournalCmd streams contents of the runtime journal
 type SystemStreamRuntimeJournalCmd struct {
 	*kingpin.CmdClause
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemSelinuxBootstrapCmd configures SELinux file contexts and ports on the node

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1356,6 +1356,10 @@ type ReportCmd struct {
 	*kingpin.CmdClause
 	// FilePath is the report tarball path
 	FilePath *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SiteCmd combines cluster related subcommands
@@ -1655,6 +1659,10 @@ type SystemReportCmd struct {
 	Compressed *bool
 	// Output optionally specifies output file path
 	Output *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStateDirCmd shows local state directory

--- a/tool/gravity/cli/journal.go
+++ b/tool/gravity/cli/journal.go
@@ -24,10 +24,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/report"
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/system"
 	"github.com/gravitational/gravity/lib/system/mount"
@@ -38,7 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string) error {
+func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string, since time.Duration) error {
 	stateDir, err := state.GetStateDir()
 	if err != nil {
 		return trace.Wrap(err)
@@ -90,13 +92,15 @@ func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string) err
 
 	zip := gzip.NewWriter(w)
 	defer zip.Close()
-	cmd := exec.CommandContext(ctx, utils.Exe.Path, "system", "stream-runtime-journal")
+	cmd := exec.CommandContext(ctx, utils.Exe.Path,
+		"system", "stream-runtime-journal",
+		"--since", since.String())
 	cmd.Stdout = zip
 	cmd.Stderr = zip
 	return trace.Wrap(cmd.Run())
 }
 
-func streamRuntimeJournal(env *localenv.LocalEnvironment) error {
+func streamRuntimeJournal(env *localenv.LocalEnvironment, since time.Duration) error {
 	runtimePackage, err := pack.FindRuntimePackage(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
@@ -117,11 +121,14 @@ func streamRuntimeJournal(env *localenv.LocalEnvironment) error {
 		return trace.Wrap(err)
 	}
 
-	const cmd = defaults.JournalctlBin
+	const cmd = defaults.JournalctlBinHost
 	args := []string{
 		cmd,
 		"--output", "export",
 		"-D", journalDir,
+	}
+	if since != 0 {
+		args = append(args, "--since", time.Now().Add(-since).Format(report.JournalDateFormat))
 	}
 	if err := syscall.Exec(cmd, args, nil); err != nil {
 		return trace.Wrap(trace.ConvertSystemError(err),

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -579,6 +579,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Collect tarball with cluster's diagnostic information.")
 	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "File name with collected diagnostic information.").Default("report.tar.gz").String()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")
@@ -715,6 +716,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()
 	g.SystemReportCmd.Output = g.SystemReportCmd.Flag("output", "optional output file path").String()
+	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStateDirCmd.CmdClause = g.SystemCmd.Command("state-dir", "show where all gravity data is stored on the node").Hidden()
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -723,8 +723,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// journal helpers
 	g.SystemExportRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("export-runtime-journal", "Export runtime journal logs to a file").Hidden()
 	g.SystemExportRuntimeJournalCmd.OutputFile = g.SystemExportRuntimeJournalCmd.Flag("output", "Name of resulting tarball. Output to stdout if unspecified").String()
+	g.SystemExportRuntimeJournalCmd.Since = g.SystemExportRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStreamRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("stream-runtime-journal", "Stream runtime journal to stdout").Hidden()
+	g.SystemStreamRuntimeJournalCmd.Since = g.SystemStreamRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemSelinuxBootstrapCmd.CmdClause = g.SystemCmd.Command("selinux-bootstrap", "Configure SELinux file contexts and ports on the node")
 	g.SystemSelinuxBootstrapCmd.Path = g.SystemSelinuxBootstrapCmd.Flag("output", "Path to output file for bootstrap script").String()

--- a/tool/gravity/cli/report.go
+++ b/tool/gravity/cli/report.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/report"
@@ -31,7 +32,9 @@ import (
 // to the stdout.
 // filters define the specific diagnostics to collect ('system', 'kubernetes'),
 // if empty all diagnostics are collected.
-func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, output string) error {
+
+func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, output string,
+	since time.Duration) error {
 	var w io.Writer = os.Stdout
 	if output != "" {
 		f, err := os.Create(output)
@@ -45,6 +48,7 @@ func systemReport(env *localenv.LocalEnvironment, filters []string, compressed b
 		Filters:    filters,
 		Compressed: compressed,
 		Packages:   env.Packages,
+		Since:      since,
 	}
 	return trace.Wrap(report.Collect(context.TODO(), config, w))
 }

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -910,9 +910,12 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():
-		return exportRuntimeJournal(localEnv, *g.SystemExportRuntimeJournalCmd.OutputFile)
+		return exportRuntimeJournal(localEnv,
+			*g.SystemExportRuntimeJournalCmd.OutputFile,
+			*g.SystemExportRuntimeJournalCmd.Since)
 	case g.SystemStreamRuntimeJournalCmd.FullCommand():
-		return streamRuntimeJournal(localEnv)
+		return streamRuntimeJournal(localEnv,
+			*g.SystemStreamRuntimeJournalCmd.Since)
 	case g.SystemSelinuxBootstrapCmd.FullCommand():
 		return bootstrapSELinux(localEnv,
 			*g.SystemSelinuxBootstrapCmd.Path,

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -782,7 +782,9 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.APIKeyDeleteCmd.Email,
 			*g.APIKeyDeleteCmd.Token)
 	case g.ReportCmd.FullCommand():
-		return getClusterReport(localEnv, *g.ReportCmd.FilePath)
+		return getClusterReport(localEnv,
+			*g.ReportCmd.FilePath,
+			*g.ReportCmd.Since)
 	// cluster commands
 	case g.SiteListCmd.FullCommand():
 		return listSites(localEnv, *g.SiteListCmd.OpsCenterURL)
@@ -903,7 +905,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		return systemReport(localEnv,
 			*g.SystemReportCmd.Filter,
 			*g.SystemReportCmd.Compressed,
-			*g.SystemReportCmd.Output)
+			*g.SystemReportCmd.Output,
+			*g.SystemReportCmd.Since)
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -122,7 +122,7 @@ func listSites(env *localenv.LocalEnvironment, opsCenterURL string) error {
 	return nil
 }
 
-func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
+func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since time.Duration) error {
 	f, err := os.Create(targetFile)
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,10 +140,14 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
 	}
 
 	// TODO(dmitri): see comments on defaults.GenerateDebugReportTimeout
-	report, err := operator.GetSiteReport(context.TODO(), ops.SiteKey{
-		AccountID:  site.AccountID,
-		SiteDomain: site.Domain,
-	})
+	report, err := operator.GetSiteReport(context.TODO(),
+		ops.GetClusterReportRequest{
+			SiteKey: ops.SiteKey{
+				AccountID:  site.AccountID,
+				SiteDomain: site.Domain,
+			},
+			Since: since,
+		})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds a time filter to `gravity report` and adds a few more system collectors.

- Reboots history: `last -x`
- Kernel information: `uname -a`
- Serf cluster: `serf members`
- Swap status: `swapon -s` (we have vmstat but wouldn't hurt)
- Etcd metrics: `curl -s  --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https://localhost:2379/metrics`

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Ports #1719, #1755

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verified additional collectors**

**Verified k8s logs are filtered by time**

**Verified journal logs are filtered by time**