### PR TITLE
Gravity report improvements

### DIFF
--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -1616,21 +1616,28 @@ $ gravity report --help
 
 usage: gravity report [<flags>]
 
-get cluster diagnostics report
+Collect tarball with cluster's diagnostic information.
 
 Flags:
-  --help       Show help (also see --help-long and --help-man).
-  --debug      Enable debug mode
-  -q, --quiet  Suppress any extra output to stdout
-  --insecure   Skip TLS verification
-  --log-file="/var/log/telekube-install.log"
-               log file with diagnostic information
-  --file="report.tar.gz"
-               target report file name
+      --help                  Show context-sensitive help (also try --help-long and --help-man).
+      --debug                 Enable debug mode.
+  -q, --quiet                 Suppress any extra output to stdout.
+      --insecure              Skip TLS verification.
+      --state-dir=STATE-DIR   Gravity local state directory.
+      --log-file="/var/log/gravity-install.log"
+                              Path to the log file with diagnostic information.
+      --file="report.tar.gz"  File name with collected diagnostic information.
+      --since=336h            Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.
 
 Example:
+  # Running with defaults will collect logs written in the last 2 weeks and zipped into report.tar.gz
+  $ gravity report
 
-$ gravity report
+  # Collect all logs written in the last day
+  $ gravity report --since 24h
+
+  # Collect all logs
+  $ gravity report --since 0s
 ```
 
 This command will collect diagnostics from all Cluster nodes into the specified tarball that you can then submit for evaluation.

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -1630,13 +1630,13 @@ Flags:
       --since=336h            Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.
 
 Example:
-  # Running with defaults will collect logs written in the last 2 weeks and zipped into report.tar.gz
+  # Running with defaults will collect logs written in the last 2 weeks and zipped into report.tar.gz.
   $ gravity report
 
-  # Collect all logs written in the last day
+  # Collect all logs written in the last day. The since flag accepts a Go duration.
   $ gravity report --since 24h
 
-  # Collect all logs
+  # Collect all logs.
   $ gravity report --since 0s
 ```
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -191,6 +191,9 @@ const (
 	// GravityUpdateDir specifies the directory used by the update process
 	GravityUpdateDir = "/var/lib/gravity/site/update"
 
+	// PlanetCredDir specifies the planet certs and keys directory
+	PlanetCredDir = "/var/state"
+
 	// GravityRPCAgentPort defines which port RPC agent is listening on
 	GravityRPCAgentPort = 3012
 

--- a/lib/install/operation.go
+++ b/lib/install/operation.go
@@ -268,7 +268,7 @@ func (i *Installer) generateDebugReport(clusterKey ops.SiteKey, path string) err
 			os.Remove(f.Name())
 		}
 	}()
-	rc, err := i.config.Operator.GetSiteReport(clusterKey)
+	rc, err := i.config.Operator.GetSiteReport(ops.GetClusterReportRequest{SiteKey: clusterKey})
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -577,11 +577,11 @@ func (o *OperatorACL) CreateProgressEntry(key SiteOperationKey, entry ProgressEn
 	return o.operator.CreateProgressEntry(key, entry)
 }
 
-func (o *OperatorACL) GetSiteReport(key SiteKey) (io.ReadCloser, error) {
-	if err := o.ClusterAction(key.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
+func (o *OperatorACL) GetSiteReport(req GetClusterReportRequest) (io.ReadCloser, error) {
+	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return o.operator.GetSiteReport(key)
+	return o.operator.GetSiteReport(req)
 }
 
 func (o *OperatorACL) ValidateDomainName(domainName string) error {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -416,7 +416,7 @@ type Sites interface {
 	CompleteFinalInstallStep(CompleteFinalInstallStepRequest) error
 
 	// GetSiteReport returns a tarball that contains all debugging information gathered for the site
-	GetSiteReport(SiteKey) (io.ReadCloser, error)
+	GetSiteReport(GetClusterReportRequest) (io.ReadCloser, error)
 
 	// SignTLSKey signs X509 Public Key with X509 certificate authority of this site
 	SignTLSKey(TLSSignRequest) (*TLSSignResponse, error)
@@ -2179,4 +2179,12 @@ func (r AuditEventRequest) String() string {
 type Audit interface {
 	// EmitAuditEvent saves the provided event in the audit log.
 	EmitAuditEvent(context.Context, AuditEventRequest) error
+}
+
+// GetClusterReportRequest specifies the request to get the cluster report
+type GetClusterReportRequest struct {
+	// SiteKey is a key used to identify site
+	SiteKey
+	// Since is used to filter collected logs by time
+	Since time.Duration `json:"since,omitempty"`
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -708,8 +708,11 @@ func (c *Client) GetSiteOperationCrashReport(key ops.SiteOperationKey) (io.ReadC
 	return file.Body(), nil
 }
 
-func (c *Client) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
-	file, err := c.GetFile(c.Endpoint("accounts", key.AccountID, "sites", key.SiteDomain, "report"), url.Values{})
+func (c *Client) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	params := url.Values{
+		"since": []string{req.Since.String()},
+	}
+	file, err := c.GetFile(c.Endpoint("accounts", req.AccountID, "sites", req.SiteDomain, "report"), params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1064,7 +1064,18 @@ func (h *WebHandler) activateSite(w http.ResponseWriter, r *http.Request, p http
    GET /portal/v1/accounts/:account_id/sites/:site_domain/report
 */
 func (h *WebHandler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(siteKey(p))
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	report, err := context.Operator.GetSiteReport(ops.GetClusterReportRequest{
+		SiteKey: siteKey(p),
+		Since:   since,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1866,7 +1877,7 @@ func (h *WebHandler) streamOperationLogs(w http.ResponseWriter, r *http.Request,
 
 */
 func (h *WebHandler) getSiteOperationCrashReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *HandlerContext) error {
-	report, err := context.Operator.GetSiteReport(siteKey(p))
+	report, err := context.Operator.GetSiteReport(ops.GetClusterReportRequest{SiteKey: siteKey(p)})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -422,12 +422,12 @@ func (r *Router) CreateProgressEntry(key ops.SiteOperationKey, entry ops.Progres
 	return client.CreateProgressEntry(key, entry)
 }
 
-func (r *Router) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
-	client, err := r.PickClient(key.SiteDomain)
+func (r *Router) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	client, err := r.PickClient(req.SiteDomain)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return client.GetSiteReport(key)
+	return client.GetSiteReport(req)
 }
 
 // ValidateServers runs pre-installation checks

--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1159,13 +1159,13 @@ func (o *Operator) CreateLogEntry(key ops.SiteOperationKey, entry ops.LogEntry) 
 	return site.createLogEntry(key, entry)
 }
 
-func (o *Operator) GetSiteReport(key ops.SiteKey) (io.ReadCloser, error) {
-	cluster, err := o.openSite(key)
+func (o *Operator) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, error) {
+	cluster, err := o.openSite(req.SiteKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return cluster.getClusterReport()
+	return cluster.getClusterReport(req.Since)
 }
 
 func (o *Operator) GetSiteOperationProgress(key ops.SiteOperationKey) (*ops.ProgressEntry, error) {

--- a/lib/ops/suite/opssuite.go
+++ b/lib/ops/suite/opssuite.go
@@ -143,7 +143,7 @@ func (s *OpsSuite) SitesCRUD(c *C) {
 	c.Assert(logStream.Close(), IsNil)
 
 	// download crashreport
-	reportStream, err := s.O.GetSiteReport(opKey.SiteKey())
+	reportStream, err := s.O.GetSiteReport(ops.GetClusterReportRequest{SiteKey: opKey.SiteKey()})
 	c.Assert(err, IsNil)
 	_, err = io.Copy(ioutil.Discard, reportStream)
 	c.Assert(err, IsNil)

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/pack"
@@ -42,12 +43,13 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 	for _, filter := range teleutils.Deduplicate(config.Filters) {
 		switch filter {
 		case FilterSystem:
-			collectors = append(collectors, NewSystemCollector()...)
+			collectors = append(collectors, NewSystemCollector(config.Since)...)
 			collectors = append(collectors, NewPackageCollector(config.Packages))
 		case FilterKubernetes:
-			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner)...)
+			collectors = append(collectors, NewKubernetesCollector(ctx, utils.Runner, config.Since)...)
 		case FilterEtcd:
 			collectors = append(collectors, etcdBackup()...)
+			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
 		}
@@ -102,9 +104,15 @@ type Config struct {
 	// Packages specifies the package service for the package
 	// diagnostics collector
 	Packages pack.PackageService
+	// Since specifies the start of the time filter. A value of 1h will report
+	// log entries starting from one hour ago up till the end of the time filter.
+	Since time.Duration
 }
 
 const (
+	// JournalDateFormat defines the timestamp format for journalctl since/until flags
+	JournalDateFormat = "2006-01-02 15:04:05"
+
 	// FilterSystem defines a report collection filter to fetch system diagnostics
 	FilterSystem = "system"
 

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/system/auditlog"
@@ -30,17 +31,17 @@ import (
 )
 
 // NewSystemCollector returns a list of collectors to fetch system information
-func NewSystemCollector() Collectors {
+func NewSystemCollector(since time.Duration) Collectors {
 	var collectors Collectors
 	add := func(additional ...Collector) {
 		collectors = append(collectors, additional...)
 	}
 
 	add(basicSystemInfo()...)
-	add(planetServices()...)
+	add(systemStatus()...)
+	add(syslogExportLogs(since))
 	add(systemFileLogs()...)
 	add(planetLogs()...)
-	add(syslogExportLogs())
 	add(auditLog())
 
 	return collectors
@@ -77,6 +78,8 @@ func basicSystemInfo() Collectors {
 		Cmd("host-system-failed", "/bin/systemctl", "--failed", "--full"),
 		Cmd("host-system-jobs", "/bin/systemctl", "list-jobs", "--full"),
 		Cmd("dmesg", "/bin/dmesg", "--raw"),
+		Cmd("reboot-history", "last", "-x"),
+		Cmd("uname", "uname", "-a"),
 		// Fetch world-readable parts of /etc/
 		fetchEtc("etc-logs.tar.gz"),
 		// memory
@@ -84,10 +87,11 @@ func basicSystemInfo() Collectors {
 		Cmd("slabtop", "slabtop", "--once"),
 		Cmd("vmstat", "vmstat", "--stats"),
 		Cmd("slabinfo", "cat", "/proc/slabinfo"),
+		Cmd("swapon", "swapon", "-s"),
 	}
 }
 
-func planetServices() Collectors {
+func systemStatus() Collectors {
 	return Collectors{
 		// etcd cluster health
 		Cmd("etcd-status", utils.PlanetCommandArgs("/usr/bin/etcdctl", "cluster-health")...),
@@ -97,15 +101,21 @@ func planetServices() Collectors {
 		Cmd("planet-system-status", utils.PlanetCommandArgs("/bin/systemctl", "status", "--full")...),
 		Cmd("planet-system-failed", utils.PlanetCommandArgs("/bin/systemctl", "--failed", "--full")...),
 		Cmd("planet-system-jobs", utils.PlanetCommandArgs("/bin/systemctl", "list-jobs", "--full")...),
+		// serf status
+		Cmd("serf-members", utils.PlanetCommandArgs(defaults.SerfBin, "members")...),
 	}
 }
 
 // syslogExportLogs fetches host journal logs
-func syslogExportLogs() Collector {
-	const script = `
-#!/bin/sh
-/bin/journalctl --no-pager --output=export | /bin/gzip -f`
-	return Script("gravity-system.log.gz", script)
+func syslogExportLogs(since time.Duration) Collector {
+	var script = `
+#!/bin/bash
+/bin/journalctl --no-pager --output=export `
+	if since != 0 {
+		script = script + fmt.Sprintf(`--since="%s" `, time.Now().Add(-since).Format(JournalDateFormat))
+	}
+	script = script + "| /bin/gzip -f"
+	return Script("gravity-journal.log.gz", script)
 }
 
 // systemFileLogs fetches gravity platform-related logs
@@ -140,6 +150,17 @@ func etcdBackup() Collectors {
 		Cmd("etcd-backup.json", utils.PlanetCommandArgs(defaults.PlanetBin, "etcd", "backup",
 			"--prefix", defaults.EtcdPlanetPrefix,
 			"--prefix", defaults.EtcdGravityPrefix)...),
+	}
+}
+
+// etcdMetrics fetches etcd metrics
+func etcdMetrics() Collectors {
+	return Collectors{
+		Cmd("etcd-metrics", utils.PlanetCommandArgs("/usr/bin/curl", "-s", "--tlsv1.2",
+			"--cacert", filepath.Join(defaults.PlanetCredDir, defaults.RootCertFilename),
+			"--cert", filepath.Join(defaults.PlanetCredDir, defaults.EtcdCertFilename),
+			"--key", filepath.Join(defaults.PlanetCredDir, defaults.EtcdKeyFilename),
+			filepath.Join(defaults.EtcdLocalAddr, "metrics"))...),
 	}
 }
 

--- a/lib/webapi/webapi.go
+++ b/lib/webapi/webapi.go
@@ -1731,9 +1731,20 @@ func (m *Handler) getJoinToken(w http.ResponseWriter, r *http.Request, p httprou
 //
 //   report.tar
 func (m *Handler) getSiteReport(w http.ResponseWriter, r *http.Request, p httprouter.Params, context *AuthContext) (interface{}, error) {
-	reader, err := context.Operator.GetSiteReport(ops.SiteKey{
-		AccountID:  context.User.GetAccountID(),
-		SiteDomain: p.ByName("domain"),
+	var since time.Duration
+	if val := r.URL.Query().Get("since"); val != "" {
+		var err error
+		if since, err = time.ParseDuration(val); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	reader, err := context.Operator.GetSiteReport(ops.GetClusterReportRequest{
+		SiteKey: ops.SiteKey{
+			AccountID:  context.User.GetAccountID(),
+			SiteDomain: p.ByName("domain"),
+		},
+		Since: since,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1711,11 +1711,19 @@ type SystemExportRuntimeJournalCmd struct {
 	*kingpin.CmdClause
 	// OutputFile specifies the path of the resulting tarball
 	OutputFile *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStreamRuntimeJournalCmd streams contents of the runtime journal
 type SystemStreamRuntimeJournalCmd struct {
 	*kingpin.CmdClause
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemSelinuxBootstrapCmd configures SELinux file contexts and ports on the node

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1364,6 +1364,10 @@ type ReportCmd struct {
 	*kingpin.CmdClause
 	// FilePath is the report tarball path
 	FilePath *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SiteCmd combines cluster related subcommands
@@ -1669,6 +1673,10 @@ type SystemReportCmd struct {
 	Compressed *bool
 	// Output optionally specifies output file path
 	Output *string
+	// Since is the duration before now that specifies the start of the time
+	// filter. Only log entries from the start of the time filter until now will
+	// be included in the report.
+	Since *time.Duration
 }
 
 // SystemStateDirCmd shows local state directory

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -1309,7 +1309,7 @@ func InstallerCleanup() error {
 // InstallerGenerateLocalReport creates a host-local debug report in the specified file
 func InstallerGenerateLocalReport(env *localenv.LocalEnvironment) func(context.Context, string) error {
 	return func(ctx context.Context, path string) error {
-		return systemReport(env, report.AllFilters, true, path)
+		return systemReport(env, report.AllFilters, true, path, time.Duration(0))
 	}
 }
 

--- a/tool/gravity/cli/journal.go
+++ b/tool/gravity/cli/journal.go
@@ -24,10 +24,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/report"
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/system"
 	"github.com/gravitational/gravity/lib/system/mount"
@@ -38,7 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string) error {
+func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string, since time.Duration) error {
 	stateDir, err := state.GetStateDir()
 	if err != nil {
 		return trace.Wrap(err)
@@ -90,13 +92,15 @@ func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string) err
 
 	zip := gzip.NewWriter(w)
 	defer zip.Close()
-	cmd := exec.CommandContext(ctx, utils.Exe.Path, "system", "stream-runtime-journal")
+	cmd := exec.CommandContext(ctx, utils.Exe.Path,
+		"system", "stream-runtime-journal",
+		"--since", since.String())
 	cmd.Stdout = zip
 	cmd.Stderr = zip
 	return trace.Wrap(cmd.Run())
 }
 
-func streamRuntimeJournal(env *localenv.LocalEnvironment) error {
+func streamRuntimeJournal(env *localenv.LocalEnvironment, since time.Duration) error {
 	runtimePackage, err := pack.FindRuntimePackage(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
@@ -117,11 +121,14 @@ func streamRuntimeJournal(env *localenv.LocalEnvironment) error {
 		return trace.Wrap(err)
 	}
 
-	const cmd = defaults.JournalctlBin
+	const cmd = defaults.JournalctlBinHost
 	args := []string{
 		cmd,
 		"--output", "export",
 		"-D", journalDir,
+	}
+	if since != 0 {
+		args = append(args, "--since", time.Now().Add(-since).Format(report.JournalDateFormat))
 	}
 	if err := syscall.Exec(cmd, args, nil); err != nil {
 		return trace.Wrap(trace.ConvertSystemError(err),

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -578,6 +578,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// get cluster diagnostics report
 	g.ReportCmd.CmdClause = g.Command("report", "Collect tarball with cluster's diagnostic information.")
 	g.ReportCmd.FilePath = g.ReportCmd.Flag("file", "File name with collected diagnostic information.").Default("report.tar.gz").String()
+	g.ReportCmd.Since = g.ReportCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	// operations on sites
 	g.SiteCmd.CmdClause = g.Command("site", "operations on gravity sites")
@@ -716,6 +717,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemReportCmd.Filter = g.SystemReportCmd.Flag("filter", "collect only specific diagnostics ('system', 'kubernetes'). Collect everything if unspecified").Strings()
 	g.SystemReportCmd.Compressed = g.SystemReportCmd.Flag("compressed", "whether to compress the tarball").Default("true").Bool()
 	g.SystemReportCmd.Output = g.SystemReportCmd.Flag("output", "optional output file path").String()
+	g.SystemReportCmd.Since = g.SystemReportCmd.Flag("since", "only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStateDirCmd.CmdClause = g.SystemCmd.Command("state-dir", "show where all gravity data is stored on the node").Hidden()
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -724,8 +724,10 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// journal helpers
 	g.SystemExportRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("export-runtime-journal", "Export runtime journal logs to a file").Hidden()
 	g.SystemExportRuntimeJournalCmd.OutputFile = g.SystemExportRuntimeJournalCmd.Flag("output", "Name of resulting tarball. Output to stdout if unspecified").String()
+	g.SystemExportRuntimeJournalCmd.Since = g.SystemExportRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemStreamRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("stream-runtime-journal", "Stream runtime journal to stdout").Hidden()
+	g.SystemStreamRuntimeJournalCmd.Since = g.SystemStreamRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
 
 	g.SystemSelinuxBootstrapCmd.CmdClause = g.SystemCmd.Command("selinux-bootstrap", "Configure SELinux file contexts and ports on the node")
 	g.SystemSelinuxBootstrapCmd.Path = g.SystemSelinuxBootstrapCmd.Flag("output", "Path to output file for bootstrap script").String()

--- a/tool/gravity/cli/report.go
+++ b/tool/gravity/cli/report.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/report"
@@ -30,7 +31,8 @@ import (
 // to the stdout.
 // filters define the specific diagnostics to collect ('system', 'kubernetes'),
 // if empty all diagnostics are collected.
-func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, output string) error {
+func systemReport(env *localenv.LocalEnvironment, filters []string, compressed bool, output string,
+	since time.Duration) error {
 	var w io.Writer = os.Stdout
 	if output != "" {
 		f, err := os.Create(output)
@@ -44,6 +46,7 @@ func systemReport(env *localenv.LocalEnvironment, filters []string, compressed b
 		Filters:    filters,
 		Compressed: compressed,
 		Packages:   env.Packages,
+		Since:      since,
 	}
 	return trace.Wrap(report.Collect(context.TODO(), config, w))
 }

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -774,7 +774,9 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			*g.APIKeyDeleteCmd.Email,
 			*g.APIKeyDeleteCmd.Token)
 	case g.ReportCmd.FullCommand():
-		return getClusterReport(localEnv, *g.ReportCmd.FilePath)
+		return getClusterReport(localEnv,
+			*g.ReportCmd.FilePath,
+			*g.ReportCmd.Since)
 	// cluster commands
 	case g.SiteListCmd.FullCommand():
 		return listSites(localEnv, *g.SiteListCmd.OpsCenterURL)
@@ -896,7 +898,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		return systemReport(localEnv,
 			*g.SystemReportCmd.Filter,
 			*g.SystemReportCmd.Compressed,
-			*g.SystemReportCmd.Output)
+			*g.SystemReportCmd.Output,
+			*g.SystemReportCmd.Since)
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -903,9 +903,12 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.SystemStateDirCmd.FullCommand():
 		return printStateDir()
 	case g.SystemExportRuntimeJournalCmd.FullCommand():
-		return exportRuntimeJournal(localEnv, *g.SystemExportRuntimeJournalCmd.OutputFile)
+		return exportRuntimeJournal(localEnv,
+			*g.SystemExportRuntimeJournalCmd.OutputFile,
+			*g.SystemExportRuntimeJournalCmd.Since)
 	case g.SystemStreamRuntimeJournalCmd.FullCommand():
-		return streamRuntimeJournal(localEnv)
+		return streamRuntimeJournal(localEnv,
+			*g.SystemStreamRuntimeJournalCmd.Since)
 	case g.SystemSelinuxBootstrapCmd.FullCommand():
 		return bootstrapSELinux(localEnv,
 			*g.SystemSelinuxBootstrapCmd.Path,

--- a/tool/gravity/cli/site.go
+++ b/tool/gravity/cli/site.go
@@ -122,7 +122,7 @@ func listSites(env *localenv.LocalEnvironment, opsCenterURL string) error {
 	return nil
 }
 
-func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
+func getClusterReport(env *localenv.LocalEnvironment, targetFile string, since time.Duration) error {
 	f, err := os.Create(targetFile)
 	if err != nil {
 		return trace.Wrap(err)
@@ -139,9 +139,12 @@ func getClusterReport(env *localenv.LocalEnvironment, targetFile string) error {
 		return trace.Wrap(err)
 	}
 
-	report, err := operator.GetSiteReport(ops.SiteKey{
-		AccountID:  site.AccountID,
-		SiteDomain: site.Domain,
+	report, err := operator.GetSiteReport(ops.GetClusterReportRequest{
+		SiteKey: ops.SiteKey{
+			AccountID:  site.AccountID,
+			SiteDomain: site.Domain,
+		},
+		Since: since,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds a time filter to `gravity report` and adds a few more system collectors.

- Reboots history: `last -x`
- Kernel information: `uname -a`
- Serf cluster: `serf members`
- Swap status: `swapon -s` (we have vmstat but wouldn't hurt)
- Etcd metrics: `curl -s  --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https://localhost:2379/metrics`

Updated 7.x Cluster Managements docs. Added examples on using the `--since` flag. 

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
* Ports https://github.com/gravitational/gravity/pull/1719, https://github.com/gravitational/gravity/pull/1755

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Update Documentation

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verified additional collectors**

**Verified k8s logs are filtered by time**

**Verified journal logs are filtered by time**
