### PR TITLE
Allow execution of `upload` from other directories.

### DIFF
--- a/lib/app/service/installer.go
+++ b/lib/app/service/installer.go
@@ -511,5 +511,6 @@ var uploadScriptTemplate = template.Must(template.New("uploadScript").Parse(`#!/
 # with the License.  You may obtain a copy of the License at
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
-./gravity --insecure update upload --state-dir=.
+scriptdir=$(dirname $(realpath $0))
+"$scriptdir/gravity" --insecure update upload --state-dir="$scriptdir"
 `))


### PR DESCRIPTION


## Description
Without this, if upgrade was run from any directory but its own, it
would fail with the following message:

  $ sudo ~/7.0.11/upgrade
  /home/robotest/7.0.11/upload: line 12: ./gravity: No such file or directory


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
Caught while testing #1823 

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Implementation
This is now consistent with all other shell scripts in the tarball.

* install
* run_preflight_checks
* upgrade

All have similar call location agnosticism.

## Testing done
Before:
```
robotest@walt-70-gc-node-0:~> sudo ~/7.0.11/upgrade
/home/robotest/7.0.11/upload: line 12: ./gravity: No such file or directory
```

After:
```
robotest@walt-70-gc-node-0:~> sudo ~/7.0.11/upgrade
Tue Jul  7 23:31:30 UTC Importing application telekube v7.0.11
Tue Jul  7 23:32:15 UTC Synchronizing application with Docker registry 10.138.0.45:5000
Tue Jul  7 23:33:38 UTC Synchronizing application with Docker registry 10.138.0.20:5000
Tue Jul  7 23:34:22 UTC Verifying cluster health
Tue Jul  7 23:34:22 UTC Application has been uploaded
Tue Jul  7 23:34:24 UTC Upgrading cluster from 6.1.29 to 7.0.11
Tue Jul  7 23:34:28 UTC Deploying agents on cluster nodes
Deployed agent on walt-70-gc-node-0 (10.138.0.45)
Deployed agent on walt-70-gc-node-1 (10.138.0.20)
```

I didn't actually rebuild a tarball, I just edited the script and then ported that to this go file.
