### PR TITLE
Collect gravity cli history

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -714,6 +714,10 @@ const (
 	// GravitySystemContainerType specifies the SELinux domain for the system containers.
 	// For instance, application hook init containers run as system containers
 	GravitySystemContainerType = "gravity_container_system_t"
+
+	// GravityCLITag is used to tag gravity cli command log entries in the
+	// system journal.
+	GravityCLITag = "gravity-cli"
 )
 
 var (

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/system/auditlog"
 	"github.com/gravitational/gravity/lib/utils"
@@ -43,6 +44,7 @@ func NewSystemCollector(since time.Duration) Collectors {
 	add(systemFileLogs()...)
 	add(planetLogs(since)...)
 	add(auditLog())
+	add(gravityCLILog(since))
 
 	return collectors
 }
@@ -218,4 +220,16 @@ func auditLog() Collector {
 { %v } | /bin/gzip -f`,
 		strings.Join(subjects, " "))
 	return Script("audit.log.gz", script)
+}
+
+// gravityCLILog fetches gravity cli log.
+func gravityCLILog(since time.Duration) Collector {
+	var script = fmt.Sprintf(`
+#!/bin/bash
+/bin/journalctl --no-pager -t %s`, constants.GravityCLITag)
+	if since != 0 {
+		script = fmt.Sprintf(`%s --since="%s"`, script, time.Now().Add(-since).Format(JournalDateFormat))
+	}
+	script = fmt.Sprintf("%s | /bin/gzip -f", script)
+	return Script("gravity-cli.log.gz", script)
 }

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"log/syslog"
+
+	"github.com/gravitational/trace"
+)
+
+// SyslogWrite writes the message to the system log with the specified priority
+// and tag.
+func SyslogWrite(priority syslog.Priority, message, tag string) error {
+	w, err := syslog.New(priority, tag)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	if _, err := w.Write([]byte(message)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -58,6 +59,10 @@ func ConfigureEnvironment() error {
 // Run parses CLI arguments and executes an appropriate gravity command
 func Run(g *Application) error {
 	log.Debugf("Executing: %v.", os.Args)
+	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+
 	err := ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR allows gravity to record gravity cli history to the system logs. All gravity commands will be recorded with tag `gravity-cli` and can be queried for with `journalctl -t gravity-cli`. Gravity cli history will also be included in the `gravity report`.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs #1799 
* Requires https://github.com/gravitational/gravity.e/pull/4308

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify gravity cli is recorded in system journal**
```
[vagrant@node-1 ~]$ sudo journalctl -t gravity-cli
Jul 08 07:22:25 node-1 gravity-cli[11704]: gravity package list
Jul 08 07:22:26 node-1 gravity-cli[11738]: /usr/bin/gravity --debug agent run
Jul 08 07:22:31 node-1 gravity-cli[11877]: /usr/bin/gravity --debug agent run
Jul 08 07:22:36 node-1 gravity-cli[12169]: /usr/bin/gravity --debug agent run
Jul 08 07:22:41 node-1 gravity-cli[12310]: /usr/bin/gravity --debug agent run
Jul 08 07:22:47 node-1 gravity-cli[12338]: /usr/bin/gravity --debug agent run
Jul 08 07:22:52 node-1 gravity-cli[12469]: /usr/bin/gravity --debug agent run
Jul 08 07:22:56 node-1 gravity-cli[12645]: gravity enter -- --notty /usr/bin/docker -- load -i /ext/share/image.tar
Jul 08 07:22:57 node-1 gravity-cli[12724]: /usr/bin/gravity --debug agent run
Jul 08 07:23:00 node-1 gravity-cli[12750]: gravity enter -- --notty /usr/bin/docker -- tag gravity-site:7.1.0-alpha.1.119 apiserver:5000/gravity-site:7.1.0-alpha.1.118
Jul 08 07:23:00 node-1 gravity-cli[12795]: gravity enter -- --notty /usr/bin/docker -- push apiserver:5000/gravity-site:7.1.0-alpha.1.118
Jul 08 07:23:02 node-1 gravity-cli[12843]: /usr/bin/gravity --debug agent run
Jul 08 07:23:05 node-1 gravity-cli[12868]: gravity enter -- --notty /usr/bin/docker -- rmi apiserver:5000/gravity-site:7.1.0-alpha.1.118
Jul 08 07:23:08 node-1 gravity-cli[13057]: /usr/bin/gravity --debug agent run
Jul 08 07:23:13 node-1 gravity-cli[13083]: /usr/bin/gravity --debug agent run
Jul 08 07:23:18 node-1 gravity-cli[13525]: /usr/bin/gravity --debug agent run
Jul 08 07:23:23 node-1 gravity-cli[13771]: /usr/bin/gravity --debug agent run
Jul 08 07:23:29 node-1 gravity-cli[13876]: /usr/bin/gravity --debug agent run
Jul 08 07:23:34 node-1 gravity-cli[13905]: /usr/bin/gravity --debug agent run
Jul 08 07:23:39 node-1 gravity-cli[14018]: /usr/bin/gravity --debug agent run
Jul 08 07:23:44 node-1 gravity-cli[14071]: /usr/bin/gravity --debug agent run
Jul 08 07:23:47 node-1 gravity-cli[14093]: gravity status
```
**Verfiy gravity cli history is included in gravity report**
```
[vagrant@node-1 ~]$ cat gravity-cli.log
-- Logs begin at Tue 2020-07-07 21:17:48 UTC, end at Wed 2020-07-08 07:28:32 UTC. --
Jul 08 07:28:20 node-1 gravity-cli[27786]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe pods --namespace monitoring
Jul 08 07:28:20 node-1 gravity-cli[27833]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe jobs --namespace monitoring
Jul 08 07:28:20 node-1 gravity-cli[27879]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe services --namespace monitoring
Jul 08 07:28:21 node-1 gravity-cli[27971]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe daemonsets --namespace monitoring
Jul 08 07:28:21 node-1 gravity-cli[28023]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe deployments --namespace monitoring
Jul 08 07:28:21 node-1 gravity-cli[28069]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe endpoints --namespace monitoring
Jul 08 07:28:21 node-1 gravity-cli[28116]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe replicationcontrollers --namespace monitoring
Jul 08 07:28:22 node-1 gravity-cli[28169]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe replicasets --namespace monitoring
Jul 08 07:28:22 node-1 gravity-cli[28175]: /usr/bin/gravity --debug agent run
Jul 08 07:28:25 node-1 gravity-cli[28882]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe pods --namespace openebs
Jul 08 07:28:25 node-1 gravity-cli[28934]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe jobs --namespace openebs
Jul 08 07:28:25 node-1 gravity-cli[28980]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe services --namespace openebs
Jul 08 07:28:25 node-1 gravity-cli[29040]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe daemonsets --namespace openebs
Jul 08 07:28:25 node-1 gravity-cli[29088]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe deployments --namespace openebs
Jul 08 07:28:26 node-1 gravity-cli[29146]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe endpoints --namespace openebs
Jul 08 07:28:26 node-1 gravity-cli[29197]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe replicationcontrollers --namespace openebs
Jul 08 07:28:26 node-1 gravity-cli[29241]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/kubectl describe replicasets --namespace openebs
Jul 08 07:28:27 node-1 gravity-cli[29398]: /usr/bin/gravity --debug agent run
Jul 08 07:28:28 node-1 gravity-cli[29517]: gravity --insecure --debug system report --filter=etcd --compressed
Jul 08 07:28:28 node-1 gravity-cli[29531]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/planet etcd backup --prefix /planet --prefix /gravity
Jul 08 07:28:28 node-1 gravity-cli[29579]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/curl -s --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https:/127.0.0.1:2379/metrics
Jul 08 07:28:29 node-1 gravity-cli[29612]: gravity --insecure --debug system report --filter system --compressed --since 10s
Jul 08 07:28:29 node-1 gravity-cli[29641]: /usr/bin/gravity exec --no-tty --no-interactive /sbin/bridge fdb show
Jul 08 07:28:30 node-1 gravity-cli[29702]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/etcdctl cluster-health
Jul 08 07:28:30 node-1 gravity-cli[29743]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/etcdctl3 endpoint health --cluster
Jul 08 07:28:30 node-1 gravity-cli[29790]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/planet status
Jul 08 07:28:31 node-1 gravity-cli[29831]: /usr/bin/gravity exec --no-tty --no-interactive /bin/systemctl status --full
Jul 08 07:28:31 node-1 gravity-cli[29863]: /usr/bin/gravity exec --no-tty --no-interactive /bin/systemctl --failed --full
Jul 08 07:28:31 node-1 gravity-cli[29894]: /usr/bin/gravity exec --no-tty --no-interactive /bin/systemctl list-jobs --full
Jul 08 07:28:31 node-1 gravity-cli[29927]: /usr/bin/gravity exec --no-tty --no-interactive /bin/systemctl list-jobs --full
Jul 08 07:28:31 node-1 gravity-cli[29959]: /usr/bin/gravity exec --no-tty --no-interactive /usr/bin/serf members
Jul 08 07:28:31 node-1 gravity-cli[30006]: /usr/bin/gravity system export-runtime-journal --since 10s
Jul 08 07:28:32 node-1 gravity-cli[30019]: /usr/bin/gravity system stream-runtime-journal --since 10s
```