### PR TITLE
(7.0) Refactor etcd disk check to be more tolerant

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -370,28 +370,22 @@ func (r *checker) CheckNode(ctx context.Context, server Server) (failed []*agent
 	})
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate remote node.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  fmt.Sprintf("failed to validate node %v", server),
-		})
+		failed = append(failed, newFailedProbe(
+			fmt.Sprintf("Failed to validate node %v", server), err.Error()))
 	}
 
 	err = checkServerProfile(server, requirements)
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate profile requirements.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  "failed to validate profile requirements",
-		})
+		failed = append(failed, newFailedProbe(
+			"Failed to validate profile requirements", err.Error()))
 	}
 
 	err = r.checkTempDir(ctx, server)
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate temporary directory.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  "failed to validate temporary directory",
-		})
+		failed = append(failed, newFailedProbe(
+			"Failed to validate temporary directory", err.Error()))
 	}
 
 	if server.IsMaster() && r.TestEtcdDisk {
@@ -407,10 +401,8 @@ func (r *checker) CheckNode(ctx context.Context, server Server) (failed []*agent
 	err = r.checkDisks(ctx, server)
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate disk requirements.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  "failed to validate disk requirements",
-		})
+		failed = append(failed, newFailedProbe(
+			"Failed to validate disk requirements", err.Error()))
 	}
 
 	return failed
@@ -427,29 +419,23 @@ func (r *checker) CheckNodes(ctx context.Context, servers []Server) (failed []*a
 	err := checkSameOS(servers)
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate same OS requirements.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  "failed to validate same OS requirement",
-		})
+		failed = append(failed, newFailedProbe(
+			"Failed to validate same OS requirement", err.Error()))
 	}
 
 	err = checkTime(time.Now().UTC(), servers)
 	if err != nil {
 		log.WithError(err).Warn("Failed to validate time drift requirements.")
-		failed = append(failed, &agentpb.Probe{
-			Detail: err.Error(),
-			Error:  "failed to validate time drift requirement",
-		})
+		failed = append(failed, newFailedProbe(
+			"Failed to validate time drift requirement", err.Error()))
 	}
 
 	if r.TestPorts {
 		err = r.checkPorts(ctx, servers)
 		if err != nil {
 			log.WithError(err).Warn("Failed to validate port requirements.")
-			failed = append(failed, &agentpb.Probe{
-				Detail: err.Error(),
-				Error:  "failed to validate port requirements",
-			})
+			failed = append(failed, newFailedProbe(
+				"Failed to validate port requirements", err.Error()))
 		}
 	}
 
@@ -457,10 +443,8 @@ func (r *checker) CheckNodes(ctx context.Context, servers []Server) (failed []*a
 		err = r.checkBandwidth(ctx, servers)
 		if err != nil {
 			log.WithError(err).Warn("Failed to validate bandwidth requirements.")
-			failed = append(failed, &agentpb.Probe{
-				Detail: err.Error(),
-				Error:  "failed to validate network bandwidth requirements",
-			})
+			failed = append(failed, newFailedProbe(
+				"Failed to validate network bandwidth requirements", err.Error()))
 		}
 	}
 

--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -262,6 +262,8 @@ type Checker interface {
 	// CheckNodes executes multi-node checks (such as network reachability,
 	// bandwidth, etc) on the provided set of servers.
 	CheckNodes(ctx context.Context, servers []Server) []*agentpb.Probe
+	// Check executes all checks on configured servers and returns failed probes.
+	Check(ctx context.Context) []*agentpb.Probe
 }
 
 type checker struct {
@@ -322,13 +324,21 @@ type Server struct {
 
 // Run runs a full set of checks on the servers specified in r.servers
 func (r *checker) Run(ctx context.Context) error {
+	failed := r.Check(ctx)
+	if len(failed) != 0 {
+		return trace.BadParameter("The following checks failed:\n%v",
+			FormatFailedChecks(failed))
+	}
+	return nil
+}
+
+// Check executes checks on r.servers and returns a list of failed probes.
+func (r *checker) Check(ctx context.Context) (failed []*agentpb.Probe) {
 	if ifTestsDisabled() {
 		log.Infof("Skipping checks due to %q set.",
 			constants.PreflightChecksOffEnvVar)
 		return nil
 	}
-
-	var failed []*agentpb.Probe
 
 	// check each server against its profile
 	for _, server := range r.Servers {
@@ -338,12 +348,7 @@ func (r *checker) Run(ctx context.Context) error {
 	// run checks that take all servers into account
 	failed = append(failed, r.CheckNodes(ctx, r.Servers)...)
 
-	if len(failed) != 0 {
-		return trace.BadParameter("The following checks failed:\n%v",
-			FormatFailedChecks(failed))
-	}
-
-	return nil
+	return failed
 }
 
 // CheckNode executes checks for the provided individual server.
@@ -390,16 +395,11 @@ func (r *checker) CheckNode(ctx context.Context, server Server) (failed []*agent
 	}
 
 	if server.IsMaster() && r.TestEtcdDisk {
-		err = r.checkEtcdDisk(ctx, server)
+		probes, err := r.checkEtcdDisk(ctx, server)
 		if err != nil {
 			log.WithError(err).Warn("Failed to validate etcd disk requirements.")
-			if isFioTestError(err) {
-				failed = append(failed, &agentpb.Probe{
-					Detail: err.Error(),
-					Error:  "failed to validate etcd disk requirements",
-				})
-			}
 		}
+		failed = append(failed, probes...)
 	}
 
 	err = r.checkDisks(ctx, server)

--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -399,6 +399,8 @@ func (r *checker) CheckNode(ctx context.Context, server Server) (failed []*agent
 		if err != nil {
 			log.WithError(err).Warn("Failed to validate etcd disk requirements.")
 		}
+		// The checker will only return probes if etcd disk test succeeded and
+		// some iops/latency requirements are not met.
 		failed = append(failed, probes...)
 	}
 

--- a/lib/checks/disks.go
+++ b/lib/checks/disks.go
@@ -142,6 +142,7 @@ const (
 	testFile = "fio.test"
 )
 
+// getEtcdMinIOPSSoft returns the soft limit for minimum number of IOPS.
 func getEtcdMinIOPSSoft() float64 {
 	value, err := utils.GetenvInt(EtcdMinIOPSSoftEnvVar)
 	if err == nil {
@@ -150,6 +151,7 @@ func getEtcdMinIOPSSoft() float64 {
 	return EtcdMinWriteIOPSSoft
 }
 
+// getEtcdMinIOPSHard returns the hard limit for minimum number of IOPS.
 func getEtcdMinIOPSHard() float64 {
 	value, err := utils.GetenvInt(EtcdMinIOPSHardEnvVar)
 	if err == nil {
@@ -158,6 +160,7 @@ func getEtcdMinIOPSHard() float64 {
 	return EtcdMinWriteIOPSHard
 }
 
+// getEtcdMaxLatencySoft returns the soft limit for maximum fsync latency.
 func getEtcdMaxLatencySoft() int64 {
 	value, err := utils.GetenvInt(EtcdMaxLatencySoftEnvVar)
 	if err == nil {
@@ -166,6 +169,7 @@ func getEtcdMaxLatencySoft() int64 {
 	return EtcdMaxFsyncLatencyMsSoft
 }
 
+// getEtcdMaxLatencyHard returns the hard limit for maximum fsync latency.
 func getEtcdMaxLatencyHard() int64 {
 	value, err := utils.GetenvInt(EtcdMaxLatencyHardEnvVar)
 	if err == nil {
@@ -175,9 +179,9 @@ func getEtcdMaxLatencyHard() int64 {
 }
 
 const (
-	// EtcdMinIOPSSoftEnvVar is the environment variable with soft iops limit.
+	// EtcdMinIOPSSoftEnvVar is the environment variable with soft IOPS limit.
 	EtcdMinIOPSSoftEnvVar = "GRAVITY_ETCD_MIN_IOPS_SOFT"
-	// EtcdMinIOPSHardEnvVar is the environment variable with hard iops limit.
+	// EtcdMinIOPSHardEnvVar is the environment variable with hard IOPS limit.
 	EtcdMinIOPSHardEnvVar = "GRAVITY_ETCD_MIN_IOPS_HARD"
 	// EtcdMaxLatencySoftEnvVar is the environment variable with soft fsync limit.
 	EtcdMaxLatencySoftEnvVar = "GRAVITY_ETCD_MAX_LATENCY_SOFT"

--- a/lib/checks/disks.go
+++ b/lib/checks/disks.go
@@ -19,37 +19,40 @@ package checks
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
-	"strings"
+	"strconv"
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/network/validation/proto"
 	"github.com/gravitational/gravity/lib/state"
 
+	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 )
 
 // checkEtcdDisk makes sure that the disk used for etcd wal satisfies
 // performance requirements.
-func (r *checker) checkEtcdDisk(ctx context.Context, server Server) error {
+func (r *checker) checkEtcdDisk(ctx context.Context, server Server) ([]*agentpb.Probe, error) {
 	// Test file should reside where etcd data will be.
 	testPath := state.InEtcdDir(server.ServerInfo.StateDir, testFile)
 	res, err := r.Remote.CheckDisks(ctx, server.AdvertiseIP, fioEtcdJob(testPath))
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	log.Debugf("Server %v disk test results: %s.", server.Hostname, res.String())
 	if len(res.Jobs) != 1 {
-		return trace.BadParameter("expected 1 job result: %v", res)
+		return nil, trace.BadParameter("expected 1 job result: %v", res)
 	}
 	iops := res.Jobs[0].GetWriteIOPS()
 	latency := res.Jobs[0].GetFsyncLatency()
-	if iops < EtcdMinWriteIOPS || latency > EtcdMaxFsyncLatencyMs {
-		return formatEtcdErrors(server, testPath, iops, latency)
+	probes := formatEtcdProbes(server, testPath, iops, latency)
+	if len(probes) > 0 {
+		return probes, nil
 	}
 	log.Infof("Server %v passed etcd disk check, has %v sequential write iops and %vms fsync latency.",
 		server.Hostname, iops, latency)
-	return nil
+	return nil, nil
 }
 
 // fioEtcdJob constructs a request to check etcd disk performance.
@@ -80,55 +83,113 @@ func fioEtcdJob(filename string) *proto.CheckDisksRequest {
 	}
 }
 
-// formatEtcdErrors returns appropritate formatted error messages based
-// on the etcd disk performance test results.
-func formatEtcdErrors(server Server, testPath string, iops float64, latency int64) error {
-	err := &fioTestError{}
-	if iops < EtcdMinWriteIOPS {
-		err.messages = append(err.messages, fmt.Sprintf("server %v has low sequential write IOPS of %v on %v (required minimum is %v)",
-			server.Hostname, iops, filepath.Dir(testPath), EtcdMinWriteIOPS))
+// formatEtcdProbes returns appropritate probes based on the etcd disk
+// performance test results.
+func formatEtcdProbes(server Server, testPath string, iops float64, latency int64) (probes []*agentpb.Probe) {
+	if iops < getEtcdIOPSHard() {
+		probes = append(probes, &agentpb.Probe{
+			Detail: fmt.Sprintf("node %v sequential write IOPS on %v is lower than %v (%v)",
+				server.Hostname, filepath.Dir(testPath), EtcdMinWriteIOPSHard, iops),
+		})
+	} else if iops < getEtcdIOPSSoft() {
+		probes = append(probes, &agentpb.Probe{
+			Detail: fmt.Sprintf("node %v sequential write IOPS on %v is lower than %v (%v) which may result in poor etcd performance",
+				server.Hostname, filepath.Dir(testPath), EtcdMinWriteIOPSSoft, iops),
+			Severity: agentpb.Probe_Warning,
+		})
 	}
-	if latency > EtcdMaxFsyncLatencyMs {
-		err.messages = append(err.messages, fmt.Sprintf("server %v has high fsync latency of %vms on %v (required maximum is %vms)",
-			server.Hostname, latency, filepath.Dir(testPath), EtcdMaxFsyncLatencyMs))
+	if latency > getEtcdLatencyHard() {
+		probes = append(probes, &agentpb.Probe{
+			Detail: fmt.Sprintf("node %v fsync latency on %v is higher than %vms (%vms)",
+				server.Hostname, filepath.Dir(testPath), EtcdMaxFsyncLatencyMsHard, latency),
+		})
+	} else if latency > getEtcdLatencySoft() {
+		probes = append(probes, &agentpb.Probe{
+			Detail: fmt.Sprintf("node %v fsync latency on %v is higher than %vms (%vms) which may result in poor etcd performance",
+				server.Hostname, filepath.Dir(testPath), EtcdMaxFsyncLatencyMsHard, latency),
+			Severity: agentpb.Probe_Warning,
+		})
 	}
-	return err
-}
-
-// fioTestError is returned when fio disk test fails to validate requirements.
-type fioTestError struct {
-	messages []string
-}
-
-// Error returns all errors encountered during fio disk test.
-func (e *fioTestError) Error() string {
-	return strings.Join(e.messages, ", ")
-}
-
-// isFioTestError returns true if the provided error is the fio disk test error.
-func isFioTestError(err error) bool {
-	_, ok := trace.Unwrap(err).(*fioTestError)
-	return ok
+	return probes
 }
 
 const (
-	// EtcdMinWriteIOPS defines the minimum number of sequential write iops
-	// required for etcd to perform effectively.
+	// EtcdMinWriteIOPSSoft defines the soft threshold for a minimum number of
+	// sequential write iops required for etcd to perform effectively.
 	//
 	// The number is recommended by etcd documentation:
 	// https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware.md#disks
 	//
-	EtcdMinWriteIOPS = 50
+	// The soft threshold will generate a warning.
+	EtcdMinWriteIOPSSoft = 50
+	// EtcdMinWriteIOPSHard is the lowest number of IOPS Gravity will tolerate
+	// before generating a critical probe failure.
+	EtcdMinWriteIOPSHard = 500 //10
 
-	// EtcdMaxFsyncLatencyMs defines the maximum fsync latency required for
-	// etcd to perform effectively, in milliseconds.
+	// EtcdMaxFsyncLatencyMsSoft defines the soft threshold for a maximum fsync
+	// latency required for etcd to perform effectively, in milliseconds.
 	//
 	// Etcd documentation recommends 10ms for optimal performance but we're
 	// being conservative here to ensure better dev/test experience:
 	// https://github.com/etcd-io/etcd/blob/master/Documentation/faq.md#what-does-the-etcd-warning-failed-to-send-out-heartbeat-on-time-mean
 	//
-	EtcdMaxFsyncLatencyMs = 50
+	// The soft threshold will generate a warning.
+	EtcdMaxFsyncLatencyMsSoft = 50
+	// EtcdMaxFsyncLatencyMsHard is the highest fsync latency Gravity prechecks
+	// will tolerate before generating a critical probe failure.
+	EtcdMaxFsyncLatencyMsHard = 1 // 150
 
 	// testFile is the name of the disk performance test file.
 	testFile = "fio.test"
+)
+
+func getEtcdIOPSSoft() float64 {
+	value, err := getEnvInt(EtcdIOPSSoftEnvVar)
+	if err == nil {
+		return float64(value)
+	}
+	return EtcdMinWriteIOPSSoft
+}
+
+func getEtcdIOPSHard() float64 {
+	value, err := getEnvInt(EtcdIOPSHardEnvVar)
+	if err == nil {
+		return float64(value)
+	}
+	return EtcdMinWriteIOPSHard
+}
+
+func getEtcdLatencySoft() int64 {
+	value, err := getEnvInt(EtcdLatencySoftEnvVar)
+	if err == nil {
+		return int64(value)
+	}
+	return EtcdMaxFsyncLatencyMsSoft
+}
+
+func getEtcdLatencyHard() int64 {
+	value, err := getEnvInt(EtcdLatencyHardEnvVar)
+	if err == nil {
+		return int64(value)
+	}
+	return EtcdMaxFsyncLatencyMsHard
+}
+
+func getEnvInt(name string) (int, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return 0, trace.NotFound("environment variable %v not set", name)
+	}
+	valueS, err := strconv.Atoi(name)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return valueS, nil
+}
+
+const (
+	EtcdIOPSSoftEnvVar    = "GRAVITY_ETCD_IOPS_SOFT"
+	EtcdIOPSHardEnvVar    = "GRAVITY_ETCD_IOPS_HARD"
+	EtcdLatencySoftEnvVar = "GRAVITY_ETCD_LATENCY_SOFT"
+	EtcdLatencyHardEnvVar = "GRAVITY_ETCD_LATENCY_HARD"
 )

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -211,6 +211,9 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
+	// GravityEnvVarPrefix is the prefix for gravity-specific environment variables.
+	GravityEnvVarPrefix = "GRAVITY_"
+
 	// Localhost is local host
 	Localhost = "127.0.0.1"
 

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -79,11 +79,12 @@ func (r *InstallerStrategy) installSelfAsService() error {
 			Timeout:          int(time.Duration(defaults.ServiceConnectTimeout).Seconds()),
 			WantedBy:         "multi-user.target",
 			WorkingDirectory: r.ApplicationDir,
+			// Propagate all gravity-related environment variables to the service.
+			Environment: utils.Getenvs(constants.GravityEnvVarPrefix),
 		},
 		NoBlock: true,
 		Name:    r.ServicePath,
 	}
-	req.ServiceSpec.Environment = utils.Getenv(constants.PreflightChecksOffEnvVar)
 	r.WithField("req", fmt.Sprintf("%+v", req)).Info("Install service.")
 	return trace.Wrap(service.Reinstall(req))
 }

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -80,7 +80,7 @@ func (r *InstallerStrategy) installSelfAsService() error {
 			WantedBy:         "multi-user.target",
 			WorkingDirectory: r.ApplicationDir,
 			// Propagate all gravity-related environment variables to the service.
-			Environment: utils.Getenvs(constants.GravityEnvVarPrefix),
+			Environment: utils.GetenvsByPrefix(constants.GravityEnvVarPrefix),
 		},
 		NoBlock: true,
 		Name:    r.ServicePath,

--- a/lib/install/phases/checks.go
+++ b/lib/install/phases/checks.go
@@ -71,16 +71,14 @@ func (r *checksExecutor) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	var failed, warnings []*agentpb.Probe
+	var failed []*agentpb.Probe
 	for _, probe := range resp.Probes {
 		if probe.Severity == agentpb.Probe_Warning {
-			warnings = append(warnings, probe)
+			r.Progress.NextStep(color.YellowString(probe.Detail))
 		} else {
+			r.Progress.NextStep(color.RedString(probe.Detail))
 			failed = append(failed, probe)
 		}
-	}
-	for _, warn := range warnings {
-		r.Progress.NextStep(color.YellowString(warn.Detail))
 	}
 	if len(failed) > 0 {
 		return trace.BadParameter("The following pre-flight checks failed:\n%v",

--- a/lib/ops/checks.go
+++ b/lib/ops/checks.go
@@ -42,14 +42,14 @@ func CheckServers(ctx context.Context,
 	servers []storage.Server,
 	agentService AgentService,
 	manifest schema.Manifest,
-) error {
+) ([]*agentpb.Probe, error) {
 	nodes, err := mergeServers(infos, servers)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	requirements, err := checks.RequirementsFromManifest(manifest)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	c, err := checks.New(checks.Config{
 		Remote:       &remoteCommands{key: opKey, AgentService: agentService},
@@ -57,15 +57,15 @@ func CheckServers(ctx context.Context,
 		Servers:      nodes,
 		Requirements: requirements,
 		Features: checks.Features{
-			TestBandwidth:    true,
-			TestPorts:        true,
-			TestEtcdDisk:     true,
+			TestBandwidth: true,
+			TestPorts:     true,
+			TestEtcdDisk:  true,
 		},
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return trace.Wrap(c.Run(ctx))
+	return c.Check(ctx), nil
 }
 
 // FormatValidationError formats validation error as a human-readable text

--- a/lib/ops/operation.go
+++ b/lib/ops/operation.go
@@ -106,6 +106,8 @@ func DescribeOperation(o storage.Operation) string {
 		return "Runtime environment update"
 	case OperationUpdateConfig:
 		return "Runtime configuration update"
+	case OperationGarbageCollect:
+		return "Garbage collection"
 	case OperationReconfigure:
 		return fmt.Sprintf("Advertise address change to %v",
 			o.GetReconfigure().IP)

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -411,9 +411,9 @@ func (o *OperatorACL) CheckSiteStatus(ctx context.Context, key SiteKey) error {
 }
 
 // ValidateServers runs pre-installation checks
-func (o *OperatorACL) ValidateServers(ctx context.Context, req ValidateServersRequest) error {
+func (o *OperatorACL) ValidateServers(ctx context.Context, req ValidateServersRequest) (*ValidateServersResponse, error) {
 	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	return o.operator.ValidateServers(ctx, req)
 }

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1875,7 +1875,7 @@ type Validation interface {
 	// ValidateDomainName validates that the chosen domain name is unique
 	ValidateDomainName(domainName string) error
 	// ValidateServers runs pre-installation checks
-	ValidateServers(context.Context, ValidateServersRequest) error
+	ValidateServers(context.Context, ValidateServersRequest) (*ValidateServersResponse, error)
 	// ValidateRemoteAccess verifies that the cluster nodes are accessible remotely
 	ValidateRemoteAccess(ValidateRemoteAccessRequest) (*ValidateRemoteAccessResponse, error)
 }
@@ -1890,6 +1890,12 @@ type ValidateServersRequest struct {
 	Servers []storage.Server `json:"servers"`
 	// OperationID identifies the operation
 	OperationID string `json:"operation_id"`
+}
+
+// ValidateServersResponse contains servers validation results.
+type ValidateServersResponse struct {
+	// Probes is a list of failed probes.
+	Probes []*agentpb.Probe
 }
 
 // Check validates this request

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1898,6 +1898,26 @@ type ValidateServersResponse struct {
 	Probes []*agentpb.Probe
 }
 
+// Warnings returns all warning-level probes.
+func (r *ValidateServersResponse) Warnings() (probes []*agentpb.Probe) {
+	for _, probe := range r.Probes {
+		if probe.Severity == agentpb.Probe_Warning {
+			probes = append(probes, probe)
+		}
+	}
+	return probes
+}
+
+// Failures returns all failed probes.
+func (r *ValidateServersResponse) Failures() (probes []*agentpb.Probe) {
+	for _, probe := range r.Probes {
+		if probe.Severity != agentpb.Probe_Warning {
+			probes = append(probes, probe)
+		}
+	}
+	return probes
+}
+
 // Check validates this request
 func (r ValidateServersRequest) Check() error {
 	if r.AccountID == "" {

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1901,7 +1901,7 @@ type ValidateServersResponse struct {
 // Warnings returns all warning-level probes.
 func (r *ValidateServersResponse) Warnings() (probes []*agentpb.Probe) {
 	for _, probe := range r.Probes {
-		if probe.Severity == agentpb.Probe_Warning {
+		if probe.Status == agentpb.Probe_Failed && probe.Severity == agentpb.Probe_Warning {
 			probes = append(probes, probe)
 		}
 	}
@@ -1911,7 +1911,7 @@ func (r *ValidateServersResponse) Warnings() (probes []*agentpb.Probe) {
 // Failures returns all failed probes.
 func (r *ValidateServersResponse) Failures() (probes []*agentpb.Probe) {
 	for _, probe := range r.Probes {
-		if probe.Severity != agentpb.Probe_Warning {
+		if probe.Status == agentpb.Probe_Failed && probe.Severity == agentpb.Probe_Critical {
 			probes = append(probes, probe)
 		}
 	}

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -1268,13 +1268,17 @@ func (c *Client) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, error
 }
 
 // ValidateServers runs pre-installation checks
-func (c *Client) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
-	_, err := c.PostJSONWithContext(ctx, c.Endpoint(
+func (c *Client) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
+	out, err := c.PostJSONWithContext(ctx, c.Endpoint(
 		"accounts", req.AccountID, "sites", req.SiteDomain, "prechecks"), req)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	var resp ops.ValidateServersResponse
+	if err = json.Unmarshal(out.Bytes(), &resp); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &resp, nil
 }
 
 func (c *Client) GetAppInstaller(req ops.AppInstallerRequest) (io.ReadCloser, error) {

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1257,11 +1257,11 @@ func (h *WebHandler) validateServers(w http.ResponseWriter, r *http.Request, p h
 	if err := d.Decode(&req); err != nil {
 		return trace.BadParameter(err.Error())
 	}
-	err := context.Operator.ValidateServers(context.Context, req)
+	resp, err := context.Operator.ValidateServers(context.Context, req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	roundtrip.ReplyJSON(w, http.StatusOK, statusOK("ok"))
+	roundtrip.ReplyJSON(w, http.StatusOK, resp)
 	return nil
 }
 

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -431,10 +431,10 @@ func (r *Router) GetSiteReport(ctx context.Context, req ops.GetClusterReportRequ
 }
 
 // ValidateServers runs pre-installation checks
-func (r *Router) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
+func (r *Router) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
 	client, err := r.WizardClient(req.SiteDomain)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	return client.ValidateServers(ctx, req)
 }

--- a/lib/ops/opsservice/checks.go
+++ b/lib/ops/opsservice/checks.go
@@ -19,36 +19,59 @@ package opsservice
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/ops"
 
+	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
 
+//
+func ValidateServers(ctx context.Context, operator ops.Operator, req ops.ValidateServersRequest) error {
+	resp, err := operator.ValidateServers(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var failed []*agentpb.Probe
+	for _, probe := range resp.Probes {
+		if probe.Severity != agentpb.Probe_Warning {
+			failed = append(failed, probe)
+		}
+	}
+	if len(failed) > 0 {
+		return trace.BadParameter("The following pre-flight checks failed:\n%v",
+			checks.FormatFailedChecks(failed))
+	}
+	return nil
+}
+
 // ValidateServers runs preflight checks before the installation
-func (o *Operator) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
+func (o *Operator) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
 	log.Infof("Validating servers: %#v.", req)
 
 	op, err := o.GetSiteOperation(req.OperationKey())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	cluster, err := o.openSite(req.SiteKey())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	infos, err := cluster.agentService().GetServerInfos(ctx, op.Key())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	err = ops.CheckServers(ctx, op.Key(), infos, req.Servers,
+	probes, err := ops.CheckServers(ctx, op.Key(), infos, req.Servers,
 		cluster.agentService(), cluster.app.Manifest)
 	if err != nil {
-		return trace.Wrap(ops.FormatValidationError(err))
+		return nil, trace.Wrap(err)
 	}
 
-	return nil
+	return &ops.ValidateServersResponse{
+		Probes: probes,
+	}, nil
 }

--- a/lib/ops/opsservice/checks.go
+++ b/lib/ops/opsservice/checks.go
@@ -27,7 +27,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//
+// ValidateServers executes preflight checks and returns formatted error if
+// any of the checks fail.
 func ValidateServers(ctx context.Context, operator ops.Operator, req ops.ValidateServersRequest) error {
 	resp, err := operator.ValidateServers(ctx, req)
 	if err != nil {
@@ -46,7 +47,8 @@ func ValidateServers(ctx context.Context, operator ops.Operator, req ops.Validat
 	return nil
 }
 
-// ValidateServers runs preflight checks before the installation
+// ValidateServers runs preflight checks before the installation and returns
+// failed probes.
 func (o *Operator) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
 	log.Infof("Validating servers: %#v.", req)
 

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -431,7 +431,7 @@ func (s *site) updateOperationState(op *ops.SiteOperation, req ops.OperationUpda
 			OperationID: op.ID,
 			Servers:     req.Servers,
 		}
-		err = s.service.ValidateServers(context.TODO(), validateReq)
+		err = ValidateServers(context.TODO(), s.service, validateReq)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -106,8 +106,8 @@ func GetenvWithDefault(name, defaultValue string) string {
 	return defaultValue
 }
 
-// Getenvs returns environment variables with names matching specified prefix.
-func Getenvs(prefix string) (environ map[string]string) {
+// GetenvsByPrefix returns environment variables with names matching specified prefix.
+func GetenvsByPrefix(prefix string) (environ map[string]string) {
 	environ = make(map[string]string)
 	for _, env := range os.Environ() {
 		name := strings.SplitN(env, "=", 2)[0]

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -103,6 +104,31 @@ func GetenvWithDefault(name, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// Getenvs returns environment variables with names matching specified prefix.
+func Getenvs(prefix string) (environ map[string]string) {
+	environ = make(map[string]string)
+	for _, env := range os.Environ() {
+		name := strings.SplitN(env, "=", 2)[0]
+		if strings.HasPrefix(name, prefix) {
+			environ[name] = os.Getenv(name)
+		}
+	}
+	return environ
+}
+
+// GetenvInt returns the specified environment variable value parsed as an integer.
+func GetenvInt(name string) (int, error) {
+	valueS, ok := os.LookupEnv(name)
+	if !ok {
+		return 0, trace.NotFound("environment variable %v not set", name)
+	}
+	valueI, err := strconv.Atoi(valueS)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return valueI, nil
 }
 
 // runningInsideContainer specifies if this process is executing inside

--- a/lib/utils/env_test.go
+++ b/lib/utils/env_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package utils
 
-import . "gopkg.in/check.v1"
+import (
+	"os"
+
+	"github.com/gravitational/trace"
+	. "gopkg.in/check.v1"
+)
 
 type EnvSuite struct{}
 
@@ -30,4 +35,29 @@ func (s *EnvSuite) TestEnv(c *C) {
 	readEnv, err := ReadEnv(path)
 	c.Assert(err, IsNil)
 	c.Assert(readEnv, DeepEquals, env)
+}
+
+func (s *EnvSuite) TestGetenvs(c *C) {
+	envs := map[string]string{
+		"TEST1_A": "v1",
+		"TEST1_B": "v2",
+	}
+	for k, v := range envs {
+		os.Setenv(k, v)
+	}
+	c.Assert(Getenvs("TEST1_"), DeepEquals, envs)
+}
+
+func (s *EnvSuite) TestGetenvInt(c *C) {
+	os.Setenv("TEST1", "42")
+	val, err := GetenvInt("TEST1")
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, 42)
+
+	os.Setenv("TEST1", "qwerty")
+	val, err = GetenvInt("TEST1")
+	c.Assert(err, NotNil)
+
+	val, err = GetenvInt("DOESNOTEXIST")
+	c.Assert(err, FitsTypeOf, trace.NotFound(""))
 }

--- a/lib/utils/env_test.go
+++ b/lib/utils/env_test.go
@@ -37,7 +37,7 @@ func (s *EnvSuite) TestEnv(c *C) {
 	c.Assert(readEnv, DeepEquals, env)
 }
 
-func (s *EnvSuite) TestGetenvs(c *C) {
+func (s *EnvSuite) TestGetenvsByPrefix(c *C) {
 	envs := map[string]string{
 		"TEST1_A": "v1",
 		"TEST1_B": "v2",
@@ -45,7 +45,7 @@ func (s *EnvSuite) TestGetenvs(c *C) {
 	for k, v := range envs {
 		os.Setenv(k, v)
 	}
-	c.Assert(Getenvs("TEST1_"), DeepEquals, envs)
+	c.Assert(GetenvsByPrefix("TEST1_"), DeepEquals, envs)
 }
 
 func (s *EnvSuite) TestGetenvInt(c *C) {

--- a/lib/webapi/operations.go
+++ b/lib/webapi/operations.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -121,7 +122,7 @@ func (m *Handler) validateServers(w http.ResponseWriter, r *http.Request, p http
 	log.Infof("validateServers: %v", req)
 
 	clusterName, operationID := p.ByName("domain"), p.ByName("operation_id")
-	err = ctx.Operator.ValidateServers(ctx.Context, ops.ValidateServersRequest{
+	err = opsservice.ValidateServers(ctx.Context, ctx.Operator, ops.ValidateServersRequest{
 		AccountID:   ctx.User.GetAccountID(),
 		SiteDomain:  clusterName,
 		OperationID: operationID,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

The current fio-based etcd disk performance check is too strict and often fails in the environment where etcd performance may not be of a big concern, without any ability to skip/override it. It results in poor experience for users, to the point where this check actually does more harm than good.

This PR splits the limits the checker verifies into soft and hard thresholds, where a soft threshold only produces a warning and hard threshold leads to a critical failure. So the behavior is as follows:

* If any of the soft limits are hit, the installer prints a warning in the output and proceeds as normal.
* If any of the hard limits are hit, it fails pre-checks and installation like now.
* As an added bonus, all warnings/failures are printed in the installer process right away now.

The old hard limits (50ms latency and 50 IOPS) are now soft limits and produce warnings. The hard limits are 150ms latency and 10 IOPS. The hard limits were chosen by gathering information from users who experienced these issues.

In addition, I added ability to override any of the soft/hard limits by setting respective environment variables. These are manual knobs that are convenient to use for debugging/troubleshooting.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1834.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Write documentation
- [x] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

I had to change the signature of opsservice's `ValidateServers` method to return failed probes as well so I could process these results in the client (installer) and print warnings/failures properly. Before, it only returns a pre-formatted error. It should not cause any incompatibility issues b/c it is only used during the installation (not upgrade).

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Override soft limits to trigger the warnings

```
ubuntu@node-1:~/installer$ export GRAVITY_ETCD_MAX_LATENCY_SOFT=1
ubuntu@node-1:~/installer$ export GRAVITY_ETCD_MIN_IOPS_SOFT=5000
ubuntu@node-1:~/installer$ sudo -E ./gravity install --advertise-addr=192.168.99.102 --cluster=test
Wed Jul  8 20:53:22 UTC	Starting enterprise installer
...
Wed Jul  8 20:53:38 UTC	Executing "/checks" locally
Wed Jul  8 20:53:38 UTC	Running pre-flight checks
Wed Jul  8 20:53:39 UTC	Execute preflight checks
Wed Jul  8 20:53:48 UTC		Still running pre-flight checks (10 seconds elapsed)
Wed Jul  8 20:53:54 UTC	Node node-1 sequential write IOPS on /var/lib/gravity/planet/etcd is lower than 5000 (130) which may result in poor etcd performance
Wed Jul  8 20:53:54 UTC	Node node-1 fsync latency on /var/lib/gravity/planet/etcd is higher than 1ms (15ms) which may result in poor etcd performance
...
```

### Override hard limits to trigger the failures

```
ubuntu@node-1:~/installer$ export GRAVITY_ETCD_MIN_IOPS_HARD=5000
ubuntu@node-1:~/installer$ export GRAVITY_ETCD_MAX_LATENCY_HARD=1
ubuntu@node-1:~/installer$ sudo -E ./gravity install --advertise-addr=192.168.99.102 --cluster=test
Wed Jul  8 20:54:32 UTC	Starting enterprise installer
...
Wed Jul  8 20:54:50 UTC	Executing "/checks" locally
Wed Jul  8 20:54:50 UTC	Running pre-flight checks
Wed Jul  8 20:54:51 UTC	Execute preflight checks
Wed Jul  8 20:55:00 UTC		Still running pre-flight checks (10 seconds elapsed)
Wed Jul  8 20:55:06 UTC	Node node-1 sequential write IOPS on /var/lib/gravity/planet/etcd is lower than 5000 (125)
Wed Jul  8 20:55:06 UTC	Node node-1 fsync latency on /var/lib/gravity/planet/etcd is higher than 1ms (17ms)
Wed Jul  8 20:55:06 UTC	Saving debug report to /home/ubuntu/installer/crashreport.tgz
[ERROR]: failed to execute phase "/checks"
	The following pre-flight checks failed:
	[×] Node node-1 sequential write IOPS on /var/lib/gravity/planet/etcd is lower than 5000 (125)
	[×] Node node-1 fsync latency on /var/lib/gravity/planet/etcd is higher than 1ms (17ms)
```

### Restore default limits and make sure install succeeds

```
ubuntu@node-1:~/installer$ unset GRAVITY_ETCD_MIN_IOPS_SOFT
ubuntu@node-1:~/installer$ unset GRAVITY_ETCD_MIN_IOPS_HARD
ubuntu@node-1:~/installer$ unset GRAVITY_ETCD_MAX_LATENCY_HARD
ubuntu@node-1:~/installer$ unset GRAVITY_ETCD_MAX_LATENCY_SOFT
ubuntu@node-1:~/installer$ sudo -E ./gravity install --advertise-addr=192.168.99.102 --cluster=test
Wed Jul  8 20:56:21 UTC	Starting enterprise installer
...
Wed Jul  8 20:56:43 UTC	Executing "/checks" locally
Wed Jul  8 20:56:43 UTC	Running pre-flight checks
Wed Jul  8 20:56:43 UTC	Execute preflight checks
Wed Jul  8 20:56:53 UTC		Still running pre-flight checks (10 seconds elapsed)
Wed Jul  8 20:56:59 UTC	Executing "/configure" locally
Wed Jul  8 20:57:00 UTC	Configuring cluster packages
Wed Jul  8 20:57:00 UTC	Configure packages for all nodes
...
```