### PR TITLE
Splitting out Github  issue_template into a few issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ labels: "type: kind/bug"
 
 ### Environment
 
- - Gravity version [e.g. 5.5.4]:
+ - Gravity version [e.g. 7.0.11]:
  - OS [e.g. Redhat 7.4]:
  - Platform [e.g. Vmware, AWS]:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,28 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
-labels: ''
-assignees: ''
-
+name: Bug Report 🐛
+about: Something isn't working as expected? Here is the right place to report.
+labels: "type: kind/bug"
 ---
 
-<!--
-**Have a question or install problem?** Please use [Our Community Site](https://community.gravitational.com).
--->
-**Describe the bug**
-<!--A clear and concise description of what the bug is.-->
+### Description
 
-**To Reproduce**
-<!--Steps to reproduce the behavior:-->
+**What happened**:
 
-**Expected behavior**
-<!--A clear and concise description of what you expected to happen.-->
+**What you expected to happen**:
 
-**Logs**
-<!--If applicable, add logs to help explain your problem.-->
+**How to reproduce it (as minimally and precisely as possible)**:
 
-**Environment (please complete the following information):**
+### Environment
+
+ - Gravity version [e.g. 5.5.4]:
  - OS [e.g. Redhat 7.4]:
- - Gravity [e.g. 5.5.4]:
  - Platform [e.g. Vmware, AWS]:
 
+**Browser environment**
 
-**Additional context**
-<!--Add any other context about the problem here.-->
+- Browser Version (for UI-related issues):
+- Install tools:
+- Others:
+
+**Relevant Debug Logs If Applicable**
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Gravity Documentation
+    url: https://gravitational.com/gravity/docs/
+    about: Check out the Gravity documentation for answers to common questions
+  - name: Gravitational Gravity community
+    url: https://community.gravitational.com/c/gravity
+    about: Ask Gravity related questions, answered by the Team and community. 
+  - name: Request a Demo
+    url: https://gravitational.com/gravity/demo/
+    about: Want to see the full power of Gravity? Our team is happy to give a demo. 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,14 @@
+---
+name: Documentation 📝
+about: Suggest better documentation for a particular tool or process. 
+labels: "type: kind/docs"
+---
+
+## Summary
+Describe the missing documentation. If it's a new feature, link to the feature ticket.
+
+### Audience
+Outline who this is for. e.g. CLI docs, new users, power users 
+
+### Location
+Should this docs update be a new guide, or an addition to an existing guide? 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for Gravity.
+labels: "type: kind/enhancement"
+---
+### Feature Request
+Describe in as much detail as possible what feature you would like to see added and how it should work. 
+
+### Motivation
+Describe why we should work on this feature request.
+
+### Who's it for?
+OSS User, Enterprise


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
We currently only have Bug Report as an issue template option for Gravity issues. I've updated Gravity issue templates to include the following:

- Bug Report
- Feature Requests
- Documentation

Also added a few useful links. This follows Teleport issue templates