### PR TITLE
[5.5.x] Collect gravity cli history

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -670,6 +670,10 @@ const (
 	AnnotationLogo = "gravitational.io/logo"
 	// AnnotationSize contains image size in bytes.
 	AnnotationSize = "gravitational.io/size"
+
+	// GravityCLITag is used to tag gravity cli command log entries in the
+	// system journal.
+	GravityCLITag = "gravity-cli"
 )
 
 var (

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"log/syslog"
+
+	"github.com/gravitational/trace"
+)
+
+// SyslogWrite writes the message to the system log with the specified priority
+// and tag.
+func SyslogWrite(priority syslog.Priority, message, tag string) error {
+	w, err := syslog.New(priority, tag)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	if _, err := w.Write([]byte(message)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -57,6 +58,10 @@ func ConfigureEnvironment() error {
 // Run parses CLI arguments and executes an appropriate gravity command
 func Run(g *Application) error {
 	log.Debugf("Executing: %v.", os.Args)
+	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+
 	err := ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR allows gravity to record gravity cli history to the system logs. All gravity commands will be recorded with tag `gravity-cli` and can be queried for with `journalctl -t gravity-cli`. Gravity cli history will also be included in the `gravity report`.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/1845
* Requires https://github.com/gravitational/gravity.e/pull/4309
## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify gravity cli is recorded in system journal**
```
[vagrant@node-1 ~]$ sudo journalctl -t gravity-cli
-- Logs begin at Fri 2020-07-10 00:28:00 UTC, end at Fri 2020-07-10 06:09:04 UTC. --
Jul 10 05:49:36 node-1 gravity-cli[28945]: ./gravity install --flavor=three --cluster=dev.test --advertise-addr=172.28.128.101 --token=token
Jul 10 05:52:31 node-1 gravity-cli[30505]: ./gravity leave --force --confirm
Jul 10 05:53:52 node-1 gravity-cli[31593]: ./gravity install --debug --cloud-provider=generic --flavor=three --cluster=dev.test --advertise-addr=172.28.128.101 --token=token1
Jul 10 05:56:47 node-1 gravity-cli[31773]: /vagrant/installer/gravity --debug system reinstall gravitational.io/teleport:3.0.5
Jul 10 05:56:47 node-1 gravity-cli[31799]: /bin/gravity package command start gravitational.io/teleport:3.0.5 dev.test/teleport-node-config-17228128101devtest:3.0.5
Jul 10 05:56:47 node-1 gravity-cli[31823]: /vagrant/installer/gravity --debug system reinstall gravitational.io/planet:5.5.54-11312 --labels purpose:runtime
Jul 10 05:56:47 node-1 gravity-cli[31854]: /bin/gravity package command start gravitational.io/planet:5.5.54-11312 dev.test/planet-config-17228128101devtest:5.5.54-11312
Jul 10 05:57:14 node-1 gravity-cli[966]: /vagrant/installer/gravity planet enter -- --notty /usr/bin/kubectl -- --kubeconfig /etc/kubernetes/scheduler.kubeconfig apply -f /ex
Jul 10 06:06:55 node-1 gravity-cli[13980]: /vagrant/installer/gravity planet enter -- --notty /usr/bin/planet -- leader resume --public-ip=172.28.128.101 --election-key=/plan
Jul 10 06:06:55 node-1 gravity-cli[14021]: /vagrant/installer/gravity planet enter -- --notty /usr/bin/planet -- leader resume --public-ip=172.28.128.103 --election-key=/plan
Jul 10 06:06:55 node-1 gravity-cli[14062]: /vagrant/installer/gravity planet enter -- --notty /usr/bin/planet -- leader resume --public-ip=172.28.128.102 --election-key=/plan
Jul 10 06:07:52 node-1 gravity-cli[14563]: gravity status
Jul 10 06:08:42 node-1 gravity-cli[14850]: gravity status
```
**Verfiy gravity cli history is included in gravity report**
```
[vagrant@node-1 ~]$ cat gravity-cli.log
-- Logs begin at Fri 2020-07-10 00:28:00 UTC, end at Fri 2020-07-10 06:10:36 UTC. --
Jul 10 06:10:31 node-1 gravity-cli[15609]: gravity --insecure --debug system report --filter=etcd --compressed
Jul 10 06:10:31 node-1 gravity-cli[15627]: /usr/bin/gravity planet enter -- --notty /usr/bin/planet -- etcd backup --prefix /planet --prefix /gravity
Jul 10 06:10:31 node-1 gravity-cli[15680]: /usr/bin/gravity planet enter -- --notty /usr/bin/curl -- -s --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https:/127.0.0.1:2379/metrics
Jul 10 06:10:32 node-1 gravity-cli[15717]: gravity --insecure --debug system report --filter system --compressed --since 10s
Jul 10 06:10:32 node-1 gravity-cli[15749]: /usr/bin/gravity planet enter -- --notty /sbin/bridge -- fdb show
Jul 10 06:10:33 node-1 gravity-cli[15823]: /usr/bin/gravity status --output=json
Jul 10 06:10:35 node-1 gravity-cli[15841]: /usr/bin/gravity planet enter -- --notty /usr/bin/etcdctl -- cluster-health
Jul 10 06:10:35 node-1 gravity-cli[15890]: /usr/bin/gravity planet enter -- --notty /usr/bin/planet -- status
Jul 10 06:10:35 node-1 gravity-cli[15935]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- status --full
Jul 10 06:10:35 node-1 gravity-cli[15971]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- --failed --full
Jul 10 06:10:35 node-1 gravity-cli[16007]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- list-jobs --full
Jul 10 06:10:35 node-1 gravity-cli[16042]: /usr/bin/gravity planet enter -- --notty /usr/bin/serf -- members
Jul 10 06:10:36 node-1 gravity-cli[16093]: /usr/bin/gravity system export-runtime-journal --since 10s
Jul 10 06:10:36 node-1 gravity-cli[16106]: /usr/bin/gravity system stream-runtime-journal --since 10s
```