### PR TITLE
(7.1) Forward-port etcd disk check updates

### DIFF
--- a/docs/7.x/installation.md
+++ b/docs/7.x/installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-This section will cover the process of creating a running Cluster or Cluster 
-Instance from a Cluster Image.  Just like a virtual machine (VM) image or AWS AMI 
-can be used to create machine instances, Gravity Cluster Images can 
+This section will cover the process of creating a running Cluster or Cluster
+Instance from a Cluster Image.  Just like a virtual machine (VM) image or AWS AMI
+can be used to create machine instances, Gravity Cluster Images can
 be used to create Cluster Instances.
 
 #### Deployment Methods
@@ -15,20 +15,20 @@ in a web browser, assisting users in Cluster creation.
 
 Both installation methods allow users to create a new Cluster from a
 Cluster Image on Linux hosts. Because a Cluster Image has no external
-dependencies, both installation methods will work behind firewalls or even in 
+dependencies, both installation methods will work behind firewalls or even in
 air-gapped server rooms.
 
 #### Prerequisites
 
-Every Cluster Image created with Gravity contains everything you need to 
+Every Cluster Image created with Gravity contains everything you need to
 create a production-ready Cluster but there are still some pre-requisites
 to be met:
 
-* You need a valid Cluster Image, i.e. a `.tar` file. See the 
+* You need a valid Cluster Image, i.e. a `.tar` file. See the
   [Building Cluster Images](pack.md) section for information on how to build one.
 * One or more Linux hosts with a compatible kernel. They can be bare metal hosts,
-  compute instances on any cloud provider, virtual machines on a private cloud, 
-  etc. Consult with the [System Requirements](requirements.md) to determine if your 
+  compute instances on any cloud provider, virtual machines on a private cloud,
+  etc. Consult with the [System Requirements](requirements.md) to determine if your
   Linux hosts are compatible with Gravity.
 * The hosts should be clean without Docker or any container
   orchestrator running on them.
@@ -77,7 +77,7 @@ $ sudo ./gravity install --advertise-addr=10.1.10.1 --token=XXX --flavor="triple
 * You have to select an arbitrary, hard to guess secret for `--token` and remember this
   value. It will be used to securely add additional nodes to the Cluster.
 * Other nodes must be able to connect to the master node via `10.1.10.1`. Make sure
-  the installer ports are not blocked, see "Installer Ports" section in the 
+  the installer ports are not blocked, see "Installer Ports" section in the
   [System Requirements](requirements.md#network) chapter.
 
 Next, start adding remaining nodes to the Cluster:
@@ -141,7 +141,7 @@ Flag               | Description
 
 Some aspects of the installation can be configured with the use of environment variables.
 
-#### GRAVITY_CHECKS_OFF
+#### `GRAVITY_CHECKS_OFF`
 
 This environment variable controls whether the installer/join agent executes the preflight checks.
 It accepts values `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False`
@@ -150,15 +150,34 @@ It accepts values `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`,
 !!! warning "Scope"
     Currently it is not possible to selectively turn checks off.
 
-#### GRAVITY_PEER_CONNECT_TIMEOUT
+#### `GRAVITY_PEER_CONNECT_TIMEOUT`
 
 This environment variable controls the initial connection validation timeout for the joining agent.
 It accepts values in Go duration format, for example `1m` (one minute) or `20s` (twenty seconds).
 The default value is `10s`.
 
-!!! note 
+!!! note
     Only configurable for Gravity versions `5.5.x` starting `5.5.24`.
 
+#### `GRAVITY_ETCD_MIN_IOPS_SOFT` / `GRAVITY_ETCD_MIN_IOPS_HARD`
+
+These environment variables allow to override the default soft/hard limits for
+the minimum number of sequential write IOPS used by Gravity during etcd data
+disk performance preflight check.
+
+The variable accepts an integer number indicating a number of IOPS. The default
+soft limit (triggers a warning) is `50` IOPS and the default hard limit (triggers
+a failure) is `10` IOPS.
+
+#### `GRAVITY_ETCD_MAX_LATENCY_SOFT` / `GRAVITY_ETCD_MAX_LATENCY_HARD`
+
+These environment variables allow to override the default soft/hard limits for
+the maximum fsync latency in milliseconds used by Gravity during etcd data disk
+performance preflight check.
+
+The variable accepts an integer number indicating a number of milliseconds. The
+default soft limit (triggers a warning) is `50` ms and the default hard limit
+(triggers a failure) is `150` ms.
 
 ## Web-based Installation
 

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -374,3 +374,20 @@ make sure it's mounted upon machine startup:
 ```
 /dev/xvdf  /var/lib/gravity/planet/etcd  ext4  defaults   0  2
 ```
+
+### Etcd Disk Performance Requirements
+
+Prior to installation, Gravity will perform a preflight check to assess performance
+characteristics of the disk used for etcd data on each master node.
+
+The check uses `fio` tool and looks at the following benchmarks:
+
+* Sequential write IOPS:
+    * If the detected IOPS is below `50`, a warning is triggered.
+    * If the detected IOPS is below `10`, a failure is triggered
+* Fsync latency:
+    * If the detected latency is higher than `50ms`, a warning is triggered.
+    * If the detected latency is higher than `150ms`, a failure is triggered.
+
+If necessary, these thresholds can be overridden at install/join time using
+[environment variables](installation.md#environment-variables).

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -208,6 +208,9 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
+	// GravityEnvVarPrefix is the prefix for gravity-specific environment variables.
+	GravityEnvVarPrefix = "GRAVITY_"
+
 	// Localhost is local host
 	Localhost = "127.0.0.1"
 

--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -39,6 +39,8 @@ type planBuilder struct {
 	Application app.Application
 	// Runtime is the Runtime of the app being installed
 	Runtime app.Application
+	// GravityPackage is the gravity package to install
+	GravityPackage loc.Locator
 	// TeleportPackage is the teleport package to install
 	TeleportPackage loc.Locator
 	// PlanetPackage is the planet package to install
@@ -144,6 +146,13 @@ func (b *planBuilder) AddPullPhase(plan *storage.OperationPlan) {
 			ExecServer:  &b.JoiningNode,
 			Package:     &b.Application.Package,
 			ServiceUser: &b.ServiceUser,
+			Pull: &storage.PullData{
+				Packages: []loc.Locator{
+					b.GravityPackage,
+					b.TeleportPackage,
+					b.PlanetPackage,
+				},
+			},
 		},
 		Requires: []string{installphases.ConfigurePhase, installphases.BootstrapPhase},
 	})
@@ -340,6 +349,11 @@ func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	gravityPackage, err := application.Manifest.Dependencies.ByName(
+		constants.GravityPackage)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	teleportPackage, err := application.Manifest.Dependencies.ByName(
 		constants.TeleportPackage)
 	if err != nil {
@@ -375,6 +389,7 @@ func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {
 	return &planBuilder{
 		Application:     *application,
 		Runtime:         *runtime,
+		GravityPackage:  *gravityPackage,
 		TeleportPackage: *teleportPackage,
 		PlanetPackage:   *planetPackage,
 		JoiningNode:     operation.Servers[0],

--- a/lib/expand/phases/checks.go
+++ b/lib/expand/phases/checks.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/rpc"
 
+	"github.com/fatih/color"
+	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
@@ -88,8 +90,22 @@ func (p *checksExecutor) Execute(ctx context.Context) error {
 	// For multi-node checks, use one of master nodes as an "anchor" so
 	// the joining node will be compared against that master (e.g. for
 	// the OS check, time drift check, etc).
-	failed := checker.CheckNode(ctx, *node)
-	failed = append(failed, checker.CheckNodes(ctx, []checks.Server{*master, *node})...)
+	probes := checker.CheckNode(ctx, *node)
+	probes = append(probes, checker.CheckNodes(ctx, []checks.Server{*master, *node})...)
+	// Sort probes out into warnings and real failures.
+	var failed []*agentpb.Probe
+	for _, probe := range probes {
+		if probe.Status != agentpb.Probe_Failed {
+			continue
+		}
+		if probe.Severity == agentpb.Probe_Warning {
+			p.Progress.NextStep(color.YellowString(probe.Detail))
+		}
+		if probe.Severity == agentpb.Probe_Critical {
+			p.Progress.NextStep(color.RedString(probe.Detail))
+			failed = append(failed, probe)
+		}
+	}
 	if len(failed) != 0 {
 		return trace.BadParameter("The following checks failed:\n%v",
 			checks.FormatFailedChecks(failed))

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -51,6 +51,7 @@ type PlanSuite struct {
 	regularAgent    *storage.LoginEntry
 	teleportPackage *loc.Locator
 	planetPackage   *loc.Locator
+	gravityPackage  *loc.Locator
 	appPackage      loc.Locator
 	serviceUser     storage.OSUser
 	cluster         *ops.Site
@@ -76,6 +77,8 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 	app, err := s.services.Apps.GetApp(s.appPackage)
 	c.Assert(err, check.IsNil)
 	s.teleportPackage, err = app.Manifest.Dependencies.ByName(constants.TeleportPackage)
+	c.Assert(err, check.IsNil)
+	s.gravityPackage, err = app.Manifest.Dependencies.ByName(constants.GravityPackage)
 	c.Assert(err, check.IsNil)
 	s.dnsConfig = storage.DNSConfig{
 		Addrs: []string{"127.0.0.3"},
@@ -281,6 +284,13 @@ func (s *PlanSuite) verifyPullPhase(c *check.C, phase storage.OperationPhase) {
 			ExecServer:  &s.joiningNode,
 			Package:     &s.appPackage,
 			ServiceUser: &s.serviceUser,
+			Pull: &storage.PullData{
+				Packages: []loc.Locator{
+					*s.gravityPackage,
+					*s.teleportPackage,
+					*s.planetPackage,
+				},
+			},
 		},
 		Requires: []string{installphases.ConfigurePhase, installphases.BootstrapPhase},
 	}, phase)

--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -79,11 +79,12 @@ func (r *InstallerStrategy) installSelfAsService() error {
 			Timeout:          int(time.Duration(defaults.ServiceConnectTimeout).Seconds()),
 			WantedBy:         "multi-user.target",
 			WorkingDirectory: r.ApplicationDir,
+			// Propagate all gravity-related environment variables to the service.
+			Environment: utils.GetenvsByPrefix(constants.GravityEnvVarPrefix),
 		},
 		NoBlock: true,
 		Name:    r.ServicePath,
 	}
-	req.ServiceSpec.Environment = utils.Getenv(constants.PreflightChecksOffEnvVar)
 	r.WithField("req", fmt.Sprintf("%+v", req)).Info("Install service.")
 	return trace.Wrap(service.Reinstall(req))
 }

--- a/lib/install/phases/pull.go
+++ b/lib/install/phases/pull.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -45,6 +46,9 @@ func NewPull(p fsm.ExecutorParams, operator ops.Operator, wizardPack, localPack 
 	wizardApps, localApps app.Applications, remote fsm.Remote) (*pullExecutor, error) {
 	if p.Phase.Data == nil || p.Phase.Data.ServiceUser == nil {
 		return nil, trace.BadParameter("service user is required")
+	}
+	if p.Phase.Data.Pull == nil {
+		return nil, trace.BadParameter("phase does not contain pull data")
 	}
 
 	serviceUser, err := userFromOSUser(*p.Phase.Data.ServiceUser)
@@ -80,6 +84,7 @@ func NewPull(p fsm.ExecutorParams, operator ops.Operator, wizardPack, localPack 
 		LocalApps:      localApps,
 		ExecutorParams: p,
 		ServiceUser:    *serviceUser,
+		Pull:           *p.Phase.Data.Pull,
 		runtimePackage: *runtimePackage,
 		remote:         remote,
 	}, nil
@@ -98,6 +103,8 @@ type pullExecutor struct {
 	LocalApps app.Applications
 	// ServiceUser is the user used for services and system storage
 	ServiceUser systeminfo.User
+	// Pull contains applications and packages to pull
+	Pull storage.PullData
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
 	// remote specifies the server remote control interface
@@ -108,11 +115,19 @@ type pullExecutor struct {
 
 // Execute executes the pull phase
 func (p *pullExecutor) Execute(ctx context.Context) error {
-	err := p.pullUserApplication()
-	if err != nil {
-		return trace.Wrap(err)
+	if len(p.Pull.Packages) != 0 {
+		err := p.pullPackages(p.Pull.Packages)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
-	err = p.pullConfiguredPackages()
+	if len(p.Pull.Apps) != 0 {
+		err := p.pullApps(p.Pull.Apps)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	err := p.pullConfiguredPackages()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -139,22 +154,40 @@ func (p *pullExecutor) Execute(ctx context.Context) error {
 	return nil
 }
 
-func (p *pullExecutor) pullUserApplication() error {
-	p.Progress.NextStep("Pulling user application")
-	p.Info("Pulling user application.")
-	// TODO do not pull user app on regular nodes
-	// FIXME: use context to promptly abort the pull
-	_, err := service.PullApp(service.AppPullRequest{
-		FieldLogger: p.FieldLogger,
-		SrcPack:     p.WizardPackages,
-		DstPack:     p.LocalPackages,
-		SrcApp:      p.WizardApps,
-		DstApp:      p.LocalApps,
-		Package:     *p.Phase.Data.Package,
-	})
-	// Ignore already exists as the steps need to be re-entrant
-	if err != nil && !trace.IsAlreadyExists(err) {
-		return trace.Wrap(err)
+func (p *pullExecutor) pullPackages(locators []loc.Locator) error {
+	p.Progress.NextStep("Pulling packages")
+	p.Infof("Pulling packages: %v.", locators)
+	for _, locator := range locators {
+		p.Progress.NextStep("Pulling package %v:%v", locator.Name, locator.Version)
+		_, err := service.PullPackage(service.PackagePullRequest{
+			FieldLogger: p.FieldLogger,
+			SrcPack:     p.WizardPackages,
+			DstPack:     p.LocalPackages,
+			Package:     locator,
+		})
+		if err != nil && !trace.IsAlreadyExists(err) { // Must be re-entrant.
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+func (p *pullExecutor) pullApps(locators []loc.Locator) error {
+	p.Progress.NextStep("Pulling applications")
+	p.Infof("Pulling applications: %v.", locators)
+	for _, locator := range locators {
+		p.Progress.NextStep("Pulling application %v:%v", locator.Name, locator.Version)
+		_, err := service.PullApp(service.AppPullRequest{
+			FieldLogger: p.FieldLogger,
+			SrcPack:     p.WizardPackages,
+			DstPack:     p.LocalPackages,
+			SrcApp:      p.WizardApps,
+			DstApp:      p.LocalApps,
+			Package:     locator,
+		})
+		if err != nil && !trace.IsAlreadyExists(err) { // Must be re-entrant.
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }

--- a/lib/install/reconfigure/plan_test.go
+++ b/lib/install/reconfigure/plan_test.go
@@ -259,6 +259,11 @@ func (s *ReconfiguratorSuite) verifyPullPhase(c *check.C, phase storage.Operatio
 					ExecServer:  &master,
 					Package:     s.suite.Package(),
 					ServiceUser: &s.suite.Cluster().ServiceUser,
+					Pull: &storage.PullData{
+						Apps: []loc.Locator{
+							*(s.suite.Package()),
+						},
+					},
 				},
 				Requires: []string{installphases.ConfigurePhase},
 			},

--- a/lib/install/suite.go
+++ b/lib/install/suite.go
@@ -58,6 +58,7 @@ type PlanSuite struct {
 	adminAgent         *storage.LoginEntry
 	regularAgent       *storage.LoginEntry
 	teleportPackage    *loc.Locator
+	gravityPackage     *loc.Locator
 	runtimePackage     loc.Locator
 	rbacPackage        *loc.Locator
 	runtimeApplication *loc.Locator
@@ -116,6 +117,8 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 	app, err := s.services.Apps.GetApp(appPackage)
 	c.Assert(err, check.IsNil)
 	s.teleportPackage, err = app.Manifest.Dependencies.ByName(constants.TeleportPackage)
+	c.Assert(err, check.IsNil)
+	s.gravityPackage, err = app.Manifest.Dependencies.ByName(constants.GravityPackage)
 	c.Assert(err, check.IsNil)
 	runtimePackage, err := app.Manifest.DefaultRuntimePackage()
 	c.Assert(err, check.IsNil)
@@ -362,6 +365,11 @@ func (s *PlanSuite) VerifyPullPhase(c *check.C, phase storage.OperationPhase) {
 					ExecServer:  &s.masterNode,
 					Package:     &s.installer.config.App.Package,
 					ServiceUser: serviceUser,
+					Pull: &storage.PullData{
+						Apps: []loc.Locator{
+							s.installer.config.App.Package,
+						},
+					},
 				},
 				Requires: []string{phases.ConfigurePhase, phases.BootstrapPhase},
 			},
@@ -372,6 +380,13 @@ func (s *PlanSuite) VerifyPullPhase(c *check.C, phase storage.OperationPhase) {
 					ExecServer:  &s.regularNode,
 					Package:     &s.installer.config.App.Package,
 					ServiceUser: serviceUser,
+					Pull: &storage.PullData{
+						Packages: []loc.Locator{
+							*s.gravityPackage,
+							*s.teleportPackage,
+							s.runtimePackage,
+						},
+					},
 				},
 				Requires: []string{phases.ConfigurePhase, phases.BootstrapPhase},
 			},

--- a/lib/ops/checks.go
+++ b/lib/ops/checks.go
@@ -42,14 +42,14 @@ func CheckServers(ctx context.Context,
 	servers []storage.Server,
 	agentService AgentService,
 	manifest schema.Manifest,
-) error {
+) ([]*agentpb.Probe, error) {
 	nodes, err := mergeServers(infos, servers)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	requirements, err := checks.RequirementsFromManifest(manifest)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	c, err := checks.New(checks.Config{
 		Remote:       &remoteCommands{key: opKey, AgentService: agentService},
@@ -57,15 +57,15 @@ func CheckServers(ctx context.Context,
 		Servers:      nodes,
 		Requirements: requirements,
 		Features: checks.Features{
-			TestBandwidth:    true,
-			TestPorts:        true,
-			TestEtcdDisk:     true,
+			TestBandwidth: true,
+			TestPorts:     true,
+			TestEtcdDisk:  true,
 		},
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return trace.Wrap(c.Run(ctx))
+	return c.Check(ctx), nil
 }
 
 // FormatValidationError formats validation error as a human-readable text

--- a/lib/ops/operatoracl.go
+++ b/lib/ops/operatoracl.go
@@ -411,9 +411,9 @@ func (o *OperatorACL) CheckSiteStatus(ctx context.Context, key SiteKey) error {
 }
 
 // ValidateServers runs pre-installation checks
-func (o *OperatorACL) ValidateServers(ctx context.Context, req ValidateServersRequest) error {
+func (o *OperatorACL) ValidateServers(ctx context.Context, req ValidateServersRequest) (*ValidateServersResponse, error) {
 	if err := o.ClusterAction(req.SiteDomain, storage.KindCluster, teleservices.VerbRead); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	return o.operator.ValidateServers(ctx, req)
 }

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -1255,13 +1255,17 @@ func (c *Client) GetApplicationEndpoints(key ops.SiteKey) ([]ops.Endpoint, error
 }
 
 // ValidateServers runs pre-installation checks
-func (c *Client) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
-	_, err := c.PostJSONWithContext(ctx, c.Endpoint(
+func (c *Client) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
+	out, err := c.PostJSONWithContext(ctx, c.Endpoint(
 		"accounts", req.AccountID, "sites", req.SiteDomain, "prechecks"), req)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	return nil
+	var resp ops.ValidateServersResponse
+	if err = json.Unmarshal(out.Bytes(), &resp); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &resp, nil
 }
 
 func (c *Client) GetAppInstaller(req ops.AppInstallerRequest) (io.ReadCloser, error) {

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -1256,11 +1256,11 @@ func (h *WebHandler) validateServers(w http.ResponseWriter, r *http.Request, p h
 	if err := d.Decode(&req); err != nil {
 		return trace.BadParameter(err.Error())
 	}
-	err := context.Operator.ValidateServers(context.Context, req)
+	resp, err := context.Operator.ValidateServers(context.Context, req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	roundtrip.ReplyJSON(w, http.StatusOK, statusOK("ok"))
+	roundtrip.ReplyJSON(w, http.StatusOK, resp)
 	return nil
 }
 

--- a/lib/ops/opsroute/forward.go
+++ b/lib/ops/opsroute/forward.go
@@ -431,10 +431,10 @@ func (r *Router) GetSiteReport(req ops.GetClusterReportRequest) (io.ReadCloser, 
 }
 
 // ValidateServers runs pre-installation checks
-func (r *Router) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
+func (r *Router) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
 	client, err := r.WizardClient(req.SiteDomain)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	return client.ValidateServers(ctx, req)
 }

--- a/lib/ops/opsservice/checks.go
+++ b/lib/ops/opsservice/checks.go
@@ -19,36 +19,61 @@ package opsservice
 import (
 	"context"
 
+	"github.com/gravitational/gravity/lib/checks"
 	"github.com/gravitational/gravity/lib/ops"
 
+	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
 
-// ValidateServers runs preflight checks before the installation
-func (o *Operator) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) error {
+// ValidateServers executes preflight checks and returns formatted error if
+// any of the checks fail.
+func ValidateServers(ctx context.Context, operator ops.Operator, req ops.ValidateServersRequest) error {
+	resp, err := operator.ValidateServers(ctx, req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var failed []*agentpb.Probe
+	for _, probe := range resp.Probes {
+		if probe.Severity != agentpb.Probe_Warning {
+			failed = append(failed, probe)
+		}
+	}
+	if len(failed) > 0 {
+		return trace.BadParameter("The following pre-flight checks failed:\n%v",
+			checks.FormatFailedChecks(failed))
+	}
+	return nil
+}
+
+// ValidateServers runs preflight checks before the installation and returns
+// failed probes.
+func (o *Operator) ValidateServers(ctx context.Context, req ops.ValidateServersRequest) (*ops.ValidateServersResponse, error) {
 	log.Infof("Validating servers: %#v.", req)
 
 	op, err := o.GetSiteOperation(req.OperationKey())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	cluster, err := o.openSite(req.SiteKey())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	infos, err := cluster.agentService().GetServerInfos(ctx, op.Key())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	err = ops.CheckServers(ctx, op.Key(), infos, req.Servers,
+	probes, err := ops.CheckServers(ctx, op.Key(), infos, req.Servers,
 		cluster.agentService(), cluster.app.Manifest)
 	if err != nil {
-		return trace.Wrap(ops.FormatValidationError(err))
+		return nil, trace.Wrap(err)
 	}
 
-	return nil
+	return &ops.ValidateServersResponse{
+		Probes: probes,
+	}, nil
 }

--- a/lib/ops/opsservice/install.go
+++ b/lib/ops/opsservice/install.go
@@ -431,7 +431,7 @@ func (s *site) updateOperationState(op *ops.SiteOperation, req ops.OperationUpda
 			OperationID: op.ID,
 			Servers:     req.Servers,
 		}
-		err = s.service.ValidateServers(context.TODO(), validateReq)
+		err = ValidateServers(context.TODO(), s.service, validateReq)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -155,12 +155,22 @@ type OperationPhaseData struct {
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`
 	// Data is arbitrary text data to provide to a phase executor
 	Data string `json:"data,omitempty" yaml:"data,omitempty"`
+	// Pull contains applications and packages that should be pulled
+	Pull *PullData `json:"pull,omitempty" yaml:"pull,omitempty"`
 	// GarbageCollect specifies configuration specific to garbage collect operation
 	GarbageCollect *GarbageCollectOperationData `json:"garbage_collect,omitempty" yaml:"garbage_collect,omitempty"`
 	// Update specifies configuration specific to update operations
 	Update *UpdateOperationData `json:"update,omitempty" yaml:"update,omitempty"`
 	// Install specifies configuration specific to install operation
 	Install *InstallOperationData `json:"install,omitempty" yaml:"install,omitempty"`
+}
+
+// PullData contains applications and packages to pull
+type PullData struct {
+	// Packages is a list of packages to pull
+	Packages []loc.Locator `json:"packages,omitempty" yaml:"packages,omitempty"`
+	// Apps is a list of applications to pull
+	Apps []loc.Locator `json:"apps,omitempty" yaml:"apps,omitempty"`
 }
 
 // ElectionChange describes changes to make to cluster elections

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -103,6 +104,31 @@ func GetenvWithDefault(name, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// GetenvsByPrefix returns environment variables with names matching specified prefix.
+func GetenvsByPrefix(prefix string) (environ map[string]string) {
+	environ = make(map[string]string)
+	for _, env := range os.Environ() {
+		name := strings.SplitN(env, "=", 2)[0]
+		if strings.HasPrefix(name, prefix) {
+			environ[name] = os.Getenv(name)
+		}
+	}
+	return environ
+}
+
+// GetenvInt returns the specified environment variable value parsed as an integer.
+func GetenvInt(name string) (int, error) {
+	valueS, ok := os.LookupEnv(name)
+	if !ok {
+		return 0, trace.NotFound("environment variable %v not set", name)
+	}
+	valueI, err := strconv.Atoi(valueS)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return valueI, nil
 }
 
 // runningInsideContainer specifies if this process is executing inside

--- a/lib/utils/env_test.go
+++ b/lib/utils/env_test.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package utils
 
-import . "gopkg.in/check.v1"
+import (
+	"os"
+
+	"github.com/gravitational/trace"
+	. "gopkg.in/check.v1"
+)
 
 type EnvSuite struct{}
 
@@ -30,4 +35,29 @@ func (s *EnvSuite) TestEnv(c *C) {
 	readEnv, err := ReadEnv(path)
 	c.Assert(err, IsNil)
 	c.Assert(readEnv, DeepEquals, env)
+}
+
+func (s *EnvSuite) TestGetenvsByPrefix(c *C) {
+	envs := map[string]string{
+		"TEST1_A": "v1",
+		"TEST1_B": "v2",
+	}
+	for k, v := range envs {
+		os.Setenv(k, v)
+	}
+	c.Assert(GetenvsByPrefix("TEST1_"), DeepEquals, envs)
+}
+
+func (s *EnvSuite) TestGetenvInt(c *C) {
+	os.Setenv("TEST1", "42")
+	val, err := GetenvInt("TEST1")
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, 42)
+
+	os.Setenv("TEST1", "qwerty")
+	val, err = GetenvInt("TEST1")
+	c.Assert(err, NotNil)
+
+	val, err = GetenvInt("DOESNOTEXIST")
+	c.Assert(err, FitsTypeOf, trace.NotFound(""))
 }

--- a/lib/webapi/operations.go
+++ b/lib/webapi/operations.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
@@ -121,7 +122,7 @@ func (m *Handler) validateServers(w http.ResponseWriter, r *http.Request, p http
 	log.Infof("validateServers: %v", req)
 
 	clusterName, operationID := p.ByName("domain"), p.ByName("operation_id")
-	err = ctx.Operator.ValidateServers(ctx.Context, ops.ValidateServersRequest{
+	err = opsservice.ValidateServers(ctx.Context, ctx.Operator, ops.ValidateServersRequest{
 		AccountID:   ctx.User.GetAccountID(),
 		SiteDomain:  clusterName,
 		OperationID: operationID,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Forward-port https://github.com/gravitational/gravity/pull/1847 that splits etcd disk check into low/high thresholds.

Also, forward-port https://github.com/gravitational/gravity/pull/1862 with a follow-up fix for etcd disk check to also consider joins, and the join fix to pull only required packages.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/1834.
* Ports https://github.com/gravitational/gravity/pull/1847, https://github.com/gravitational/gravity/pull/1862.
* Requires https://github.com/gravitational/gravity.e/pull/4315.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback
