### PR TITLE
[6.1.x] Collect gravity cli history

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -710,6 +710,10 @@ const (
 	//
 	// Used in audit events.
 	ServiceSystem = "@system"
+
+	// GravityCLITag is used to tag gravity cli command log entries in the
+	// system journal.
+	GravityCLITag = "gravity-cli"
 )
 
 var (

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -714,6 +714,9 @@ const (
 	// GravityCLITag is used to tag gravity cli command log entries in the
 	// system journal.
 	GravityCLITag = "gravity-cli"
+
+	// Redacted is used as a replacement string for sensitive data.
+	Redacted = "*****"
 )
 
 var (

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"log/syslog"
+
+	"github.com/gravitational/trace"
+)
+
+// SyslogWrite writes the message to the system log with the specified priority
+// and tag.
+func SyslogWrite(priority syslog.Priority, message, tag string) error {
+	w, err := syslog.New(priority, tag)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	if _, err := w.Write([]byte(message)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/cli"
+
+	"github.com/gravitational/trace"
+)
+
+// Executable executes a gravity command.
+type Executable func() error
+
+// CmdExecer handles execution of a gravity command.
+type CmdExecer struct {
+	// Exe specifies an executable gravity command.
+	Exe Executable
+	// Parser specifies the gravity arguments parser function.
+	Parser cli.ArgsParserFunc
+	// Args specifies the provided gravity command arguments.
+	Args []string
+	// ExtraArgs specifies the provided extra arguments.
+	ExtraArgs []string
+}
+
+// Execute executes the gravity command while logging the start and completion
+// of the command.
+func (r *CmdExecer) Execute() (err error) {
+	sanitizedCmd, err := r.getRedactedCmd()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cmdString := strings.Join(sanitizedCmd, " ")
+	if len(r.ExtraArgs) > 0 {
+		cmdString = fmt.Sprintf("%s -- %s", cmdString, strings.Join(r.ExtraArgs, " "))
+	}
+
+	logEntry(fmt.Sprintf("[RUNNING]: %s", cmdString))
+	defer func() {
+		if r := recover(); r != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [PANIC]: %v", cmdString, r))
+			panic(r)
+		}
+		if err != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
+			return
+		}
+		logEntry(fmt.Sprintf("[SUCCESS]: %s", cmdString))
+	}()
+
+	err = r.Exe()
+	return trace.Wrap(err)
+}
+
+// getRedactedCmd removes potentially sensitive data from the args and returns
+// the sanitized cmd as a list of strings.
+func (r *CmdExecer) getRedactedCmd() (cmd []string, err error) {
+	commandArgs := cli.CommandArgs{
+		Parser: r.Parser,
+		FlagsToReplace: []cli.Flag{
+			cli.NewFlag("token", constants.Redacted),
+			cli.NewFlag("registry-password", constants.Redacted),
+			cli.NewFlag("password", constants.Redacted),
+			cli.NewFlag("license", constants.Redacted),
+			cli.NewFlag("ops-token", constants.Redacted),
+			cli.NewFlag("ops-tunnel-token", constants.Redacted),
+			cli.NewFlag("encryption-key", constants.Redacted),
+		},
+	}
+	args, err := commandArgs.Update(r.Args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return append([]string{utils.Exe.Path}, args...), nil
+}
+
+// logEntry writes the provided entry into the system journal with the
+// gravity-cli tag.
+func logEntry(entry string) {
+	if err := utils.SyslogWrite(syslog.LOG_INFO, entry, constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -58,6 +59,10 @@ func ConfigureEnvironment() error {
 // Run parses CLI arguments and executes an appropriate gravity command
 func Run(g *Application) error {
 	log.Debugf("Executing: %v.", os.Args)
+	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+
 	err := ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,6 +38,7 @@ import (
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/cli"
 
 	"github.com/gravitational/configure/cstrings"
 	teleutils "github.com/gravitational/teleport/lib/utils"
@@ -57,23 +57,9 @@ func ConfigureEnvironment() error {
 }
 
 // Run parses CLI arguments and executes an appropriate gravity command
-func Run(g *Application) error {
+func Run(g *Application) (err error) {
 	log.Debugf("Executing: %v.", os.Args)
-	if runErr := run(g); runErr != nil {
-		msg := fmt.Sprintf("Failed to exec [%s]: %s", strings.Join(os.Args, " "), trace.UserMessage(runErr))
-		if logErr := utils.SyslogWrite(syslog.LOG_INFO, msg, constants.GravityCLITag); logErr != nil {
-			log.WithError(logErr).Warn("Failed to write to system logs.")
-		}
-		return runErr
-	}
-	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
-		log.WithError(err).Warn("Failed to write to system logs.")
-	}
-	return nil
-}
-
-func run(g *Application) error {
-	err := ConfigureEnvironment()
+	err = ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -91,7 +77,14 @@ func run(g *Application) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return Execute(g, cmd, extraArgs)
+
+	execer := CmdExecer{
+		Exe:       getExec(g, cmd, extraArgs),
+		Parser:    cli.ArgsParserFunc(parseArgs),
+		Args:      args,
+		ExtraArgs: extraArgs,
+	}
+	return execer.Execute()
 }
 
 // InitAndCheck initializes the CLI application according to the provided
@@ -256,6 +249,13 @@ func InitAndCheck(g *Application, cmd string) error {
 	}
 
 	return nil
+}
+
+// getExec returns the Executable function to execute the specified gravity cmd.
+func getExec(g *Application, cmd string, extraArgs []string) Executable {
+	return func() error {
+		return Execute(g, cmd, extraArgs)
+	}
 }
 
 // Execute executes the gravity command given with cmd


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Gravity cli commands will be recorded in the system journal and tagged with `gravity-cli`. Logs can be queried for with `journalctl -t gravity-cli`.
- Gravity cli history will also be included in the `gravity report`.
- Potentially sensitve data will be redacted from the logs and values replaced with `*****`.
- The start/ffinish of a particular command can be tracked using the proc id, `journalctl _PID=[pid]`.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/1845, https://github.com/gravitational/gravity/pull/1889
* Requires https://github.com/gravitational/gravity.e/pull/4310
## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify gravity cli is recorded in system journal**

**Verfiy gravity cli history is included in gravity report**
```
[vagrant@node-1 ~]$ cat gravity-cli.log
-- Logs begin at Fri 2020-07-10 20:26:59 UTC, end at Mon 2020-07-13 04:28:00 UTC. --
Jul 13 04:27:55 node-1 gravity-cli[5646]: [RUNNING]: /usr/bin/gravity system report --insecure --filter "etcd" --compressed
Jul 13 04:27:55 node-1 gravity-cli[5661]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /usr/bin/curl -- -s --tlsv1.2 --cacert /var/state/root.cert --cert /var/state/etcd.cert --key /var/state/etcd.key https:/127.0.0.1:2379/metrics
Jul 13 04:27:56 node-1 gravity-cli[5646]: [SUCCESS]: /usr/bin/gravity system report --insecure --filter "etcd" --compressed
Jul 13 04:27:56 node-1 gravity-cli[5698]: [RUNNING]: /usr/bin/gravity system report --insecure --filter "system" --compressed --since "10s"
Jul 13 04:27:56 node-1 gravity-cli[5729]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /sbin/bridge -- fdb show
Jul 13 04:27:58 node-1 gravity-cli[5799]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /usr/bin/etcdctl -- cluster-health
Jul 13 04:27:58 node-1 gravity-cli[5843]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /usr/bin/etcdctl3 -- endpoint health --cluster
Jul 13 04:27:58 node-1 gravity-cli[5898]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /usr/bin/planet -- status
Jul 13 04:27:59 node-1 gravity-cli[5943]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- status --full
Jul 13 04:27:59 node-1 gravity-cli[5977]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- --failed --full
Jul 13 04:27:59 node-1 gravity-cli[6012]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- list-jobs --full
Jul 13 04:27:59 node-1 gravity-cli[6047]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /bin/systemctl -- list-jobs --full
Jul 13 04:27:59 node-1 gravity-cli[6084]: [RUNNING]: /usr/bin/gravity planet enter -- --notty /usr/bin/serf -- members
Jul 13 04:28:00 node-1 gravity-cli[6136]: [RUNNING]: /usr/bin/gravity system export-runtime-journal --since "10s"
Jul 13 04:28:00 node-1 gravity-cli[6148]: [RUNNING]: /usr/bin/gravity system stream-runtime-journal --since "10s"
Jul 13 04:28:00 node-1 gravity-cli[6136]: [SUCCESS]: /usr/bin/gravity system export-runtime-journal --since "10s"
```

**Verify log entry of a successfully completed gravity command**
```
Jul 13 04:24:48 node-1 gravity-cli[4607]: [RUNNING]: /usr/bin/gravity status cluster
Jul 13 04:24:48 node-1 gravity-cli[4607]: [SUCCESS]: /usr/bin/gravity status cluster
```

**Verify log entry of a failed gravity command. Also verify sensitive data is redacted**
```
Jul 13 04:24:56 node-1 gravity-cli[4642]: [RUNNING]: /usr/bin/gravity install --token "*****"
Jul 13 04:24:56 node-1 gravity-cli[4642]: [FAILURE]: /usr/bin/gravity install --token "*****": [ERROR]: install token is too short, min length is 6
```