### PR TITLE
[7.0.x] Collect gravity cli history

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -718,6 +718,10 @@ const (
 	// GravitySystemContainerType specifies the SELinux domain for the system containers.
 	// For instance, application hook init containers run as system containers
 	GravitySystemContainerType = "gravity_container_system_t"
+
+	// GravityCLITag is used to tag gravity cli command log entries in the
+	// system journal.
+	GravityCLITag = "gravity-cli"
 )
 
 var (

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -722,6 +722,9 @@ const (
 	// GravityCLITag is used to tag gravity cli command log entries in the
 	// system journal.
 	GravityCLITag = "gravity-cli"
+
+	// Redacted is used as a replacement string for sensitive data.
+	Redacted = "*****"
 )
 
 var (

--- a/lib/utils/cli/cli_test.go
+++ b/lib/utils/cli/cli_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/gravitational/gravity/lib/constants"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -38,11 +41,12 @@ func (*S) SetUpSuite(c *check.C) {
 
 func (*S) TestUpdatesCommandLine(c *check.C) {
 	var testCases = []struct {
-		comment     string
-		inputArgs   []string
-		flags       []Flag
-		removeFlags []string
-		outputArgs  []string
+		comment      string
+		inputArgs    []string
+		flags        []Flag
+		replaceFlags []Flag
+		removeFlags  []string
+		outputArgs   []string
 	}{
 		{
 			comment:   "Does not overwrite existing flags",
@@ -102,14 +106,47 @@ func (*S) TestUpdatesCommandLine(c *check.C) {
 			},
 			removeFlags: []string{"path"},
 		},
+		{
+			comment:    "Redact install token",
+			inputArgs:  []string{"install", `--token=token`, "--debug"},
+			outputArgs: []string{"install", "--token", fmt.Sprintf(`"%s"`, constants.Redacted), "--debug"},
+			replaceFlags: []Flag{
+				NewFlag("token", constants.Redacted),
+			},
+		},
+		{
+			comment:   "Redact user create password",
+			inputArgs: []string{"user", "create", `--email=email`, `--password=password`},
+			outputArgs: []string{"user create",
+				"--email", `"email"`,
+				"--password", fmt.Sprintf(`"%s"`, constants.Redacted),
+			},
+			replaceFlags: []Flag{
+				NewFlag("password", constants.Redacted),
+			},
+		},
+		{
+			comment:   "Redact multiple flags",
+			inputArgs: []string{"test", `--secret1`, `secret1`, `--secret2`, `secret2`, `test`},
+			outputArgs: []string{"test",
+				"--secret1", fmt.Sprintf(`"%s"`, constants.Redacted),
+				"--secret2", fmt.Sprintf(`"%s"`, constants.Redacted),
+				`"test"`,
+			},
+			replaceFlags: []Flag{
+				NewFlag("secret1", constants.Redacted),
+				NewFlag("secret2", constants.Redacted),
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		comment := check.Commentf(testCase.comment)
 		commandArgs := CommandArgs{
-			Parser:        ArgsParserFunc(parseArgs),
-			FlagsToAdd:    testCase.flags,
-			FlagsToRemove: testCase.removeFlags,
+			Parser:         ArgsParserFunc(parseArgs),
+			FlagsToAdd:     testCase.flags,
+			FlagsToRemove:  testCase.removeFlags,
+			FlagsToReplace: testCase.replaceFlags,
 		}
 		args, err := commandArgs.Update(testCase.inputArgs)
 		c.Assert(err, check.IsNil)
@@ -120,11 +157,23 @@ func (*S) TestUpdatesCommandLine(c *check.C) {
 func parseArgs(args []string) (*kingpin.ParseContext, error) {
 	app := kingpin.New("test", "")
 	app.Flag("debug", "").Bool()
-	cmd := app.Command("install", "")
-	cmd.Arg("path", "").String()
-	cmd.Flag("token", "").String()
-	cmd.Flag("selinux", "").Default("true").Bool()
-	cmd.Flag("advertise-addr", "").String()
-	cmd.Flag("cloud-provider", "").String()
+
+	installCmd := app.Command("install", "")
+	installCmd.Arg("path", "").String()
+	installCmd.Flag("token", "").String()
+	installCmd.Flag("selinux", "").Default("true").Bool()
+	installCmd.Flag("advertise-addr", "").String()
+	installCmd.Flag("cloud-provider", "").String()
+
+	userCmd := app.Command("user", "")
+	userCreateCmd := userCmd.Command("create", "")
+	userCreateCmd.Flag("password", "").String()
+	userCreateCmd.Flag("email", "").String()
+
+	testCmd := app.Command("test", "")
+	testCmd.Arg("arg", "").String()
+	testCmd.Flag("secret1", "").String()
+	testCmd.Flag("secret2", "").String()
+
 	return app.ParseContext(args)
 }

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"log/syslog"
+
+	"github.com/gravitational/trace"
+)
+
+// SyslogWrite writes the message to the system log with the specified priority
+// and tag.
+func SyslogWrite(priority syslog.Priority, message, tag string) error {
+	w, err := syslog.New(priority, tag)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	if _, err := w.Write([]byte(message)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/cli"
+
+	"github.com/gravitational/trace"
+)
+
+// Executable executes a gravity command.
+type Executable func() error
+
+// CmdExecer handles execution of a gravity command.
+type CmdExecer struct {
+	// Exe specifies an executable gravity command.
+	Exe Executable
+	// Parser specifies the gravity arguments parser function.
+	Parser cli.ArgsParserFunc
+	// Args specifies the provided gravity command arguments.
+	Args []string
+	// ExtraArgs specifies the provided extra arguments.
+	ExtraArgs []string
+}
+
+// Execute executes the gravity command while logging the start and completion
+// of the command.
+func (r *CmdExecer) Execute() (err error) {
+	sanitizedCmd, err := r.getRedactedCmd()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cmdString := strings.Join(sanitizedCmd, " ")
+	if len(r.ExtraArgs) > 0 {
+		cmdString = fmt.Sprintf("%s -- %s", cmdString, strings.Join(r.ExtraArgs, " "))
+	}
+
+	logEntry(fmt.Sprintf("[RUNNING]: %s", cmdString))
+	defer func() {
+		if r := recover(); r != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [PANIC]: %v", cmdString, r))
+			panic(r)
+		}
+		if err != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
+			return
+		}
+		logEntry(fmt.Sprintf("[SUCCESS]: %s", cmdString))
+	}()
+
+	err = r.Exe()
+	return trace.Wrap(err)
+}
+
+// getRedactedCmd removes potentially sensitive data from the args and returns
+// the sanitized cmd as a list of strings.
+func (r *CmdExecer) getRedactedCmd() (cmd []string, err error) {
+	commandArgs := cli.CommandArgs{
+		Parser: r.Parser,
+		FlagsToReplace: []cli.Flag{
+			cli.NewFlag("token", constants.Redacted),
+			cli.NewFlag("registry-password", constants.Redacted),
+			cli.NewFlag("password", constants.Redacted),
+			cli.NewFlag("license", constants.Redacted),
+			cli.NewFlag("ops-token", constants.Redacted),
+			cli.NewFlag("ops-tunnel-token", constants.Redacted),
+			cli.NewFlag("encryption-key", constants.Redacted),
+		},
+	}
+	args, err := commandArgs.Update(r.Args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return append([]string{utils.Exe.Path}, args...), nil
+}
+
+// logEntry writes the provided entry into the system journal with the
+// gravity-cli tag.
+func logEntry(entry string) {
+	if err := utils.SyslogWrite(syslog.LOG_INFO, entry, constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -58,6 +59,10 @@ func ConfigureEnvironment() error {
 // Run parses CLI arguments and executes an appropriate gravity command
 func Run(g *Application) error {
 	log.Debugf("Executing: %v.", os.Args)
+	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+
 	err := ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Gravity cli commands will be recorded in the system journal and tagged with `gravity-cli`. Logs can be queried for with `journalctl -t gravity-cli`.
- Gravity cli history will also be included in the `gravity report`.
- Potentially sensitve data will be redacted from the logs and values replaced with `*****`.
- The start/ffinish of a particular command can be tracked using the proc id, `journalctl _PID=[pid]`.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/1845, https://github.com/gravitational/gravity/pull/1889
* Requires https://github.com/gravitational/gravity.e/pull/4311
## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify gravity cli is recorded in system journal**

**Verfiy gravity cli history is included in gravity report**
```
[vagrant@node-1 ~]$ cat gravity-cli.log
-- Logs begin at Fri 2020-07-10 20:26:59 UTC, end at Mon 2020-07-13 04:54:10 UTC. --
Jul 13 04:54:05 node-1 gravity-cli[25665]: [RUNNING]: /usr/bin/gravity system report --insecure --filter "etcd" --compressed
Jul 13 04:54:05 node-1 gravity-cli[25682]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/planet" "etcd" "backup" "--prefix" "/planet" "--prefix" "/gravity"
Jul 13 04:54:06 node-1 gravity-cli[25734]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/curl" "-s" "--tlsv1.2" "--cacert" "/var/state/root.cert" "--cert" "/var/state/etcd.cert" "--key" "/var/state/etcd.key" "https:/127.0.0.1:2379/metrics"
Jul 13 04:54:06 node-1 gravity-cli[25665]: [SUCCESS]: /usr/bin/gravity system report --insecure --filter "etcd" --compressed
Jul 13 04:54:06 node-1 gravity-cli[25770]: [RUNNING]: /usr/bin/gravity system report --insecure --filter "system" --compressed --since "10s"
Jul 13 04:54:06 node-1 gravity-cli[25800]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/sbin/bridge" "fdb" "show"
Jul 13 04:54:07 node-1 gravity-cli[25857]: [RUNNING]: /usr/bin/gravity status cluster --output "json"
Jul 13 04:54:08 node-1 gravity-cli[25857]: [SUCCESS]: /usr/bin/gravity status cluster --output "json"
Jul 13 04:54:08 node-1 gravity-cli[25876]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/etcdctl" "cluster-health"
Jul 13 04:54:08 node-1 gravity-cli[25922]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/etcdctl3" "endpoint" "health" "--cluster"
Jul 13 04:54:08 node-1 gravity-cli[25982]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/planet" "status"
Jul 13 04:54:09 node-1 gravity-cli[26027]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/bin/systemctl" "status" "--full"
Jul 13 04:54:09 node-1 gravity-cli[26062]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/bin/systemctl" "--failed" "--full"
Jul 13 04:54:09 node-1 gravity-cli[26100]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/bin/systemctl" "list-jobs" "--full"
Jul 13 04:54:09 node-1 gravity-cli[26138]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/bin/systemctl" "list-jobs" "--full"
Jul 13 04:54:09 node-1 gravity-cli[26178]: [RUNNING]: /usr/bin/gravity exec --no-tty --no-interactive "/usr/bin/serf" "members"
Jul 13 04:54:10 node-1 gravity-cli[26231]: [RUNNING]: /usr/bin/gravity system export-runtime-journal --since "10s"
Jul 13 04:54:10 node-1 gravity-cli[26243]: [RUNNING]: /usr/bin/gravity system stream-runtime-journal --since "10s"
Jul 13 04:54:10 node-1 gravity-cli[26231]: [SUCCESS]: /usr/bin/gravity system export-runtime-journal --since "10s"
```

**Verify log entry of a successfully completed gravity command**
```
Jul 13 04:52:38 node-1 gravity-cli[24748]: [RUNNING]: /usr/bin/gravity status cluster
Jul 13 04:52:38 node-1 gravity-cli[24748]: [SUCCESS]: /usr/bin/gravity status cluster
```

**Verify log entry of a failed gravity command. Also verify sensitive data is redacted**
```
Jul 13 04:52:21 node-1 gravity-cli[24585]: [RUNNING]: /usr/bin/gravity install --token "*****"
Jul 13 04:52:21 node-1 gravity-cli[24585]: [FAILURE]: /usr/bin/gravity install --token "*****": [ERROR]: install token is too short, min length is 6
```