### PR TITLE
(7.0) Pull only required packages during join

### DIFF
--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -146,10 +146,12 @@ func (b *planBuilder) AddPullPhase(plan *storage.OperationPlan) {
 			ExecServer:  &b.JoiningNode,
 			Package:     &b.Application.Package,
 			ServiceUser: &b.ServiceUser,
-			Packages: []loc.Locator{
-				b.GravityPackage,
-				b.TeleportPackage,
-				b.PlanetPackage,
+			Pull: &storage.PullData{
+				Packages: []loc.Locator{
+					b.GravityPackage,
+					b.TeleportPackage,
+					b.PlanetPackage,
+				},
 			},
 		},
 		Requires: []string{installphases.ConfigurePhase, installphases.BootstrapPhase},

--- a/lib/expand/builder.go
+++ b/lib/expand/builder.go
@@ -39,6 +39,8 @@ type planBuilder struct {
 	Application app.Application
 	// Runtime is the Runtime of the app being installed
 	Runtime app.Application
+	// GravityPackage is the gravity package to install
+	GravityPackage loc.Locator
 	// TeleportPackage is the teleport package to install
 	TeleportPackage loc.Locator
 	// PlanetPackage is the planet package to install
@@ -144,6 +146,11 @@ func (b *planBuilder) AddPullPhase(plan *storage.OperationPlan) {
 			ExecServer:  &b.JoiningNode,
 			Package:     &b.Application.Package,
 			ServiceUser: &b.ServiceUser,
+			Packages: []loc.Locator{
+				b.GravityPackage,
+				b.TeleportPackage,
+				b.PlanetPackage,
+			},
 		},
 		Requires: []string{installphases.ConfigurePhase, installphases.BootstrapPhase},
 	})
@@ -340,6 +347,11 @@ func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	gravityPackage, err := application.Manifest.Dependencies.ByName(
+		constants.GravityPackage)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	teleportPackage, err := application.Manifest.Dependencies.ByName(
 		constants.TeleportPackage)
 	if err != nil {
@@ -375,6 +387,7 @@ func (p *Peer) getPlanBuilder(ctx operationContext) (*planBuilder, error) {
 	return &planBuilder{
 		Application:     *application,
 		Runtime:         *runtime,
+		GravityPackage:  *gravityPackage,
 		TeleportPackage: *teleportPackage,
 		PlanetPackage:   *planetPackage,
 		JoiningNode:     operation.Servers[0],

--- a/lib/expand/phases/checks.go
+++ b/lib/expand/phases/checks.go
@@ -24,9 +24,9 @@ import (
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/rpc"
-	"github.com/gravitational/satellite/agent/proto/agentpb"
 
 	"github.com/fatih/color"
+	"github.com/gravitational/satellite/agent/proto/agentpb"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )

--- a/lib/expand/plan_test.go
+++ b/lib/expand/plan_test.go
@@ -51,6 +51,7 @@ type PlanSuite struct {
 	regularAgent    *storage.LoginEntry
 	teleportPackage *loc.Locator
 	planetPackage   *loc.Locator
+	gravityPackage  *loc.Locator
 	appPackage      loc.Locator
 	serviceUser     storage.OSUser
 	cluster         *ops.Site
@@ -76,6 +77,8 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 	app, err := s.services.Apps.GetApp(s.appPackage)
 	c.Assert(err, check.IsNil)
 	s.teleportPackage, err = app.Manifest.Dependencies.ByName(constants.TeleportPackage)
+	c.Assert(err, check.IsNil)
+	s.gravityPackage, err = app.Manifest.Dependencies.ByName(constants.GravityPackage)
 	c.Assert(err, check.IsNil)
 	s.dnsConfig = storage.DNSConfig{
 		Addrs: []string{"127.0.0.3"},
@@ -282,6 +285,13 @@ func (s *PlanSuite) verifyPullPhase(c *check.C, phase storage.OperationPhase) {
 			ExecServer:  &s.joiningNode,
 			Package:     &s.appPackage,
 			ServiceUser: &s.serviceUser,
+			Pull: &storage.PullData{
+				Packages: []loc.Locator{
+					*s.gravityPackage,
+					*s.teleportPackage,
+					*s.planetPackage,
+				},
+			},
 		},
 		Requires: []string{installphases.ConfigurePhase, installphases.BootstrapPhase},
 	}, phase)

--- a/lib/install/phases/pull.go
+++ b/lib/install/phases/pull.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/utils"
 
@@ -44,6 +45,9 @@ func NewPull(p fsm.ExecutorParams, operator ops.Operator, wizardPack, localPack 
 	wizardApps, localApps app.Applications, remote fsm.Remote) (*pullExecutor, error) {
 	if p.Phase.Data == nil || p.Phase.Data.ServiceUser == nil {
 		return nil, trace.BadParameter("service user is required")
+	}
+	if p.Phase.Data.Pull == nil {
+		return nil, trace.BadParameter("phase does not contain pull data")
 	}
 
 	serviceUser, err := systeminfo.UserFromOSUser(*p.Phase.Data.ServiceUser)
@@ -97,6 +101,8 @@ type pullExecutor struct {
 	LocalApps app.Applications
 	// ServiceUser is the user used for services and system storage
 	ServiceUser systeminfo.User
+	// Pull contains applications and packages to pull
+	Pull storage.PullData
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
 	// remote specifies the server remote control interface

--- a/lib/install/reconfigure/plan_test.go
+++ b/lib/install/reconfigure/plan_test.go
@@ -259,6 +259,11 @@ func (s *ReconfiguratorSuite) verifyPullPhase(c *check.C, phase storage.Operatio
 					ExecServer:  &master,
 					Package:     s.suite.Package(),
 					ServiceUser: &s.suite.Cluster().ServiceUser,
+					Pull: &storage.PullData{
+						Apps: []loc.Locator{
+							*(s.suite.Package()),
+						},
+					},
 				},
 				Requires: []string{installphases.ConfigurePhase},
 			},

--- a/lib/install/suite.go
+++ b/lib/install/suite.go
@@ -58,6 +58,7 @@ type PlanSuite struct {
 	adminAgent         *storage.LoginEntry
 	regularAgent       *storage.LoginEntry
 	teleportPackage    *loc.Locator
+	gravityPackage     *loc.Locator
 	runtimePackage     loc.Locator
 	rbacPackage        *loc.Locator
 	runtimeApplication *loc.Locator
@@ -116,6 +117,8 @@ func (s *PlanSuite) SetUpSuite(c *check.C) {
 	app, err := s.services.Apps.GetApp(appPackage)
 	c.Assert(err, check.IsNil)
 	s.teleportPackage, err = app.Manifest.Dependencies.ByName(constants.TeleportPackage)
+	c.Assert(err, check.IsNil)
+	s.gravityPackage, err = app.Manifest.Dependencies.ByName(constants.GravityPackage)
 	c.Assert(err, check.IsNil)
 	runtimePackage, err := app.Manifest.DefaultRuntimePackage()
 	c.Assert(err, check.IsNil)
@@ -362,6 +365,11 @@ func (s *PlanSuite) VerifyPullPhase(c *check.C, phase storage.OperationPhase) {
 					ExecServer:  &s.masterNode,
 					Package:     &s.installer.config.App.Package,
 					ServiceUser: serviceUser,
+					Pull: &storage.PullData{
+						Apps: []loc.Locator{
+							s.installer.config.App.Package,
+						},
+					},
 				},
 				Requires: []string{phases.ConfigurePhase, phases.BootstrapPhase},
 			},
@@ -372,6 +380,13 @@ func (s *PlanSuite) VerifyPullPhase(c *check.C, phase storage.OperationPhase) {
 					ExecServer:  &s.regularNode,
 					Package:     &s.installer.config.App.Package,
 					ServiceUser: serviceUser,
+					Pull: &storage.PullData{
+						Packages: []loc.Locator{
+							*s.gravityPackage,
+							*s.teleportPackage,
+							s.runtimePackage,
+						},
+					},
 				},
 				Requires: []string{phases.ConfigurePhase, phases.BootstrapPhase},
 			},

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -132,8 +132,6 @@ type OperationPhaseData struct {
 	Master *Server `json:"master,omitempty" yaml:"master,omitempty"`
 	// Package is the package locator for the phase, e.g. update package
 	Package *loc.Locator `json:"package,omitempty" yaml:"package,omitempty"`
-	// Packages contains a list of packages for the phase, e.g. packages to pull
-	Packages []loc.Locator `json:"packages,omitempty" yaml:"packages,omitempty"`
 	// Labels can optionally identify the package
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// InstalledPackage references the installed application package
@@ -157,12 +155,22 @@ type OperationPhaseData struct {
 	ServiceUser *OSUser `json:"service_user,omitempty" yaml:"service_user,omitempty"`
 	// Data is arbitrary text data to provide to a phase executor
 	Data string `json:"data,omitempty" yaml:"data,omitempty"`
+	// Pull contains applications and packages that should be pulled
+	Pull *PullData `json:"pull,omitempty" yaml:"pull,omitempty"`
 	// GarbageCollect specifies configuration specific to garbage collect operation
 	GarbageCollect *GarbageCollectOperationData `json:"garbage_collect,omitempty" yaml:"garbage_collect,omitempty"`
 	// Update specifies configuration specific to update operations
 	Update *UpdateOperationData `json:"update,omitempty" yaml:"update,omitempty"`
 	// Install specifies configuration specific to install operation
 	Install *InstallOperationData `json:"install,omitempty" yaml:"install,omitempty"`
+}
+
+// PullData contains applications and packages to pull
+type PullData struct {
+	// Packages is a list of packages to pull
+	Packages []loc.Locator `json:"packages,omitempty" yaml:"packages,omitempty"`
+	// Apps is a list of applications to pull
+	Apps []loc.Locator `json:"apps,omitempty" yaml:"apps,omitempty"`
 }
 
 // ElectionChange describes changes to make to cluster elections

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -132,6 +132,8 @@ type OperationPhaseData struct {
 	Master *Server `json:"master,omitempty" yaml:"master,omitempty"`
 	// Package is the package locator for the phase, e.g. update package
 	Package *loc.Locator `json:"package,omitempty" yaml:"package,omitempty"`
+	// Packages contains a list of packages for the phase, e.g. packages to pull
+	Packages []loc.Locator `json:"packages,omitempty" yaml:"packages,omitempty"`
 	// Labels can optionally identify the package
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// InstalledPackage references the installed application package


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This pull request updates join's `/pull` phase to only pull necessary packages from the cluster (gravity, teleport, planet) instead of the entire application. This should help some customers who are experiencing issues when pulling large packages from the cluster via internal load balancer on AWS (something that retries won't fix), and will also make join a little faster and more efficient as we don't really need those packages to be laying around on all nodes.

This is a much smaller and less risky approach than the original one I took with excluding disabled packages from built cluster images (the more I worked on it the deeper it got - something I'd like to avoid making in LTS release).

Also, I have just realized that when working on etcd disk check warning in https://github.com/gravitational/gravity/pull/1847, I only updated the install operation but didn't touch join. So I have also updated join's `/checks` phase with the same behavior: to print warning probes and fail on critical probes.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Join master and regular node and verify only required packages were pulled:

```
ubuntu@node-2:~$ sudo gravity package list

[gravitational.io]
------------------

* gravitational.io/gravity:7.0.12 111MB installed:installed
* gravitational.io/planet:7.0.35-11706 515MB purpose:runtime,installed:installed
* gravitational.io/teleport:3.2.14 33MB installed:installed
```

Also, run the same tests as in https://github.com/gravitational/gravity/pull/1847 to make sure the disk check warnings are working properly.

