### PR TITLE
Revert "[5.5.x] Update DNS application hook"

### DIFF
--- a/assets/dns-app/hooks/entrypoint.sh
+++ b/assets/dns-app/hooks/entrypoint.sh
@@ -3,12 +3,6 @@ set -e
 
 echo "Assuming changeset from the environment: $RIG_CHANGESET"
 if [ $1 = "update" ]; then
-    echo "Checking: $RIG_CHANGESET"
-    if rig status $RIG_CHANGESET --retry-attempts=1 --retry-period=1s --quiet; then exit 0; fi
-
-    echo "Starting update, changeset: $RIG_CHANGESET"
-    rig cs delete --force -c cs/$RIG_CHANGESET
-
     echo "Deleting old resources"
     rig delete ds/kube-dns-v18 --resource-namespace=kube-system --force --debug
     rig delete ds/kube-dns --resource-namespace=kube-system --force --debug


### PR DESCRIPTION
Reverts gravitational/gravity#1429

Reverting it because upgrade from 5.2.x version should delete kube-dns and all that resources.