### PR TITLE
[5.5.X] Backport: More efficient app endpoints retrieval. (#952)

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -460,6 +460,8 @@ const (
 
 	// KubeSystemNamespace is a k8s namespace
 	KubeSystemNamespace = "kube-system"
+	// AllNamespaces is the filter to search across all namespaces
+	AllNamespaces = ""
 
 	// GrafanaContextCookie hold the name of the cluster used in
 	// certain web handlers to determine the currently selected domain without including it


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Backport of https://github.com/gravitational/gravity/pull/952 to 5.5.x to improve the speed of collecting endpoints and significantly decrease time for `gravity status` output in clusters with a lot of endpoints and namespaces.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/952

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
1. Uploaded the built binary on the cluster with 90+ endpoints and 12 namespaces.
2. Updated gravity-site daemon set to use the new binary.
3. Tested `gravity status`.
Results before: ~10 sec.
Results after: ~0.3 sec.

## Additional information
<!--Optional. Anything else that may be relevant.-->
