### PR TITLE
Update docs based on 7.0 cloud provisioner config testing

### DIFF
--- a/docs/5.x/installation.md
+++ b/docs/5.x/installation.md
@@ -142,7 +142,7 @@ documentation.
 
 The installation process is implemented as a state machine split into multiple steps (phases).
 Every time a step fails, the install pauses and allows one to inspect and correct the cause of the failure.
-See [Managing an ongoing operation](https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation) section for details
+See [Managing an ongoing operation](cluster.md#managing-an-ongoing-operation) section for details
 on working with the operation plan.
 
 If the installation has failed, the installer will print a warning and generate a debug report:

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -560,8 +560,9 @@ The flag can be specified multiple times to add as many LTS versions as required
     Direct upgrades support is available since Gravity version `5.5.21`.
     Newer Gravity versions will receive support for direct upgrades in the near future.
 
+<!-- The "managing operations" header is linked from gravity binaries. Exercise care if editing. -->
+<div id="managing-an-ongoing-operation" ></div>
 ## Managing Operations
-<!-- This section header is linked from gravity binaries. Exercise care if editing. -->
 
 Some operations in a Gravity Cluster require cooperation from all Cluster nodes.
 Examples are installs, upgrades and garbage collection.

--- a/docs/7.x/cluster.md
+++ b/docs/7.x/cluster.md
@@ -561,6 +561,7 @@ The flag can be specified multiple times to add as many LTS versions as required
     Newer Gravity versions will receive support for direct upgrades in the near future.
 
 ## Managing Operations
+<!-- This section header is linked from gravity binaries. Exercise care if editing. -->
 
 Some operations in a Gravity Cluster require cooperation from all Cluster nodes.
 Examples are installs, upgrades and garbage collection.

--- a/docs/7.x/installation.md
+++ b/docs/7.x/installation.md
@@ -267,48 +267,57 @@ Flag      | Description
 `--manual` | Launch operation in manual mode.
 
 
-## AWS
-
-AWS is the most frequently used infrastructure for Gravity Clusters, that's why
-AWS is natively supported, i.e. the behavior of `gravity` CLI command will
-change when it detects that it's running on a AWS instance.
-
-In practice, this means that Kubernetes networking will be configured with the AWS
-native network features.
-
 ## Generic Linux Hosts
 
 In order to reliably run in any environment, Gravity aims to be infrastructure
 and cloud-agnostic. Gravity makes no assumption about the nature of the network
 or either the hosts are virtualized or bare metal.
 
+## AWS
+
+The default behavior of `gravity install` CLI command will change when
+it detects that it's running on a AWS instance. Kubernetes networking will
+be configured with AWS native network features. For more information see
+[Kubernetes AWS Cloud Provider Documentation](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws).
+
+Before installation make sure that AWS instances intended to run Gravity
+satisfy all of Gravity [system requirements](requirements.md). In addition to these
+generic requirements, AWS instances also must be configured in the following way to
+ensure proper AWS integration:
+
+* Instances must have an [IAM role with sufficient permissions](requirements.md#aws-iam-policy).
+
+Once the AWS instances have been properly provisioned, launch Gravity installation as
+[described above](#cli-installation).  Either omit the `--cloud-provider` flag or
+specify `--cloud-provider=aws` to enable AWS integration. AWS integration can be
+disabled by specifying the `--cloud-provider=generic` flag.
+
 ## Azure
 
-Gravity can be successfully deployed into an Azure environment using the same,
-generic approach as with any Generic Linux Hosts.
+Gravity can be successfully deployed into an Azure environment using the same
+approach as [Generic Linux Hosts](#generic-linux-hosts).
 
 ## Google Compute Engine
 
-Before installation make sure that GCE instances used for installation
+The default behavior of `gravity install` CLI command will change when
+it detects that it's running on a GCE instance. Kubernetes networking will
+be configured with GCP native network features. For more information see
+[Kubernetes GCE Cloud Provider Documentation](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#gce).
+
+Before installation make sure that GCE instances intended to run Gravity
 satisfy all of Gravity [system requirements](requirements.md). In addition to these
-generic requirements, GCE nodes also must be configured in the following way to
+generic requirements, GCE instances also must be configured in the following way to
 ensure proper cloud provider integration:
 
-* Network interface must have IP forwarding turned on. It is required for the
-overlay network to work properly.
+* Network interface must have IP forwarding turned on. This is required for the
+overlay network to work properly. See [Google Cloud's Documentation](https://cloud.google.com/vpc/docs/using-routes#canipforward)
 * Instances must be assigned a [network tag](https://cloud.google.com/vpc/docs/add-remove-network-tags)
-matching the name of the Cluster. It is required to ensure that created load
+matching the name of the Cluster. This is required to ensure that created load
 balancers discover proper instances.
-* Cloud API access scopes must include read/write permissions for Compute Engine.
+* Instance Cloud API access scopes must include read/write permissions for Compute Engine.
+This is required to create routes between nodes.
 
-Once the nodes have been properly configured, copy the installer tarball and
-launch installation as described above:
-
-```bsh
-node1$ sudo ./gravity install --advertise-addr=<addr> --token=<token> --cluster=<cluster> --cloud-provider=gce
-node2$ sudo ./gravity join <installer-addr> --advertise-addr=<addr> --token=<token> --cloud-provider=gce
-```
-
-Note that the `--cloud-provider` flag is optional and, if unspecified, will be
-auto-detected if install/join process is running on a GCE instance.
-
+Once the GCE instances have been properly provisioned, launch Gravity installation as
+[described above](#cli-installation).  Either omit the `--cloud-provider` flag or
+specify `--cloud-provider=gce` to enable GCE integration. GCE integration can be
+disabled by specifying the `--cloud-provider=generic` flag.

--- a/docs/7.x/quickstart.md
+++ b/docs/7.x/quickstart.md
@@ -242,7 +242,7 @@ agent by issuing 'gravity resume' command.
 
 If the installation fails, use 'gravity plan' to inspect the state and
 'gravity resume' to continue the operation.
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details.
 
 Sun Apr 26 23:55:11 UTC Connecting to installer
 Sun Apr 26 23:55:32 UTC Connected to installer

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -67,10 +67,10 @@ Hardware requirements are specific to the workload running in the cluster but
 the following guidelines are recommended to support bare Gravity cluster
 installations.
 
-| Role   | CPU    | RAM | Disk                                               |
-|--------|--------|-----|----------------------------------------------------|
-| master | 2 vCPU | 4GB | 100GB SSD for Gravity data, 20GB SSD for etcd data |
-| node   | 1 vCPU | 2GB | 100GB SSD for Gravity data                         |
+| Role   | CPU    | RAM  | Disk                                                 |
+|--------|--------|------|------------------------------------------------------|
+| master | 2 vCPU | 4GiB | 100GiB SSD for Gravity data, 50GiB SSD for etcd data |
+| node   | 1 vCPU | 2GiB | 100GiB SSD for Gravity data                          |
 
 ## Network
 
@@ -134,10 +134,10 @@ These ports are used for Cluster operation and should be open between cluster no
 | 3012                    | TCP                | HTTPS                | all         | all         | Gravity RPC agent                        |
 
 !!! note "Source/Destination Legend"
-  * all - Any node which is a member of the cluster
-  * ext - Any source outside the cluster
-  * localhost - The port is only used within the host where the request started
-  * controllers - Nodes which are designated "controller" (aka "master") role
+    * all - Any node which is a member of the cluster
+    * ext - Any source outside the cluster
+    * localhost - The port is only used within the host where the request started
+    * controllers - Nodes which are designated "controller" (aka "master") role
 
 !!! note "Custom vxlan port"
     If the default overlay network port (`8472`) was changed by supplying
@@ -362,8 +362,8 @@ the application's own bookkeeping with respect to e.g. deployed clusters' health
 and reachability. As a result, it is helpful to have a reliable, performance
 isolated disk.
 
-To achieve this, by default, Gravity looks for a disk mounted at
-`/var/lib/gravity/planet/etcd`. We recommend you mount a dedicated disk there,
+To achieve this, by default Gravity master nodes look for a disk mounted at
+`/var/lib/gravity/planet/etcd`. We recommend each master mounts a dedicated disk there,
 `ext4` formatted with at least 50GiB of free space. A reasonably high performance
 SSD is preferred. On AWS, we recommend an `io1` class EBS volume with at least
 1500 provisioned IOPS.

--- a/docs/7.x/testplan.md
+++ b/docs/7.x/testplan.md
@@ -380,7 +380,13 @@ root$ gravity resource create environ.yaml --confirm
 
 This scenario updates the cluster configuration.
 
-Prerequisites: multi-node cluster with at least 1 node `--role=knode` and 1 `--role=node|master`.
+Prerequisites:
+* 3+ node cluster running in AWS or GCP, with cloud provider integration configured
+  * [AWS](https://gravitational.com/gravity/docs/installation/#aws) [IAM config](https://gravitational.com/gravity/docs/requirements/#aws-iam-policy)
+  * [GCP](https://gravitational.com/gravity/docs/installation/#google-compute-engine)
+* At least two masters (`--role=node|master`)
+* At least one regular node (`--role=knode`)
+
 Having both `knode` and `node|master` is necessary to test both master and regular node update paths.
 
 [config.yaml]
@@ -407,7 +413,7 @@ spec:
 ```
 
 ```bash
-root$ gravity resource create config.yaml --confirm
+$ sudo gravity resource create config.yaml --confirm
 ```
 
 - [ ] Verify the operation completes successfully.
@@ -421,6 +427,7 @@ kind: ClusterConfiguration
 version: v1
 spec:
   global:
+    cloudProvider: aws
     cloudConfig: |
       [global]
       # Update node tags
@@ -428,19 +435,20 @@ spec:
       node-tags=test-cluster
 ```
 
+Note: `cloudProvider:`'s value depends on which provider the cluster is provisioned on.
+
 Now, create the operation in manual mode:
 
 ```bash
-root$ gravity resource create cloud-config.yaml --confirm -m
+$ sudo gravity resource create cloud-config.yaml --confirm --manual
 ```
 
 - [ ] Verify that the operation plan only contains update steps for master nodes as only cloud configuration is being updated.
-- [ ] Verify can complete the operation successfully with `gravity plan resume`.
-  - [ ] Verify cloud configuration file has been written in `/etc/kubernetes/cloud-config.conf` with the following contents:
-  ```
-  [global]
-  node-tags=test-cluster
-  ```
+- [ ] Verify the operation successfully completes upon `gravity plan resume`.
+
+- [ ] Verify cloud configuration has changed:
+  - `sudo gravity exec cat /etc/kubernetes/cloud-config.conf` should show updated `node-tags`
+  - `sudo gravity resource get clusterconfig`
 
 ### Collecting Garbage
 

--- a/docs/7.x/testplan.md
+++ b/docs/7.x/testplan.md
@@ -435,7 +435,7 @@ spec:
       node-tags=test-cluster
 ```
 
-Note: `cloudProvider:`'s value depends on which provider the cluster is provisioned on.
+Note: `cloudProvider`'s value depends on which provider the cluster is provisioned on.
 
 Now, create the operation in manual mode:
 

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -191,7 +191,7 @@ agent by issuing 'gravity resume' command.
 
 If the installation fails, use 'gravity plan' to inspect the state and
 'gravity resume' to continue the operation.
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details.
 
 Sun Apr 26 23:55:11 UTC Connecting to installer
 Sun Apr 26 23:55:32 UTC Connected to installer

--- a/lib/update/cluster/phases/gc.go
+++ b/lib/update/cluster/phases/gc.go
@@ -64,7 +64,7 @@ func (*phaseGC) PostCheck(context.Context) error {
 }
 
 func trimJournalFiles(remote fsm.Remote, logger log.FieldLogger) error {
-	logger.Info("Gabrage collect obsolete journal files.")
+	logger.Info("Garbage collect obsolete journal files.")
 	commands := [][]string{
 		// Force flush journal buffers and rotate files
 		utils.PlanetCommandArgs(defaults.JournalctlBin, "--flush", "--rotate"),

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -324,5 +324,5 @@ The operation might take a few minutes to complete.
 "Are you sure?`
 	updateConfigManualOperationBanner = `The operation has been created in manual mode.
 
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.`
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details on working with operation plan.`
 )

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -408,7 +408,7 @@ type clusterInitializer struct {
 const (
 	updateClusterManualOperationBanner = `The operation has been created in manual mode.
 
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.`
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details on working with operation plan.`
 )
 
 func checkCanUpdate(cluster ops.Site, operator ops.Operator, manifest schema.Manifest) error {

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -268,5 +268,5 @@ The operation might take several minutes to complete depending on the cluster si
 "Are you sure?`
 	updateEnvironManualOperationBanner = `The operation has been created in manual mode.
 
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.`
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details on working with operation plan.`
 )

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -914,7 +914,7 @@ agent by issuing 'gravity resume' command.
 
 If the installation fails, use 'gravity plan' to inspect the state and
 'gravity resume' to continue the operation.
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details.
 `))
 }
 
@@ -925,7 +925,7 @@ press Ctrl+C two times in a row.
 
 If you get disconnected from the terminal, you can reconnect to the installer
 agent by issuing 'gravity resume' command.
-See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.
+See https://gravitational.com/gravity/docs/cluster/#managing-operations for details.
 `))
 }
 


### PR DESCRIPTION
## Description
Minor docs tweaks found while walking through part of the 7.0 test plan.  The individual commit messages have more context for each change on its own.

## Type of change
* Docs
* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
All this cleanup was discovered while working on #1826 

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<details><summary><code>make docs; make docs-lint</code></summary>

```
walt@work:~/git/gravity$ make docs-lint
make -C docs lint
make[1]: Entering directory '/home/walt/git/gravity/docs'
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-lint
cd 4.x && milv -ignore-external
NO ISSUES :-)
cd 5.x && milv -ignore-external
NO ISSUES :-)
cd 6.x && milv -ignore-external
NO ISSUES :-)
cd 7.x && milv -ignore-external
NO ISSUES :-)
make[1]: Leaving directory '/home/walt/git/gravity/docs'
walt@work:~/git/gravity$ make docs
make -C docs
make[1]: Entering directory '/home/walt/git/gravity/docs'
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-compile-docs
mkdocs build --strict --config-file 4.x.yaml --site-dir ../build/docs/4.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/4.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 5.x.yaml --site-dir ../build/docs/5.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/5.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 6.x.yaml --site-dir ../build/docs/6.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/6.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - testplan.md
  - workshops.md 
mkdocs build --strict --config-file 7.x.yaml --site-dir ../build/docs/7.x
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/build/docs/7.x 
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - ingress.md
  - testplan.md
  - workshops.md 
cd ../build/docs && rm -f latest && ln -s 7.x latest
make[1]: Leaving directory '/home/walt/git/gravity/docs'
```
</details>

I also tested that the `#managing-an-ongoing-operation` id works correctly via `make run-docs`.  Unfortunately, I don't have a good way to show this (without a video or something) so you'll have to take my word for it.

Lastly,  despite my attempt at improving our `--cloud-provider` documentation, I still have not been able to correctly set up a cluster with 100% working cloud provider in AWS or GCP.  Fortunately, I didn't need working networking to complete the test plan.... so I'm posting what I have, and hopefully the next engineer who runs this test plan can further build on the level of detail.