### PR TITLE
(5.5) Better errors for teleport nodes pre-check

### DIFF
--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -256,10 +256,10 @@ Please rebuild it as described in https://gravitational.com/gravity/docs/cluster
 )
 
 var (
-	// TeleportTokenVersion is version of the release affected by the issue
-	// with Teleport using incorrect auth token on joined nodes.
+	// TeleportBrokenJoinTokenVersion is version of the release affected by
+	// the issue with Teleport using incorrect auth token on joined nodes.
 	//
 	// Github issue: https://github.com/gravitational/gravity/issues/1445.
 	// KB: https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649.
-	TeleportTokenVersion = semver.New("5.5.40")
+	TeleportBrokenJoinTokenVersion = semver.New("5.5.40")
 )

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -254,3 +254,12 @@ const (
 This cluster image does not contain required intermediate runtimes.
 Please rebuild it as described in https://gravitational.com/gravity/docs/cluster/#direct-upgrades-from-older-lts-versions.`
 )
+
+var (
+	// TeleportTokenVersion is version of the release affected by the issue
+	// with Teleport using incorrect auth token on joined nodes.
+	//
+	// Github issue: https://github.com/gravitational/gravity/issues/1445.
+	// KB: https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649.
+	TeleportTokenVersion = semver.New("5.5.40")
+)

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -172,7 +172,7 @@ func newCollector(env *localenv.LocalEnvironment) (*vacuum.Collector, error) {
 	ctx := context.TODO()
 	req := deployAgentsRequest{
 		clusterState: cluster.ClusterState,
-		clusterName:  cluster.Domain,
+		cluster:      *cluster,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
 	}

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -31,10 +31,12 @@ import (
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
 	pb "github.com/gravitational/gravity/lib/rpc/proto"
 	rpcserver "github.com/gravitational/gravity/lib/rpc/server"
+	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/update"
 	clusterupdate "github.com/gravitational/gravity/lib/update/cluster"
@@ -171,7 +173,7 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 
 	req := deployAgentsRequest{
 		clusterState: cluster.ClusterState,
-		clusterName:  cluster.Domain,
+		cluster:      *cluster,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
 		leaderParams: leaderParams,
@@ -191,21 +193,18 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 	return deployAgents(localCtx, localEnv, req)
 }
 
-func verifyCluster(ctx context.Context,
-	clusterState storage.ClusterState,
-	proxy *teleclient.ProxyClient,
-) (servers []rpc.DeployServer, err error) {
+func verifyCluster(ctx context.Context, req deployAgentsRequest) (servers []rpc.DeployServer, err error) {
 	var missing []string
 	servers = make([]rpc.DeployServer, 0, len(servers))
 
-	for _, server := range clusterState.Servers {
+	for _, server := range req.clusterState.Servers {
 		deployServer := rpc.NewDeployServer(server)
 		// do a quick check to make sure we can connect to the teleport node
-		client, err := proxy.ConnectToNode(ctx, deployServer.NodeAddr,
+		client, err := req.proxy.ConnectToNode(ctx, deployServer.NodeAddr,
 			defaults.SSHUser, false)
 		if err != nil {
-			log.Errorf("Failed to connect to teleport on node %v: %v.",
-				deployServer, trace.DebugReport(err))
+			log.WithError(err).Errorf("Failed to connect to teleport on node %v.",
+				deployServer)
 			missing = append(missing, server.Hostname)
 		} else {
 			client.Close()
@@ -215,15 +214,62 @@ func verifyCluster(ctx context.Context,
 		}
 	}
 	if len(missing) != 0 {
-		return nil, trace.NotFound(
-			"Teleport is unavailable "+
-				"on the following cluster nodes: %s. Please "+
-				"make sure that the Teleport service is running "+
-				"and try again.", strings.Join(missing, ", "))
+		base := req.cluster.App.Manifest.Base()
+		if base != nil && base.Version == opsservice.TeleportTokenVersion.String() {
+			return nil, trace.NotFound(teleportTokenMessage,
+				strings.Join(missing, ", "), base.Version)
+		}
+		return nil, trace.NotFound(teleportUnavailableMessage,
+			strings.Join(missing, ", "), getTeleportVersion(req.cluster.App.Manifest))
 	}
 
 	return servers, nil
 }
+
+func getTeleportVersion(manifest schema.Manifest) string {
+	teleportPackage, err := manifest.Dependencies.ByName(constants.TeleportPackage)
+	if err == nil {
+		return teleportPackage.Version
+	}
+	return "<version>"
+}
+
+const (
+	// teleportTokenMessage is displayed when some Teleport nodes are
+	// unavailable during agents deployment due to the issue with incorrect
+	// Teleport join token.
+	teleportTokenMessage = `Teleport is unavailable on the following cluster nodes: %[1]s.
+
+Gravity version %[2]v you're currently running has a known issue with Teleport
+using an incorrect auth token on the joined nodes preventing Teleport nodes from
+joining.
+
+This cluster may be affected by this issue if new nodes were joined to it after
+upgrade to %[2]v. See the following KB article for remediation actions:
+
+https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649
+
+After fixing the issue, "./gravity status" can be used to confirm the status of
+Teleport on each node using "remote access" field.
+
+Once all Teleport nodes have joined successfully, launch the upgrade again.
+`
+	// teleportUnavailableMessage is displayed when some Teleport nodes are
+	// unavailable during agents deployment.
+	teleportUnavailableMessage = `Teleport is unavailable on the following cluster nodes: %[1]s.
+
+Please check the status and logs of Teleport systemd service on the specified
+nodes and make sure it's running:
+
+systemctl status gravity__gravitational.io__teleport__%[2]v
+journalctl -u gravity__gravitational.io__teleport__%[2]v --no-pager
+
+After fixing the issue, "./gravity status" can be used to confirm the status of
+Teleport on each node using "remote access" field.
+
+Once all Teleport nodes are running, launch the upgrade again.
+`
+)
 
 func upsertRPCCredentialsPackage(
 	servers []rpc.DeployServer,
@@ -269,18 +315,18 @@ func deployAgents(ctx context.Context, env *localenv.LocalEnvironment, req deplo
 
 // newDeployAgentsRequest creates a new request to deploy agents on the local cluster
 func newDeployAgentsRequest(ctx context.Context, env *localenv.LocalEnvironment, req deployAgentsRequest) (*rpc.DeployAgentsRequest, error) {
-	servers, err := verifyCluster(ctx, req.clusterState, req.proxy)
+	servers, err := verifyCluster(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	gravityPackage := getGravityPackage()
 	secretsPackageTemplate := loc.Locator{
-		Repository: req.clusterName,
+		Repository: req.cluster.Domain,
 		Version:    gravityPackage.Version,
 	}
 	secretsPackage, err := upsertRPCCredentialsPackage(
-		servers, req.clusterEnv.ClusterPackages, req.clusterName, secretsPackageTemplate)
+		servers, req.clusterEnv.ClusterPackages, req.cluster.Domain, secretsPackageTemplate)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -374,7 +420,7 @@ func getGravityPackage() loc.Locator {
 type deployAgentsRequest struct {
 	clusterEnv   *localenv.ClusterEnvironment
 	clusterState storage.ClusterState
-	clusterName  string
+	cluster      ops.Site
 	proxy        *teleclient.ProxyClient
 	leaderParams string
 	leader       *storage.Server

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -215,7 +215,7 @@ func verifyCluster(ctx context.Context, req deployAgentsRequest) (servers []rpc.
 	}
 	if len(missing) != 0 {
 		base := req.cluster.App.Manifest.Base()
-		if base != nil && base.Version == opsservice.TeleportTokenVersion.String() {
+		if base != nil && base.Version == opsservice.TeleportBrokenJoinTokenVersion.String() {
 			return nil, trace.NotFound(teleportTokenMessage,
 				strings.Join(missing, ", "), base.Version)
 		}

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -115,7 +115,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 		// Use server list from the operation plan to always have a consistent
 		// view of the cluster (i.e. with servers correctly reflecting cluster roles)
 		clusterState: clusterStateFromPlan(*plan),
-		clusterName:  cluster.Domain,
+		cluster:      *cluster,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
 		leader:       leader,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Prior to deploying the agents on the cluster nodes (before upgrade or any other operation that needs agents, or using `gravity agent deploy`), we verify that all Teleport nodes are available. This PR updates scenario when some Teleport nodes are not available with better error messages and clearer instructions:

* Detect if upgrading from 5.5.40 affected by the [Teleport token issue](https://github.com/gravitational/gravity/issues/1445) and return an appropriate error message linking to KB.
* In other cases, just a better message with more specific instructions on how to check Teleport.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1817.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Prep

Install a cluster and shutdown Teleport on one of the nodes.

### Upgrade from 5.5.40

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Tue Jul 14 21:36:15 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.2
Tue Jul 14 21:36:16 UTC	Deploying agents on cluster nodes
Tue Jul 14 21:36:16 UTC	Encountered error, will shutdown agents
Tue Jul 14 21:36:16 UTC	Shutting down the agents
[ERROR]: Teleport is unavailable on the following cluster nodes: node-2.

Gravity version 5.5.40 you're currently running has a known issue with Teleport
using an incorrect auth token on the joined nodes preventing Teleport nodes from
joining.

This cluster may be affected by this issue if new nodes were joined to it after
upgrade to 5.5.40. See the following KB article for remediation actions:

https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649

After fixing the issue, "./gravity status" can be used to confirm the status of
Teleport on each node in the "remote access" field.

Once all Teleport nodes have joined successfully, launch the upgrade again.
```

### Upgrade from other version

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Tue Jul 14 21:38:34 UTC	Upgrading cluster from 5.5.41 to 5.5.50-dev.2
Tue Jul 14 21:38:34 UTC	Deploying agents on cluster nodes
Tue Jul 14 21:38:34 UTC	Encountered error, will shutdown agents
Tue Jul 14 21:38:34 UTC	Shutting down the agents
[ERROR]: Teleport is unavailable on the following cluster nodes: node-2.

Please check the status and logs of Teleport systemd service on the specified
nodes and make sure it's running:

systemctl status gravity__gravitational.io__teleport__3.0.5
journalctl -u gravity__gravitational.io__teleport__3.0.5 --no-pager

After fixing the issue, "./gravity status" can be used to confirm the status of
Teleport on each node using "remote access" field.

Once all Teleport nodes are running, launch the upgrade again.
```