### PR TITLE
Remove selinux configuration for wizard installer

### DIFF
--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -758,21 +758,27 @@ var InterruptSignals = signals.WithSignals(
 	os.Interrupt,
 	syscall.SIGTERM,
 	syscall.SIGQUIT,
+	syscall.SIGHUP,
 )
 
 // NewInstallerConnectStrategy returns default installer service connect strategy
 func NewInstallerConnectStrategy(env *localenv.LocalEnvironment, config InstallConfig, commandArgs cli.CommandArgs) (strategy installerclient.ConnectStrategy, err error) {
 	commandArgs.FlagsToAdd = append(commandArgs.FlagsToAdd,
 		cli.NewFlag("token", config.Token),
-		cli.NewBoolFlag("selinux", config.SELinux),
+		cli.NewBoolFlag("from-service", true),
+		cli.NewArg("path", config.StateDir),
 	)
-	commandArgs.FlagsToRemove = append(commandArgs.FlagsToRemove, "selinux")
+	if config.Mode != constants.InstallModeInteractive {
+		commandArgs.FlagsToAdd = append(commandArgs.FlagsToAdd,
+			cli.NewBoolFlag("selinux", config.SELinux),
+		)
+	}
+	commandArgs.FlagsToRemove = append(commandArgs.FlagsToRemove, "token", "selinux", "path", "from-service")
 	args, err := commandArgs.Update(os.Args[1:])
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	args = append([]string{utils.Exe.Path}, args...)
-	args = append(args, "--from-service", utils.Exe.WorkingDir)
 	servicePath, err := state.GravityInstallDir(defaults.GravityRPCInstallerServiceName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -787,13 +793,20 @@ func NewInstallerConnectStrategy(env *localenv.LocalEnvironment, config InstallC
 
 // newReconfiguratorConnectStrategy returns a new service connect strategy
 // for the agent executing the cluster reconfiguration operation.
-func newReconfiguratorConnectStrategy(env *localenv.LocalEnvironment, config InstallConfig, commandArgs cli.CommandArgs) (strategy installerclient.ConnectStrategy, err error) {
+func newReconfiguratorConnectStrategy(
+	env *localenv.LocalEnvironment,
+	config InstallConfig,
+	commandArgs cli.CommandArgs,
+) (strategy installerclient.ConnectStrategy, err error) {
+	commandArgs.FlagsToAdd = append(commandArgs.FlagsToAdd,
+		cli.NewBoolFlag("from-service", true),
+	)
+	commandArgs.FlagsToRemove = append(commandArgs.FlagsToRemove, "from-service")
 	args, err := commandArgs.Update(os.Args[1:])
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	args = append([]string{utils.Exe.Path}, args...)
-	args = append(args, "--from-service")
 	servicePath, err := state.GravityInstallDir(defaults.GravityRPCInstallerServiceName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -815,17 +828,19 @@ func newAutoAgentConnectStrategy(env *localenv.LocalEnvironment, config JoinConf
 		Parser: cli.ArgsParserFunc(parseArgs),
 		// Pass additional configuration to service if not explicitly specified.
 		FlagsToAdd: []cli.Flag{
+			cli.NewBoolFlag("from-service", true),
 			cli.NewFlag("token", config.Token),
 			cli.NewFlag("advertise-addr", config.AdvertiseAddr),
 			cli.NewFlag("service-addr", config.PeerAddrs),
 		},
+		// Avoid duplicates on command line
+		FlagsToRemove: []string{"token", "advertise-addr", "service-addr", "from-service"},
 	}
 	args, err := commandArgs.Update(os.Args[1:])
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	args = append([]string{utils.Exe.Path}, args...)
-	args = append(args, "--from-service")
 	servicePath, err := state.GravityInstallDir(defaults.GravityRPCAgentServiceName)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -840,11 +855,25 @@ func newAutoAgentConnectStrategy(env *localenv.LocalEnvironment, config JoinConf
 
 // newAgentConnectStrategy returns default service connect strategy for a joining agent
 func newAgentConnectStrategy(env *localenv.LocalEnvironment, config JoinConfig) (strategy installerclient.ConnectStrategy, err error) {
-	args := append([]string{utils.Exe.Path}, os.Args[1:]...)
-	args = append(args, "--from-service")
-	if !config.SELinux {
-		args = append(args, "--no-selinux")
+	// TODO: accept command line parser as argument if the join command
+	// is to be extended on enterprise side
+	commandArgs := cli.CommandArgs{
+		Parser: cli.ArgsParserFunc(parseArgs),
+		// Pass additional configuration to service if not explicitly specified.
+		FlagsToAdd: []cli.Flag{
+			cli.NewBoolFlag("from-service", true),
+			cli.NewFlag("token", config.Token),
+			cli.NewFlag("advertise-addr", config.AdvertiseAddr),
+			cli.NewBoolFlag("selinux", config.SELinux),
+		},
+		// Avoid duplicates on command line
+		FlagsToRemove: []string{"token", "advertise-addr", "selinux", "from-service"},
 	}
+	args, err := commandArgs.Update(os.Args[1:])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	args = append([]string{utils.Exe.Path}, args...)
 	servicePath, err := state.GravityInstallDir(defaults.GravityRPCAgentServiceName)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
SElinux configuration is not available for the wizard installer.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs  https://github.com/gravitational/gravity/issues/1724.
* Ports https://github.com/gravitational/gravity/pull/1725

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Wizard-based installer

 1. Run wizard installer
```
$ ./install
```
 2. Follow the wizard steps and ensure the successful completion of the installer

### CLI-based installer

 1. Install 3-node cluster by first installing a single node
 1. Add additional nodes with `gravity join`
 1. Ensure the operations are successful

## Additional information
<!--Optional. Anything else that may be relevant.-->
