### PR TITLE
Sanitize gravity cli cmd logs

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -721,6 +721,9 @@ const (
 	// GravityCLITag is used to tag gravity cli command log entries in the
 	// system journal.
 	GravityCLITag = "gravity-cli"
+
+	// Redacted is used as a replacement string for sensitive data.
+	Redacted = "*****"
 )
 
 var (

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -61,7 +61,11 @@ func (r *CmdExecer) Execute() (err error) {
 			logEntry(fmt.Sprintf("[FAILURE]: %s: [PANIC]: %v", cmdString, r))
 			panic(r)
 		}
-		logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
+		if err != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
+			return
+		}
+		logEntry(fmt.Sprintf("[SUCCESS]: %s", cmdString))
 	}()
 
 	err = r.Exe()

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -50,7 +50,10 @@ func (r *CmdExecer) Execute() (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	cmdString := fmt.Sprintf("%s -- %s", strings.Join(sanitizedCmd, " "), strings.Join(r.ExtraArgs, " "))
+	cmdString := strings.Join(sanitizedCmd, " ")
+	if len(r.ExtraArgs) > 0 {
+		cmdString = fmt.Sprintf("%s -- %s", cmdString, strings.Join(r.ExtraArgs, " "))
+	}
 
 	logEntry(fmt.Sprintf("[RUNNING]: %s", cmdString))
 	defer func() {

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -46,7 +46,7 @@ type CmdExecer struct {
 // Execute executes the gravity command while logging the start and completion
 // of the command.
 func (r *CmdExecer) Execute() (err error) {
-	sanitizedCmd, err := r.redactCmd()
+	sanitizedCmd, err := r.getRedactedCmd()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -68,9 +68,9 @@ func (r *CmdExecer) Execute() (err error) {
 	return trace.Wrap(err)
 }
 
-// redactCmd removes potentially sensitive data from the args and returns the
-// sanitized cmd as a list of strings.
-func (r *CmdExecer) redactCmd() (cmd []string, err error) {
+// getRedactedCmd removes potentially sensitive data from the args and returns
+// the sanitized cmd as a list of strings.
+func (r *CmdExecer) getRedactedCmd() (cmd []string, err error) {
 	commandArgs := cli.CommandArgs{
 		Parser: r.Parser,
 		FlagsToReplace: []cli.Flag{
@@ -83,11 +83,11 @@ func (r *CmdExecer) redactCmd() (cmd []string, err error) {
 			cli.NewFlag("encryption-key", constants.Redacted),
 		},
 	}
-	r.Args, err = commandArgs.Update(r.Args)
+	args, err := commandArgs.Update(r.Args)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return append([]string{utils.Exe.Path}, r.Args...), nil
+	return append([]string{utils.Exe.Path}, args...), nil
 }
 
 // logEntry writes the provided entry into the system journal with the

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// LogCLIRunning writes the running cmd as a log entry into the system journal
+// with the gravity-cli tag.
+func LogCLIRunning(cmd string) {
+	entry := fmt.Sprintf("[RUNNING]: %s", cmd)
+	if err := utils.SyslogWrite(syslog.LOG_INFO, entry, constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+}
+
+// LogCLICompleted writes the completed cmd as a log entry into the system journal
+// with the gravity-cli tag. Failed commands will be logged with the returned
+// error.
+func LogCLICompleted(cmd string, err error) {
+	var entry string
+	if err != nil {
+		entry = fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmd, trace.UserMessage(err))
+	} else {
+		entry = fmt.Sprintf("[SUCCESS]: %s", cmd)
+	}
+	if err := utils.SyslogWrite(syslog.LOG_INFO, entry, constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+}
+
+// SanitizeCmd removes potentially sensitive data from the cmdString.
+func SanitizeCmd(g *Application, cmd, cmdString string) string {
+	switch cmd {
+	case g.InstallCmd.FullCommand():
+		if *g.InstallCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.InstallCmd.Token)
+		}
+	case g.JoinCmd.FullCommand():
+		if *g.JoinCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.JoinCmd.Token)
+		}
+	case g.AutoJoinCmd.FullCommand():
+		if *g.AutoJoinCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.AutoJoinCmd.Token)
+		}
+	case g.WizardCmd.FullCommand():
+		if *g.WizardCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.WizardCmd.Token)
+		}
+	case g.OpsAgentCmd.FullCommand():
+		if *g.OpsAgentCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.OpsAgentCmd.Token)
+		}
+	case g.APIKeyDeleteCmd.FullCommand():
+		if *g.APIKeyDeleteCmd.Token != "" {
+			cmdString = Redact(cmdString, *g.APIKeyDeleteCmd.Token)
+		}
+	case g.AppInstallCmd.FullCommand():
+		if *g.AppInstallCmd.RegistryPassword != "" {
+			cmdString = Redact(cmdString, *g.AppInstallCmd.RegistryPassword)
+		}
+	case g.AppUpgradeCmd.FullCommand():
+		if *g.AppUpgradeCmd.RegistryPassword != "" {
+			cmdString = Redact(cmdString, *g.AppUpgradeCmd.RegistryPassword)
+		}
+	case g.AppSyncCmd.FullCommand():
+		if *g.AppSyncCmd.RegistryPassword != "" {
+			cmdString = Redact(cmdString, *g.AppSyncCmd.RegistryPassword)
+		}
+	case g.OpsConnectCmd.FullCommand():
+		if *g.OpsConnectCmd.Password != "" {
+			cmdString = Redact(cmdString, *g.OpsConnectCmd.Password)
+		}
+	case g.UserCreateCmd.FullCommand():
+		if *g.UserCreateCmd.Password != "" {
+			cmdString = Redact(cmdString, *g.UserCreateCmd.Password)
+		}
+	}
+
+	return cmdString
+}
+
+// Redact replaces any instances of value found in cmd with the redacted string.
+func Redact(cmd, value string) string {
+	return strings.ReplaceAll(cmd, value, constants.Redacted)
+}

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -56,7 +56,7 @@ func (r *CmdExecer) Execute() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logEntry(fmt.Sprintf("[FAILURE]: %s: [PANIC]: %v", cmdString, r))
-			return
+			panic(r)
 		}
 		logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
 	}()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -82,6 +82,7 @@ func Run(g *Application) (err error) {
 		return trace.Wrap(err)
 	}
 	cmdString := strings.Join(sanitizedCmd, " ")
+	cmdString = fmt.Sprintf("%s -- %s", cmdString, strings.Join(extraArgs, " "))
 
 	LogCLIRunning(cmdString)
 	defer func() {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Gravity cli commands will now be logged twice. Once when the command starts execution and another after it completes. Potentially sensitive data will also be redacted from the logs.

The log entries already include the process ID so a UUID is not included with the log entries. Use `journalctl _PID=[pid]` to track start/finish of a particular comand.
## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates #https://github.com/gravitational/gravity/issues/1799
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #https://github.com/gravitational/gravity.e/pull/4316

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify log entry of a successfully completed gravity command**
```
Jul 11 12:00:22 node-1 gravity-cli[13177]: [RUNNING]: gravity status history
Jul 11 12:00:22 node-1 gravity-cli[13177]: [SUCCESS]: gravity status history
```
**Verify log entry of a failed gravity command. Also verify sensitive data is redacted**
```
Jul 11 12:00:36 node-1 gravity-cli[13238]: [RUNNING]: gravity install --token *****
Jul 11 12:00:36 node-1 gravity-cli[13238]: [FAILURE]: gravity install --token *****: [ERROR]: install token is too short, min length is 6
```

## Limitations?

One thing that seems inconsistent was when `gravity status` reported a degraded cluster. The command runs and displays the status, but an error is still returned. Is this okay as is?
```
Jul 11 06:29:31 node-1 gravity-cli[6226]: [RUNNING] gravity status
Jul 11 06:29:31 node-1 gravity-cli[6226]: [FAILURE] gravity status: [ERROR]: degraded
```

There is still one inconsistent case I ran into. `gravity status` has a boolean `--token` flag that is used to request just the cluster token. Output:
```
Jul 11 14:23:45 node-1 gravity-cli[8759]: [RUNNING]: /usr/bin/gravity status cluster --token "*****"
```