### PR TITLE
Remove `tele login` from automation.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,6 @@ timestamps {
         robotest : {
           if (env.RUN_ROBOTEST == 'run') {
             withCredentials([
-                [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                 [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -111,7 +111,6 @@ timestamps {
           robotest : {
             if (env.RUN_ROBOTEST == 'run') {
               withCredentials([
-                  [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                   [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/Makefile
+++ b/Makefile
@@ -501,10 +501,8 @@ publish-artifacts: opscenter telekube
 	if [ -z "$(TELE_KEY)" ] || [ -z "$(DISTRIBUTION_OPSCENTER)" ]; then \
 	   echo "TELE_KEY or DISTRIBUTION_OPSCENTER are not set"; exit 1; \
 	fi;
-	$(GRAVITY_BUILDDIR)/tele logout
-	$(GRAVITY_BUILDDIR)/tele login -o $(DISTRIBUTION_OPSCENTER) --token=$(TELE_KEY)
-	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/telekube.tar
-	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/opscenter.tar
+	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/telekube.tar  --hub=$(DISTRIBUTION_OPSCENTER) --token=$(TELE_KEY)
+	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/opscenter.tar --hub=$(DISTRIBUTION_OPSCENTER) --token=$(TELE_KEY)
 
 #
 # scan-artifacts uploads a copy of all vendored containers to a docker registry for scanning and vulnerability reporting

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -6,7 +6,6 @@ set -o pipefail
 readonly TARGET=${1:?Usage: $0 [pr|nightly] [upgrade_from_dir]}
 export UPGRADE_FROM_DIR=${2:-$(pwd)/../upgrade_from}
 
-readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}
 readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
@@ -47,8 +46,9 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR
+$tele logout
 for release in ${!UPGRADE_MAP[@]}; do
-  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --hub=https://get.gravitational.io:443 --token="$GET_GRAVITATIONAL_IO_APIKEY"
+  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar
 done
 
 docker pull $ROBOTEST_REPO


### PR DESCRIPTION
## Description
While backporting #1837 I discovered unauthenticated tele can fetch artifacts
from  https://get.gravitational.io:443, and that use of `tele login` is deprecated in
contemporary gravity.  This changeset removes `tele login` from both robotest
and release automation.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
The removal of login is content that came up during the ports of #1837 (#1879 in particular), and was included in all 4.  I wanted to bring it to master for consistency's sake.  Changing uploads is for for future portability.

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Implementation
There is a preexisting race risk that some other process logs into a different hub and stores the session in `/home/jenkins/.gravity/config`. This will cause fetching artifacts to break as `tele pull` would look at something other than the default.

This is a risk I'm willing to take, for a couple reasons:

* It is preexisting.
* The utility of checking tele's default pull behavior (p0 functionality for new customers) for regressions greatly outweighs the risk of this breaking.
* We need the target opscenter to be stable for 5.5 and 6.1 where the `--hub|--ops` flags don't exist on `tele pull`.
* I checked all the automation in the gravity repo: `make publish-artifacts` will login to `DISTRIBUTION_OPSCENTER ?= https://get.gravitational.io`, which is safe for pulls. Otherwise it'll likely be an out of band "employee was tinkering around under the jenkins user" event if this changes -- not a use case I'm particularly concerned about or want to implicitly support.
* It makes merging a bit easier.

## Testing done
Testing push auth:
```
walt@work:~/git/gravity$ echo 'hello world!' > test.txt
walt@work:~/git/gravity$ ./e/build/7.1.0-alpha.1.126/tele logout
logged out
walt@work:~/git/gravity$ ./e/build/7.1.0-alpha.1.126/tele push test.txt --hub=https://get.gravitational.io:443 --token=<redacted>

Thu Jul 16 22:09:49 UTC Using Hub https://get.gravitational.io:443
Thu Jul 16 22:09:49 UTC Unpacking image into /tmp/tele038517511
Thu Jul 16 22:09:49 UTC Push finished in now
[ERROR]: unexpected EOF
```

Testing pull auth:
```
walt@work:~/git/gravity$ ./e/build/7.1.0-alpha.1.126/tele logout                               
logged out                                                                                                                                                                                    
walt@work:~/git/gravity$ ./e/build/7.1.0-alpha.1.126/tele pull gravity:7.0.12 --output grav.tar                                                                                               
Thu Jul 16 21:33:00 UTC Not logged in. Using default Gravitational Hub
Thu Jul 16 21:33:00 UTC Requesting cluster image from https://get.gravitational.io             
        Still requesting cluster image from https://get.gravitational.io (10 seconds elapsed)
```

The PR build will check the rest of the pull changes.  I don't know a great way to check the push futher as I don't actually want to release.  It'll get checked when we publish our first 7.1 pre-release build.