### PR TITLE
Add 7.0.12 to upgrade matrix, remove 7.0.0.

### DIFF
--- a/build.assets/robotest/nightly_config.sh
+++ b/build.assets/robotest/nightly_config.sh
@@ -9,6 +9,7 @@ source $(dirname $0)/utils.sh
 declare -A UPGRADE_MAP
 
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7 debian:9 ubuntu:18" # compatible LTS version
+UPGRADE_MAP[7.0.12]="ubuntu:16"  # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.0]="ubuntu:16"
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="redhat:7" # compatible non-LTS version
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009

--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -8,7 +8,10 @@ source $(dirname $0)/utils.sh
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="ubuntu:18" # compatible LTS version
-UPGRADE_MAP[7.0.0]="ubuntu:16"
+UPGRADE_MAP[7.0.12]="ubuntu:16"  # 7.0.12 is the first LTS 7.0 release
+UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
+# UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
+
 # 6.2 and 6.3 ignored in PR builds per https://github.com/gravitational/gravity/pull/1760#pullrequestreview-437838773
 # UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="redhat:7" # compatible non-LTS version
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009


### PR DESCRIPTION
## Description
7.0.12 is the first LTS release of 7.0.0.  We want to maintain upgrade
compatibility with this.

7.0.0 suffers from intermittent failures that waste robotest resources
due to the bug fixed in https://github.com/gravitational/planet/pull/671.
The benefit gained from testing from 7.0.0 < the time and money wasted
on these failures. Thus we prefer testing from 7.0.7 for PR builds,
it is the first build with this fix.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Works around https://github.com/gravitational/planet/pull/671.

## TODOs

- [x] Self-review the change
- [ ] Address review feedback

## Testing done
The pr build should be sufficient.  Here are the new configs:

```
walt@work:~/git/gravity$ ./build.assets/robotest/pr_config.sh                         
install={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","storage_driver":"overlay2"}
install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.7.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
walt@work:~/git/gravity$ ./build.assets/robotest/nightly_config.sh
install={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","storage_driver":"overlay2"}
install={"flavor":"six","nodes":6,"role":"node","os":"redhat:7","storage_driver":"overlay2"}
install={"flavor":"three","nodes":3,"role":"node","os":"debian:9","storage_driver":"overlay2"}
install={"flavor":"six","nodes":6,"role":"node","os":"debian:9","storage_driver":"overlay2"}
install={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","storage_driver":"overlay2"}
install={"flavor":"six","nodes":6,"role":"node","os":"ubuntu:16","storage_driver":"overlay2"}
install={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","storage_driver":"overlay2"}
install={"flavor":"six","nodes":6,"role":"node","os":"ubuntu:18","storage_driver":"overlay2"}
install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
resize={"to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"six","nodes":6,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"one","nodes":1,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.0.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_6.2.0.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_6.2.5.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_6.3.18.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"centos:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"debian:9","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
```


## Additional information
I don't presently have good data on what % of 7.0.0 -> master runs are failing.  @UnderGreen tells me this is a notable source of failure though.
