### PR TITLE
[5.5.x] Sanitize gravity cli cmd logs

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -676,6 +676,9 @@ const (
 	// GravityCLITag is used to tag gravity cli command log entries in the
 	// system journal.
 	GravityCLITag = "gravity-cli"
+
+	// Redacted is used as a replacement string for sensitive data.
+	Redacted = "*****"
 )
 
 var (

--- a/lib/utils/cli/cli.go
+++ b/lib/utils/cli/cli.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 Gravitational, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/utils/cli/cli.go
+++ b/lib/utils/cli/cli.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2020 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// CommandArgs manipulates command-line arguments.
+type CommandArgs struct {
+	// Parser is used to parse provided command-line.
+	Parser ArgsParser
+	// FlagsToAdd is a list of additional flags to add to resulting command.
+	FlagsToAdd []Flag
+	// FlagsToReplace is a list of flags to replace in the command.
+	// A flag is only replaced if it has been provided.
+	FlagsToReplace []Flag
+	// FlagsToRemove is a list of flags to omit from the resulting command.
+	FlagsToRemove []string
+}
+
+// Update returns new command line for the provided command taking into account
+// flags that need to be added or removed as configured.
+// Positional arguments are moved to the end.
+//
+// If a flag needs to be replaced (possibly to update the value), it needs to be
+// placed into both FlagsToAdd and FlagsToRemove.
+//
+// The resulting command line adheres to command line format accepted by systemd.
+// See https://www.freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines for details
+func (r *CommandArgs) Update(command []string) (args []string, err error) {
+	ctx, err := r.Parser.ParseArgs(command)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse command: %v", command)
+	}
+	for _, flag := range r.addRemoveFlags(ctx) {
+		args = append(args, flag.Format()...)
+	}
+	outputCommand := ctx.SelectedCommand.FullCommand()
+	return append([]string{outputCommand}, args...), nil
+}
+
+func (r *CommandArgs) addRemoveFlags(ctx *kingpin.ParseContext) (flags []Flag) {
+	var args []Flag
+	seen := make(map[string]struct{})
+
+	// replace is an index to easily look up flags that need to be replaced
+	replace := make(map[string]Flag)
+	for _, flag := range r.FlagsToReplace {
+		replace[flag.Name()] = flag
+	}
+
+	for _, el := range ctx.Elements {
+		switch c := el.Clause.(type) {
+		case *kingpin.ArgClause:
+			if utils.StringInSlice(r.FlagsToRemove, c.Model().Name) {
+				// Remove the positional argument
+				continue
+			}
+			seen[c.Model().Name] = struct{}{}
+			args = append(args, NewArg(c.Model().Name, *el.Value))
+		case *kingpin.FlagClause:
+			if utils.StringInSlice(r.FlagsToRemove, c.Model().Name) {
+				// Remove the flag
+				continue
+			}
+			seen[c.Model().Name] = struct{}{}
+
+			if flag, exists := replace[c.Model().Name]; exists {
+				flags = append(flags, flag)
+				continue
+			}
+
+			if _, ok := c.Model().Value.(boolCmdlineFlag); ok {
+				flags = append(flags, newBoolFlag(c.Model().Name, *el.Value))
+			} else {
+				flags = append(flags, NewFlag(c.Model().Name, *el.Value))
+			}
+		}
+	}
+	for _, flag := range r.FlagsToAdd {
+		if arg, ok := flag.(arg); ok {
+			if _, exists := seen[arg.name]; !exists {
+				args = append(args, arg)
+			}
+			continue
+		}
+		if _, exists := seen[flag.Name()]; !exists {
+			flags = append(flags, flag)
+		}
+	}
+	// Return the new command line with positional arguments following non-positional flags
+	return append(flags, args...)
+}
+
+// NewArg creates a new positional argument
+func NewArg(name, value string) Flag {
+	return arg{name: name, value: value}
+}
+
+// Name returns the argument's name
+func (r arg) Name() string {
+	return r.name
+}
+
+// Formats returns this argument formatted for command line
+func (r arg) Format() []string {
+	return []string{fmt.Sprint(strconv.Quote(r.value))}
+}
+
+type arg struct {
+	name  string
+	value string
+}
+
+// Flag represents a command-line flag
+type Flag interface {
+	// Format formats the flag for command line
+	Format() []string
+	// Name returns the flag's name
+	Name() string
+}
+
+// NewFlag creates a new named command-line option with a value.
+func NewFlag(name, value string) Flag {
+	return stringFlag{name: name, value: value}
+}
+
+// Name returns the flag's name
+func (r stringFlag) Name() string {
+	return r.name
+}
+
+// Formats returns this flag formatted for command line
+func (r stringFlag) Format() []string {
+	return []string{fmt.Sprint("--", r.name), strconv.Quote(r.value)}
+}
+
+// stringFlag represents a named command-line flag with a value.
+type stringFlag struct {
+	// name is the flag name.
+	name string
+	// value is the flag value.
+	value string
+}
+
+// NewBoolFlag creates a new boolean command-line flag.
+func NewBoolFlag(name string, value bool) Flag {
+	return boolFlag{name: name, value: value}
+}
+
+// Name returns this flag's name
+func (r boolFlag) Name() string {
+	return r.name
+}
+
+// Formats returns this flag formatted for command line
+func (r boolFlag) Format() []string {
+	if r.value {
+		return []string{fmt.Sprint("--", r.name)}
+	}
+	return []string{fmt.Sprint("--no-", r.name)}
+}
+
+func newBoolFlag(name, value string) Flag {
+	return boolFlag{name: name, value: value == "true"}
+}
+
+// boolFlag represents a boolean command-line flag.
+// Boolean flag does not have a value and can be flipped
+// by prefixing it with a 'no-' prefix:
+//
+//  --bool-value	to enable bool-value
+//  --no-bool-value	to disale bool-value
+type boolFlag struct {
+	// name is the flag name.
+	name string
+	// value is the flag value.
+	value bool
+}
+
+// boolCmdlineFlag describes a boolean commane-line flag.
+// It exists to support kingpin boolean flags since the package itself
+// does not export the type
+type boolCmdlineFlag interface {
+	// IsBoolFlag returns true to indicate a boolean flag.
+	IsBoolFlag() bool
+}
+
+// ParseArgs parses the specified command line arguments into a parse context.
+func (r ArgsParserFunc) ParseArgs(args []string) (*kingpin.ParseContext, error) {
+	return r(args)
+}
+
+// ArgsParserFunc is a functional wrapper for ArgsParser to enable ordinary
+// functions as ArgsParsers.
+type ArgsParserFunc func(args []string) (*kingpin.ParseContext, error)
+
+// ArgsParser parses command line arguments.
+type ArgsParser interface {
+	// ParseArgs parses the specified command line arguments into a parse context.
+	ParseArgs(args []string) (*kingpin.ParseContext, error)
+}

--- a/lib/utils/cli/cli_test.go
+++ b/lib/utils/cli/cli_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 Gravitational, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/utils/cli/cli_test.go
+++ b/lib/utils/cli/cli_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2020 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gravitational/gravity/lib/constants"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/check.v1"
+)
+
+func TestCLI(t *testing.T) { check.TestingT(t) }
+
+type S struct{}
+
+var _ = check.Suite(&S{})
+
+func (*S) SetUpSuite(c *check.C) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(os.Stderr)
+}
+
+func (*S) TestUpdatesCommandLine(c *check.C) {
+	var testCases = []struct {
+		comment      string
+		inputArgs    []string
+		flags        []Flag
+		replaceFlags []Flag
+		removeFlags  []string
+		outputArgs   []string
+	}{
+		{
+			comment:   "Does not overwrite existing flags",
+			inputArgs: []string{"install", `--token=token`, "--debug"},
+			flags:     []Flag{NewFlag("token", "different token")},
+			outputArgs: []string{
+				"install", "--token", `"token"`, "--debug",
+			},
+		},
+		{
+			comment:     "Quotes flags and args",
+			inputArgs:   []string{"install", `--token=some token`, "/path/to/data", "--cloud-provider=generic"},
+			flags:       []Flag{NewFlag("advertise-addr", "localhost:8080")},
+			removeFlags: []string{"cloud-provider"},
+			outputArgs: []string{
+				"install", "--token", `"some token"`, "--advertise-addr", `"localhost:8080"`, `"/path/to/data"`,
+			},
+		},
+		{
+			comment:   "Handles negated flags",
+			inputArgs: []string{"install", "--no-selinux", "/path/to/data"},
+			outputArgs: []string{
+				"install", "--no-selinux", `"/path/to/data"`,
+			},
+		},
+		{
+			comment: "Replaces boolean flag with opposite value",
+			// selinux is on by default
+			inputArgs: []string{"install", "/path/to/data"},
+			outputArgs: []string{
+				"install", "--no-selinux", `"/path/to/data"`,
+			},
+			flags: []Flag{
+				NewBoolFlag("selinux", false),
+			},
+			removeFlags: []string{"selinux"},
+		},
+		{
+			comment:    "Redact install token",
+			inputArgs:  []string{"install", `--token=token`, "--debug"},
+			outputArgs: []string{"install", "--token", fmt.Sprintf(`"%s"`, constants.Redacted), "--debug"},
+			replaceFlags: []Flag{
+				NewFlag("token", constants.Redacted),
+			},
+		},
+		{
+			comment:   "Redact user create password",
+			inputArgs: []string{"user", "create", `--email=email`, `--password=password`},
+			outputArgs: []string{"user create",
+				"--email", `"email"`,
+				"--password", fmt.Sprintf(`"%s"`, constants.Redacted),
+			},
+			replaceFlags: []Flag{
+				NewFlag("password", constants.Redacted),
+			},
+		},
+		{
+			comment:   "Redact multiple flags",
+			inputArgs: []string{"test", `--secret1`, `secret1`, `--secret2`, `secret2`, `test`},
+			outputArgs: []string{"test",
+				"--secret1", fmt.Sprintf(`"%s"`, constants.Redacted),
+				"--secret2", fmt.Sprintf(`"%s"`, constants.Redacted),
+				`"test"`,
+			},
+			replaceFlags: []Flag{
+				NewFlag("secret1", constants.Redacted),
+				NewFlag("secret2", constants.Redacted),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		comment := check.Commentf(testCase.comment)
+		commandArgs := CommandArgs{
+			Parser:         ArgsParserFunc(parseArgs),
+			FlagsToAdd:     testCase.flags,
+			FlagsToRemove:  testCase.removeFlags,
+			FlagsToReplace: testCase.replaceFlags,
+		}
+		args, err := commandArgs.Update(testCase.inputArgs)
+		c.Assert(err, check.IsNil)
+		c.Assert(args, check.DeepEquals, testCase.outputArgs, comment)
+	}
+}
+
+func parseArgs(args []string) (*kingpin.ParseContext, error) {
+	app := kingpin.New("test", "")
+	app.Flag("debug", "").Bool()
+
+	installCmd := app.Command("install", "")
+	installCmd.Arg("path", "").String()
+	installCmd.Flag("token", "").String()
+	installCmd.Flag("selinux", "").Default("true").Bool()
+	installCmd.Flag("advertise-addr", "").String()
+	installCmd.Flag("cloud-provider", "").String()
+
+	userCmd := app.Command("user", "")
+	userCreateCmd := userCmd.Command("create", "")
+	userCreateCmd.Flag("password", "").String()
+	userCreateCmd.Flag("email", "").String()
+
+	testCmd := app.Command("test", "")
+	testCmd.Arg("arg", "").String()
+	testCmd.Flag("secret1", "").String()
+	testCmd.Flag("secret2", "").String()
+
+	return app.ParseContext(args)
+}

--- a/tool/gravity/cli/logging.go
+++ b/tool/gravity/cli/logging.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"log/syslog"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/constants"
+	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/cli"
+
+	"github.com/gravitational/trace"
+)
+
+// Executable executes a gravity command.
+type Executable func() error
+
+// CmdExecer handles execution of a gravity command.
+type CmdExecer struct {
+	// Exe specifies an executable gravity command.
+	Exe Executable
+	// Parser specifies the gravity arguments parser function.
+	Parser cli.ArgsParserFunc
+	// Args specifies the provided gravity command arguments.
+	Args []string
+	// ExtraArgs specifies the provided extra arguments.
+	ExtraArgs []string
+}
+
+// Execute executes the gravity command while logging the start and completion
+// of the command.
+func (r *CmdExecer) Execute() (err error) {
+	sanitizedCmd, err := r.getRedactedCmd()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cmdString := strings.Join(sanitizedCmd, " ")
+	if len(r.ExtraArgs) > 0 {
+		cmdString = fmt.Sprintf("%s -- %s", cmdString, strings.Join(r.ExtraArgs, " "))
+	}
+
+	logEntry(fmt.Sprintf("[RUNNING]: %s", cmdString))
+	defer func() {
+		if r := recover(); r != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [PANIC]: %v", cmdString, r))
+			panic(r)
+		}
+		if err != nil {
+			logEntry(fmt.Sprintf("[FAILURE]: %s: [ERROR]: %s", cmdString, trace.UserMessage(err)))
+			return
+		}
+		logEntry(fmt.Sprintf("[SUCCESS]: %s", cmdString))
+	}()
+
+	err = r.Exe()
+	return trace.Wrap(err)
+}
+
+// getRedactedCmd removes potentially sensitive data from the args and returns
+// the sanitized cmd as a list of strings.
+func (r *CmdExecer) getRedactedCmd() (cmd []string, err error) {
+	commandArgs := cli.CommandArgs{
+		Parser: r.Parser,
+		FlagsToReplace: []cli.Flag{
+			cli.NewFlag("token", constants.Redacted),
+			cli.NewFlag("registry-password", constants.Redacted),
+			cli.NewFlag("password", constants.Redacted),
+			cli.NewFlag("license", constants.Redacted),
+			cli.NewFlag("ops-token", constants.Redacted),
+			cli.NewFlag("ops-tunnel-token", constants.Redacted),
+			cli.NewFlag("encryption-key", constants.Redacted),
+		},
+	}
+	args, err := commandArgs.Update(r.Args)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return append([]string{utils.Exe.Path}, args...), nil
+}
+
+// logEntry writes the provided entry into the system journal with the
+// gravity-cli tag.
+func logEntry(entry string) {
+	if err := utils.SyslogWrite(syslog.LOG_INFO, entry, constants.GravityCLITag); err != nil {
+		log.WithError(err).Warn("Failed to write to system logs.")
+	}
+}

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log/syslog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -38,6 +37,7 @@ import (
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/utils"
+	"github.com/gravitational/gravity/lib/utils/cli"
 
 	"github.com/gravitational/configure/cstrings"
 	teleutils "github.com/gravitational/teleport/lib/utils"
@@ -56,13 +56,9 @@ func ConfigureEnvironment() error {
 }
 
 // Run parses CLI arguments and executes an appropriate gravity command
-func Run(g *Application) error {
+func Run(g *Application) (err error) {
 	log.Debugf("Executing: %v.", os.Args)
-	if err := utils.SyslogWrite(syslog.LOG_INFO, strings.Join(os.Args, " "), constants.GravityCLITag); err != nil {
-		log.WithError(err).Warn("Failed to write to system logs.")
-	}
-
-	err := ConfigureEnvironment()
+	err = ConfigureEnvironment()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -86,7 +82,14 @@ func Run(g *Application) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return Execute(g, cmd, extraArgs)
+
+	execer := CmdExecer{
+		Exe:       getExec(g, cmd, extraArgs),
+		Parser:    cli.ArgsParserFunc(parseArgs),
+		Args:      args,
+		ExtraArgs: extraArgs,
+	}
+	return execer.Execute()
 }
 
 // InitAndCheck initializes the CLI application according to the provided
@@ -241,6 +244,13 @@ func InitAndCheck(g *Application, cmd string) error {
 	}
 
 	return nil
+}
+
+// getExec returns the Executable function to execute the specified gravity cmd.
+func getExec(g *Application, cmd string, extraArgs []string) Executable {
+	return func() error {
+		return Execute(g, cmd, extraArgs)
+	}
 }
 
 // Execute executes the gravity command given with cmd

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/tool/common"
 
 	"github.com/gravitational/trace"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // LocalEnvironmentFactory defines an interface for creating operation-specific environments
@@ -160,4 +162,11 @@ func uninstallExistingAgentService() error {
 		return trace.Wrap(err)
 	}
 	return svm.UninstallService(defaults.GravityRPCAgentServiceName)
+}
+
+func parseArgs(args []string) (*kingpin.ParseContext, error) {
+	app := kingpin.New("gravity", "")
+	app.Terminate(func(int) {})
+	app.Writer(ioutil.Discard)
+	return RegisterCommands(app).ParseContext(args)
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Gravity cli commands will now be logged twice. Once when the command starts execution and another after it completes. Potentially sensitive data will also be redacted from the logs.

The log entries already include the process ID so a UUID is not included with the log entries. Use `journalctl _PID=[pid]` to track start/finish of a particular command.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/gravity.e/pull/4318
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1889

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback


## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

**Verify log entry of a successfully completed gravity command**
```
Jul 13 03:52:06 node-1 gravity-cli[18289]: [RUNNING]: /usr/bin/gravity status cluster
Jul 13 03:52:06 node-1 gravity-cli[18289]: [SUCCESS]: /usr/bin/gravity status cluster
```

**Verify log entry of a failed gravity command. Also verify sensitive data is redacted**
```
Jul 13 03:53:04 node-1 gravity-cli[18678]: [RUNNING]: /usr/bin/gravity install --token "*****"
Jul 13 03:53:04 node-1 gravity-cli[18678]: [FAILURE]: /usr/bin/gravity install --token "*****": [ERROR]: detected previous installation state ...
```