### PR TITLE
(5.5) Background plan resume / plan tail

### DIFF
--- a/lib/fsm/follow.go
+++ b/lib/fsm/follow.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/gravity/lib/storage"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// GetPlanFunc is a function that returns an operation plan.
+type GetPlanFunc func() (*storage.OperationPlan, error)
+
+// PlanEvent represents an operation plan event.
+type PlanEvent interface{}
+
+// PlanChanged is sent when plan phases change states.
+type PlanChanged struct {
+	// Change is a plan phase change.
+	Change storage.PlanChange
+	// Plan is the resolved operation plan.
+	Plan storage.OperationPlan
+}
+
+// PlanFinished is sent when the plan is fully completed or rolled back.
+type PlanFinished struct {
+	// Plan is the resolved operation plan.
+	Plan storage.OperationPlan
+}
+
+// FollowOperationPlan returns a channel that receives phase updates for the
+// specified plan.
+func FollowOperationPlan(ctx context.Context, getPlan GetPlanFunc) (<-chan PlanEvent, error) {
+	previousPlan, err := getPlan()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ch := make(chan PlanEvent, 100)
+	go func() {
+		// Send initial events to the channel, excluding unstarted phases.
+		for _, change := range GetPlanProgress(*previousPlan) {
+			ch <- &PlanChanged{Plan: *previousPlan, Change: change}
+		}
+		if IsCompleted(previousPlan) || IsRolledBack(previousPlan) {
+			ch <- &PlanFinished{Plan: *previousPlan}
+			return
+		}
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				newPlan, err := getPlan()
+				if err != nil {
+					logrus.WithError(err).Error("Failed to reload plan.")
+					continue
+				}
+				diff, err := DiffPlan(*previousPlan, *newPlan)
+				if err != nil {
+					logrus.WithError(err).Error("Failed to diff plans.")
+					continue
+				}
+				for _, change := range diff {
+					ch <- &PlanChanged{Plan: *newPlan, Change: change}
+				}
+				if IsCompleted(newPlan) || IsRolledBack(newPlan) {
+					ch <- &PlanFinished{Plan: *newPlan}
+					return
+				}
+				previousPlan = newPlan
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}

--- a/lib/fsm/follow.go
+++ b/lib/fsm/follow.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/storage"
 
-	"github.com/gravitational/trace"
+	"github.com/cenkalti/backoff"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,66 +30,99 @@ import (
 type GetPlanFunc func() (*storage.OperationPlan, error)
 
 // PlanEvent represents an operation plan event.
-type PlanEvent interface{}
+type PlanEvent interface {
+	// IsPlanEvent returns true for events representing plan changes.
+	IsPlanEvent() bool
+}
 
-// PlanChanged is sent when plan phases change states.
-type PlanChanged struct {
+// PlanChangeEvent is sent when plan phases change states.
+type PlanChangeEvent struct {
 	// Change is a plan phase change.
 	Change storage.PlanChange
 	// Plan is the resolved operation plan.
 	Plan storage.OperationPlan
 }
 
-// PlanFinished is sent when the plan is fully completed or rolled back.
-type PlanFinished struct {
+// IsPlanEvent is for satisfying PlanEvent interface.
+func (e *PlanChangeEvent) IsPlanEvent() bool { return true }
+
+// PlanFinishEvent is sent when the plan is fully completed or rolled back.
+type PlanFinishEvent struct {
 	// Plan is the resolved operation plan.
 	Plan storage.OperationPlan
 }
 
+// IsPlanEvent is for satisfying PlanEvent interface.
+func (e *PlanFinishEvent) IsPlanEvent() bool { return true }
+
 // FollowOperationPlan returns a channel that receives phase updates for the
 // specified plan.
-func FollowOperationPlan(ctx context.Context, getPlan GetPlanFunc) (<-chan PlanEvent, error) {
-	previousPlan, err := getPlan()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+func FollowOperationPlan(ctx context.Context, getPlan GetPlanFunc) <-chan PlanEvent {
 	ch := make(chan PlanEvent, 100)
+	// Send an initial batch of events from the initial state of the plan.
+	plan, err := getPlan()
+	if err != nil {
+		logrus.WithError(err).Error("Failed to load plan.")
+	}
+	if plan != nil {
+		for _, change := range GetPlanProgress(*plan) {
+			ch <- &PlanChangeEvent{Change: change, Plan: *plan}
+		}
+		if IsCompleted(plan) || IsRolledBack(plan) {
+			ch <- &PlanFinishEvent{Plan: *plan}
+			return ch
+		}
+	}
+	// Then launch a goroutine that will be monitoring the progress.
 	go func() {
-		// Send initial events to the channel, excluding unstarted phases.
-		for _, change := range GetPlanProgress(*previousPlan) {
-			ch <- &PlanChanged{Plan: *previousPlan, Change: change}
-		}
-		if IsCompleted(previousPlan) || IsRolledBack(previousPlan) {
-			ch <- &PlanFinished{Plan: *previousPlan}
-			return
-		}
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
+		tickerBackoff := getFollowBackoffPolicy()
+		ticker := backoff.NewTicker(tickerBackoff)
+		defer func() {
+			ticker.Stop()
+			logrus.Info("Operation plan watcher done.")
+		}()
 		for {
 			select {
 			case <-ticker.C:
-				newPlan, err := getPlan()
+				nextPlan, err := getPlan()
 				if err != nil {
 					logrus.WithError(err).Error("Failed to reload plan.")
 					continue
 				}
-				diff, err := DiffPlan(*previousPlan, *newPlan)
+				changes, err := DiffPlan(plan, *nextPlan)
 				if err != nil {
 					logrus.WithError(err).Error("Failed to diff plans.")
 					continue
 				}
-				for _, change := range diff {
-					ch <- &PlanChanged{Plan: *newPlan, Change: change}
+				for _, change := range changes {
+					ch <- &PlanChangeEvent{Change: change, Plan: *nextPlan}
 				}
-				if IsCompleted(newPlan) || IsRolledBack(newPlan) {
-					ch <- &PlanFinished{Plan: *newPlan}
+				if IsCompleted(nextPlan) || IsRolledBack(nextPlan) {
+					ch <- &PlanFinishEvent{Plan: *nextPlan}
 					return
 				}
-				previousPlan = newPlan
+				// Update the current plan for comparison on the next cycle and
+				// reset the backoff so the ticker keeps ticking every second
+				// as long as there are no errors.
+				plan = nextPlan
+				tickerBackoff.Reset()
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-	return ch, nil
+	return ch
+}
+
+// getFollowBackoffPolicy returns retry/backoff policy for the plan follower.
+//
+// Backoff triggers when plan reload fails. Otherwise, the backoff is reset
+// on each cycle to maintain the constant retry at initial interval.
+func getFollowBackoffPolicy() backoff.BackOff {
+	return &backoff.ExponentialBackOff{
+		InitialInterval: time.Second,
+		Multiplier:      backoff.DefaultMultiplier,
+		MaxInterval:     5 * time.Second,
+		Clock:           backoff.SystemClock,
+	}
 }

--- a/lib/fsm/follow_test.go
+++ b/lib/fsm/follow_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsm
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *FSMSuite) TestFollowOperationPlan(c *check.C) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	engine := newTestEngine(func() storage.OperationPlan {
+		return *(s.planner.newPlan(
+			s.planner.initPhase(storage.OperationPhaseStateUnstarted),
+			s.planner.bootstrapPhase(
+				s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateUnstarted)),
+			s.planner.upgradePhase(storage.OperationPhaseStateUnstarted)))
+	})
+
+	// Emit a couple of plan changes prior to starting the watch.
+	tsInit := s.clock.Now()
+	engine.ChangePhaseState(ctx, StateChange{
+		Phase:   "/init",
+		State:   storage.OperationPhaseStateCompleted,
+		created: tsInit,
+	})
+	tsBootstrap := s.clock.Now().Add(time.Minute)
+	engine.ChangePhaseState(ctx, StateChange{
+		Phase:   "/bootstrap/node-1",
+		State:   storage.OperationPhaseStateCompleted,
+		created: tsBootstrap,
+	})
+
+	// Save the initial plan state (before watch) for comparison later.
+	planAfterBootstrap, err := engine.GetPlan()
+	c.Assert(err, check.IsNil)
+
+	// Launch the plan watcher.
+	eventsCh, err := FollowOperationPlan(ctx, func() (*storage.OperationPlan, error) {
+		return engine.GetPlan()
+	})
+	c.Assert(err, check.IsNil)
+
+	// Change a phase state after the watch has been established as well.
+	tsUpgrade := s.clock.Now().Add(2 * time.Minute)
+	engine.ChangePhaseState(ctx, StateChange{
+		Phase:   "/upgrade",
+		State:   storage.OperationPhaseStateCompleted,
+		created: tsUpgrade,
+	})
+
+	planAfterUpgrade, err := engine.GetPlan()
+	c.Assert(err, check.IsNil)
+
+	// All received plan events will be collected here after the watch stops.
+	var events []PlanEvent
+
+L:
+	for {
+		select {
+		case event := <-eventsCh:
+			events = append(events, event)
+			if _, isFinished := event.(*PlanFinished); isFinished {
+				break L
+			}
+		case <-ctx.Done():
+			c.Fatalf("Timeout following operation plan")
+		}
+	}
+
+	c.Assert([]PlanEvent{
+		&PlanChanged{
+			Plan: *planAfterBootstrap,
+			Change: storage.PlanChange{
+				PhaseID:    "/init",
+				PhaseIndex: 0,
+				NewState:   storage.OperationPhaseStateCompleted,
+				Created:    tsInit,
+			},
+		},
+		&PlanChanged{
+			Plan: *planAfterBootstrap,
+			Change: storage.PlanChange{
+				PhaseID:    "/bootstrap/node-1",
+				PhaseIndex: 1,
+				NewState:   storage.OperationPhaseStateCompleted,
+				Created:    tsBootstrap,
+			},
+		},
+		&PlanChanged{
+			Plan: *planAfterUpgrade,
+			Change: storage.PlanChange{
+				PhaseID:    "/upgrade",
+				PhaseIndex: 2,
+				NewState:   storage.OperationPhaseStateCompleted,
+				Created:    tsUpgrade,
+			},
+		},
+		&PlanFinished{
+			Plan: *planAfterUpgrade,
+		},
+	}, compare.DeepEquals, events)
+}

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"time"
 
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/rpc"
@@ -606,8 +605,6 @@ type StateChange struct {
 	State string
 	// Error is the error that happened during phase execution
 	Error trace.Error
-	// created overrides the time for the state change, only used in tests.
-	created time.Time
 }
 
 // String returns a textual representation of this state change

--- a/lib/fsm/testhelpers.go
+++ b/lib/fsm/testhelpers.go
@@ -30,16 +30,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func newTestEngine(plan storage.OperationPlan) *testEngine {
+func newTestEngine(getPlan func() storage.OperationPlan) *testEngine {
 	return &testEngine{
-		plan:  plan,
-		clock: clockwork.NewFakeClock(),
+		getPlan: getPlan,
+		clock:   clockwork.NewFakeClock(),
 	}
 }
 
 // testEngine is fsm engine used in tests. Keeps its changelog in memory.
 type testEngine struct {
-	plan      storage.OperationPlan
+	getPlan   func() storage.OperationPlan
 	changelog storage.PlanChangelog
 	clock     clockwork.Clock
 }
@@ -59,7 +59,10 @@ func (t *testEngine) GetExecutor(p ExecutorParams, r Remote) (PhaseExecutor, err
 // ChangePhaseState records the provided phase state change in the test engine.
 func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error {
 	// Make sure that new changelog entries get the most recent timestamp.
-	timestamp := t.clock.Now().Add(time.Duration(len(t.changelog)) * time.Minute)
+	timestamp := ch.created
+	if timestamp.IsZero() {
+		timestamp = t.clock.Now().Add(time.Duration(len(t.changelog)) * time.Minute)
+	}
 	t.changelog = append(t.changelog, storage.PlanChange{
 		PhaseID:  ch.Phase,
 		NewState: ch.State,
@@ -70,7 +73,7 @@ func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error
 
 // GetPlan returns the test plan with the changelog applied.
 func (t *testEngine) GetPlan() (*storage.OperationPlan, error) {
-	return ResolvePlan(t.plan, t.changelog), nil
+	return ResolvePlan(t.getPlan(), t.changelog), nil
 }
 
 // RunCommand is not implemented by the test engine.

--- a/lib/fsm/testhelpers.go
+++ b/lib/fsm/testhelpers.go
@@ -58,15 +58,22 @@ func (t *testEngine) GetExecutor(p ExecutorParams, r Remote) (PhaseExecutor, err
 
 // ChangePhaseState records the provided phase state change in the test engine.
 func (t *testEngine) ChangePhaseState(ctx context.Context, ch StateChange) error {
-	// Make sure that new changelog entries get the most recent timestamp.
-	timestamp := ch.created
-	if timestamp.IsZero() {
-		timestamp = t.clock.Now().Add(time.Duration(len(t.changelog)) * time.Minute)
-	}
 	t.changelog = append(t.changelog, storage.PlanChange{
 		PhaseID:  ch.Phase,
 		NewState: ch.State,
-		Created:  timestamp,
+		// Make sure that new changelog entries get the most recent timestamp.
+		Created: t.clock.Now().Add(time.Duration(len(t.changelog)) * time.Minute),
+	})
+	return nil
+}
+
+// changePhaseStateWithTimestamp records the provided phase state change in the
+// test engine with the specified timestamp.
+func (t *testEngine) changePhaseStateWithTimestamp(ctx context.Context, ch StateChange, created time.Time) error {
+	t.changelog = append(t.changelog, storage.PlanChange{
+		PhaseID:  ch.Phase,
+		NewState: ch.State,
+		Created:  created,
 	})
 	return nil
 }

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/systeminfo"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -139,6 +140,59 @@ func ResolvePlan(plan storage.OperationPlan, changelog storage.PlanChangelog) *s
 	return &plan
 }
 
+// DiffPlan returns the difference between the next and previous plans in the
+// form of a changelog.
+func DiffPlan(prevPlan, nextPlan storage.OperationPlan) (diff []storage.PlanChange, err error) {
+	// Quick sanity check that this is the same plan.
+	if prevPlan.OperationID != nextPlan.OperationID {
+		return nil, trace.BadParameter("can't diff different plans: %v %v", prevPlan, nextPlan)
+	}
+	// Since this is the same plan, should be safe to assume they have the
+	// same phases with different states.
+	prevPhases := prevPlan.GetLeafPhases()
+	nextPhases := nextPlan.GetLeafPhases()
+	if len(prevPhases) != len(nextPhases) {
+		return nil, trace.BadParameter("plans have different lengths: %v %v", prevPlan, nextPlan)
+	}
+	for i, prevPhase := range prevPhases {
+		nextPhase := nextPhases[i]
+		if prevPhase.ID != nextPhase.ID {
+			return nil, trace.BadParameter("phase ids don't match: %v %v", prevPhase, nextPhase)
+		}
+		if prevPhase.State != nextPhase.State || prevPhase.Updated != nextPhase.Updated {
+			diff = append(diff, storage.PlanChange{
+				ClusterName: nextPlan.ClusterName,
+				OperationID: nextPlan.OperationID,
+				PhaseID:     nextPhase.ID,
+				PhaseIndex:  i,
+				NewState:    nextPhase.State,
+				Created:     nextPhase.Updated,
+				Error:       nextPhase.Error,
+			})
+		}
+	}
+	return diff, nil
+}
+
+// GetPlanProgress returns phases of the plan that have been executed so far
+// in the form of a changelog.
+func GetPlanProgress(plan storage.OperationPlan) (progress []storage.PlanChange) {
+	for i, phase := range plan.GetLeafPhases() {
+		if !phase.IsUnstarted() {
+			progress = append(progress, storage.PlanChange{
+				ClusterName: plan.ClusterName,
+				OperationID: plan.OperationID,
+				PhaseID:     phase.ID,
+				PhaseIndex:  i,
+				NewState:    phase.State,
+				Created:     phase.Updated,
+				Error:       phase.Error,
+			})
+		}
+	}
+	return progress
+}
+
 // DiffChangelog returns a list of changelog entries from "local" that are missing from "remote"
 func DiffChangelog(local, remote storage.PlanChangelog) []storage.PlanChange {
 	remoteEntries := make(map[string]struct{})
@@ -253,4 +307,22 @@ func addPhases(phase *storage.OperationPhase, result *[]*storage.OperationPhase)
 	for i := range phase.Phases {
 		addPhases(&phase.Phases[i], result)
 	}
+}
+
+// CheckPlanCoordinator ensures that the node this function is invoked on is the
+// coordinator node specified in the plan.
+//
+// This is mainly important for making sure the plan is executed on the lead
+// node for a particular plan - for example, for etcd upgrades, where state
+// can only be kept in sync on the lead master node itself.
+func CheckPlanCoordinator(p *storage.OperationPlan) error {
+	if p.OfflineCoordinator == nil {
+		return nil
+	}
+	err := systeminfo.HasInterface(p.OfflineCoordinator.AdvertiseIP)
+	if err != nil && trace.IsNotFound(err) {
+		return trace.BadParameter("Plan must be resumed on node %v/%v",
+			p.OfflineCoordinator.Hostname, p.OfflineCoordinator.AdvertiseIP)
+	}
+	return trace.Wrap(err)
 }

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -140,9 +140,14 @@ func ResolvePlan(plan storage.OperationPlan, changelog storage.PlanChangelog) *s
 	return &plan
 }
 
-// DiffPlan returns the difference between the next and previous plans in the
+// DiffPlan returns the difference between the previous and the next plans in the
 // form of a changelog.
-func DiffPlan(prevPlan, nextPlan storage.OperationPlan) (diff []storage.PlanChange, err error) {
+func DiffPlan(prevPlan *storage.OperationPlan, nextPlan storage.OperationPlan) (diff []storage.PlanChange, err error) {
+	// If the current plan is not provided, the diff is all attempted phases
+	// from the next plan.
+	if prevPlan == nil {
+		return GetPlanProgress(nextPlan), nil
+	}
 	// Quick sanity check that this is the same plan.
 	if prevPlan.OperationID != nextPlan.OperationID {
 		return nil, trace.BadParameter("can't diff different plans: %v %v", prevPlan, nextPlan)

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fsm
 
 import (
+	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/storage"
 
 	"gopkg.in/check.v1"
@@ -48,4 +49,73 @@ func (s *FSMUtilsSuite) TestIsRolledBack(c *check.C) {
 			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
 		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
 	c.Assert(IsRolledBack(plan), check.Equals, true)
+}
+
+func (s *FSMUtilsSuite) TestGetPlanProgress(c *check.C) {
+	plan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateUnstarted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+	c.Assert(GetPlanProgress(*plan), compare.DeepEquals, []storage.PlanChange(nil))
+
+	plan = s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateFailed)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+	c.Assert(GetPlanProgress(*plan), compare.DeepEquals, []storage.PlanChange{
+		{
+			PhaseID:    "/init",
+			PhaseIndex: 0,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-1",
+			PhaseIndex: 1,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-2",
+			PhaseIndex: 2,
+			NewState:   storage.OperationPhaseStateFailed,
+		},
+	})
+}
+
+func (s *FSMUtilsSuite) TestDiffPlan(c *check.C) {
+	prevPlan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateUnstarted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateUnstarted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateUnstarted)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	nextPlan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateFailed)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	diff, err := DiffPlan(*prevPlan, *nextPlan)
+	c.Assert(err, check.IsNil)
+	c.Assert(diff, compare.DeepEquals, []storage.PlanChange{
+		{
+			PhaseID:    "/init",
+			PhaseIndex: 0,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-1",
+			PhaseIndex: 1,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-2",
+			PhaseIndex: 2,
+			NewState:   storage.OperationPhaseStateFailed,
+		},
+	})
 }

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -99,7 +99,36 @@ func (s *FSMUtilsSuite) TestDiffPlan(c *check.C) {
 			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateFailed)),
 		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
 
-	diff, err := DiffPlan(*prevPlan, *nextPlan)
+	diff, err := DiffPlan(prevPlan, *nextPlan)
+	c.Assert(err, check.IsNil)
+	c.Assert(diff, compare.DeepEquals, []storage.PlanChange{
+		{
+			PhaseID:    "/init",
+			PhaseIndex: 0,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-1",
+			PhaseIndex: 1,
+			NewState:   storage.OperationPhaseStateCompleted,
+		},
+		{
+			PhaseID:    "/bootstrap/node-2",
+			PhaseIndex: 2,
+			NewState:   storage.OperationPhaseStateFailed,
+		},
+	})
+}
+
+func (s *FSMUtilsSuite) TestDiffPlanNoPrevious(c *check.C) {
+	nextPlan := s.planner.newPlan(
+		s.planner.initPhase(storage.OperationPhaseStateCompleted),
+		s.planner.bootstrapPhase(
+			s.planner.bootstrapSubPhase("node-1", storage.OperationPhaseStateCompleted),
+			s.planner.bootstrapSubPhase("node-2", storage.OperationPhaseStateFailed)),
+		s.planner.upgradePhase(storage.OperationPhaseStateUnstarted))
+
+	diff, err := DiffPlan(nil, *nextPlan)
 	c.Assert(err, check.IsNil)
 	c.Assert(diff, compare.DeepEquals, []storage.PlanChange{
 		{

--- a/lib/install/bootstrap.go
+++ b/lib/install/bootstrap.go
@@ -101,8 +101,7 @@ func (i *Installer) completeFinalInstallStep() error {
 // OnPlanComplete is called when the operation plan finishes execution
 func (i *Installer) OnPlanComplete(fsm *fsm.FSM, fsmErr error) {
 	if err := fsm.Complete(fsmErr); err != nil {
-		i.Errorf("Failed to complete operation: %v.",
-			trace.DebugReport(err))
+		i.WithError(err).Error("Failed to complete operation.")
 	}
 }
 

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -97,6 +97,11 @@ func getLeafPhases(phase OperationPhase) (result []OperationPhase) {
 	return result
 }
 
+// Len returns the number of leaf phases the plan consists of.
+func (p *OperationPlan) Len() int {
+	return len(p.GetLeafPhases())
+}
+
 // OperationPhase represents a single operation plan phase
 type OperationPhase struct {
 	// ID is the ID of the phase within operation
@@ -361,6 +366,8 @@ type PlanChange struct {
 	OperationID string `json:"operation_id"`
 	// PhaseID is the ID of the phase the change refers to
 	PhaseID string `json:"phase_id"`
+	// PhaseIndex is an optional index number of the phase in the plan
+	PhaseIndex int `json:"phase_index,omitempty"`
 	// NewState is the state the phase moved into
 	NewState string `json:"new_state"`
 	// Created is the change timestamp

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -99,6 +99,23 @@ func (r *Updater) RunPhase(ctx context.Context, phase string, phaseTimeout time.
 	}))
 }
 
+// Check validates the provided FSM parameters.
+func (r *Updater) Check(params fsm.Params) error {
+	if params.PhaseID != fsm.RootPhase {
+		return nil
+	}
+	// Make sure resume is launched from the correct node.
+	plan, err := r.GetPlan()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = fsm.CheckPlanCoordinator(plan)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // RollbackPhase rolls back the specified phase.
 func (r *Updater) RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error {
 	if params.PhaseID == fsm.RootPhase {

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -95,8 +95,7 @@ func executeConfigPhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RunPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
-	return trace.Wrap(err)
+	return executeOrForkPhase(env, updater, params, operation)
 }
 
 func rollbackConfigPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/gravitational/gravity/lib/app"
@@ -36,6 +37,7 @@ import (
 	"github.com/gravitational/gravity/lib/schema"
 	statusapi "github.com/gravitational/gravity/lib/status"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/systemservice"
 	"github.com/gravitational/gravity/lib/update"
 	clusterupdate "github.com/gravitational/gravity/lib/update/cluster"
 	"github.com/gravitational/gravity/tool/common"
@@ -183,8 +185,86 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RunPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
-	return trace.Wrap(err)
+	return executeOrForkPhase(env, updater, params, operation)
+}
+
+// gravityResumeServiceName is the name of systemd service that executes
+// the gravity resume command.
+const gravityResumeServiceName = "gravity-resume.service"
+
+// executeOrForkPhase either directly executes the specified operation phase,
+// or launches a one-shot systemd service that executes it in the background.
+func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
+	// If given the --block flag, we're running as a systemd unit (or a user
+	// requested the command to execute in foreground), so proceed to perform
+	// the command (resume or single phase) directly.
+	if params.Block {
+		return updater.RunPhase(context.TODO(),
+			params.PhaseID,
+			params.Timeout,
+			params.Force)
+	}
+	// Before launching the service, perform a few prechecks, for example to
+	// make sure that the operation is being resumed from the correct node.
+	//
+	// TODO(r0mant): Also, make sure agents are running on the cluster nodes:
+	// https://github.com/gravitational/gravity/issues/1667
+	if err := updater.Check(params.toFSM()); err != nil {
+		return trace.Wrap(err)
+	}
+	// Make sure to launch the unit command with the --block flag.
+	args := append(os.Args[1:], "--debug", "--block")
+	env.PrintStep("Starting %v service", gravityResumeServiceName)
+	if err := launchOneshotService(gravityResumeServiceName, args); err != nil {
+		return trace.Wrap(err)
+	}
+	env.PrintStep(`Service %[1]v has been launched.
+
+To monitor the operation progress:
+
+  sudo gravity plan --operation-id=%[2]v --tail
+
+To monitor the service logs:
+
+  sudo journalctl -u %[1]v -f
+`, gravityResumeServiceName, operation.ID)
+	return nil
+}
+
+// launchOneshotService launches the specified command as a one-shot systemd
+// service with the specified name.
+func launchOneshotService(name string, args []string) error {
+	systemd, err := systemservice.New()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// See if the service is already running.
+	status, err := systemd.StatusService(name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Since we're using a one-shot service, it will be in "activating" state
+	// for the duration of the command execution. In fact, one-shot services
+	// never reach "active" state, but we're checking it too just in case.
+	switch status {
+	case systemservice.ServiceStatusActivating, systemservice.ServiceStatusActive:
+		return trace.AlreadyExists("service %v is already running", name)
+	}
+	// Launch the systemd unit that runs the specified command using same binary.
+	gravityPath, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	command := strings.Join(append([]string{gravityPath}, args...), " ")
+	return systemd.InstallService(systemservice.NewServiceRequest{
+		Name:    name,
+		NoBlock: true,
+		ServiceSpec: systemservice.ServiceSpec{
+			User:         constants.RootUIDString,
+			Type:         constants.OneshotService,
+			StartCommand: command,
+		},
+	})
 }
 
 func rollbackUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -494,6 +494,8 @@ type PlanDisplayCmd struct {
 	*kingpin.CmdClause
 	// Output is output format
 	Output *constants.Format
+	// Follow allows to follow the operation plan progress
+	Follow *bool
 }
 
 // PlanExecuteCmd executes a phase of an active operation
@@ -523,6 +525,8 @@ type PlanResumeCmd struct {
 	*kingpin.CmdClause
 	// PhaseTimeout is the phase timeout
 	PhaseTimeout *time.Duration
+	// Block indicates whether the command should run in foreground or as a systemd unit
+	Block *bool
 }
 
 // PlanCompleteCmd completes the operation plan
@@ -650,6 +654,8 @@ type UpgradeCmd struct {
 	SkipVersionCheck *bool
 	// DockerDevice updates Docker device in the cluster state to the provided one
 	DockerDevice *string
+	// Block indicates whether the command should run in foreground or as a systemd unit
+	Block *bool
 }
 
 // StatusCmd combines subcommands for displaying status information

--- a/tool/gravity/cli/environ.go
+++ b/tool/gravity/cli/environ.go
@@ -84,8 +84,7 @@ func executeEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ Loc
 		return trace.Wrap(err)
 	}
 	defer updater.Close()
-	err = updater.RunPhase(context.TODO(), params.PhaseID, params.Timeout, params.Force)
-	return trace.Wrap(err)
+	return executeOrForkPhase(env, updater, params, operation)
 }
 
 func rollbackEnvironPhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -50,6 +50,16 @@ type PhaseParams struct {
 	SkipVersionCheck bool
 	// DryRun allows to only print execute/rollback phases
 	DryRun bool
+	// Block indicates whether the command should be run in foreground or as a systemd unit
+	Block bool
+}
+
+func (p PhaseParams) toFSM() fsm.Params {
+	return fsm.Params{
+		PhaseID: p.PhaseID,
+		Force:   p.Force,
+		DryRun:  p.DryRun,
+	}
 }
 
 func executePhase(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams) error {

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -204,15 +204,11 @@ func outputOrFollowPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlan
 func followPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	eventsCh, err := fsm.FollowOperationPlan(ctx, getPlan)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	// Iterate over updates received from the watcher. There are 2 stop
 	// conditions for the watch:
 	//  * Phase failed -> exit with error.
 	//  * Plan fully completed or rolled back -> exit without error.
-	for eventI := range eventsCh {
+	for eventI := range fsm.FollowOperationPlan(ctx, getPlan) {
 		switch event := eventI.(type) {
 		case *fsm.PlanChanged:
 			localEnv.Printf("%v\t[%3v/%3v] Phase %v is %v\n",

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -210,7 +210,7 @@ func followPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc) er
 	//  * Plan fully completed or rolled back -> exit without error.
 	for eventI := range fsm.FollowOperationPlan(ctx, getPlan) {
 		switch event := eventI.(type) {
-		case *fsm.PlanChanged:
+		case *fsm.PlanChangeEvent:
 			localEnv.Printf("%v\t[%3v/%3v] Phase %v is %v\n",
 				color.BlueString(event.Change.Created.Format(constants.HumanDateFormatSeconds)),
 				event.Change.PhaseIndex+1,
@@ -220,7 +220,7 @@ func followPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc) er
 			if event.Change.NewState == storage.OperationPhaseStateFailed {
 				return trace.Errorf(string(event.Change.Error.Err))
 			}
-		case *fsm.PlanFinished:
+		case *fsm.PlanFinishEvent:
 			if fsm.IsCompleted(&event.Plan) {
 				localEnv.Printf("%v\t%v\n",
 					color.BlueString(time.Now().Format(constants.HumanDateFormatSeconds)),

--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/gravitational/gravity/lib/constants"
@@ -71,7 +70,12 @@ func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) err
 	return trace.Wrap(err)
 }
 
-func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string, format constants.Format) error {
+type displayPlanOptions struct {
+	format constants.Format
+	follow bool
+}
+
+func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, operationID string, opts displayPlanOptions) error {
 	op, err := getLastOperation(localEnv, environ, operationID)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -87,101 +91,170 @@ func displayOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvi
 		return trace.BadParameter(invalidOperationBanner, op.String(), op.ID)
 	}
 	if op.IsCompleted() && op.hasPlan {
-		return displayClusterOperationPlan(localEnv, op.Key(), format)
+		return displayClusterOperationPlan(localEnv, op.Key(), opts)
 	}
 	switch op.Type {
 	case ops.OperationInstall:
-		err = displayInstallOperationPlan(op.Key(), format)
+		err = displayInstallOperationPlan(localEnv, op.Key(), opts)
 	case ops.OperationExpand:
-		err = displayExpandOperationPlan(environ, op.Key(), format)
+		err = displayExpandOperationPlan(localEnv, environ, op.Key(), opts)
 	case ops.OperationUpdate:
-		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), opts)
 	case ops.OperationUpdateRuntimeEnviron:
-		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), opts)
 	case ops.OperationUpdateConfig:
-		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), format)
+		err = displayUpdateOperationPlan(localEnv, environ, op.Key(), opts)
 	case ops.OperationGarbageCollect:
-		err = displayClusterOperationPlan(localEnv, op.Key(), format)
+		err = displayClusterOperationPlan(localEnv, op.Key(), opts)
 	default:
 		return trace.BadParameter("cannot display plan for %q operation as it does not support plans", op.TypeString())
 	}
 	if err != nil && trace.IsNotFound(err) {
 		// Fallback to cluster plan
-		return displayClusterOperationPlan(localEnv, op.Key(), format)
+		return displayClusterOperationPlan(localEnv, op.Key(), opts)
 	}
 	return trace.Wrap(err)
 }
 
-func displayClusterOperationPlan(env *localenv.LocalEnvironment, opKey ops.SiteOperationKey, format constants.Format) error {
-	clusterEnv, err := env.NewClusterEnvironment()
-	if err != nil {
-		return trace.Wrap(err)
+func getClusterOperationPlanFunc(localEnv *localenv.LocalEnvironment, opKey ops.SiteOperationKey) fsm.GetPlanFunc {
+	return func() (*storage.OperationPlan, error) {
+		clusterEnv, err := localEnv.NewClusterEnvironment()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		plan, err := clusterEnv.Operator.GetOperationPlan(opKey)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return plan, nil
 	}
-	plan, err := clusterEnv.Operator.GetOperationPlan(opKey)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = outputPlan(*plan, format)
-	return trace.Wrap(err)
 }
 
-func displayUpdateOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey, format constants.Format) error {
-	updateEnv, err := environ.NewUpdateEnv()
+func displayClusterOperationPlan(localEnv *localenv.LocalEnvironment, opKey ops.SiteOperationKey, opts displayPlanOptions) error {
+	return outputOrFollowPlan(localEnv, getClusterOperationPlanFunc(localEnv, opKey), opts)
+}
+
+func getUpdateOperationPlanFunc(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey) fsm.GetPlanFunc {
+	return func() (*storage.OperationPlan, error) {
+		updateEnv, err := environ.NewUpdateEnv()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		plan, err := fsm.GetOperationPlan(updateEnv.Backend, opKey.SiteDomain, opKey.OperationID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		reconciledPlan, err := tryReconcilePlan(context.TODO(), localEnv, updateEnv, *plan)
+		if err != nil {
+			logrus.WithError(err).Warn("Failed to reconcile plan.")
+		} else {
+			plan = reconciledPlan
+		}
+		return plan, nil
+	}
+}
+
+func displayUpdateOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey, opts displayPlanOptions) error {
+	return outputOrFollowPlan(localEnv, getUpdateOperationPlanFunc(localEnv, environ, opKey), opts)
+}
+
+func getInstallOperationPlanFunc(opKey ops.SiteOperationKey) fsm.GetPlanFunc {
+	return func() (*storage.OperationPlan, error) {
+		plan, err := getPlanFromWizard(opKey)
+		if err == nil {
+			log.Debug("Showing install operation plan retrieved from wizard process.")
+			return plan, nil
+		}
+		return nil, trace.NotFound("could not retrieve plan from wizard process")
+	}
+}
+
+func displayInstallOperationPlan(localEnv *localenv.LocalEnvironment, opKey ops.SiteOperationKey, opts displayPlanOptions) error {
+	return outputOrFollowPlan(localEnv, getInstallOperationPlanFunc(opKey), opts)
+}
+
+func getExpandOperationPlanFunc(environ LocalEnvironmentFactory, opKey ops.SiteOperationKey) fsm.GetPlanFunc {
+	return func() (*storage.OperationPlan, error) {
+		joinEnv, err := environ.NewJoinEnv()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		defer joinEnv.Close()
+		plan, err := fsm.GetOperationPlan(joinEnv.Backend, opKey.SiteDomain, opKey.OperationID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		log.Debug("Showing join operation plan retrieved from local join backend.")
+		return plan, nil
+	}
+}
+
+// displayExpandOperationPlan shows plan of the join operation from the local join backend
+func displayExpandOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey, opts displayPlanOptions) error {
+	return outputOrFollowPlan(localEnv, getExpandOperationPlanFunc(environ, opKey), opts)
+}
+
+func outputOrFollowPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc, opts displayPlanOptions) error {
+	if !opts.follow {
+		return outputPlan(localEnv, getPlan, opts.format)
+	}
+	return followPlan(localEnv, getPlan)
+}
+
+func followPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eventsCh, err := fsm.FollowOperationPlan(ctx, getPlan)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	plan, err := fsm.GetOperationPlan(updateEnv.Backend, opKey.SiteDomain, opKey.OperationID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	reconciledPlan, err := tryReconcilePlan(context.TODO(), localEnv, updateEnv, *plan)
-	if err != nil {
-		logrus.WithError(err).Warn("Failed to reconcile plan.")
-	} else {
-		plan = reconciledPlan
-	}
-	err = outputPlan(*plan, format)
-	if err != nil {
-		return trace.Wrap(err)
+	// Iterate over updates received from the watcher. There are 2 stop
+	// conditions for the watch:
+	//  * Phase failed -> exit with error.
+	//  * Plan fully completed or rolled back -> exit without error.
+	for eventI := range eventsCh {
+		switch event := eventI.(type) {
+		case *fsm.PlanChanged:
+			localEnv.Printf("%v\t[%3v/%3v] Phase %v is %v\n",
+				color.BlueString(event.Change.Created.Format(constants.HumanDateFormatSeconds)),
+				event.Change.PhaseIndex+1,
+				event.Plan.Len(),
+				event.Change.PhaseID,
+				event.Change.NewState)
+			if event.Change.NewState == storage.OperationPhaseStateFailed {
+				return trace.Errorf(string(event.Change.Error.Err))
+			}
+		case *fsm.PlanFinished:
+			if fsm.IsCompleted(&event.Plan) {
+				localEnv.Printf("%v\t%v\n",
+					color.BlueString(time.Now().Format(constants.HumanDateFormatSeconds)),
+					color.GreenString("Operation plan is completed"))
+			} else if fsm.IsRolledBack(&event.Plan) {
+				localEnv.Printf("%v\t%v\n",
+					color.BlueString(time.Now().Format(constants.HumanDateFormatSeconds)),
+					color.GreenString("Operation plan is rolled back"))
+			}
+			return nil
+		}
 	}
 	return nil
 }
 
-func displayInstallOperationPlan(opKey ops.SiteOperationKey, format constants.Format) error {
-	plan, err := getPlanFromWizard(opKey)
-	if err == nil {
-		log.Debug("Showing install operation plan retrieved from wizard process.")
-		return trace.Wrap(outputPlan(*plan, format))
-	}
-	return trace.Wrap(outputPlan(*plan, format))
-}
-
-// displayExpandOperationPlan shows plan of the join operation from the local join backend
-func displayExpandOperationPlan(environ LocalEnvironmentFactory, opKey ops.SiteOperationKey, format constants.Format) error {
-	joinEnv, err := environ.NewJoinEnv()
+func outputPlan(localEnv *localenv.LocalEnvironment, getPlan fsm.GetPlanFunc, format constants.Format) (err error) {
+	plan, err := getPlan()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer joinEnv.Close()
-	plan, err := fsm.GetOperationPlan(joinEnv.Backend, opKey.SiteDomain, opKey.OperationID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	log.Debug("Showing join operation plan retrieved from local join backend.")
-	return outputPlan(*plan, format)
-}
-
-func outputPlan(plan storage.OperationPlan, format constants.Format) (err error) {
 	switch format {
 	case constants.EncodingYAML:
-		err = fsm.FormatOperationPlanYAML(os.Stdout, plan)
+		err = fsm.FormatOperationPlanYAML(localEnv, *plan)
 	case constants.EncodingJSON:
-		err = fsm.FormatOperationPlanJSON(os.Stdout, plan)
+		err = fsm.FormatOperationPlanJSON(localEnv, *plan)
 	case constants.EncodingText:
-		fsm.FormatOperationPlanText(os.Stdout, plan)
+		fsm.FormatOperationPlanText(localEnv, *plan)
 		err = explainPlan(plan.Phases)
 	case constants.EncodingShort:
-		fsm.FormatOperationPlanShort(os.Stdout, plan)
+		fsm.FormatOperationPlanShort(localEnv, *plan)
 		err = explainPlan(plan.Phases)
 	default:
 		return trace.BadParameter("unknown output format %q", format)

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -139,6 +139,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.PlanDisplayCmd.CmdClause = g.PlanCmd.Command("display", "Display a plan for an ongoing operation").Default()
 	g.PlanDisplayCmd.Output = common.Format(g.PlanDisplayCmd.Flag("output", "Output format for the plan, text, json or yaml").Short('o').Default(string(constants.EncodingText)))
+	g.PlanDisplayCmd.Follow = g.PlanDisplayCmd.Flag("tail", "Follow the operation plan progress until it finishes").Short('f').Bool()
 
 	g.PlanExecuteCmd.CmdClause = g.PlanCmd.Command("execute", "Execute specified operation phase")
 	g.PlanExecuteCmd.Phase = g.PlanExecuteCmd.Flag("phase", "Phase ID to execute").String()
@@ -152,6 +153,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.PlanResumeCmd.CmdClause = g.PlanCmd.Command("resume", "Resume last aborted operation")
 	g.PlanResumeCmd.PhaseTimeout = g.PlanResumeCmd.Flag("timeout", "Phase timeout").Default(defaults.PhaseTimeout).Hidden().Duration()
+	g.PlanResumeCmd.Block = g.PlanResumeCmd.Flag("block", "Launch plan resume in foreground instead of a systemd unit").Bool()
 
 	g.PlanCompleteCmd.CmdClause = g.PlanCmd.Command("complete", "Mark operation as completed")
 
@@ -189,6 +191,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.UpgradeCmd.Resume = g.UpgradeCmd.Flag("resume", "Resume upgrade from the last failed step").Bool()
 	g.UpgradeCmd.SkipVersionCheck = g.UpgradeCmd.Flag("skip-version-check", "Bypass version compatibility check").Hidden().Bool()
 	g.UpgradeCmd.DockerDevice = g.UpgradeCmd.Flag("docker-device", "Update Docker device in cluster state to the one specified").Hidden().String()
+	g.UpgradeCmd.Block = g.UpgradeCmd.Flag("block", "When resuming the upgrade plan, launch it in foreground instead of a systemd unit").Bool()
 
 	g.UpdateUploadCmd.CmdClause = g.UpdateCmd.Command("upload", "Upload update package to locally running site").Hidden()
 	g.UpdateUploadCmd.OpsCenterURL = g.UpdateUploadCmd.Flag("ops-url", "Optional OpsCenter URL to upload new packages to (defaults to local gravity site)").Default(defaults.GravityServiceURL).String()

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -169,6 +169,7 @@ type updater interface {
 	RunPhase(ctx context.Context, phase string, phaseTimeout time.Duration, force bool) error
 	RollbackPhase(ctx context.Context, params fsm.Params, phaseTimeout time.Duration) error
 	Complete(error) error
+	Check(params fsm.Params) error
 }
 
 func clusterStateFromPlan(plan storage.OperationPlan) (result storage.ClusterState) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This pull requests implements a couple of resiliency improvements for the `plan resume` command. The main issue was that users would often launch it and lose SSH connection (esp. relevant if launching from our web UI's terminal) which would basically terminate the resume since it executes in foreground.

* Update `gravity plan resume` to launch resume from a one-shot systemd service by default.
  * It also accepts `--block` flag for the old behavior to run in foreground.
* Add `gravity plan --tail` to be able to monitor plan progress.
  * This is useful not just for resume but in general for watching the plan.
  * Tail will exit with 0 if plan completes successfully, and non-0 if a phase completes with an error.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Refs https://github.com/gravitational/gravity/issues/1807, refs https://github.com/gravitational/gravity/issues/841.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Resume in background (now default)

```
ubuntu@node-1:~/upgrade$ sudo ./upload
Wed Jul 22 01:10:36 UTC	Importing cluster image telekube v5.5.50-dev.8
Wed Jul 22 01:11:15 UTC	Synchronizing application with Docker registry 192.168.99.102:5000
Wed Jul 22 01:11:35 UTC	Verifying cluster health
Wed Jul 22 01:11:35 UTC	Cluster image has been uploaded
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Wed Jul 22 01:12:04 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.8
Wed Jul 22 01:12:04 UTC	Deploying agents on cluster nodes
Wed Jul 22 01:12:08 UTC	Deployed agent on node-1 (192.168.99.102)
The operation has been created in manual mode.

See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.
ubuntu@node-1:~/upgrade$ sudo ./gravity plan resume --help
usage: gravity plan resume [<flags>]

Resume last aborted operation

Flags:
      --help                 Show context-sensitive help (also try --help-long and --help-man).
      --debug                Enable debug mode
  -q, --quiet                Suppress any extra output to stdout
      --insecure             Skip TLS verification
      --state-dir=STATE-DIR  Directory for local state
      --log-file="/var/log/gravity-install.log"
                             log file with diagnostic information
      --operation-id=OPERATION-ID
                             ID of the active operation. If not specified, the last operation will be used
      --block                Launch plan resume in foreground instead of a systemd unit

ubuntu@node-1:~/upgrade$ sudo ./gravity plan resume
Wed Jul 22 01:12:23 UTC	Starting gravity-resume.service service
Wed Jul 22 01:12:23 UTC	Service gravity-resume.service has been launched.

To monitor the operation progress:

  sudo gravity plan --operation-id=d6d43cae-edcd-49e7-b056-cb1a9f50ffed --tail

To monitor the service logs:

  sudo journalctl -u gravity-resume.service -f

ubuntu@node-1:~/upgrade$ sudo ./gravity plan --operation-id=d6d43cae-edcd-49e7-b056-cb1a9f50ffed --tail
Wed Jul 22 01:12:25 UTC	[  1/ 26] Phase /init/node-1 is completed
Wed Jul 22 01:12:26 UTC	[  2/ 26] Phase /checks is completed
Wed Jul 22 01:12:27 UTC	[  3/ 26] Phase /pre-update is in_progress
Wed Jul 22 01:12:33 UTC	[  3/ 26] Phase /pre-update is completed
Wed Jul 22 01:12:33 UTC	[  4/ 26] Phase /bootstrap/node-1 is in_progress
...
Wed Jul 22 01:18:07 UTC	[ 26/ 26] Phase /gc/node-1 is in_progress
Wed Jul 22 01:18:08 UTC	[ 26/ 26] Phase /gc/node-1 is completed
Wed Jul 22 01:18:09 UTC	Operation plan is completed
```

### Resume blocking (old behavior)

```
ubuntu@node-1:~/upgrade$ sudo ./upload
Wed Jul 22 01:31:33 UTC	Importing cluster image telekube v5.5.50-dev.8
Wed Jul 22 01:32:18 UTC	Synchronizing application with Docker registry 192.168.99.102:5000
Wed Jul 22 01:32:36 UTC	Verifying cluster health
Wed Jul 22 01:32:36 UTC	Cluster image has been uploaded
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Wed Jul 22 01:32:41 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.8
Wed Jul 22 01:32:41 UTC	Deploying agents on cluster nodes
Wed Jul 22 01:32:45 UTC	Deployed agent on node-1 (192.168.99.102)
The operation has been created in manual mode.

See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details on working with operation plan.
ubuntu@node-1:~/upgrade$ sudo ./gravity plan resume --block
Wed Jul 22 01:32:52 UTC	Executing "/init/node-1" locally
Wed Jul 22 01:32:53 UTC	initializing the operation
Wed Jul 22 01:32:53 UTC	Executing "/checks" locally
Wed Jul 22 01:32:55 UTC	Executing "/pre-update" locally
Wed Jul 22 01:33:01 UTC	Executing "/bootstrap/node-1" locally
	Still executing "/bootstrap/node-1" locally (10 seconds elapsed)
...
Wed Jul 22 01:37:57 UTC	Executing "/migration/labels" locally
Wed Jul 22 01:37:58 UTC	Executing "/app/telekube" locally
Wed Jul 22 01:37:59 UTC	Executing "/gc/node-1" locally
Wed Jul 22 01:38:00 UTC	operation(update(b95dcc7c-29c6-48f8-8f4e-a47a14abd018), cluster=test, created=2020-07-22 01:32) finished in 5 minutes
```