### PR TITLE
Added test for log forwarder surviving upgrades

### DIFF
--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -548,6 +548,7 @@ Execute `gravity gc`.
 
   Log forwarder settings
   - [ ] Verify that Creating/Deleting/Editing a log forwarder works.
+  - [ ] Verify that after creating a log forwarder resource, it survive upgrades.
 
 #### Audit Logs
 - [ ] Verify that Audit events of different types are shown.

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -62,12 +62,13 @@ spec:
   - [ ] Verify can log into local cluster UI using the user created above.
   - [ ] Verify can join a node using CLI (`gravity join`).
   - [ ] Verify can remove a node using CLI (`gravity leave`).
-
+  - [ ] Verify can create a log forwarder resource via CLI
 #### UI mode
 
 - [ ] Install Telekube cluster image in standalone UI wizard mode.
   - [ ] Verify can complete bandwagon through wizard UI.
   - [ ] Verify can log into local cluster UI with the user created in bandwagon.
+  - [ ] Verify can create a log forwarder resource via WEB UI
 
 #### With Cluster Image Downloaded From The Hub
 
@@ -846,3 +847,4 @@ app.manifest.extensions.logs.disabled: true
 ```
   - [ ] Verify that K8s tab is displayed.
   - [ ] Verify that Nodes screen displays K8s labels.
+i

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -134,6 +134,7 @@ spec:
 
 - [ ] Install a 1-node cluster of previous LTS version.
 - [ ] Upgrade the cluster to the current version.
+  - [ ] Verify that after customizing the log forwarder resource, changes survive the upgrade.
 - [ ] Join another node to the cluster.
   - [ ] Verify the node joined successfully.
 
@@ -548,7 +549,6 @@ Execute `gravity gc`.
 
   Log forwarder settings
   - [ ] Verify that Creating/Deleting/Editing a log forwarder works.
-  - [ ] Verify that after creating a log forwarder resource, it survive upgrades.
 
 #### Audit Logs
 - [ ] Verify that Audit events of different types are shown.


### PR DESCRIPTION
Updated test for log forwarder surviving upgrades

## Description
Added a single line of test to verify that log forwarder ConfigMap survives through upgrades.

## Linked tickets and other PRs
https://github.com/gravitational/gravity/issues/1681