### PR TITLE
[7.0.x] minor fixes

### DIFF
--- a/lib/app/hooks/diff.go
+++ b/lib/app/hooks/diff.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // diffPodSets returns a difference in Pods between existing and new.
@@ -126,14 +127,15 @@ func (p *podDiff) String() string {
 	return out.String()
 }
 
-func describe(v interface{}) string {
-	switch val := v.(type) {
+func describe(obj runtime.Object) string {
+	switch obj := obj.(type) {
 	case *v1.Pod:
-		return fmt.Sprintf("Pod %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Pod %q in namespace %q", obj.Name, obj.Namespace)
 	case *batchv1.Job:
-		return fmt.Sprintf("Job %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Job %q in namespace %q", obj.Name, obj.Namespace)
+	default:
+		return fmt.Sprintf("<unknown>")
 	}
-	return "<unknown>"
 }
 
 type phaseDiff struct {

--- a/lib/app/hooks/diff.go
+++ b/lib/app/hooks/diff.go
@@ -133,9 +133,8 @@ func describe(obj runtime.Object) string {
 		return fmt.Sprintf("Pod %q in namespace %q", obj.Name, obj.Namespace)
 	case *batchv1.Job:
 		return fmt.Sprintf("Job %q in namespace %q", obj.Name, obj.Namespace)
-	default:
-		return fmt.Sprintf("<unknown>")
 	}
+	return "<unknown>"
 }
 
 type phaseDiff struct {

--- a/lib/app/hooks/hooks.go
+++ b/lib/app/hooks/hooks.go
@@ -300,7 +300,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 	err := r.checkJob(ctx, &job, &jobControl, podSet, w)
 	diff := humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 	if err == nil {
-		fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+		fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 		return nil
 	}
 	log.Debugf("%v: %v", diff, err)
@@ -316,7 +316,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 			diff = humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 			err = r.checkJob(ctx, &job, &jobControl, podSet, w)
 			if err == nil {
-				fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+				fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 				return nil
 			}
 			log.Debugf("%v: %v", diff, err)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -355,7 +355,7 @@ const (
 	SerfBin = "/usr/bin/serf"
 
 	// JournalctlBin is the default location of the journalctl inside planet
-	JournalctlBin = "/usr/bin/journalctl"
+	JournalctlBin = "/bin/journalctl"
 
 	// JournalctlBinHost is the default location of the journalctl on host
 	JournalctlBinHost = "/bin/journalctl"

--- a/lib/rpc/server/callable.go
+++ b/lib/rpc/server/callable.go
@@ -22,7 +22,6 @@ import (
 	"syscall"
 
 	pb "github.com/gravitational/gravity/lib/rpc/proto"
-	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -40,7 +39,6 @@ func osExec(ctx context.Context, stream pb.OutgoingMessageStream, args []string,
 }
 
 // exec executes the command specified with args streaming stdout/stderr to stream
-// TODO: separate RPC failures (like failure to send messages to the stream) from command errors
 func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, args []string, log log.FieldLogger) error {
 	seq := atomic.AddInt32(&c.seq, 1)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
@@ -52,24 +50,10 @@ func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, a
 		return trace.Wrap(err, "failed to start").AddField("path", cmd.Path)
 	}
 
-	err = stream.Send(&pb.Message{Element: &pb.Message_ExecStarted{ExecStarted: &pb.ExecStarted{
-		Args: args,
-		Seq:  seq,
-	}}})
-	if err != nil {
-		log.WithError(err).Warn("Failed to notify stream of command start.")
-	}
+	notifyAndLogError(stream, newCommandStartedEvent(seq, args))
 	err = cmd.Wait()
 	if err == nil {
-		if err := stream.Send(&pb.Message{
-			Element: &pb.Message_ExecCompleted{
-				ExecCompleted: &pb.ExecCompleted{
-					Seq: seq,
-				},
-			},
-		}); err != nil {
-			log.WithError(err).Warn("Failed to notify stream of command completion.")
-		}
+		notifyAndLogError(stream, newCommandCompletedEvent(seq))
 		return nil
 	}
 
@@ -80,14 +64,47 @@ func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, a
 		}
 	}
 
-	if err := stream.Send(&pb.Message{Element: &pb.Message_ExecCompleted{ExecCompleted: &pb.ExecCompleted{
-		Seq:      seq,
-		ExitCode: int32(exitCode),
-		Error:    pb.EncodeError(trace.Wrap(err)),
-	}}}); err != nil {
-		log.WithError(err).Warn("Failed to notify stream of command completion with error.")
+	notifyAndLogError(stream, newCommandCompletedWithErrorEvent(seq, int32(exitCode), err))
+	return trace.Wrap(err)
+}
+
+func notifyAndLogError(stream pb.OutgoingMessageStream, msg *pb.Message) {
+	if err := stream.Send(msg); err != nil {
+		log.WithError(err).Warn("Failed to notify stream.")
 	}
-	return utils.NewExitCodeError(exitCode)
+}
+
+func newCommandStartedEvent(seq int32, args []string) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecStarted{
+			ExecStarted: &pb.ExecStarted{
+				Args: args,
+				Seq:  seq,
+			},
+		},
+	}
+}
+
+func newCommandCompletedEvent(seq int32) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecCompleted{
+			ExecCompleted: &pb.ExecCompleted{
+				Seq: seq,
+			},
+		},
+	}
+}
+
+func newCommandCompletedWithErrorEvent(seq, exitCode int32, err error) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecCompleted{
+			ExecCompleted: &pb.ExecCompleted{
+				Seq:      seq,
+				ExitCode: exitCode,
+				Error:    pb.EncodeError(err),
+			},
+		},
+	}
 }
 
 type osCommand struct {

--- a/lib/rpc/server/callable.go
+++ b/lib/rpc/server/callable.go
@@ -70,7 +70,7 @@ func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, a
 
 func notifyAndLogError(stream pb.OutgoingMessageStream, msg *pb.Message) {
 	if err := stream.Send(msg); err != nil {
-		log.WithError(err).Warn("Failed to notify stream.")
+		log.WithError(err).Warnf("Failed to notify stream: %v.", msg)
 	}
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR fixes the following issues:
  * annotate errors for each etcd step (i.e invocation of `planet etcd`)  with command output for better visibility.
  * when executing a command for the remote caller, the command execution has precedence over streaming gRPC events. So when a command fails, exec should relay this error consistently.
  * when describing hook jobs in logs, avoid use of naked `interface{}` values to catch type violations.

These are some things I stumbled upon when working on intermediate upgrades port and I wanted to PR separately.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
Updates https://github.com/gravitational/gravity/issues/1732

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
The changes were tested as part of a bigger changeset and involved upgrading `5.5.49` to a working intermediate upgrades branch via `6.1.31` as intermediary on 3 controller plane node cluster and a 3 node cluster with a single controller and 2 worker nodes.

