### PR TITLE
(5.5) Add tiller server pre-check

### DIFF
--- a/lib/helm/client.go
+++ b/lib/helm/client.go
@@ -258,6 +258,7 @@ func Ping(dnsAddress string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer client.Close()
 	return client.Ping()
 }
 

--- a/lib/helm/client.go
+++ b/lib/helm/client.go
@@ -228,10 +228,24 @@ func (c *Client) Revisions(name string) ([]Release, error) {
 	return releases, nil
 }
 
+// Ping pings the Tiller pod and ensures it's up and running.
+func (c *Client) Ping() error {
+	return c.client.PingTiller()
+}
+
 // Close closes the Helm client.
 func (c *Client) Close() error {
 	c.tunnel.Close()
 	return nil
+}
+
+// Ping pings the cluster's Tiller pod and ensures it's up and running.
+func Ping(dnsAddress string) error {
+	client, err := NewClient(ClientConfig{DNSAddress: dnsAddress})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return client.Ping()
 }
 
 // getKubeClient returns a cluster's Kubernetes client and its config.

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -385,6 +385,11 @@ func (m Manifest) FirstNodeProfileName() (string, error) {
 	return profile.Name, nil
 }
 
+// CatalogDisabled returns true if the application catalog feature is disabled.
+func (m Manifest) CatalogDisabled() bool {
+	return m.Extensions != nil && m.Extensions.Catalog != nil && m.Extensions.Catalog.Disabled
+}
+
 // Header is manifest header
 type Header struct {
 	metav1.TypeMeta

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/helm"
 	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/localenv"
@@ -44,6 +45,7 @@ import (
 
 	"github.com/buger/goterm"
 	"github.com/coreos/go-semver/semver"
+	"github.com/fatih/color"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/version"
 )
@@ -359,7 +361,37 @@ func (r *clusterInitializer) validatePreconditions(localEnv *localenv.LocalEnvir
 	if err := r.checkDockerDevice(cluster, operator); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := r.checkTiller(localEnv, updateApp.Manifest); err != nil {
+		return trace.Wrap(err)
+	}
 	r.updateLoc = updateApp.Package
+	return nil
+}
+
+// checkTiller verifies tiller server health before kicking off upgrade.
+func (r *clusterInitializer) checkTiller(env *localenv.LocalEnvironment, manifest schema.Manifest) error {
+	if manifest.CatalogDisabled() {
+		log.Info("Tiller server is disabled, not checking its health.")
+		return nil
+	}
+	err := helm.Ping(env.DNS.Addr())
+	if err != nil {
+		log.WithError(err).Error("Failed to ping tiller pod.")
+		if r.force {
+			env.PrintStep(color.YellowString(`Tiller server health check failed, "helm upgrade" may not work!`))
+			return nil
+		}
+		return trace.BadParameter(`Tiller server health check failed with the following error:
+
+    %q
+
+This means that "helm upgrade" and other Helm commands may not work correctly. If
+the application upgrade requires Helm, make sure that Tiller pod is up, running
+and reachable before retrying the upgrade.
+
+This warning can be bypassed by providing a --force flag to the upgrade command.`, err)
+	}
+	log.Info("Tiller server ping success.")
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Add a pre-upgrade check that makes sure that Tiller server is up and running and alerts the user if it's not, otherwise they might run into issues later when their application upgrade tries to do helm upgrade.

The pre-check can be bypassed by providing a `--force` flag, as other warnings (which may be useful if, for example, Tiller is down for some reason by the user doesn't care since the application doesn't need it). In this case the warning will still be printed to the terminal.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/1905.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Scale tiller to 0 and try to launch the upgrade:

```
ubuntu@node-1:~/upgrade$ kubectl -nkube-system scale deploy tiller-deploy --replicas=0
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Thu Jul 23 22:47:19 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.9
[ERROR]: Tiller server health check failed with the following error:

    "could not find tiller"

This means that "helm upgrade" and other Helm commands may not work correctly. If
the application upgrade requires Helm, make sure that Tiller pod is up, running
and reachable before retrying the upgrade.

This warning can be bypassed by providing a --force flag to the upgrade command.
```

### Try to launch with --force and see a warning

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual --force
Thu Jul 23 22:48:24 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.9
Thu Jul 23 22:48:24 UTC	Tiller server health check failed, "helm upgrade" may not work!
Thu Jul 23 22:48:25 UTC	Deploying agents on cluster nodes
Thu Jul 23 22:48:28 UTC	Deployed agent on node-1 (192.168.99.102)
```

### Scale it back and verify upgrade launches fine

```
ubuntu@node-1:~/upgrade$ kubectl -nkube-system scale deploy tiller-deploy --replicas=1
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Thu Jul 23 22:50:18 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.9
Thu Jul 23 22:50:18 UTC	Deploying agents on cluster nodes
Thu Jul 23 22:50:21 UTC	Deployed agent on node-1 (192.168.99.102)
```

### Disable catalog and verify tiller is not checked

```yaml
extensions:
  catalog:
    disabled: true
```

```
ubuntu@node-1:~/upgrade$ kubectl -nkube-system scale deploy tiller-deploy --replicas=0
ubuntu@node-1:~/upgrade$ sudo ./gravity --debug upgrade --manual
Thu Jul 23 22:56:00 UTC	Upgrading cluster from 5.5.40 to 5.5.50-dev.9
Thu Jul 23 22:56:00 UTC	Deploying agents on cluster nodes
Thu Jul 23 22:56:02 UTC	Deployed agent on node-1 (192.168.99.102)
```