### PR TITLE
Increase precedence of CentOS:7 testing, pin 7.0.13.

### DIFF
--- a/build.assets/robotest/nightly_config.sh
+++ b/build.assets/robotest/nightly_config.sh
@@ -8,19 +8,22 @@ source $(dirname $0)/utils.sh
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7 debian:9 ubuntu:18" # compatible LTS version
-UPGRADE_MAP[7.0.12]="ubuntu:16"  # 7.0.12 is the first LTS 7.0 release
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7 redhat:7 debian:9 ubuntu:18" # compatible LTS version
+UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
+UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.0]="ubuntu:16"
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="redhat:7" # compatible non-LTS version
+
+# 6.2 and 6.3 won't be supported upgrades to 7.1, but they're not *intentionally* broken yet
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7" # compatible non-LTS version
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="redhat:7" # compatible non-LTS version
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="centos:7" # compatible non-LTS version
 UPGRADE_MAP[6.2.0]="ubuntu:16"
 
 UPGRADE_VERSIONS=${!UPGRADE_MAP[@]}
 
 function build_upgrade_size_suite {
   local from_tarball=/$(tag_to_tarball $(recommended_upgrade_tag $(branch 7.0.x)))
-  local os="redhat:7"
+  local os="centos:7"
   local cluster_sizes=( \
     '"flavor":"three","nodes":3,"role":"node"' \
     '"flavor":"six","nodes":6,"role":"node"' \
@@ -75,7 +78,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local test_os="redhat:7 debian:9 ubuntu:16 ubuntu:18"
+  local test_os="redhat:7 centos:7 debian:9 ubuntu:16 ubuntu:18"
   local cluster_sizes=( \
     '"flavor":"three","nodes":3,"role":"node"' \
     '"flavor":"six","nodes":6,"role":"node"')

--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -7,8 +7,9 @@ source $(dirname $0)/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="ubuntu:18" # compatible LTS version
-UPGRADE_MAP[7.0.12]="ubuntu:16"  # 7.0.12 is the first LTS 7.0 release
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7" # compatible LTS version
+UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
+UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
 # UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
 
@@ -17,6 +18,7 @@ UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 # UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="redhat:7" # compatible non-LTS version
 # UPGRADE_MAP[6.2.0]="ubuntu:16"
+
 
 UPGRADE_VERSIONS=${!UPGRADE_MAP[@]}
 
@@ -53,7 +55,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local test_os="redhat:7"
+  local test_os="centos:7"
   local cluster_size='"flavor":"three","nodes":3,"role":"node"'
   suite+=$(cat <<EOF
  install={${cluster_size},"os":"${test_os}","storage_driver":"overlay2"}


### PR DESCRIPTION
## Description
After discussions with heavy users of Gravity 6.3.x and 7.0.x, we want
to do more CentOS:7 testing (and 8, but it isn't available without
https://github.com/gravitational/robotest/issues/258).

Thus we replace several ubuntu/redhat scenarios in PR builds with CentOS
versions of the same thing.

Furthermore, testing 7.0.13 upgrades with CentOS is particularly
important to our field usage, so this version is pinned.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
N/A - This came from a request from a signifigant user, and didn't merit an issue of its own.

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Audit automated results
- [x] Address review feedback

## Testing done
I generated the configs before & after with a command like:

```
walt@work:~/git/gravity$ ./build.assets/robotest/pr_config.sh | sort > pr.after                                                                                                               
```
I then diffed the changes. PR:
```
walt@work:~/git/gravity$ diff pr.before pr.after                                                                                                                                              
1c1                                                                                                                                                                                           
< install={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","storage_driver":"overlay2"}                                                                                              
---                                                                                                                                                                                           
> install={"flavor":"three","nodes":3,"role":"node","os":"centos:7","storage_driver":"overlay2"}                                                                                              
5c5                                                                                                                                                                                           
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}                           
---                                                                                                                                                                                           
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"centos:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}                            
7c7                                                                                                                                                                                           
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}                           
---                                                                                                                                                                                           
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}                           
```
Nightly:
```
walt@work:~/git/gravity$ diff nightly.before nightly.after                   
0a1
> install={"flavor":"six","nodes":6,"role":"node","os":"centos:7","storage_driver":"overlay2"}
4a6
> install={"flavor":"three","nodes":3,"role":"node","os":"centos:7","storage_driver":"overlay2"}
13,14c15,19
< upgrade={"flavor":"one","nodes":1,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
< upgrade={"flavor":"six","nodes":6,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
---
> upgrade={"flavor":"one","nodes":1,"role":"node","os":"centos:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
> upgrade={"flavor":"six","nodes":6,"role":"node","os":"centos:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"centos:7","from":"/telekube_6.2.5.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"centos:7","from":"/telekube_6.3.18.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"centos:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
16,19d20
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"debian:9","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_6.2.5.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_6.3.18.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
22,23c23
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
< upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
---
> upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
```
