### PR TITLE
Remove `~jenkins/.gravity/config` shared state from robotest

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -46,9 +46,8 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR
-$tele logout
 for release in ${!UPGRADE_MAP[@]}; do
-  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar
+  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest
 done
 
 docker pull $ROBOTEST_REPO


### PR DESCRIPTION
## Description
This PR replaces a `tele logout` with a custom `--state-directory` to achieve the same effect.

## Context
In this Gravity 6.1.32  Jenkins publish job, we saw publishing fail with the following error:

```
----> Publishing Gravity to https://get.gravitational.io...
/tmp/tmp.vfPmgoL1D0/gravity/e//build/6.1.32/gravity package delete --ops-url=https://get.gravitational.io  --force gravitational.io/gravity_linux_x86_64:6.1.32 && /tmp/tmp.vfPmgoL1D0/gravity/e//build/6.1.32/gravity package import --ops-url=https://get.gravitational.io  /tmp/tmp.vfPmgoL1D0/gravity/e//build/6.1.32/gravity gravitational.io/gravity_linux_x86_64:6.1.32
\u001b[31m[ERROR]: access denied to perform action 'delete' on repository
```

This is because several different parts of the build/release process rely on `~jenkins/.gravity/config`. Some want to be logged out (robotest), and some logged in (publishing artifacts). Exacerbating the issue, different builds on the same executor all share this single file leading to highly racy behavior.  This has been a theoretical risk since ce93812c3edcd4095afbf03373afad3841cd1750, but was moved from theoretical to practical by https://github.com/gravitational/gravity/pull/1890 and ports.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Fixes a release automation regression introduced in #1890 and ports.

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [ ] Delete uploaded test artifacts

## Testing done
From a previous version of the PR:
<details><summary><code>make publish-telekube</code></summary>

```
walt@work:~/git/gravity$ make publish-telekube   
make -C build.assets publish-telekube
make[1]: Entering directory '/home/walt/git/gravity/build.assets'
// snip build stuff ...
if [ -z "redacted" ] || [ -z "https://get.gravitational.io" ]; then \
   echo "TELE_KEY or DISTRIBUTION_OPSCENTER are not set"; exit 1; \
fi;
tele login --ops https://get.gravitational.io --key=redacted --state-dir=/home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish
Ops Center:     get.gravitational.io
Username:       meta@gravitational.io
Cluster:        N/A
Expires:        Never
-e 
----> Publishing Gravity to https://get.gravitational.io...

/home/walt/git/gravity//build/7.1.0-alpha.1.147/gravity package delete --ops-url=https://get.gravitational.io --state-dir=/home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish --force gravitational.io/gravity_linux_x86_64:7.1.0-alpha.1.147 && \
/home/walt/git/gravity//build/7.1.0-alpha.1.147/gravity package import --ops-url=https://get.gravitational.io --state-dir=/home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish /home/walt/git/gravity//build/7.1.0-alpha.1.147/gravity gravitational.io/gravity_linux_x86_64:7.1.0-alpha.1.147
gravitational.io/gravity_linux_x86_64:7.1.0-alpha.1.147 imported: gravitational.io/gravity_linux_x86_64:7.1.0-alpha.1.147 97MB
-e 
----> Publishing Tele to https://get.gravitational.io...

/home/walt/git/gravity//build/7.1.0-alpha.1.147/gravity package delete --ops-url=https://get.gravitational.io --state-dir=/home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish --force gravitational.io/tele_linux_x86_64:7.1.0-alpha.1.147 && \
/home/walt/git/gravity//build/7.1.0-alpha.1.147/gravity package import --ops-url=https://get.gravitational.io --state-dir=/home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish /home/walt/git/gravity//build/7.1.0-alpha.1.147/tele gravitational.io/tele_linux_x86_64:7.1.0-alpha.1.147
gravitational.io/tele_linux_x86_64:7.1.0-alpha.1.147 imported: gravitational.io/tele_linux_x86_64:7.1.0-alpha.1.147 75MB
// snip ...
walt@work:~/git/gravity$ cat /home/walt/git/gravity//build/7.1.0-alpha.1.147/.publish/config
current: https://get.gravitational.io:443
opscenters:
- email: meta@gravitational.io
  token: redacted
  opscenter: https://get.gravitational.io:443
  expires: 0001-01-01T00:00:00Z
  account_id: 00000000-0000-0000-0000-000000000001
```

I will delete these test artifacts after this PR merges.
</details>

Relevant to the current change.
<details><summary><code>make robotest-run-suite</code></summary>

```
walt@work:~/git/gravity$ make robotest-run-suite
./build.assets/robotest/run.sh pr /home/walt/git/gravity/upgrade_from
install={"flavor":"three","nodes":3,"role":"node","os":"redhat:7","storage_driver":"overlay2"}
install={"installer_url":"/installer/opscenter.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.7.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","from":"/telekube_7.0.13.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","from":"/telekube_7.0.12.tar","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
Wed Jul 29 19:54:20 UTC Downloading telekube:7.0.7
```
</details>

## Additional information
I will backport this to 7.0, 6.1, and 5.5 once it is vetted. Publishing on those branches may be impacted until they get the fix.

The backports will also need to cover `make publish-artifacts`.

https://github.com/gravitational/gravity/blob/8647231397078e9e796df9556a33f2e5a682c269/Makefile#L499-L505

Not all branches support the `--hub` and `--token` syntax on `tele push` and thus may require a state dir & login.
