### PR TITLE
(5.5) Add command for updating teleport node auth servers

### DIFF
--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -248,6 +248,8 @@ type Application struct {
 	SystemTeleportMasterTokenCmd SystemTeleportMasterTokenCmd
 	// SystemTeleportNodeTokenCmd updates Teleport node auth token
 	SystemTeleportNodeTokenCmd SystemTeleportNodeTokenCmd
+	// SystemTeleportAuthServersCmd updates Teleport node auth servers
+	SystemTeleportAuthServersCmd SystemTeleportAuthServersCmd
 	// SystemRotateCertsCmd renews cluster certificates on local node
 	SystemRotateCertsCmd SystemRotateCertsCmd
 	// SystemRotateRPCCredsCmd renews cluster RPC credentials
@@ -1413,6 +1415,15 @@ type SystemTeleportNodeTokenCmd struct {
 	Package *string
 	// Token is the auth token to set
 	Token *string
+}
+
+// SystemTeleportAuthServersCmd updates Teleport node auth servers
+type SystemTeleportAuthServersCmd struct {
+	*kingpin.CmdClause
+	// Package is the Teleport node config package
+	Package *string
+	// AuthServers is a list of auth servers to set in the config
+	AuthServers *[]string
 }
 
 // SystemRotateCertsCmd renews cluster certificates on local node

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -601,6 +601,9 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemTeleportNodeTokenCmd.CmdClause = g.SystemTeleportCmd.Command("set-node-token", "Set auth token in Teleport node config")
 	g.SystemTeleportNodeTokenCmd.Package = g.SystemTeleportNodeTokenCmd.Flag("package", "Package with Teleport node config. Provide 'node' to try and auto-detect package").Required().String()
 	g.SystemTeleportNodeTokenCmd.Token = g.SystemTeleportNodeTokenCmd.Flag("token", "Auth token to set").Required().String()
+	g.SystemTeleportAuthServersCmd.CmdClause = g.SystemTeleportCmd.Command("set-auth-servers", "Set auth servers in Teleport node config")
+	g.SystemTeleportAuthServersCmd.Package = g.SystemTeleportAuthServersCmd.Flag("package", "Package with Teleport node config. Provide 'node' to try and auto-detect package").Default("node").String()
+	g.SystemTeleportAuthServersCmd.AuthServers = g.SystemTeleportAuthServersCmd.Flag("auth-server", "Auth servers to set").Required().Strings()
 
 	g.SystemRotateCertsCmd.CmdClause = g.SystemCmd.Command("rotate-certs", "Renew cluster certificates on a node").Hidden()
 	g.SystemRotateCertsCmd.ClusterName = g.SystemRotateCertsCmd.Arg("cluster-name", "Name of the local cluster").String()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -792,6 +792,10 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		return updateTeleportNodeToken(localEnv,
 			*g.SystemTeleportNodeTokenCmd.Package,
 			*g.SystemTeleportNodeTokenCmd.Token)
+	case g.SystemTeleportAuthServersCmd.FullCommand():
+		return updateTeleportNodeAuthServers(localEnv,
+			*g.SystemTeleportAuthServersCmd.Package,
+			*g.SystemTeleportAuthServersCmd.AuthServers)
 	case g.SystemReinstallCmd.FullCommand():
 		return systemReinstall(localEnv,
 			*g.SystemReinstallCmd.Package,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Add a system CLI command for manipulating another part of teleport configuration - auth servers, to provide a manual recovery way for https://github.com/gravitational/gravity/issues/1515.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/1943.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Write documentation
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Install a cluster. Check teleport config:

```
ubuntu@node-1:~/installer$ sudo gravity system teleport show-config --package=node
Using Teleport node config from test/teleport-node-config-19216899102test:3.0.5
teleport:
  ...
  auth_servers:
  - 127.0.0.1:3025
  - 192.168.99.102:3025
  ...
```

Update auth servers:

```
ubuntu@node-1:~/installer$ sudo gravity system teleport set-auth-servers --auth-server=192.168.99.103
Using Teleport node config from test/teleport-node-config-19216899102test:3.0.5
Teleport node auth servers updated. Please restart Teleport service using 'sudo systemctl restart *teleport*'
```

Check config again and make sure new auth server is there:

```
ubuntu@node-1:~/installer$ sudo gravity system teleport show-config --package=node
Using Teleport node config from test/teleport-node-config-19216899102test:3.0.5
teleport:
  ...
  auth_servers:
  - 127.0.0.1:3025
  - 192.168.99.102:3025
  - 192.168.99.103:3025
  ...
```

## Additional information
<!--Optional. Anything else that may be relevant.-->

Will also need to write a KB article for this.