### PR TITLE
Move 6.1.32 notes to 6.1.33

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -7,7 +7,7 @@ Find the latest Open Source Gravity releases at [Gravity Downloads](https://grav
 | Version             | Latest Patch | LTS | Release Date         | End of Support *        | Kubernetes Version   | Teleport Version |
 | ------------------- | ------------ | --- | -------------------- | ----------------------- | -------------------- | ---------------- |
 | [7.0](#70-releases) | 7.0.13       | Yes | April 3, 2020        | July 9, 2022            | 1.17.9               | 3.2.13           |
-| [6.1](#61-releases) | 6.1.32       | Yes | August 2, 2019       | November 10, 2021       | 1.15.12              | 3.2.12           |
+| [6.1](#61-releases) | 6.1.33       | Yes | August 2, 2019       | November 10, 2021       | 1.15.12              | 3.2.12           |
 | [5.5](#55-releases) | 5.5.49       | Yes | March 8, 2019        | March 8, 2021           | 1.13.11              | 3.0.6-gravity    |
 
 Gravity offers one Long Term Support (LTS) version for every 2nd Kubernetes
@@ -529,7 +529,7 @@ to learn how to gain insight into how the cluster status changes over time.
 
 ## 6.1 Releases
 
-### 6.1.32 LTS (July 28th, 2020)
+### 6.1.33 LTS (July 30th, 2020)
 
 #### Improvements
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

6.1.32 went out with an older version of planet, 6.1.33 is being published now with the correct version.

Also, update e reference - it was out of date.