### PR TITLE
(7.0) Remove `~jenkins/.gravity/config` shared state from robotest

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -46,9 +46,8 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR
-$tele logout
 for release in ${!UPGRADE_MAP[@]}; do
-  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar
+  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest
 done
 
 docker pull $ROBOTEST_REPO


### PR DESCRIPTION
## Description
Port of https://github.com/gravitational/gravity/pull/1941.  This needs to be in all branches, since all branches presently share `~jenkins/.gravity`.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Ports https://github.com/gravitational/gravity/pull/1941.

## TODOs
- [x] Self-review the change
- [ ] Perform manual testing
- [x] Address review feedback

## Testing done
None for this port.  See original PR for testing & discussion.
