### PR TITLE
[5.5.x] Fix failed mac build due to undefined KernelVersion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -876,7 +876,7 @@
   revision = "2e451040dbe9def043beba737d92a6b773bbd3f2"
 
 [[projects]]
-  digest = "1:240d1f24322224c8e8fd6f4e73bb78fb105b7c85f75784c1fc2eb4f1ead83c34"
+  digest = "1:5a44491633f3870ec6b38b60d2ef7b2370c84bf227385d41720f9fc2aded1234"
   name = "github.com/gravitational/satellite"
   packages = [
     "agent",
@@ -895,8 +895,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "119e0df3db436e590cae1c5d2e5cac8398c88fe6"
-  version = "5.5.22"
+  revision = "c99a8aabc0e3f737623103825b30caa2900d0057"
+  version = "5.5.23"
 
 [[projects]]
   digest = "1:49f6abbce9ade5f43508429e4af1adcce55d27adcd62719fea049decc766a7c9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/gravitational/satellite"
-  version = "=5.5.22"
+  version = "=5.5.23"
 
 [[constraint]]
   name = "github.com/xtgo/set"

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import "fmt"
+
+// KernelVersion describes an abbreviated version of a Linux kernel.
+// It contains the kernel version (including major/minor components) and
+// patch number
+//
+// Example:
+//  $ uname -r
+//  $ 4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+type KernelVersion struct {
+	// Release specifies the release of the kernel
+	Release int
+	// Major specifies the major version component
+	Major int
+	// Minor specifies the minor version component
+	Minor int
+	// Patch specifies the patch or build number
+	Patch int
+}
+
+// String returns the kernel version formatted as Release.Major.Minor-Patch.
+func (r *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
@@ -17,39 +17,12 @@ limitations under the License.
 package monitoring
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/gravitational/trace"
 )
-
-// KernelVersion describes an abbreviated version of a Linux kernel.
-// It contains the kernel version (including major/minor components) and
-// patch number
-//
-// Example:
-//  $ uname -r
-//  $ 4.4.9-112-generic
-//
-// The result will be:
-//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
-type KernelVersion struct {
-	// Release specifies the release of the kernel
-	Release int
-	// Major specifies the major version component
-	Major int
-	// Minor specifies the minor version component
-	Minor int
-	// Patch specifies the patch or build number
-	Patch int
-}
-
-// String returns the kernel version formatted as Release.Major.Minor-Patch.
-func (r *KernelVersion) String() string {
-	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
-}
 
 // KernelConstraintFunc is a function to determine if the kernel version
 // satisfies a particular condition.


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Fixes failed mac builds due to undefined KernelVersion.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Requires https://github.com/gravitational/satellite/pull/251

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
