### PR TITLE
Remove cmd to deploy agent on single node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/gravitational/oxy v0.0.0-20180629203109-e4a7e35311e6 // indirect
 	github.com/gravitational/rigging v0.0.0-20191021212636-83b2e9505286
 	github.com/gravitational/roundtrip v1.0.0
-	github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8
+	github.com/gravitational/satellite v0.0.9-0.20200803211125-ffa83169a36c
 	github.com/gravitational/tail v1.0.1
 	github.com/gravitational/teleport v3.2.15-0.20200309221853-bebf7a500543+incompatible
 	github.com/gravitational/trace v1.1.11
@@ -137,7 +137,7 @@ require (
 	go.etcd.io/bbolt v1.3.5 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
+	golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3
 	gonum.org/v1/gonum v0.6.1 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/gravitational/oxy v0.0.0-20180629203109-e4a7e35311e6 // indirect
 	github.com/gravitational/rigging v0.0.0-20191021212636-83b2e9505286
 	github.com/gravitational/roundtrip v1.0.0
-	github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f
+	github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8
 	github.com/gravitational/tail v1.0.1
 	github.com/gravitational/teleport v3.2.15-0.20200309221853-bebf7a500543+incompatible
 	github.com/gravitational/trace v1.1.11
@@ -135,9 +135,9 @@ require (
 	github.com/zclconf/go-cty v0.0.0-20180829180805-c2393a5d54f2 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
-	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
+	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
 	gonum.org/v1/gonum v0.6.1 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,8 @@ github.com/gravitational/satellite v0.0.9-0.20200719235809-3ab8d7d0d681 h1:nnUER
 github.com/gravitational/satellite v0.0.9-0.20200719235809-3ab8d7d0d681/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f h1:iVq37Tg0pbl8hwCVPw1IYw/Bd23e1cGHHGxeFIUd/C0=
 github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8 h1:M/37jmEAtuBh6IJ+041PD6wstx4xeBf8ALLe4HX3OJU=
+github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/tail v1.0.1 h1:Yv5nh+zV0yHQ9D9kXGEOFpUoA+Ti5uXHwOGioKSIeng=
 github.com/gravitational/tail v1.0.1/go.mod h1:3aRU+xPwNCaXykBn4jhiXsSJXX7jalcZtvCYGckNbPw=
 github.com/gravitational/teleport v3.2.15-0.20200110233851-f4445fa60013+incompatible h1:zXwIbEof+bTDqbYW97fZe7BWEuHa7ccrNe2PcMt8kYU=

--- a/go.sum
+++ b/go.sum
@@ -558,6 +558,8 @@ github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f h1:iVq37
 github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8 h1:M/37jmEAtuBh6IJ+041PD6wstx4xeBf8ALLe4HX3OJU=
 github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
+github.com/gravitational/satellite v0.0.9-0.20200803211125-ffa83169a36c h1:oh+T9F8xL6MKjVo7oSrp37C8DaumByLnL3PQfIZi2F8=
+github.com/gravitational/satellite v0.0.9-0.20200803211125-ffa83169a36c/go.mod h1:gqyBdtaefi/t7Mw//N/eoC4c3YriZZssmOiZ6NPvuek=
 github.com/gravitational/tail v1.0.1 h1:Yv5nh+zV0yHQ9D9kXGEOFpUoA+Ti5uXHwOGioKSIeng=
 github.com/gravitational/tail v1.0.1/go.mod h1:3aRU+xPwNCaXykBn4jhiXsSJXX7jalcZtvCYGckNbPw=
 github.com/gravitational/teleport v3.2.15-0.20200110233851-f4445fa60013+incompatible h1:zXwIbEof+bTDqbYW97fZe7BWEuHa7ccrNe2PcMt8kYU=

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1449,8 +1449,6 @@ type RPCAgentDeployCmd struct {
 	NodeArgs *string
 	// Version specifies the version of the agent to be deployed
 	Version *string
-	// Hostname specifies the hostname of the node to deploy the agent on
-	Hostname *string
 }
 
 // RPCAgentShutdownCmd requests RPC agents to shut down

--- a/tool/gravity/cli/gc.go
+++ b/tool/gravity/cli/gc.go
@@ -175,7 +175,6 @@ func newCollector(env *localenv.LocalEnvironment) (*vacuum.Collector, error) {
 		cluster:      *cluster,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
-		servers:      cluster.ClusterState.Servers,
 		version:      version.Get().Version,
 	}
 	creds, err := deployAgents(ctx, env, req)

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -625,7 +625,6 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.RPCAgentDeployCmd.LeaderArgs = g.RPCAgentDeployCmd.Flag("leader", "Additional arguments to leader node agent").String()
 	g.RPCAgentDeployCmd.NodeArgs = g.RPCAgentDeployCmd.Flag("node", "Additional arguments to regular node agent").String()
 	g.RPCAgentDeployCmd.Version = g.RPCAgentDeployCmd.Flag("version", "Agent version to deploy").String()
-	g.RPCAgentDeployCmd.Hostname = g.RPCAgentDeployCmd.Arg("hostname", "Hostname of the node to deploy the agent on").String()
 
 	g.RPCAgentShutdownCmd.CmdClause = g.RPCAgentCmd.Command("shutdown", "Request agents to shut down")
 

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -169,8 +169,6 @@ type deployOptions struct {
 	nodeArgs string
 	// version specifies the version of the agent to be deployed
 	version string
-	// hostname specifies the hostname of the node to deploy the agent on
-	hostname string
 }
 
 func rpcAgentDeploy(localEnv *localenv.LocalEnvironment, options deployOptions) error {
@@ -226,17 +224,6 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 		version:      options.version,
 	}
 
-	// If hostname is specified in the options, deploy agent only on specified node
-	if options.hostname != "" {
-		server, err := req.clusterState.FindServer(options.hostname)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		req.servers = append(req.servers, *server)
-	} else {
-		req.servers = cluster.ClusterState.Servers
-	}
-
 	// Force this node to be the operation leader
 	req.leader, err = findLocalServer(cluster.ClusterState.Servers)
 	if err != nil {
@@ -247,7 +234,6 @@ func rpcAgentDeployHelper(ctx context.Context, localEnv *localenv.LocalEnvironme
 
 	localCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)
 	defer cancel()
-
 	return deployAgents(localCtx, localEnv, req)
 }
 
@@ -263,9 +249,9 @@ func verifyNode(ctx context.Context, server rpc.DeployServer, proxy *teleclient.
 
 func verifyCluster(ctx context.Context, req deployAgentsRequest) (servers []rpc.DeployServer, err error) {
 	var missing []string
-	servers = make([]rpc.DeployServer, 0, len(servers))
+	servers = make([]rpc.DeployServer, 0, len(req.clusterState.Servers))
 
-	for _, server := range req.servers {
+	for _, server := range req.clusterState.Servers {
 		deployServer := rpc.NewDeployServer(server)
 
 		// do a quick check to make sure we can connect to the teleport node

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -1012,7 +1012,6 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 				leaderArgs: *g.RPCAgentDeployCmd.LeaderArgs,
 				nodeArgs:   *g.RPCAgentDeployCmd.NodeArgs,
 				version:    *g.RPCAgentDeployCmd.Version,
-				hostname:   *g.RPCAgentDeployCmd.Hostname,
 			})
 	case g.RPCAgentInstallCmd.FullCommand():
 		return rpcAgentInstall(localEnv, *g.RPCAgentInstallCmd.Args)

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -113,18 +113,14 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	clusterState := clusterStateFromPlan(*plan)
-
 	req := init.updateDeployRequest(deployAgentsRequest{
 		// Use server list from the operation plan to always have a consistent
 		// view of the cluster (i.e. with servers correctly reflecting cluster roles)
-		clusterState: clusterState,
+		clusterState: clusterStateFromPlan(*plan),
 		cluster:      *cluster,
 		clusterEnv:   clusterEnv,
 		proxy:        proxy,
 		leader:       leader,
-		servers:      clusterState.Servers,
 		nodeParams:   constants.RPCAgentSyncPlanFunction,
 		version:      version.Get().Version,
 	})

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import "fmt"
+
+// KernelVersion describes an abbreviated version of a Linux kernel.
+// It contains the kernel version (including major/minor components) and
+// patch number
+//
+// Example:
+//  $ uname -r
+//  $ 4.4.9-112-generic
+//
+// The result will be:
+//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
+type KernelVersion struct {
+	// Release specifies the release of the kernel
+	Release int
+	// Major specifies the major version component
+	Major int
+	// Minor specifies the minor version component
+	Minor int
+	// Patch specifies the patch or build number
+	Patch int
+}
+
+// String returns the kernel version formatted as Release.Major.Minor-Patch.
+func (r *KernelVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
+}

--- a/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
+++ b/vendor/github.com/gravitational/satellite/monitoring/kernel_linux.go
@@ -17,39 +17,12 @@ limitations under the License.
 package monitoring
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/gravitational/trace"
 )
-
-// KernelVersion describes an abbreviated version of a Linux kernel.
-// It contains the kernel version (including major/minor components) and
-// patch number
-//
-// Example:
-//  $ uname -r
-//  $ 4.4.9-112-generic
-//
-// The result will be:
-//  KernelVersion{Release: 4, Major: 4, Minor: 9, Patch: 112}
-type KernelVersion struct {
-	// Release specifies the release of the kernel
-	Release int
-	// Major specifies the major version component
-	Major int
-	// Minor specifies the minor version component
-	Minor int
-	// Patch specifies the patch or build number
-	Patch int
-}
-
-// String returns the kernel version formatted as Release.Major.Minor-Patch.
-func (r *KernelVersion) String() string {
-	return fmt.Sprintf("%d.%d.%d-%d", r.Release, r.Major, r.Minor, r.Patch)
-}
 
 // KernelConstraintFunc is a function to determine if the kernel version
 // satisfies a particular condition.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -387,7 +387,7 @@ github.com/gravitational/oxy/utils
 github.com/gravitational/rigging
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8
+# github.com/gravitational/satellite v0.0.9-0.20200803211125-ffa83169a36c
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/cache
 github.com/gravitational/satellite/agent/health
@@ -742,7 +742,7 @@ golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190423024810-112230192c58
 golang.org/x/sync/errgroup
-# golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
+# golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3 => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2 => golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -387,7 +387,7 @@ github.com/gravitational/oxy/utils
 github.com/gravitational/rigging
 # github.com/gravitational/roundtrip v1.0.0
 github.com/gravitational/roundtrip
-# github.com/gravitational/satellite v0.0.9-0.20200720191657-4877c91ae81f
+# github.com/gravitational/satellite v0.0.9-0.20200731235122-08cb2ae939a8
 github.com/gravitational/satellite/agent
 github.com/gravitational/satellite/agent/cache
 github.com/gravitational/satellite/agent/health
@@ -464,6 +464,7 @@ github.com/gravitational/teleport/lib/web/ui
 github.com/gravitational/teleport/lib/wrappers
 # github.com/gravitational/trace v1.1.11
 github.com/gravitational/trace
+github.com/gravitational/trace/trail
 # github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
 github.com/gravitational/ttlmap
 # github.com/gravitational/ttlmap/v2 v2.0.0-20200702161230-1bbfd908876d
@@ -691,7 +692,7 @@ go.mongodb.org/mongo-driver/bson/bsonrw
 go.mongodb.org/mongo-driver/bson/bsontype
 go.mongodb.org/mongo-driver/bson/primitive
 go.mongodb.org/mongo-driver/x/bsonx/bsoncore
-# golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 => golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
+# golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de => golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
@@ -741,7 +742,7 @@ golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190423024810-112230192c58
 golang.org/x/sync/errgroup
-# golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
+# golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2 => golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Removes cmd to deploy agent on a single node. Was not implemented properly and might not be all that useful.
- Bump satellite to fix issue with `KernelVersion`.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Requires https://github.com/gravitational/satellite/pull/253

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

**Verify agent deploy works as usual**
