### PR TITLE
Do not fail for non-existing mountpoint directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,7 +508,7 @@ publish-artifacts: opscenter telekube
 # scan-artifacts uploads a copy of all vendored containers to a docker registry for scanning and vulnerability reporting
 #
 .PHONY: scan-artifacts
-scan-artifacts:
+scan-artifacts: telekube
 	$(GRAVITY) app sync \
 		--registry=$(TELE_COPY_TO_REGISTRY) \
 		--registry-username=$(TELE_COPY_TO_USER) \

--- a/lib/systeminfo/systeminfo.go
+++ b/lib/systeminfo/systeminfo.go
@@ -29,6 +29,7 @@ import (
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/gravitational/trace"
 	"github.com/mitchellh/go-ps"
+	log "github.com/sirupsen/logrus"
 )
 
 // New returns a new instance of system information
@@ -263,6 +264,7 @@ func collectFilesystemUsage(fs []storage.Filesystem) (result storage.FilesystemS
 		if !os.IsNotExist(err) {
 			return nil, trace.Wrap(err, "failed to get mount info on %v", mount.DirName)
 		}
+		log.WithField("path", mount.DirName).Warn("Directory for mountpoint not found - skipping.")
 	}
 	return result, nil
 }

--- a/lib/systeminfo/systeminfo.go
+++ b/lib/systeminfo/systeminfo.go
@@ -255,10 +255,14 @@ func collectFilesystemUsage(fs []storage.Filesystem) (result storage.FilesystemS
 		if utils.StringInSlice(exceptFstypes, mount.Type) {
 			continue
 		}
-		if err := usage.Get(mount.DirName); err != nil {
+		err := usage.Get(mount.DirName)
+		if err == nil {
+			result[mount.DirName] = storage.FilesystemUsage{TotalKB: usage.Total, FreeKB: usage.Free}
+			continue
+		}
+		if !os.IsNotExist(err) {
 			return nil, trace.Wrap(err, "failed to get mount info on %v", mount.DirName)
 		}
-		result[mount.DirName] = storage.FilesystemUsage{TotalKB: usage.Total, FreeKB: usage.Free}
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Treat non-existing directories as warnings when agent collects mountpoint metadata during startup. Although existing distributions are supposed to have `/etc/mtab` as a symlink to `/proc/self/mounts`, there were reports of `/etc/mtab` containing bogus entries (see linked issue).

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/1958

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Make a copy of `/etc/mtab` temporarily to be able to manipulate it.
Add an entry for a non-existing directory, e.g.:
```
/dev/sda1 /non/existing/path xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
```

Attempt an installation with a release version (e.g.: `6.1.30`)
```
Mon Aug  3 13:03:15 UTC	Starting enterprise installer

To abort the installation and clean up the system,
press Ctrl+C two times in a row.

If you get disconnected from the terminal, you can reconnect to the installer
agent by issuing 'gravity resume' command.

If the installation fails, use 'gravity plan' to inspect the state and
'gravity resume' to continue the operation.
See https://gravitational.com/gravity/docs/cluster/#managing-an-ongoing-operation for details.

Mon Aug  3 13:03:16 UTC	Connecting to installer
Mon Aug  3 13:03:23 UTC	Connected to installer
Mon Aug  3 13:03:25 UTC	Operation has been created
```
and in the logs there will be an error logged in a loop:
```
2020-08-03T13:03:27Z INFO             Retrying in 1.482032636s. error:[
ERROR REPORT:
Original Error: syscall.Errno no such file or directory
Stack Trace:
	...
User Message: failed to get mount info on /non/existing/path
	no such file or directory] utils/logging.go:103
...
2020-08-03T13:03:27Z INFO             Retrying in 1.779789152s. error:[
ERROR REPORT:
Original Error: *errors.errorString waiting for agents to join
Stack Trace:
	...
User Message: waiting for agents to join] utils/logging.go:10
```

Abort the installation.
Install the version from this branch, ensure the installation is successful:
```
...
Mon Aug  3 10:31:36 UTC	Connect to installer
Mon Aug  3 10:31:36 UTC	Connecting to installer
Mon Aug  3 10:31:38 UTC	Executing "/election" locally
Mon Aug  3 10:31:38 UTC	Enable leader elections
Mon Aug  3 10:31:39 UTC	Enable cluster leader elections
Mon Aug  3 10:31:39 UTC	Executing operation finished in 5 minutes
Mon Aug  3 10:31:40 UTC	Operation has completed
Mon Aug  3 10:31:40 UTC	The operation has finished successfully in 5m27s
```
