### PR TITLE
Bump nodejs image version to 12.18.3

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,11 +1,6 @@
-FROM node:8.11.2-slim
-
-# Fixes jessie repository
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+FROM node:12.18.3-stretch-slim
 
 RUN apt-get update && apt-get install git -y
-
-RUN npm i npm@6.4.1 -g
 
 # prepare to install only package.json dependencies
 RUN mkdir -p /app


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Bump nodejs image to 12.18.3 because 8x is EOL.

## Type of change
<!--Required. Keep only those that apply.-->
* Internal change (not necessarily a bug fix or a new feature)

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
- [x] Manually checked all UI elements after installation.

## Additional information
<!--Optional. Anything else that may be relevant.-->
