### PR TITLE
[7.0.x] Increase priority class for dns application

### DIFF
--- a/assets/dns-app/resources/dns.yaml
+++ b/assets/dns-app/resources/dns.yaml
@@ -95,10 +95,9 @@ spec:
         k8s-app: kube-dns
         gravitational.io/critical-pod: ''
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       serviceAccountName: coredns
       tolerations:
         - operator: "Exists"
@@ -178,10 +177,9 @@ spec:
       labels:
         k8s-app: kube-dns-worker
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       serviceAccountName: coredns
       tolerations:
         - operator: "Exists"


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
One of the customers mentioned that `scheduler.alpha.kubernetes.io/critical-pod: ''` overrides fiedl `priorityClassName`. And also we are increasing priority class to the maximum one for coredns pods.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
