### PR TITLE
Fix two robotest issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ timestamps {
         robotest : {
           if (env.RUN_ROBOTEST == 'run') {
             withCredentials([
+                [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                 [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -111,6 +111,7 @@ timestamps {
           robotest : {
             if (env.RUN_ROBOTEST == 'run') {
               withCredentials([
+                  [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                   [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -6,6 +6,7 @@ set -o pipefail
 readonly TARGET=${1:?Usage: $0 [pr|nightly] [upgrade_from_dir]}
 export UPGRADE_FROM_DIR=${2:-$(pwd)/../upgrade_from}
 
+readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}
 readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
@@ -47,7 +48,7 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR
 for release in ${!UPGRADE_MAP[@]}; do
-  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest
+  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest --hub=https://get.gravitational.io:443 --token="$GET_GRAVITATIONAL_IO_APIKEY"
 done
 
 docker pull $ROBOTEST_REPO

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -12,7 +12,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.1.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
# Description
This PR contains two robotest fixes.

1)  Revert most of 01a5087adad01c5b23c7977115a4f206b723b6e0 mitigating failures like:

```
04:37:31 [robotest] [1mSun Aug  9 04:37:30 UTC[0m	Using Hub https://ci-ops.gravitational.io:443
04:37:31 [robotest] [1mSun Aug  9 04:37:30 UTC[0m	Requesting cluster image from https://ci-ops.gravitational.io:443
04:37:31 [robotest] [1mSun Aug  9 04:37:31 UTC[0m	Download finished in 1 second 
04:37:31 [robotest] [31m[ERROR]: remote error: tls: bad certificate
04:37:31 [robotest] [0mmake[1]: *** [robotest-run-suite] Error 255
```

`--state-dir` is insufficient to isolate `tele pull` from opscenter credentials in ~/. Without an explicit login this pull will attempt to connect to the last used hub and stolon/pithos CI will occasionally change the last used hub to https://ci-ops.gravitational.io:443:

https://github.com/gravitational/stolon-app/blob/211395e55c3028a977a5519b1c2cb22382c35cba/Jenkinsfile#L43-L45

After this change, the last used hub should be irrelevant.

2)  updated robotest version 2.0.0 -> 2.1.0.  While 2.1.0 contains many fixes and improvements, https://github.com/gravitational/robotest/pull/260 is the one we care about here, mitigating #1999.

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
Contributes to #1999.
Reverts most of #1890.


## TODOs
- [x] Self-review the change
- [x] Make sure CI passes
- [x] Address review feedback

## Testing done
The CI run is sufficient testing.

## Additional information
I'm working on a 2nd patch want to get robotest pulls sandboxed such that fetching/building robotest artifacts cannot share credentials with any other process. Sharing login state in ~jenkins has been a consistent painpoint througout July and August
