### PR TITLE
(7.0) Fix two robotest issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ timestamps {
         robotest : {
           if (env.RUN_ROBOTEST == 'run') {
             withCredentials([
+                [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                 [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                 [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -111,6 +111,7 @@ timestamps {
           robotest : {
             if (env.RUN_ROBOTEST == 'run') {
               withCredentials([
+                  [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
                   [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -6,6 +6,7 @@ set -o pipefail
 readonly TARGET=${1:?Usage: $0 [pr|nightly] [upgrade_from_dir]}
 export UPGRADE_FROM_DIR=${2:-$(pwd)/../upgrade_from}
 
+readonly GET_GRAVITATIONAL_IO_APIKEY=${GET_GRAVITATIONAL_IO_APIKEY:?API key for distribution Ops Center required}
 readonly GRAVITY_BUILDDIR=${GRAVITY_BUILDDIR:?Set GRAVITY_BUILDDIR to the build directory}
 readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
@@ -47,7 +48,7 @@ export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR
 for release in ${!UPGRADE_MAP[@]}; do
-  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest
+  $tele pull telekube:$release --output=$UPGRADE_FROM_DIR/telekube_$release.tar --state-dir $GRAVITY_BUILDDIR/.robotest --hub=https://get.gravitational.io:443 --token="$GET_GRAVITATIONAL_IO_APIKEY"
 done
 
 docker pull $ROBOTEST_REPO

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -12,7 +12,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.1.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
Backport of #1997.

## Type of change
* Regression fix (non-breaking change which fixes a regression)


## Linked tickets and other PRs
* Backport of #1997.
* Contributes to #1999

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Make sure Automation passes
- [x] Address review feedback

## Testing done
None. The CI build is sufficient.

## Additional information
* @a-palchikov's https://github.com/gravitational/gravity/pull/1982 includes a superset of these fixes.  If that goes into 7.0 first, we don't need this PR.  This is only useful if we want a quicker mitigation in 7.0 to unblock other PRs  -- should #1982 be held up for any other reasons.
