### PR TITLE
Bump docs go version to > 1.14.0.

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,7 +3,7 @@
 # A multi step build is used to keep the go toolchain outside the final container
 
 # milv-builder, contains the whole go toolchain
-FROM quay.io/gravitational/debian-venti:go1.14-stretch AS milv-builder
+FROM quay.io/gravitational/debian-venti:go1.14.4-buster AS milv-builder
 RUN GO111MODULE=on go get -u -v github.com/magicmatatjahu/milv@v0.0.6
 
 # docbox, contains everything for building gravity documentation


### PR DESCRIPTION
## Description
Without this, `go get` will fail on Linux 5.4.0 (Ubuntu 20.04) when it
hits https://github.com/golang/go/issues/37436, with the following signature:

```
 walt@work:~/git/gravity/docs$ make docs
// snip
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed
```

While this won't affect our current release infra (kernel 3.10.0), it is
an important fix for developers running affected kernel versions.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


## Linked tickets and other PRs
N/A. 

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<details><summary><code>make docs</code> before</summary>

Test setup:

```
walt@work:~/git/gravity$ git diff
diff --git a/docs/Makefile b/docs/Makefile
index 6f84bb1e..878c9000 100644
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,6 +42,7 @@ shell: $(DOCBOX_ID_FILE)
 $(DOCBOX_ID_FILE): Dockerfile
        mkdir -p $(BUILDDIR)
        docker build \
+               --no-cache \
                --build-arg UID=$$(id -u) \
                --build-arg GID=$$(id -g) \
                --build-arg WORKDIR=$(WORKDIR) \
walt@work:~/git/gravity$ make -C docs clean
make: Entering directory '/home/walt/git/gravity/docs'
rm -rf ../build/.docs-buildbox.id ../build/docs
make: Leaving directory '/home/walt/git/gravity/docs'
```
```
walt@work:~/git/gravity$ make docs
make -C docs
make[1]: Entering directory '/home/walt/git/gravity/docs'
mkdir -p ../build/docs
docker build \
        --no-cache \
        --build-arg UID=$(id -u) \
        --build-arg GID=$(id -g) \
        --build-arg WORKDIR=/home \
        --build-arg PORT=6601 \
        --tag docs-buildbox:latest .
Sending build context to Docker daemon  11.14MB
Step 1/11 : FROM quay.io/gravitational/debian-venti:go1.14-stretch AS milv-builder
 ---> cd741211fe17
Step 2/11 : RUN GO111MODULE=on go get -u -v github.com/magicmatatjahu/milv@v0.0.6
 ---> Running in 8892c192a81c
go: downloading github.com/magicmatatjahu/milv v0.0.6
go: finding module for package github.com/pkg/errors
go: finding module for package golang.org/x/net/html
go: finding module for package gopkg.in/yaml.v2
go: finding module for package github.com/olekukonko/tablewriter
go: finding module for package github.com/schollz/closestmatch
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading github.com/schollz/closestmatch v1.0.0
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/olekukonko/tablewriter v0.0.4
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: downloading github.com/schollz/closestmatch v2.1.0+incompatible
go: found github.com/olekukonko/tablewriter in github.com/olekukonko/tablewriter v0.0.4
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
go: found github.com/schollz/closestmatch in github.com/schollz/closestmatch v2.1.0+incompatible
go: found golang.org/x/net/html in golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: found gopkg.in/yaml.v2 in gopkg.in/yaml.v2 v2.3.0
go: downloading github.com/mattn/go-runewidth v0.0.7
go: golang.org/x/net upgrade => v0.0.0-20200707034311-ab3426394381
go: github.com/mattn/go-runewidth upgrade => v0.0.9
go: downloading github.com/mattn/go-runewidth v0.0.9
golang.org/x/net/html/atom
github.com/mattn/go-runewidth
github.com/pkg/errors
github.com/magicmatatjahu/milv/cli
gopkg.in/yaml.v2
golang.org/x/net/html
github.com/schollz/closestmatch
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed

runtime stack:
runtime.throw(0xa3b43e, 0xc)
        /usr/local/go/src/runtime/panic.go:1112 +0x72
runtime.mlockGsignal(0xc0009d0180)
        /usr/local/go/src/runtime/os_linux_x86.go:72 +0x107
runtime.mpreinit(0xc000978a80)
        /usr/local/go/src/runtime/os_linux.go:341 +0x78
runtime.mcommoninit(0xc000978a80)
        /usr/local/go/src/runtime/proc.go:630 +0x108
runtime.allocm(0xc00003b000, 0x0, 0x1)
        /usr/local/go/src/runtime/proc.go:1390 +0x14e
runtime.newm(0x0, 0xc00003b000)
        /usr/local/go/src/runtime/proc.go:1704 +0x39
runtime.startm(0xc00003b000, 0xec8800)
        /usr/local/go/src/runtime/proc.go:1869 +0x12a
runtime.handoffp(0xc00003b000)
        /usr/local/go/src/runtime/proc.go:1901 +0x2f7
runtime.retake(0x4b5f9e5aac137, 0xc000033800)
        /usr/local/go/src/runtime/proc.go:4628 +0x157
runtime.sysmon()
        /usr/local/go/src/runtime/proc.go:4537 +0x138
runtime.mstart1()
        /usr/local/go/src/runtime/proc.go:1097 +0xc3
runtime.mstart()
        /usr/local/go/src/runtime/proc.go:1062 +0x6e

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc000544f68)
        /usr/local/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc000544f60)
        /usr/local/go/src/sync/waitgroup.go:130 +0x64
cmd/go/internal/work.(*Builder).Do(0xc000754be0, 0xc000788a00)
        /usr/local/go/src/cmd/go/internal/work/exec.go:187 +0x3ae
cmd/go/internal/work.InstallPackages(0xc0000982b0, 0x1, 0x1, 0xc000094600, 0x1, 0x1)
        /usr/local/go/src/cmd/go/internal/work/build.go:605 +0xb2d
cmd/go/internal/modget.runGet(0xebd5e0, 0xc0000200e0, 0x1, 0x1)
        /usr/local/go/src/cmd/go/internal/modget/get.go:690 +0x2e1d
main.main()
        /usr/local/go/src/cmd/go/main.go:189 +0x569

goroutine 1101 [syscall]:
syscall.Syscall6(0xf7, 0x1, 0x5c, 0xc000c94f40, 0x1000004, 0x0, 0x0, 0x4d3b01, 0xc00006e8a0, 0xc000c94f80)
        /usr/local/go/src/syscall/asm_linux_amd64.s:41 +0x5
os.(*Process).blockUntilWaitable(0xc00088ce10, 0x40db16, 0xc0001f0300, 0x1)
        /usr/local/go/src/os/wait_waitid.go:31 +0x98
os.(*Process).wait(0xc00088ce10, 0xa82120, 0xa82128, 0xa82118)
        /usr/local/go/src/os/exec_unix.go:22 +0x39
os.(*Process).Wait(...)
        /usr/local/go/src/os/exec.go:125
os/exec.(*Cmd).Wait(0xc0008b8420, 0x0, 0x0)
        /usr/local/go/src/os/exec/exec.go:502 +0x60
os/exec.(*Cmd).Run(0xc0008b8420, 0x881853ea, 0xec8260)
        /usr/local/go/src/os/exec/exec.go:340 +0x5c
cmd/go/internal/work.(*Builder).runOut(0xc000754be0, 0xc000365900, 0xc000c18040, 0x34, 0x0, 0x0, 0x0, 0xc00079dcc0, 0x11, 0x14, ...)
        /usr/local/go/src/cmd/go/internal/work/exec.go:1928 +0x5bc
cmd/go/internal/work.gcToolchain.gc(0xc000754be0, 0xc000365900, 0xc00088cab0, 0x23, 0xc0003f2160, 0x9a, 0xb0, 0x0, 0x0, 0xc000c95500, ...)
        /usr/local/go/src/cmd/go/internal/work/gc.go:142 +0xc98
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc000365900, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:678 +0x1715
cmd/go/internal/work.(*Builder).Do.func2(0xc000365900)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 104 [IO wait]:
internal/poll.runtime_pollWait(0x7efdc85c7f08, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000338598, 0x72, 0x2000, 0x2016, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000338580, 0xc000014500, 0x2016, 0x2016, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc000338580, 0xc000014500, 0x2016, 0x2016, 0x203000, 0xffd6e3726e69b614, 0x1000000c2cc8291)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000094040, 0xc000014500, 0x2016, 0x2016, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc00028e2a0, 0xc000014500, 0x2016, 0x2016, 0xc0002579b0, 0x4c7d62, 0xc0002579c8)
        /usr/local/go/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0000493d8, 0xb2cea0, 0xc00028e2a0, 0x40ba65, 0x9ac8c0, 0xa1c520)
        /usr/local/go/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc000049180, 0xb2d340, 0xc000094040, 0x5, 0xc000094040, 0x27)
        /usr/local/go/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000049180, 0x0, 0x0, 0xc0000494a0)
        /usr/local/go/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/local/go/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc000049180, 0xc0000fc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).Read(0xc00029eba0, 0xc000260038, 0x9, 0x9, 0x0, 0xc000257d20, 0x767484)
        /usr/local/go/src/bufio/bufio.go:226 +0x24f
io.ReadAtLeast(0xb2c960, 0xc00029eba0, 0xc000260038, 0x9, 0x9, 0x9, 0xc0003d4700, 0xc0000b7000, 0x11)
        /usr/local/go/src/io/io.go:310 +0x87
io.ReadFull(...)
        /usr/local/go/src/io/io.go:329
net/http.http2readFrameHeader(0xc000260038, 0x9, 0x9, 0xb2c960, 0xc00029eba0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1479 +0x87
net/http.(*http2Framer).ReadFrame(0xc000260000, 0xc000302000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1737 +0xa1
net/http.(*http2clientConnReadLoop).run(0xc000257fa8, 0x1, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:8246 +0x8d
net/http.(*http2ClientConn).readLoop(0xc000602600)
        /usr/local/go/src/net/http/h2_bundle.go:8174 +0x6f
created by net/http.(*http2Transport).newClientConn
        /usr/local/go/src/net/http/h2_bundle.go:7174 +0x64a

goroutine 16 [IO wait]:
internal/poll.runtime_pollWait(0x7efdc85c7d48, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000290698, 0x72, 0xfd00, 0xfda7, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000290680, 0xc000644000, 0xfda7, 0xfda7, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc000290680, 0xc000644000, 0xfda7, 0xfda7, 0x203000, 0x61cba6fdaf272d8c, 0x10000001bd1c7dd)
        /usr/local/go/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0002a4068, 0xc000644000, 0xfda7, 0xfda7, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc0003c20c0, 0xc000644000, 0xfda7, 0xfda7, 0xc0000529b0, 0x4c7d62, 0xc0000529c8)
        /usr/local/go/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0002805d8, 0xb2cea0, 0xc0003c20c0, 0x40ba65, 0x9ac8c0, 0xa1c520)
        /usr/local/go/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc000280380, 0xb2d340, 0xc0002a4068, 0x5, 0xc0002a4068, 0x27)
        /usr/local/go/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000280380, 0x0, 0x0, 0xc0002806a0)
        /usr/local/go/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/local/go/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc000280380, 0xc00016f000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).Read(0xc00030d7a0, 0xc000261538, 0x9, 0x9, 0x0, 0xc000052d20, 0x767484)
        /usr/local/go/src/bufio/bufio.go:226 +0x24f
io.ReadAtLeast(0xb2c960, 0xc00030d7a0, 0xc000261538, 0x9, 0x9, 0x9, 0xc0003f4980, 0xc00016e000, 0x11)
        /usr/local/go/src/io/io.go:310 +0x87
io.ReadFull(...)
        /usr/local/go/src/io/io.go:329
net/http.http2readFrameHeader(0xc000261538, 0x9, 0x9, 0xb2c960, 0xc00030d7a0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1479 +0x87
net/http.(*http2Framer).ReadFrame(0xc000261500, 0xc000704000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:1737 +0xa1
net/http.(*http2clientConnReadLoop).run(0xc000052fa8, 0x0, 0x0)
        /usr/local/go/src/net/http/h2_bundle.go:8246 +0x8d
net/http.(*http2ClientConn).readLoop(0xc000001980)
        /usr/local/go/src/net/http/h2_bundle.go:8174 +0x6f
created by net/http.(*http2Transport).newClientConn
        /usr/local/go/src/net/http/h2_bundle.go:7174 +0x64a

goroutine 1099 [syscall]:
syscall.Syscall6(0xf7, 0x1, 0x60, 0xc000c98f40, 0x1000004, 0x0, 0x0, 0x4d3b01, 0xc0008a03c0, 0xc000c98f80)
        /usr/local/go/src/syscall/asm_linux_amd64.s:41 +0x5
os.(*Process).blockUntilWaitable(0xc00044c630, 0x40db16, 0xc00053c300, 0x1)
        /usr/local/go/src/os/wait_waitid.go:31 +0x98
os.(*Process).wait(0xc00044c630, 0xa82120, 0xa82128, 0xa82118)
        /usr/local/go/src/os/exec_unix.go:22 +0x39
os.(*Process).Wait(...)
        /usr/local/go/src/os/exec.go:125
os/exec.(*Cmd).Wait(0xc0009dac60, 0x0, 0x0)
        /usr/local/go/src/os/exec/exec.go:502 +0x60
os/exec.(*Cmd).Run(0xc0009dac60, 0x885274bd, 0xec8260)
        /usr/local/go/src/os/exec/exec.go:340 +0x5c
cmd/go/internal/work.(*Builder).runOut(0xc000754be0, 0xc000365cc0, 0xc0002f6900, 0x2c, 0x0, 0x0, 0x0, 0xc000788280, 0x11, 0x14, ...)
        /usr/local/go/src/cmd/go/internal/work/exec.go:1928 +0x5bc
cmd/go/internal/work.gcToolchain.gc(0xc000754be0, 0xc000365cc0, 0xc00056cfc0, 0x23, 0xc000388000, 0x154, 0x180, 0x0, 0x0, 0xc000c99500, ...)
        /usr/local/go/src/cmd/go/internal/work/gc.go:142 +0xc98
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc000365cc0, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:678 +0x1715
cmd/go/internal/work.(*Builder).Do.func2(0xc000365cc0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 844 [IO wait]:
internal/poll.runtime_pollWait(0x7efdc8651ce0, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc0008a0318, 0x72, 0x201, 0x200, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0008a0300, 0xc000220000, 0x200, 0x200, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x19b
os.(*File).read(...)
        /usr/local/go/src/os/file_unix.go:263
os.(*File).Read(0xc0000942b0, 0xc000220000, 0x200, 0x200, 0xc000a46690, 0x447242, 0xc000a466a0)
        /usr/local/go/src/os/file.go:116 +0x71
bytes.(*Buffer).ReadFrom(0xc000293590, 0xb2d5e0, 0xc0000942b0, 0x7efdc83ab568, 0xc000293590, 0xc000a46701)
        /usr/local/go/src/bytes/buffer.go:204 +0xb1
io.copyBuffer(0xb2c9c0, 0xc000293590, 0xb2d5e0, 0xc0000942b0, 0x0, 0x0, 0x0, 0x4068a5, 0xc00006e960, 0xc000a467b0)
        /usr/local/go/src/io/io.go:391 +0x2fc
io.Copy(...)
        /usr/local/go/src/io/io.go:364
os/exec.(*Cmd).writerDescriptor.func1(0xc00006e960, 0xc000a467b0)
        /usr/local/go/src/os/exec/exec.go:310 +0x63
os/exec.(*Cmd).Start.func1(0xc0009dac60, 0xc000204360)
        /usr/local/go/src/os/exec/exec.go:436 +0x27
created by os/exec.(*Cmd).Start
        /usr/local/go/src/os/exec/exec.go:435 +0x608

goroutine 1097 [runnable]:
sync.runtime_nanotime(0x4)
        /usr/local/go/src/runtime/sema.go:615 +0x3a
sync.(*Mutex).lockSlow(0xef3910)
        /usr/local/go/src/sync/mutex.go:136 +0x1b9
sync.(*Mutex).Lock(...)
        /usr/local/go/src/sync/mutex.go:81
sync.(*RWMutex).Lock(0xef3910)
        /usr/local/go/src/sync/rwmutex.go:98 +0x97
syscall.forkExec(0xc000217f00, 0x20, 0xc00000d0e0, 0x1d, 0x1e, 0xc000a74ee0, 0x18, 0xe131df9400010200, 0xc00071f180)
        /usr/local/go/src/syscall/exec_unix.go:193 +0x200
syscall.StartProcess(...)
        /usr/local/go/src/syscall/exec_unix.go:248
os.startProcess(0xc000217f00, 0x20, 0xc00000d0e0, 0x1d, 0x1e, 0xc000a75078, 0x0, 0x0, 0x0)
        /usr/local/go/src/os/exec_posix.go:52 +0x2c0
os.StartProcess(0xc000217f00, 0x20, 0xc00000d0e0, 0x1d, 0x1e, 0xc000a75078, 0x19, 0x0, 0xc000a75001)
        /usr/local/go/src/os/exec.go:102 +0x7c
os/exec.(*Cmd).Start(0xc000972580, 0x3530610c, 0x4b5f9e5a8e98d)
        /usr/local/go/src/os/exec/exec.go:417 +0x50c
os/exec.(*Cmd).Run(0xc000972580, 0x894045c0, 0xec8260)
        /usr/local/go/src/os/exec/exec.go:337 +0x2b
cmd/go/internal/work.(*Builder).runOut(0xc000754be0, 0xc000737a40, 0xc0000280a0, 0x48, 0x0, 0x0, 0x0, 0xc0000f4f00, 0x18, 0x28, ...)
        /usr/local/go/src/cmd/go/internal/work/exec.go:1928 +0x5bc
cmd/go/internal/work.gcToolchain.gc(0xc000754be0, 0xc000737a40, 0xc000126450, 0x23, 0xc000151500, 0x1d9, 0x33e, 0x0, 0x0, 0xc000a75500, ...)
        /usr/local/go/src/cmd/go/internal/work/gc.go:142 +0xc98
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc000737a40, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:678 +0x1715
cmd/go/internal/work.(*Builder).Do.func2(0xc000737a40)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1102 [syscall]:
syscall.Syscall6(0xf7, 0x1, 0x67, 0xc000a70f40, 0x1000004, 0x0, 0x0, 0x48, 0x49, 0xc000a70f80)
        /usr/local/go/src/syscall/asm_linux_amd64.s:41 +0x5
os.(*Process).blockUntilWaitable(0xc0004b6660, 0x40dd04, 0xc00019a000, 0x1)
        /usr/local/go/src/os/wait_waitid.go:31 +0x98
os.(*Process).wait(0xc0004b6660, 0xa82120, 0xa82128, 0xa82118)
        /usr/local/go/src/os/exec_unix.go:22 +0x39
os.(*Process).Wait(...)
        /usr/local/go/src/os/exec.go:125
os/exec.(*Cmd).Wait(0xc0009722c0, 0x0, 0x0)
        /usr/local/go/src/os/exec/exec.go:502 +0x60
os/exec.(*Cmd).Run(0xc0009722c0, 0x889ca71b, 0xec8260)
        /usr/local/go/src/os/exec/exec.go:340 +0x5c
cmd/go/internal/work.(*Builder).runOut(0xc000754be0, 0xc000364a00, 0xc0005b4000, 0x39, 0x0, 0x0, 0x0, 0xc000afe000, 0xf, 0x14, ...)
        /usr/local/go/src/cmd/go/internal/work/exec.go:1928 +0x5bc
cmd/go/internal/work.gcToolchain.gc(0xc000754be0, 0xc000364a00, 0xc00079f5f0, 0x23, 0xc000afc000, 0xf4, 0x186, 0x0, 0x0, 0xc000a71500, ...)
        /usr/local/go/src/cmd/go/internal/work/gc.go:142 +0xc98
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc000364a00, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:678 +0x1715
cmd/go/internal/work.(*Builder).Do.func2(0xc000364a00)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1131 [IO wait]:
internal/poll.runtime_pollWait(0x7efdc85c7808, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00006e7f8, 0x72, 0x201, 0x200, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00006e7e0, 0xc000220400, 0x200, 0x200, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x19b
os.(*File).read(...)
        /usr/local/go/src/os/file_unix.go:263
os.(*File).Read(0xc000010210, 0xc000220400, 0x200, 0x200, 0xc000314690, 0x447242, 0xc0003146a0)
        /usr/local/go/src/os/file.go:116 +0x71
bytes.(*Buffer).ReadFrom(0xc000696360, 0xb2d5e0, 0xc000010210, 0x7efdc83ab568, 0xc000696360, 0xc000314701)
        /usr/local/go/src/bytes/buffer.go:204 +0xb1
io.copyBuffer(0xb2c9c0, 0xc000696360, 0xb2d5e0, 0xc000010210, 0x0, 0x0, 0x0, 0x4068a5, 0xc0000a44e0, 0xc0003147b0)
        /usr/local/go/src/io/io.go:391 +0x2fc
io.Copy(...)
        /usr/local/go/src/io/io.go:364
os/exec.(*Cmd).writerDescriptor.func1(0xc0000a44e0, 0xc0003147b0)
        /usr/local/go/src/os/exec/exec.go:310 +0x63
os/exec.(*Cmd).Start.func1(0xc0008b8420, 0xc00000e500)
        /usr/local/go/src/os/exec/exec.go:436 +0x27
created by os/exec.(*Cmd).Start
        /usr/local/go/src/os/exec/exec.go:435 +0x608

goroutine 1100 [runnable]:
os.(*File).Read(0xc0002a44b0, 0xc000cf4000, 0x8000, 0x8000, 0x308f, 0x0, 0x0)
        /usr/local/go/src/os/file.go:112 +0x240
io.copyBuffer(0x7efdc864f0f8, 0xc00033f500, 0xb2d5e0, 0xc0002a44b0, 0xc000cf4000, 0x8000, 0x8000, 0xc0000253a0, 0xc0000cd120, 0x4ef752)
        /usr/local/go/src/io/io.go:405 +0x122
io.Copy(...)
        /usr/local/go/src/io/io.go:364
cmd/go/internal/cache.FileHash(0xc0000253a0, 0x19, 0x0, 0x0, 0x0, 0x0, 0x19, 0xc0000253a0)
        /usr/local/go/src/cmd/go/internal/cache/hash.go:149 +0x330
cmd/go/internal/work.(*Builder).fileHash(0xc000754be0, 0xc0000253a0, 0x19, 0xc0000253a0, 0x19)
        /usr/local/go/src/cmd/go/internal/work/buildid.go:403 +0x3c
cmd/go/internal/work.(*Builder).buildActionID(0xc000754be0, 0xc0008dcdc0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:321 +0xc2b
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc0008dcdc0, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:402 +0x50f0
cmd/go/internal/work.(*Builder).Do.func2(0xc0008dcdc0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1103 [syscall]:
syscall.Syscall(0x3, 0x12, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/syscall/asm_linux_amd64.s:18 +0x5
syscall.Close(0x12, 0xc000706320, 0x14)
        /usr/local/go/src/syscall/zsyscall_linux_amd64.go:285 +0x40
syscall.forkExec(0xc00092f4a0, 0x20, 0xc0001fe140, 0x13, 0x14, 0xc0000c8ee0, 0x18, 0x9ce1782500000200, 0xc0008d0700)
        /usr/local/go/src/syscall/exec_unix.go:209 +0x39f
syscall.StartProcess(...)
        /usr/local/go/src/syscall/exec_unix.go:248
os.startProcess(0xc00092f4a0, 0x20, 0xc0001fe140, 0x13, 0x14, 0xc0000c9078, 0x0, 0x0, 0x0)
        /usr/local/go/src/os/exec_posix.go:52 +0x2c0
os.StartProcess(0xc00092f4a0, 0x20, 0xc0001fe140, 0x13, 0x14, 0xc0000c9078, 0x19, 0x0, 0xc0000c9001)
        /usr/local/go/src/os/exec.go:102 +0x7c
os/exec.(*Cmd).Start(0xc00045c840, 0x352b28c6, 0x4b5f9e5a3b0cd)
        /usr/local/go/src/os/exec/exec.go:417 +0x50c
os/exec.(*Cmd).Run(0xc00045c840, 0x893b0d00, 0xec8260)
        /usr/local/go/src/os/exec/exec.go:337 +0x2b
cmd/go/internal/work.(*Builder).runOut(0xc000754be0, 0xc000736280, 0xc0001c80f0, 0x43, 0x0, 0x0, 0x0, 0xc0001fe000, 0xf, 0x14, ...)
        /usr/local/go/src/cmd/go/internal/work/exec.go:1928 +0x5bc
cmd/go/internal/work.gcToolchain.gc(0xc000754be0, 0xc000736280, 0xc0006fc420, 0x23, 0xc0001ce000, 0x108, 0x1a4, 0x0, 0x0, 0xc0000c9500, ...)
        /usr/local/go/src/cmd/go/internal/work/gc.go:142 +0xc98
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc000736280, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:678 +0x1715
cmd/go/internal/work.(*Builder).Do.func2(0xc000736280)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1098 [runnable]:
syscall.Syscall6(0x101, 0xffffffffffffff9c, 0xc0002ca480, 0x80041, 0x1b6, 0x0, 0x0, 0xf, 0x80041, 0x0)
        /usr/local/go/src/syscall/asm_linux_amd64.s:41 +0x5
syscall.openat(0xffffffffffffff9c, 0xc0002ca360, 0x5b, 0x80041, 0x265c030c000001b6, 0x5af30f580afc9baf, 0x3a65818defdea914, 0x55f881f56323acf6)
        /usr/local/go/src/syscall/zsyscall_linux_amd64.go:68 +0xbb
syscall.Open(...)
        /usr/local/go/src/syscall/syscall_linux.go:138
os.openFileNolog(0xc0002ca360, 0x5b, 0x41, 0xc0000001b6, 0x2, 0xc00021a280, 0x42)
        /usr/local/go/src/os/file_unix.go:200 +0x8f
os.OpenFile(0xc0002ca360, 0x5b, 0x41, 0x3a65818d000001b6, 0x55f881f56323acf6, 0xa35d3c, 0x1)
        /usr/local/go/src/os/file.go:307 +0x63
cmd/go/internal/cache.(*Cache).putIndexEntry(0xc00000eca0, 0x265c030cd861e60c, 0x5af30f580afc9baf, 0x3a65818defdea914, 0x55f881f56323acf6, 0xb695ca7e3b3aa721, 0x5958e3772a650986, 0x808a5f97375ec936, 0x6dbfb98d87f08615, 0xa5, ...)
        /usr/local/go/src/cmd/go/internal/cache/cache.go:371 +0x2ba
cmd/go/internal/cache.(*Cache).put(0xc00000eca0, 0x265c030cd861e60c, 0x5af30f580afc9baf, 0x3a65818defdea914, 0x55f881f56323acf6, 0xb31680, 0xc000694ea0, 0xc0001aee01, 0x0, 0x0, ...)
        /usr/local/go/src/cmd/go/internal/cache/cache.go:433 +0x2eb
cmd/go/internal/cache.(*Cache).Put(...)
        /usr/local/go/src/cmd/go/internal/cache/cache.go:403
cmd/go/internal/cache.(*Cache).PutBytes(0xc00000eca0, 0x265c030cd861e60c, 0x5af30f580afc9baf, 0x3a65818defdea914, 0x55f881f56323acf6, 0xc00038a240, 0xa5, 0x11c, 0x3a65818defdea914, 0x55f881f56323acf6)
        /usr/local/go/src/cmd/go/internal/cache/cache.go:438 +0xdf
cmd/go/internal/work.(*Builder).cacheSrcFiles(0xc000754be0, 0xc00079d680, 0xc0001a8750, 0xd, 0xd)
        /usr/local/go/src/cmd/go/internal/work/exec.go:845 +0x264
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc00079d680, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:615 +0x1179
cmd/go/internal/work.(*Builder).Do.func2(0xc00079d680)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1096 [runnable]:
syscall.Syscall6(0x11, 0x9, 0xc000c9b320, 0x8, 0x0, 0x0, 0x0, 0x8, 0x8, 0x0)
        /usr/local/go/src/syscall/asm_linux_amd64.s:41 +0x5
syscall.Pread(0x9, 0xc000c9b320, 0x8, 0x8, 0x0, 0xa820d8, 0xb2e260, 0xc0004f21b8)
        /usr/local/go/src/syscall/zsyscall_linux_amd64.go:1211 +0x72
internal/poll.(*FD).Pread(0xc0008a05a0, 0xc000c9b320, 0x8, 0x8, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:196 +0xa1
os.(*File).pread(...)
        /usr/local/go/src/os/file_unix.go:272
os.(*File).ReadAt(0xc0000942e8, 0xc000c9b320, 0x8, 0x8, 0x0, 0x0, 0x0, 0x14)
        /usr/local/go/src/os/file.go:134 +0x103
cmd/internal/buildid.ReadFile(0xc00044c1b0, 0x23, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/cmd/internal/buildid/buildid.go:40 +0x104
cmd/go/internal/work.(*Builder).useCache(0xc000754be0, 0xc0008dc140, 0x4bfa07728b474827, 0x5e9e9883e3222d90, 0x293d14a9581c79b, 0x5fd1966d96f721f5, 0xc00044c1b0, 0x23, 0x1)
        /usr/local/go/src/cmd/go/internal/work/buildid.go:448 +0xf45
cmd/go/internal/work.(*Builder).build(0xc000754be0, 0xc0008dc140, 0x0, 0x0)
        /usr/local/go/src/cmd/go/internal/work/exec.go:402 +0x515c
cmd/go/internal/work.(*Builder).Do.func2(0xc0008dc140)
        /usr/local/go/src/cmd/go/internal/work/exec.go:118 +0x358
cmd/go/internal/work.(*Builder).Do.func3(0xc000544f60, 0xc000754be0, 0xc0004bfd60)
        /usr/local/go/src/cmd/go/internal/work/exec.go:178 +0x76
created by cmd/go/internal/work.(*Builder).Do
        /usr/local/go/src/cmd/go/internal/work/exec.go:165 +0x38a

goroutine 1157 [IO wait]:
internal/poll.runtime_pollWait(0x7efdc86515e0, 0x72, 0xffffffffffffffff)
        /usr/local/go/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc0006b43d8, 0x72, 0x201, 0x200, 0xffffffffffffffff)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0006b43c0, 0xc000220200, 0x200, 0x200, 0x0, 0x0, 0x0)
        /usr/local/go/src/internal/poll/fd_unix.go:169 +0x19b
os.(*File).read(...)
        /usr/local/go/src/os/file_unix.go:263
os.(*File).Read(0xc0005f60e8, 0xc000220200, 0x200, 0x200, 0xc000800e90, 0x447242, 0xc000800ea0)
        /usr/local/go/src/os/file.go:116 +0x71
bytes.(*Buffer).ReadFrom(0xc0004b01b0, 0xb2d5e0, 0xc0005f60e8, 0x7efdc83ab568, 0xc0004b01b0, 0xc000800f01)
        /usr/local/go/src/bytes/buffer.go:204 +0xb1
io.copyBuffer(0xb2c9c0, 0xc0004b01b0, 0xb2d5e0, 0xc0005f60e8, 0x0, 0x0, 0x0, 0x4068a5, 0xc0003801e0, 0xc000800fb0)
        /usr/local/go/src/io/io.go:391 +0x2fc
io.Copy(...)
        /usr/local/go/src/io/io.go:364
os/exec.(*Cmd).writerDescriptor.func1(0xc0003801e0, 0xc000800fb0)
        /usr/local/go/src/os/exec/exec.go:310 +0x63
os/exec.(*Cmd).Start.func1(0xc0009722c0, 0xc000a86080)
        /usr/local/go/src/os/exec/exec.go:436 +0x27
created by os/exec.(*Cmd).Start
        /usr/local/go/src/os/exec/exec.go:435 +0x608
The command '/bin/sh -c GO111MODULE=on go get -u -v github.com/magicmatatjahu/milv@v0.0.6' returned a non-zero code: 2
make[1]: *** [Makefile:44: ../build/.docs-buildbox.id] Error 2
make[1]: Leaving directory '/home/walt/git/gravity/docs'
make: *** [Makefile:776: docs] Error 2
walt@work:~/git/gravity$
```

</details>

<details><summary><code>make docs</code> after</summary>

```
walt@work:~/git/gravity$ make -C docs clean
make: Entering directory '/home/walt/git/gravity/docs'
rm -rf ../build/.docs-buildbox.id ../build/docs
make: Leaving directory '/home/walt/git/gravity/docs'
walt@work:~/git/gravity$ make docs
make -C docs
make[1]: Entering directory '/home/walt/git/gravity/docs'
mkdir -p ../build/docs
docker build \
        --no-cache \
        --build-arg UID=$(id -u) \
        --build-arg GID=$(id -g) \
        --build-arg WORKDIR=/home \
        --build-arg PORT=6601 \
        --tag docs-buildbox:latest .
Sending build context to Docker daemon  11.14MB
Step 1/11 : FROM quay.io/gravitational/debian-venti:go1.14.4-buster AS milv-builder
 ---> d47d74f5b0c0
Step 2/11 : RUN GO111MODULE=on go get -u -v github.com/magicmatatjahu/milv@v0.0.6
 ---> Running in c0330c90aeb4
go: downloading github.com/magicmatatjahu/milv v0.0.6
go: finding module for package golang.org/x/net/html
go: finding module for package gopkg.in/yaml.v2
go: finding module for package github.com/schollz/closestmatch
go: finding module for package github.com/pkg/errors
go: finding module for package github.com/olekukonko/tablewriter
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading github.com/schollz/closestmatch v1.0.0
go: downloading github.com/olekukonko/tablewriter v0.0.4
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/schollz/closestmatch v2.1.0+incompatible
go: found github.com/olekukonko/tablewriter in github.com/olekukonko/tablewriter v0.0.4
go: found github.com/pkg/errors in github.com/pkg/errors v0.9.1
go: found github.com/schollz/closestmatch in github.com/schollz/closestmatch v2.1.0+incompatible
go: found golang.org/x/net/html in golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: found gopkg.in/yaml.v2 in gopkg.in/yaml.v2 v2.3.0
go: downloading github.com/mattn/go-runewidth v0.0.7
go: golang.org/x/net upgrade => v0.0.0-20200707034311-ab3426394381
go: github.com/mattn/go-runewidth upgrade => v0.0.9
go: downloading github.com/mattn/go-runewidth v0.0.9
golang.org/x/net/html/atom
github.com/mattn/go-runewidth
github.com/pkg/errors
github.com/magicmatatjahu/milv/cli
github.com/schollz/closestmatch
golang.org/x/net/html
gopkg.in/yaml.v2
github.com/olekukonko/tablewriter
github.com/magicmatatjahu/milv/pkg
github.com/magicmatatjahu/milv
Removing intermediate container c0330c90aeb4
 ---> 66e46e1dfd63
Step 3/11 : FROM quay.io/gravitational/mkdocs-base:1.0.3-1
 ---> 64250a644023
Step 4/11 : ARG UID
 ---> Running in bf7349d5f984
Removing intermediate container bf7349d5f984
 ---> e7645da3394d
Step 5/11 : ARG GID
 ---> Running in 950c1e80b688
Removing intermediate container 950c1e80b688
 ---> 9259c13d12b2
Step 6/11 : ARG WORKDIR
 ---> Running in 8a5b9bde10c0
Removing intermediate container 8a5b9bde10c0
 ---> abca2b2cad23
Step 7/11 : ARG PORT
 ---> Running in 33ad974145ba
Removing intermediate container 33ad974145ba
 ---> 4dae9c0fd58b
Step 8/11 : RUN groupadd builder --gid=$GID -o && useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash
 ---> Running in 9a7736a3e495
Removing intermediate container 9a7736a3e495
 ---> f3eb83eca229
Step 9/11 : COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 ---> 61230237ad2f
Step 10/11 : VOLUME [$WORKDIR]
 ---> Running in 831b5b8f59d7
Removing intermediate container 831b5b8f59d7
 ---> 5f4fbf7b61c6
Step 11/11 : EXPOSE $PORT
 ---> Running in 516269b0722b
Removing intermediate container 516269b0722b
 ---> d52801881d9c
Successfully built d52801881d9c
Successfully tagged docs-buildbox:latest
# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141
touch ../build/.docs-buildbox.id
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-compile-docs
mkdocs build --strict --config-file 4.x.yaml --site-dir ../build/docs/4.x
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/build/docs/4.x
mkdocs build --strict --config-file 5.x.yaml --site-dir ../build/docs/5.x
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/build/docs/5.x
mkdocs build --strict --config-file 6.x.yaml --site-dir ../build/docs/6.x
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/build/docs/6.x
mkdocs build --strict --config-file 7.x.yaml --site-dir ../build/docs/7.x
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/build/docs/7.x
cd ../build/docs && rm -f latest && ln -s 7.x latest
make[1]: Leaving directory '/home/walt/git/gravity/docs'
walt@work:~/git/gravity$
```
</details>

Beyond that, the docs job should cover everything Jenkins related.