### PR TITLE
[5.5.x] backport fixes from 7.0.x branch

### DIFF
--- a/lib/app/hooks/diff.go
+++ b/lib/app/hooks/diff.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // diffPodSets returns a difference in Pods between existing and new.
@@ -126,12 +127,12 @@ func (p *podDiff) String() string {
 	return out.String()
 }
 
-func describe(v interface{}) string {
-	switch val := v.(type) {
+func describe(obj runtime.Object) string {
+	switch obj := obj.(type) {
 	case *v1.Pod:
-		return fmt.Sprintf("Pod %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Pod %q in namespace %q", obj.Name, obj.Namespace)
 	case *batchv1.Job:
-		return fmt.Sprintf("Job %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Job %q in namespace %q", obj.Name, obj.Namespace)
 	}
 	return "<unknown>"
 }

--- a/lib/app/hooks/hooks.go
+++ b/lib/app/hooks/hooks.go
@@ -298,7 +298,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 	err := r.checkJob(ctx, &job, &jobControl, podSet, w)
 	diff := humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 	if err == nil {
-		fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+		fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 		return nil
 	}
 	log.Debugf("%v: %v", diff, err)
@@ -314,7 +314,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 			diff = humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 			err = r.checkJob(ctx, &job, &jobControl, podSet, w)
 			if err == nil {
-				fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+				fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 				return nil
 			}
 			log.Debugf("%v: %v", diff, err)

--- a/lib/rpc/server/callable.go
+++ b/lib/rpc/server/callable.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"bytes"
+	"io"
 	"os/exec"
 	"sync/atomic"
 	"syscall"
@@ -39,26 +41,26 @@ func osExec(ctx context.Context, stream pb.OutgoingMessageStream, args []string,
 }
 
 // exec executes the command specified with args streaming stdout/stderr to stream
-// TODO: separate RPC failures (like failure to send messages to the stream) from command errors
-func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, args []string, log log.FieldLogger) error {
+func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, args []string, logger log.FieldLogger) error {
 	seq := atomic.AddInt32(&c.seq, 1)
+	var errOut bytes.Buffer
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Stdout = &streamWriter{stream, pb.ExecOutput_STDOUT, seq}
-	cmd.Stderr = &streamWriter{stream, pb.ExecOutput_STDERR, seq}
+	cmd.Stderr = io.MultiWriter(
+		&streamWriter{stream, pb.ExecOutput_STDERR, seq},
+		&errOut,
+	)
 
 	err := cmd.Start()
 	if err != nil {
-		return trace.Wrap(err, "failed to start %v", cmd.Path)
+		return trace.Wrap(err, "failed to start").AddField("path", cmd.Path)
 	}
 
-	stream.Send(&pb.Message{Element: &pb.Message_ExecStarted{&pb.ExecStarted{
-		Args: args,
-		Seq:  seq,
-	}}})
+	notifyAndLogError(stream, newCommandStartedEvent(seq, args))
 	err = cmd.Wait()
 	if err == nil {
-		err = stream.Send(&pb.Message{Element: &pb.Message_ExecCompleted{&pb.ExecCompleted{Seq: seq}}})
-		return trace.Wrap(err)
+		notifyAndLogError(stream, newCommandCompletedEvent(seq))
+		return nil
 	}
 
 	exitCode := ExitCodeUndefined
@@ -68,15 +70,48 @@ func (c *osCommand) exec(ctx context.Context, stream pb.OutgoingMessageStream, a
 		}
 	}
 
-	errWrite := stream.Send(&pb.Message{Element: &pb.Message_ExecCompleted{&pb.ExecCompleted{
-		Seq:      seq,
-		ExitCode: int32(exitCode),
-		Error:    pb.EncodeError(trace.Wrap(err)),
-	}}})
-	if errWrite != nil {
-		log.Warnf("failed to send exec completed message: %v", err)
-	}
+	logger.WithField("output", errOut.String()).Warn("Command finished with error.")
+	notifyAndLogError(stream, newCommandCompletedWithErrorEvent(seq, int32(exitCode), err))
 	return trace.Wrap(err)
+}
+
+func notifyAndLogError(stream pb.OutgoingMessageStream, msg *pb.Message) {
+	if err := stream.Send(msg); err != nil {
+		log.WithError(err).Warnf("Failed to notify stream: %v.", msg)
+	}
+}
+
+func newCommandStartedEvent(seq int32, args []string) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecStarted{
+			ExecStarted: &pb.ExecStarted{
+				Args: args,
+				Seq:  seq,
+			},
+		},
+	}
+}
+
+func newCommandCompletedEvent(seq int32) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecCompleted{
+			ExecCompleted: &pb.ExecCompleted{
+				Seq: seq,
+			},
+		},
+	}
+}
+
+func newCommandCompletedWithErrorEvent(seq, exitCode int32, err error) *pb.Message {
+	return &pb.Message{
+		Element: &pb.Message_ExecCompleted{
+			ExecCompleted: &pb.ExecCompleted{
+				Seq:      seq,
+				ExitCode: exitCode,
+				Error:    pb.EncodeError(err),
+			},
+		},
+	}
 }
 
 type osCommand struct {
@@ -97,7 +132,7 @@ func (s *streamWriter) Write(p []byte) (n int, err error) {
 		Seq:  s.seq,
 	}
 
-	err = s.stream.Send(&pb.Message{Element: &pb.Message_ExecOutput{data}})
+	err = s.stream.Send(&pb.Message{Element: &pb.Message_ExecOutput{ExecOutput: data}})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR ports a few changes from the 7.0.x branch regarding the consistency of error logging and a couple of other issues to increase visibility into operation failures when remote commands are involved.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/2006
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1914

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
Also I stumbled on a couple of data races when I ran the tests so this PR includes a fix.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
TODO
