### PR TITLE
Backport https://github.com/gravitational/gravity/pull/1914.

### DIFF
--- a/lib/app/hooks/diff.go
+++ b/lib/app/hooks/diff.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // diffPodSets returns a difference in Pods between existing and new.
@@ -126,12 +127,12 @@ func (p *podDiff) String() string {
 	return out.String()
 }
 
-func describe(v interface{}) string {
-	switch val := v.(type) {
+func describe(obj runtime.Object) string {
+	switch obj := obj.(type) {
 	case *v1.Pod:
-		return fmt.Sprintf("Pod %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Pod %q in namespace %q", obj.Name, obj.Namespace)
 	case *batchv1.Job:
-		return fmt.Sprintf("Job %q in namespace %q", val.Name, val.Namespace)
+		return fmt.Sprintf("Job %q in namespace %q", obj.Name, obj.Namespace)
 	}
 	return "<unknown>"
 }

--- a/lib/app/hooks/hooks.go
+++ b/lib/app/hooks/hooks.go
@@ -297,7 +297,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 	err := r.checkJob(ctx, &job, &jobControl, podSet, w)
 	diff := humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 	if err == nil {
-		fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+		fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 		return nil
 	}
 	log.Debugf("%v: %v", diff, err)
@@ -313,7 +313,7 @@ func (r *Runner) monitorPods(ctx context.Context, eventsC <-chan watch.Event,
 			diff = humanize.RelTime(start, time.Now(), "elapsed", "elapsed")
 			err = r.checkJob(ctx, &job, &jobControl, podSet, w)
 			if err == nil {
-				fmt.Fprintf(w, "%v has completed, %v.\n", describe(job), diff)
+				fmt.Fprintf(w, "%v has completed, %v.\n", describe(&job), diff)
 				return nil
 			}
 			log.Debugf("%v: %v", diff, err)


### PR DESCRIPTION
Fix data races in plan follower tests.
Also use the static gravity path inside the container.

Updates https://github.com/gravitational/gravity/issues/2006.

(cherry picked from commit 722592a65f0de454d5d09572addde7177116913b)

