### PR TITLE
[7.0.x] revert base version for intermediate upgrades

### DIFF
--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -16,7 +16,9 @@ UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.1.x))]="redhat:7" # compatible 
 UPGRADE_MAP[6.1.0]="debian:9"
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7" # compatible non-LTS version
 # Upgrade path with an intermediate hop. The chosen version will exercise a double etcd upgrade from v3.3.11 to v3.3.22 to v3.4.9
-UPGRADE_MAP[5.5.10]="centos:7"
+# Disabled to an issue with etcd upgrades which needs further investigation.
+#UPGRADE_MAP[5.5.10]="centos:7"
+UPGRADE_MAP[5.5.49]="centos:7"
 
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 # 6.2 ignored in PR builds per https://github.com/gravitational/gravity/pull/1760#pullrequestreview-437838773


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR reverts the base 5.5.x version for intermediate upgrades to `5.5.49` since the upgrades from `5.5.10` have an issue which warrants further investigation.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing

