### PR TITLE
[7.0.x] fix intermediate upgrade build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,13 +59,9 @@ timestamps {
     }
     stage('build-gravity') {
       withCredentials([
-      [$class: 'SSHUserPrivateKeyBinding', credentialsId: '08267d86-0b3a-4101-841e-0036bf780b11', keyFileVariable: 'GITHUB_SSH_KEY'],
-      [
-        $class: 'UsernamePasswordMultiBinding',
-        credentialsId: 'jenkins-aws-s3',
-        usernameVariable: 'AWS_ACCESS_KEY_ID',
-        passwordVariable: 'AWS_SECRET_ACCESS_KEY',
-      ],
+      sshUserPrivateKey(credentialsId: '08267d86-0b3a-4101-841e-0036bf780b11', keyFileVariable: 'GITHUB_SSH_KEY'),
+      usernamePassword(credentialsId: 'jenkins-aws-s3', usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY'),
+      string(credentialsId:'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'),
       ]) {
         sh 'make -C e production telekube-intermediate-upgrade opscenter'
       }
@@ -77,17 +73,18 @@ timestamps {
         parallel (
         build : {
           withCredentials([
-          [$class: 'SSHUserPrivateKeyBinding', credentialsId: '08267d86-0b3a-4101-841e-0036bf780b11', keyFileVariable: 'GITHUB_SSH_KEY']]) {
+          sshUserPrivateKey(credentialsId: '08267d86-0b3a-4101-841e-0036bf780b11', keyFileVariable: 'GITHUB_SSH_KEY')
+          ]) {
             sh 'make test && make -C e test'
           }
         },
         robotest : {
           if (env.RUN_ROBOTEST == 'run') {
             withCredentials([
-                [$class: 'StringBinding', credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'],
-                [$class: 'FileBinding', credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'],
-                [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
-                [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
+                string(credentialsId: 'GET_GRAVITATIONAL_IO_APIKEY', variable: 'GET_GRAVITATIONAL_IO_APIKEY'),
+                file(credentialsId:'ROBOTEST_LOG_GOOGLE_APPLICATION_CREDENTIALS', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                file(credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'),
+                file(credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'),
                 ]) {
                   sh 'make -C e robotest-run-suite'
             }

--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,7 @@ telekube: $(GRAVITY_BUILDDIR)/telekube.tar
 
 .PHONY: telekube-intermediate-upgrade
 telekube-intermediate-upgrade: GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
-telekube-intermediate-upgrade: GRAVITY_INSTALLER_OPTIONS=--upgrade-via=$(GRAVITY_INTERMEDIATE_RELEASE)
+telekube-intermediate-upgrade: GRAVITY_INSTALLER_OPTIONS:=$(GRAVITY_INSTALLER_OPTIONS) --upgrade-via=$(GRAVITY_INTERMEDIATE_RELEASE)
 telekube-intermediate-upgrade: $(GRAVITY_BUILDDIR)/telekube.tar
 
 $(GRAVITY_BUILDDIR)/telekube.tar: packages


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR contains the cherry-picked changes from https://github.com/gravitational/gravity/pull/1982 to fix the intermediate upgrade build step. Otherwise, builds are subject to environment changes regarding the tele
login state.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1982
* Requires https://github.com/gravitational/gravity.e/pull/4329

- [x] Self-review the change
