### PR TITLE
[6.1.x] fix tele build with custom container configuration

### DIFF
--- a/lib/app/service/app.go
+++ b/lib/app/service/app.go
@@ -905,8 +905,8 @@ func (r *applications) checkImportRequirements(manifest *schema.Manifest, req *a
 	}
 
 	// check dependencies-packages
-	for _, dep := range manifest.Dependencies.Packages {
-		locator, err := r.processMetadata(dep.Locator)
+	for _, dep := range manifest.Dependencies.GetPackages() {
+		locator, err := r.processMetadata(dep)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -920,8 +920,8 @@ func (r *applications) checkImportRequirements(manifest *schema.Manifest, req *a
 	}
 
 	// check dependencies-apps
-	for _, dep := range manifest.Dependencies.Apps {
-		locator, err := r.processMetadata(dep.Locator)
+	for _, dep := range manifest.Dependencies.GetApps() {
+		locator, err := r.processMetadata(dep)
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Use Dependencies.GetPackages API instead direct package access as it needs to filter out the container package since it is only used for backwards compatibility with the distribution hub and should be removed once the hub has been updated to a more recent version.
The error I made with testing was using the development tele build workflow while I need to test the user tele build workflow.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/1940

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

With tele version 6.1.34:
[app.yaml]
```
systemOptions:
  baseImage: <custom planet reference>
```
```
$ tele build app.yaml
...
User Message: missing dependency: package {gravitational.io/planet:6.1.32-11512}] tele/main.go:23
[ERROR]: missing dependency: package {gravitational.io/planet:6.1.32-11512}
```

After the change:
```
$ tele build app.yaml
...
* [4/6] Creating application
* [5/6] Generating the cluster snapshot
* [6/6] Saving the snapshot as telekube-0.0.0.tar
* [6/6] Build completed in 2 minutes
```

## Additional information
<!--Optional. Anything else that may be relevant.-->
