### PR TITLE
Verify agents are active before resuming upgrade

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -225,9 +225,6 @@ const (
 	// AgentStopTimeout is amount of time agent gets to gracefully shut down
 	AgentStopTimeout = 10 * time.Second
 
-	// AgentStatusTimeout specifies the timeout for agent status query
-	AgentStatusTimeout = 5 * time.Second
-
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -235,8 +235,7 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 // executeOrForkPhase either directly executes the specified operation phase,
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
-	// "/" PhaseID indicates a resume operation. Verify all agents are active before resuming.
-	if params.PhaseID == "/" {
+	if params.isResume() {
 		if err := verifyAgentsActive(env); err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -218,6 +218,14 @@ func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 }
 
 func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ LocalEnvironmentFactory, params PhaseParams, operation ops.SiteOperation) error {
+	allActive, err := verifyActiveAgents(env)
+	if err != nil {
+		return trace.Wrap(err, "failed to verify agent status")
+	}
+	if !allActive {
+		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `gravity agent deploy`")
+	}
+
 	updateEnv, err := environ.NewUpdateEnv()
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -236,7 +236,7 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
 	if params.isResume() {
-		if err := verifyAgentsActive(env); err != nil {
+		if err := verifyOrDeployAgents(env); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -183,7 +183,7 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
 
-	if err := verifyAgentsActive(localEnv); err != nil {
+	if err := verifyOrDeployAgents(localEnv); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -182,6 +182,17 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 	default:
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
+
+	statusList, err := collectAgentStatus(localEnv)
+	if err != nil {
+		return trace.Wrap(err, "failed to collect agent status")
+	}
+
+	if !statusList.AgentsActive() {
+		localEnv.Println(statusList.String())
+		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `gravity agent deploy`")
+	}
+
 	if !confirmed && !params.DryRun {
 		localEnv.Printf(planRollbackWarning, operationList([]clusterOperation{*operation}).formatTable())
 		if err := enforceConfirmation("Proceed?"); err != nil {

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -183,14 +183,8 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
 
-	statusList, err := collectAgentStatus(localEnv)
-	if err != nil {
-		return trace.Wrap(err, "failed to collect agent status")
-	}
-
-	if !statusList.AgentsActive() {
-		localEnv.Println(statusList.String())
-		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `gravity agent deploy`")
+	if err := verifyAgentsActive(localEnv); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if !confirmed && !params.DryRun {

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -471,6 +471,19 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 	return statusList, nil
 }
 
+// verifyAgentsActive verifies that all agents are active.
+func verifyAgentsActive(env *localenv.LocalEnvironment) error {
+	statusList, err := collectAgentStatus(env)
+	if err != nil {
+		return trace.Wrap(err, "failed to collect agent status")
+	}
+	if !statusList.AgentsActive() {
+		env.Println(statusList.String())
+		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
+	}
+	return nil
+}
+
 func executeAutomaticUpgrade(ctx context.Context, localEnv, upgradeEnv *localenv.LocalEnvironment, args []string) error {
 	return trace.Wrap(clusterupdate.AutomaticUpgrade(ctx, localEnv, upgradeEnv))
 }

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -471,13 +471,18 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 	return statusList, nil
 }
 
-// verifyAgentsActive verifies that all agents are active.
-func verifyAgentsActive(env *localenv.LocalEnvironment) error {
+// verifyOrDeployAgents verifies that all agents are active or attempts to
+// re-deploy agents.
+func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	statusList, err := collectAgentStatus(env)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect agent status")
 	}
-	if !statusList.AgentsActive() {
+	if statusList.AgentsActive() {
+		return nil
+	}
+	if err := rpcAgentDeploy(env, deployOptions{}); err != nil {
+		log.WithError(err).Error("Failed to deploy agents.")
 		env.Println(statusList.String())
 		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
 	}

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -461,7 +461,7 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 
 	timeout, err := utils.GetenvDuration(constants.AgentStatusTimeoutEnvVar)
 	if err != nil {
-		timeout = defaults.AgentStatusTimeout
+		timeout = defaults.AgentRequestTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This change will make sure that all upgrade agents are online before resuming an upgrade or before rolling back an upgrade. Resume/Rollback operations will attempt to re-deploy agents if any agents are offline.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/1667

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade resume re-deploys agents if some are offline**
- Start upgrade.
- Shutdown agents with `./gravity agent shutdown`.
- Resume upgrade with `./gravity upgrade --resume`.
- Verify agents are re-deployed and upgrade resumes.

**Verify rollback re-deploys agents if some are offline**
- Start upgrade.
- Shutdown agents with `./gravity agent shutdown`.
- Rollback upgrade with `/./gravity rollback`.
- Verify agents are re-deployed and rolls back upgrade.
