### PR TITLE
(7.0) Compare hostnames when searching for default hub credentials

### DIFF
--- a/lib/localenv/credentials/credentials.go
+++ b/lib/localenv/credentials/credentials.go
@@ -188,7 +188,7 @@ func (s *credentialsService) For(clusterURL string) (*Credentials, error) {
 		}
 	}
 	// If haven't found anything, see if this is the default distribution hub.
-	if clusterURL == defaults.DistributionOpsCenter {
+	if url.hostname == defaults.DistributionOpsCenterName {
 		s.Debugf("Returning default credentials for %v.", clusterURL)
 		return defaultCredentials, nil
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Fixes an issue with tele not finding credentials for default hub if token isn't provided:

```
➜  e git:(version/7.0.x) GRAVITY_K8S_VERSION=1.17.9 /code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/tele build \
        /code/go/src/github.com/gravitational/gravity//assets/telekube/resources/app.yaml -f \
        --version=7.0.14-dev.24 \
        --state-dir=/code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/packages \
        --skip-version-check \
        --hub=https://get.gravitational.io  \
        -o /code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/telekube.tar
Mon Aug 17 22:39:23 UTC	Building cluster image telekube 7.0.14-dev.24
Mon Aug 17 22:39:23 UTC	Selecting base image version
	Will use base image version 7.0.14-dev.24
Mon Aug 17 22:39:23 UTC	Build finished in now
[ERROR]: no credentials for https://get.gravitational.io:443
```

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Requires https://github.com/gravitational/gravity.e/pull/4330.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

`make telekube` works fine now:

```
GRAVITY_K8S_VERSION=1.17.9 /code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/tele build \
	/code/go/src/github.com/gravitational/gravity//assets/telekube/resources/app.yaml -f \
	--version=7.0.14-dev.24 \
	--state-dir=/code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/packages \
	--skip-version-check \
	--hub https://get.gravitational.io \
	-o /code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/telekube.tar
Mon Aug 17 23:43:06 UTC	Building cluster image telekube 7.0.14-dev.24
Mon Aug 17 23:43:06 UTC	Selecting base image version
	Will use base image version 7.0.14-dev.24
Mon Aug 17 23:43:06 UTC	Syncing packages for 7.0.14-dev.24
Mon Aug 17 23:43:06 UTC	Local package cache is up-to-date
Mon Aug 17 23:43:06 UTC	Embedding application container images
	Using local image quay.io/gravitational/debian-tall:buster
	Using local image quay.io/gravitational/debian-tall:buster
	Using local image quay.io/gravitational/provisioner:ci.82
	Vendored image gravitational/debian-tall:buster
	Still embedding application container images (10 seconds elapsed)
	Vendored image gravitational/provisioner:ci.82
Mon Aug 17 23:43:22 UTC	Creating application
Mon Aug 17 23:43:29 UTC	Generating the cluster image
	Still generating the cluster image (10 seconds elapsed)
Mon Aug 17 23:43:42 UTC	Saving the image as /code/go/src/github.com/gravitational/gravity/e//build/7.0.14-dev.24/telekube.tar
Mon Aug 17 23:43:52 UTC	Build finished in 46 seconds
make[1]: Leaving directory '/code/go/src/github.com/gravitational/gravity'
```