### PR TITLE
[6.1] fallback on corrupted planet metadata

### DIFF
--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -169,7 +169,7 @@ func (s *PlanSuite) TestUpdatesEtcdFromManifestWithoutLabels(c *check.C) {
 	updateRuntimePackage := loc.MustParseLocator("example.com/runtime:1.0.1")
 	createRuntimePackagesWithAssumedEtcdVersion(runtimePackage, updateRuntimePackage,
 		etcdVersion{update: "3.3.3"}, services.Packages, c)
-	etcd, err := shouldUpdateEtcd(runtimePackage, updateRuntimePackage, services.Packages)
+	etcd, err := shouldUpdateEtcd(runtimePackage, updateRuntimePackage, runtimePackage, services.Packages)
 	c.Assert(err, check.IsNil)
 	c.Assert(etcd, check.DeepEquals, &etcdVersion{
 		update: "3.3.3",
@@ -184,7 +184,7 @@ func (s *PlanSuite) TestCorrectlyDeterminesWhetherToUpdateEtcd(c *check.C) {
 		installed: "3.3.2",
 		update:    "3.3.3",
 	}, services.Packages, c)
-	etcd, err := shouldUpdateEtcd(runtimePackage, updateRuntimePackage, services.Packages)
+	etcd, err := shouldUpdateEtcd(runtimePackage, updateRuntimePackage, runtimePackage, services.Packages)
 	c.Assert(err, check.IsNil)
 	c.Assert(etcd, check.DeepEquals, &etcdVersion{
 		installed: "3.3.2",


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This patch uses the previous method of determining whether to upgrade etcd as a fallback method when reading corrupted metadata from planet. The metadata stored within /etc/planet/orbit.manifest.json didn't have the sed applied to it, leading to many versions of planet to return the string REPLACE_ETCD_LATEST_VERSION instead of the actual version. In this case, we fallback to trying to determine the version from the default runtime package, which would be the original shipped planet image which has the correct metadata.


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates https://github.com/gravitational/gravity/issues/2031

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
I basically used https://github.com/gravitational/gravity/pull/1962 as the reference, to use the previous method of determining whether to upgrade etcd as a fallback.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
I haven't tried to test this yet, as yesterday when I was trying I wasn't able to reproduce the problem, and I'm not exactly sure why. I'll make sure this passes robotest, but we might need to release it for the customer experiencing this error to verify.

## Additional information
<!--Optional. Anything else that may be relevant.-->
