### PR TITLE
(7.0) Add ability to override FSM spec

### DIFF
--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -29,9 +29,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type FSMSpecFunc func(FSMConfig) fsm.FSMSpecFunc
+
+var FSMSpec FSMSpecFunc = DefaultFSMSpec
+
 // FSMSpec returns a function that returns an appropriate phase executor
 // based on the provided params
-func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
+func DefaultFSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 	return func(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
 		switch {
 		case strings.HasPrefix(p.Phase.ID, phases.InitPhase):

--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -29,12 +29,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// FSMSpecFunc defines a function that returns install FSM spec based on the config.
 type FSMSpecFunc func(FSMConfig) fsm.FSMSpecFunc
 
+// FSMSpec is the install FSM spec.
+//
+// It may be overriden by external implementations to support additional
+// install operation phases (e.g. by the enterprise version).
 var FSMSpec FSMSpecFunc = DefaultFSMSpec
 
-// FSMSpec returns a function that returns an appropriate phase executor
-// based on the provided params
+// DefaultFSMSpec returns a function that returns an the default install FSM
+// spec for the provided install FSM config.
 func DefaultFSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 	return func(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
 		switch {

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -684,7 +684,7 @@ func (c *Config) GetPlanBuilder(operator ops.Operator, cluster ops.Site, op ops.
 	}
 	// pick one of master nodes for executing phases that need to
 	// be executed from any master node
-	master := masters[len(masters)-1]
+	master := masters[0]
 	// prepare information about application packages that will be required
 	// during plan generation
 	teleportPackage, err := cluster.App.Manifest.Dependencies.ByName(

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -684,7 +684,7 @@ func (c *Config) GetPlanBuilder(operator ops.Operator, cluster ops.Site, op ops.
 	}
 	// pick one of master nodes for executing phases that need to
 	// be executed from any master node
-	master := masters[0]
+	master := masters[len(masters)-1]
 	// prepare information about application packages that will be required
 	// during plan generation
 	teleportPackage, err := cluster.App.Manifest.Dependencies.ByName(


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR refactors the install FSM spec a little bit in order to allow enterprise edition to override the default FSM spec with the enterprise-specific one that supports additional phases.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/989, closes https://github.com/gravitational/gravity/issues/2036.
* Requires https://github.com/gravitational/gravity.e/pull/4331.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Before the change

Get the "/license" phase (which is enterprise-specific) to execute on the remote node and see it fail:

```
Thu Aug 20 01:54:23 UTC	Executing "/license" on remote node node-4
Thu Aug 20 01:54:23 UTC	Install the cluster license
Thu Aug 20 01:54:24 UTC	Executing operation finished in 3 minutes
Thu Aug 20 01:54:24 UTC	Saving debug report to /home/ubuntu/app-with-license/crashreport.tgz
[ERROR]: failed to execute phase "/license"
	failed to execute command [plan execute --phase /license --operation-id 0612d259-0419-4be0-b284-a8cfb8b5f5b8]: [ERROR]: rpc error: code = Unknown desc = unknown phase "/license"

		rpc error: code = Unknown desc = panic for command {Args:[/home/ubuntu/gravity plan execute --phase /license --operation-id 0612d259-0419-4be0-b284-a8cfb8b5f5b8] SelfCommand:true Env:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}: runtime error: invalid memory address or nil pointer dereference
```

### After the change

Under the same scenario the phase executes successfully:

```
Thu Aug 20 02:26:44 UTC	Executing "/license" on remote node node-4
Thu Aug 20 02:26:45 UTC	Install the cluster license
```

## Additional information

Needs backports.