### PR TITLE
(5.5) Display kapacitor alerts in gravity status

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -559,6 +559,9 @@ const (
 	// InfluxDBSecretName is the name of secret containing InfluxDB administrator credentials
 	InfluxDBSecretName = "influxdb"
 
+	// KapacitorService is the Kapacitor API service address.
+	KapacitorServiceAddr = "http://kapacitor.monitoring.svc.cluster.local:9092"
+
 	// WriteFactor is a default amount of acknowledged writes for object storage
 	// to be considered successfull
 	WriteFactor = 1

--- a/lib/ops/monitoring/kapacitor.go
+++ b/lib/ops/monitoring/kapacitor.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitoring
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gravitational/gravity/lib/defaults"
+
+	"github.com/fatih/color"
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// GetAlerts returns all active Kapacitor alerts of the level warning or higher.
+//
+// The provided HTTP client should be able to resolve K8s service names.
+func GetAlerts(httpClient *http.Client) ([]StateResponse, error) {
+	kapacitor, err := NewKapacitor(httpClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	alerts, err := kapacitor.GetAlerts()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return alerts, nil
+}
+
+// Kapacitor is the Kapactor API client.
+type Kapacitor struct {
+	// Client is the underlying HTTP client.
+	*roundtrip.Client
+	// FieldLogger is used for logging.
+	logrus.FieldLogger
+}
+
+// NewKapacitor returns a new Kapacitor API client.
+func NewKapacitor(httpClient *http.Client) (*Kapacitor, error) {
+	client, err := roundtrip.NewClient(defaults.KapacitorServiceAddr, "", roundtrip.HTTPClient(httpClient))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Kapacitor{
+		Client:      client,
+		FieldLogger: logrus.WithField(trace.Component, "kapacitor"),
+	}, nil
+}
+
+// GetAlerts returns all active Kapacitor alerts with level warning or higher.
+func (k *Kapacitor) GetAlerts() (result []StateResponse, err error) {
+	response, err := Get(k.Client, k.Endpoint("/kapacitor/v1/alerts/topics"), url.Values{"min-level": []string{levelWarning}})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var topics TopicsResponse
+	if err := json.Unmarshal(response.Bytes(), &topics); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, topic := range topics.Topics {
+		response, err := Get(k.Client, k.Endpoint(topic.EventsLink.Link), url.Values{"min-level": []string{levelWarning}})
+		if err != nil {
+			k.WithError(err).Errorf("Failed to retrieve topic events: %v.", topic)
+			continue
+		}
+		var events EventsResponse
+		if err := json.Unmarshal(response.Bytes(), &events); err != nil {
+			k.WithError(err).Errorf("Failed to unmarshal events response: %v.", string(response.Bytes()))
+			continue
+		}
+		for _, event := range events.Events {
+			result = append(result, event.State)
+		}
+	}
+	return result, nil
+}
+
+// TopicsResponse contains list of active alerts.
+type TopicsResponse struct {
+	// Topics is a list of individual alerts.
+	Topics []TopicResponse `json:"topics"`
+}
+
+// TopicResponse represents an individual alert.
+type TopicResponse struct {
+	// EventsLink contains link to the alert events.
+	EventsLink EventsLinkResponse `json:"events-link"`
+}
+
+// EventsLinkResponse contains link to the alert events.
+type EventsLinkResponse struct {
+	// Link is the URL to the alert events.
+	Link string `json:"href"`
+}
+
+// EventsResponse contains active alert events.
+type EventsResponse struct {
+	// Events is a list of alert events.
+	Events []EventResponse `json:"events"`
+}
+
+// EventResponse contains a single alert event.
+type EventResponse struct {
+	// State contains event information.
+	State StateResponse `json:"state"`
+}
+
+// StateResponse contains alert event information.
+type StateResponse struct {
+	// Message is the event message.
+	Message string `json:"message"`
+	// Level is the event level.
+	Level string `json:"level"`
+}
+
+// String format the event so it can be printed to the console.
+func (r StateResponse) String() string {
+	switch r.Level {
+	case levelWarning:
+		return color.YellowString("[%v] %v", r.Level, r.Message)
+	case levelCritical:
+		return color.RedString("[%v] %v", r.Level, r.Message)
+	}
+	return fmt.Sprintf("[%v] %v", r.Level, r.Message)
+}
+
+const (
+	// levelWarning is the Kapacitor warning alert level.
+	levelWarning = "WARNING"
+	// levelCritical is the Kapacitor critical alert level.
+	levelCritical = "CRITICAL"
+)

--- a/lib/ops/monitoring/kapacitor.go
+++ b/lib/ops/monitoring/kapacitor.go
@@ -32,7 +32,7 @@ import (
 
 // GetAlerts returns all active Kapacitor alerts of the level warning or higher.
 //
-// The provided HTTP client should be able to resolve K8s service names.
+// The provided HTTP client must be able to resolve K8s service names.
 func GetAlerts(httpClient *http.Client) ([]StateResponse, error) {
 	kapacitor, err := NewKapacitor(httpClient)
 	if err != nil {
@@ -131,8 +131,8 @@ type StateResponse struct {
 	Level string `json:"level"`
 }
 
-// String format the event so it can be printed to the console.
-func (r StateResponse) String() string {
+// Format formats the event so it can be printed to the console.
+func (r StateResponse) Format() string {
 	switch r.Level {
 	case levelWarning:
 		return color.YellowString("[%v] %v", r.Level, r.Message)

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -117,7 +117,7 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		log.WithError(err).WithField("operation-id", operationID).Warn("Failed to query operation.")
 	}
 
-	status.KapacitorAlerts, err = opsmonitoring.GetAlerts(httplib.NewClient(httplib.WithLocalResolver(cluster.DNSConfig.Addr())))
+	status.KapacitorAlerts, err = fetchKapacitorAlerts(cluster)
 	if err != nil {
 		log.WithError(err).Warn("Failed to query Kapacitor alerts.")
 	}
@@ -427,6 +427,16 @@ func fetchOperationByID(clusterKey ops.SiteKey, operationID string, operator ops
 	}
 	status.Operation = fromOperationAndProgress(*operation, *progress)
 	return nil
+}
+
+func fetchKapacitorAlerts(cluster ops.Site) ([]opsmonitoring.StateResponse, error) {
+	// Very old clusters (5.0) do not have a DNS config defined so just skip
+	// them, it is only relevant when upgrading from 5.0 to 5.5.
+	if cluster.DNSConfig.IsEmpty() {
+		return nil, nil
+	}
+	return opsmonitoring.GetAlerts(httplib.NewClient(
+		httplib.WithLocalResolver(cluster.DNSConfig.Addr())))
 }
 
 func updateClusterNodes(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {

--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -436,7 +436,8 @@ func fetchKapacitorAlerts(cluster ops.Site) ([]opsmonitoring.StateResponse, erro
 		return nil, nil
 	}
 	return opsmonitoring.GetAlerts(httplib.NewClient(
-		httplib.WithLocalResolver(cluster.DNSConfig.Addr())))
+		httplib.WithLocalResolver(cluster.DNSConfig.Addr()),
+		httplib.WithTimeout(5*time.Second)))
 }
 
 func updateClusterNodes(clusterKey ops.SiteKey, operator ops.Operator, status *Status) error {

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -308,7 +308,7 @@ func formatVersion(version *proto.Version) string {
 
 func printClusterAlerts(alerts []monitoring.StateResponse, w io.Writer) {
 	for _, alert := range alerts {
-		fmt.Fprintf(w, "\t* %s\n", alert)
+		fmt.Fprintf(w, "\t* %s\n", alert.Format())
 	}
 }
 

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/localenv"
 	"github.com/gravitational/gravity/lib/ops"
+	"github.com/gravitational/gravity/lib/ops/monitoring"
 	"github.com/gravitational/gravity/lib/rpc/proto"
 	"github.com/gravitational/gravity/lib/schema"
 	statusapi "github.com/gravitational/gravity/lib/status"
@@ -286,6 +287,11 @@ func printStatusText(cluster clusterStatus) {
 		printAgentStatus(*cluster.Agent, w)
 	}
 
+	if len(cluster.KapacitorAlerts) != 0 {
+		fmt.Fprintf(w, "Cluster alerts:\n")
+		printClusterAlerts(cluster.KapacitorAlerts, w)
+	}
+
 	w.Flush()
 
 	if len(cluster.FailedLocalProbes) != 0 {
@@ -298,6 +304,12 @@ func formatVersion(version *proto.Version) string {
 		return version.Version
 	}
 	return "n/a"
+}
+
+func printClusterAlerts(alerts []monitoring.StateResponse, w io.Writer) {
+	for _, alert := range alerts {
+		fmt.Fprintf(w, "\t* %s\n", alert)
+	}
 }
 
 func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Active Kapacitor alerts of level warning or critical will be displayed in gravity status. This should help with troubleshooting problems with high CPU/mem usage and other things that Kapacitor collects by default (or custom user alerts).

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/2002.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

```
ubuntu@node-1:~/installer$sudo ./gravity status
Cluster name:		test
Cluster status:		degraded (one or more of cluster nodes are not healthy)
Application:		telekube, version 5.5.52-dev.1
Gravity version:	5.5.52-dev.2 (client) / 5.5.52-dev.1 (server)
Join token:		edb5c19fc7a7
Periodic updates:	Not Configured
Remote support:		Not Configured
Last completed operation:
    * operation_install (a07c4fe6-9978-4ec8-afc6-7a123a73f0f5)
      started:		Thu Aug 20 03:43 UTC (13 hours ago)
      completed:	Thu Aug 20 03:43 UTC (13 hours ago)
Cluster endpoints:
    * Authentication gateway:
        - 192.168.99.102:32009
    * Cluster management URL:
        - https://192.168.99.102:32009
Cluster nodes:
    Masters:
        * node-1 (192.168.99.102, node)
            Status:		degraded
            [×]			ipv4 forwarding is off, see https://www.gravitational.com/gravity/docs/faq/#ipv4-forwarding ()
            Remote access:	online
Cluster alerts:
	* [CRITICAL] etcd cluster is unhealthy
	* [CRITICAL] InfluxDB is down or no connection between Kapacitor and InfluxDB
	* [CRITICAL] br_netfilter module is not loaded on node 192.168.99.102
	* [CRITICAL] Node  is down
```