### PR TITLE
(6.1) Bump robotest image to 2.1.0.

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.0.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.1.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
For consistency, this is a 6.1.x backport of https://github.com/gravitational/gravity/pull/1997.

This improves our base images/distrobutions, and has some logging/fail fast improvments.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Ports #1997.

## TODOs
- [x] Self-review the change
- [x] Audit the automated results
- [x] Address review feedback

## Testing done
None.  The PR build is sufficient.

## Additional Information
6.1.x does not need the tele pull fixes because it predates https://github.com/gravitational/gravity/commit/f6b2e74c39837d36ff03af974dbf80b3ddbe465b and thus doesn't attempt to read credentials from `~/.tsh`.  It is fully isolated by `--state-dir`.

I expected to see 6.1.x need the updated robotest CentOS image because 5.5.50+ has https://github.com/gravitational/gravity/pull/1919, and we test upgrades from 5.5.latest to 6.1.  However the 5.5.x version of @bernardjkim's code does not appear to block upgrades, unlike the 7.0.x version.

The above means 6.1.x doesn't really need either of the https://github.com/gravitational/gravity/pull/1997 fixes.  Nontheless,  Robotest 2.1.0 still has some nice QoL improvements for debugging/analysis and we'll need to pick it up before https://github.com/gravitational/gravity/pull/1967 is backported.