### PR TITLE
(5.5) Add flannel restart phase

### DIFF
--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -262,4 +262,7 @@ var (
 	// Github issue: https://github.com/gravitational/gravity/issues/1445.
 	// KB: https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649.
 	TeleportBrokenJoinTokenVersion = semver.New("5.5.40")
+	// NethealthEnabledVersion is version of the first release with overlay
+	// network checker enabled in the cluster.
+	NethealthEnabledVersion = semver.New("5.5.46")
 )

--- a/lib/update/cluster/executor.go
+++ b/lib/update/cluster/executor.go
@@ -90,6 +90,8 @@ const (
 	dockerMount = "mount"
 	// planetStart is the phase that starts Planet systemd unit.
 	planetStart = "planet_start"
+	// flannelRestart is the phase that restarts flanneld.
+	flannelRestart = "flannel_restart"
 )
 
 // fsmSpec returns the function that returns an appropriate phase executor
@@ -187,6 +189,8 @@ func fsmSpec(c Config) fsm.FSMSpecFunc {
 			return libphase.NewDockerMount(p, remote, logger)
 		case planetStart:
 			return libphase.NewPlanetStart(p, remote, logger)
+		case flannelRestart:
+			return libphase.NewFlannelRestartPhase(p, logger)
 		default:
 			return nil, trace.BadParameter(
 				"phase %q requires executor %q (potential mismatch between upgrade versions)",

--- a/lib/update/cluster/phases/flannel.go
+++ b/lib/update/cluster/phases/flannel.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/fsm"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// NewFlannelRestartPhase returns executor that restarts flanneld.
+func NewFlannelRestartPhase(p fsm.ExecutorParams, logger logrus.FieldLogger) (*flannelRestart, error) {
+	return &flannelRestart{
+		FieldLogger: logger,
+	}, nil
+}
+
+// Execute cleans up after the upgrade.
+//
+// Clean up tasks include:
+//  * trimming the container journal
+func (r *flannelRestart) Execute(ctx context.Context) error {
+	r.Info("Restarting flanneld.")
+	out, err := fsm.RunCommand(utils.PlanetCommandArgs(defaults.SystemctlBin, "restart", "flanneld"))
+	if err != nil {
+		return trace.Wrap(err, "failed to restart flanneld: %s", string(out))
+	}
+	return nil
+}
+
+// Rollback is no-op for this phase.
+func (*flannelRestart) Rollback(context.Context) error {
+	return nil
+}
+
+// PreCheck is no-op for this phase.
+func (*flannelRestart) PreCheck(context.Context) error {
+	return nil
+}
+
+// PostCheck is no-op for this phase.
+func (*flannelRestart) PostCheck(context.Context) error {
+	return nil
+}
+
+// flannelRestart is the phase that restarts flanneld.
+type flannelRestart struct {
+	// FieldLogger is used for logging.
+	logrus.FieldLogger
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This pull request adds a phase to the upgrade procedure that restarts flanneld service in order to workaround some potential overlay network issues we encountered with flannel before.

* The phase runs as a very first step, even prior to /init.
* It's only present for upgrades from 5.5.46 and earlier since later versions have an overlay network checker.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/2019.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

```
ubuntu@node-1:~/upgrade$ sudo ./gravity plan
Phase                    Description                                                State         Node               Requires                           Updated
-----                    -----------                                                -----         ----               --------                           -------
* flannel                Restart flanneld                                           Unstarted     -                  -                                  -
  * node-1               Restart flanneld on node "node-1"                          Unstarted     -                  -                                  -



ubuntu@node-1:~/upgrade$ sudo ./gravity plan execute --phase=/flannel
Fri Aug 21 00:08:49 UTC	Executing "/flannel/node-1" locally
Fri Aug 21 00:08:50 UTC	Executing phase "/flannel" finished in 1 second



ubuntu@node-1:~/upgrade$ sudo gravity exec systemctl status flanneld
● flanneld.service - Flannel
   Loaded: loaded (/lib/systemd/system/flanneld.service; static; vendor preset: enabled)
   Active: active (running) since Fri 2020-08-21 00:08:50 UTC; 6s ago



ubuntu@node-1:~/upgrade$ sudo ./gravity plan
Phase                    Description                                                State         Node               Requires                           Updated
-----                    -----------                                                -----         ----               --------                           -------
✓ flannel                Restart flanneld                                           Completed     -                  -                                  Fri Aug 21 00:08 UTC
  ✓ node-1               Restart flanneld on node "node-1"                          Completed     -                  -                                  Fri Aug 21 00:08 UTC
```