### PR TITLE
[5.5.x] Verify agents are active before resuming upgrade

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -215,9 +215,6 @@ const (
 	// AgentConnectTimeout specifies the timeout for the initial connect
 	AgentConnectTimeout = 1 * time.Minute
 
-	// AgentStatusTimeout specifies the timeout for agent status query
-	AgentStatusTimeout = 5 * time.Second
-
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -198,6 +198,13 @@ const gravityResumeServiceName = "gravity-resume.service"
 // executeOrForkPhase either directly executes the specified operation phase,
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
+	// "/" PhaseID indicates a resume operation. Verify all agents are active before resuming.
+	if params.PhaseID == "/" {
+		if err := verifyAgentsActive(env); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	// If given the --block flag, we're running as a systemd unit (or a user
 	// requested the command to execute in foreground), so proceed to perform
 	// the command (resume or single phase) directly.

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -198,8 +198,7 @@ const gravityResumeServiceName = "gravity-resume.service"
 // executeOrForkPhase either directly executes the specified operation phase,
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
-	// "/" PhaseID indicates a resume operation. Verify all agents are active before resuming.
-	if params.PhaseID == "/" {
+	if params.IsResume() {
 		if err := verifyAgentsActive(env); err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -54,6 +54,11 @@ type PhaseParams struct {
 	Block bool
 }
 
+// IsResume returns true if the phase ID indicates a resume operation.
+func (p PhaseParams) IsResume() bool {
+	return p.PhaseID == "/"
+}
+
 func (p PhaseParams) toFSM() fsm.Params {
 	return fsm.Params{
 		PhaseID: p.PhaseID,

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -113,6 +113,11 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 	default:
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
+
+	if err := verifyAgentsActive(localEnv); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if !confirmed && !params.DryRun {
 		localEnv.Printf(planRollbackWarning, operationList([]clusterOperation{*operation}).formatTable())
 		if err := enforceConfirmation("Proceed?"); err != nil {

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -42,9 +42,7 @@ import (
 	"github.com/gravitational/gravity/lib/update"
 	clusterupdate "github.com/gravitational/gravity/lib/update/cluster"
 	"github.com/gravitational/gravity/lib/utils"
-	"github.com/gravitational/gravity/tool/common"
 
-	"github.com/buger/goterm"
 	"github.com/cenkalti/backoff"
 	teleclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/trace"
@@ -428,49 +426,60 @@ func rpcAgentShutdown(env *localenv.LocalEnvironment) error {
 func rpcAgentStatus(env *localenv.LocalEnvironment) error {
 	env.PrintStep("Collecting RPC agent status")
 
-	operator, err := env.SiteOperator()
+	statusList, err := collectAgentStatus(env)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	env.Println(statusList.String())
+
+	if !statusList.AgentsActive() {
+		return trace.BadParameter("some agents are offline")
+	}
+
+	return nil
+}
+
+// collectAgentStatus collects the gravity agent status from all members of the
+// cluster.
+func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusList, err error) {
+	operator, err := env.SiteOperator()
+	if err != nil {
+		return statusList, trace.Wrap(err)
 	}
 
 	creds, err := fsm.GetClientCredentials()
 	if err != nil {
-		return trace.Wrap(err)
+		return statusList, trace.Wrap(err)
 	}
 
 	cluster, err := operator.GetLocalSite()
 	if err != nil {
-		return trace.Wrap(err)
+		return statusList, trace.Wrap(err)
 	}
 
 	timeout, err := utils.GetenvDuration(constants.AgentStatusTimeoutEnvVar)
 	if err != nil {
-		timeout = defaults.AgentStatusTimeout
+		timeout = defaults.AgentRequestTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	statusList := rpc.CollectAgentStatus(ctx, cluster.ClusterState.Servers, fsm.NewAgentRunner(creds))
+	statusList = rpc.CollectAgentStatus(ctx, cluster.ClusterState.Servers, fsm.NewAgentRunner(creds))
+	return statusList, nil
+}
 
-	var errs []error
-
-	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	common.PrintTableHeader(t, []string{"Hostname", "Address", "Status", "Version"})
-	for _, status := range statusList {
-		fmt.Fprintf(t, "%s\t%s\t%s\t%s\n", status.Hostname, status.Address, status.Status, status.Version)
-		if status.Error != nil {
-			log.WithError(status.Error).Debugf("Failed to collect agent status on %s.", status.Address)
-			errs = append(errs, status.Error)
-		}
+// verifyAgentsActive verifies that all agents are active.
+func verifyAgentsActive(env *localenv.LocalEnvironment) error {
+	statusList, err := collectAgentStatus(env)
+	if err != nil {
+		return trace.Wrap(err, "failed to collect agent status")
 	}
-	env.Println(t.String())
-
-	if len(errs) > 0 {
-		log.Warn("Some agents are offline.")
-		return trace.BadParameter("some agents are offline")
+	if !statusList.AgentsActive() {
+		env.Println(statusList.String())
+		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This change will make sure that all upgrade agents are online before resuming an upgrade or before rolling back an upgrade.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2017

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade resume fails and notifies an agent is offline**
- Start upgrade
- Reboot node
- Disable & Stop gravity-agent.service
- Verify `gravity upgrade --resume` fails to resume upgrade with appropriate error
```
[vagrant@node-1 installer]$ sudo ./gravity upgrade --resume
Hostname     Address            Status      Version
--------     -------            ------      -------
node-1       172.28.128.101     Offline

[ERROR]: some agents are offline; ensure all agents are deployed with `./gravity agent deploy`
```

- Verify `gravity plan resume` fails to resume upgrade with appropriate error
```
[vagrant@node-1 installer]$ sudo ./gravity plan resume
Hostname     Address            Status      Version
--------     -------            ------      -------
node-1       172.28.128.101     Offline

[ERROR]: some agents are offline; ensure all agents are deployed with `./gravity agent deploy`
```
**Verify upgrade resumes after re-deploying agents**
```
[vagrant@node-1 installer]$ sudo ./gravity upgrade --resume
Fri Aug 21 17:23:50 UTC Starting gravity-resume.service service
Fri Aug 21 17:23:50 UTC Service gravity-resume.service has been launched.

To monitor the operation progress:

  sudo gravity plan --operation-id=a37b24b5-2d7b-44fa-b356-dbf058b8b95b --tail

To monitor the service logs:

  sudo journalctl -u gravity-resume.service -f

```

**Verify `gravity rollback` fails to rollback upgrade with appropriate error**
```
[vagrant@node-1 installer]$ sudo ./gravity rollback
Hostname     Address            Status      Version
--------     -------            ------      -------
node-1       172.28.128.101     Offline

[ERROR]: some agents are offline; ensure all agents are deployed with `./gravity agent deploy`
```
**Verify rollback after re-deploying agents**
```
[vagrant@node-1 installer]$ sudo ./gravity rollback
You are about to rollback the following operation:

Type                 ID                                       State                  Created
----                 --                                       -----                  -------
operation_update     a37b24b5-2d7b-44fa-b356-dbf058b8b95b     update_in_progress     2020-08-21 08:07

Consider checking the operation plan and using --dry-run flag first to see which actions will be performed.
You can suppress this warning in future by providing --confirm flag.

Proceed? (yes/no):
yes
Fri Aug 21 17:24:16 UTC Rolling back "/config/node-1" locally
Fri Aug 21 17:24:18 UTC Rolling back "/masters/node-1/untaint" locally
Fri Aug 21 17:24:20 UTC Rolling back "/masters/node-1/endpoints" locally
Fri Aug 21 17:24:25 UTC Rolling back "/masters/node-1/uncordon" locally
Fri Aug 21 17:24:31 UTC Rolling back "/masters/node-1/taint" locally
Fri Aug 21 17:24:34 UTC Rolling back "/masters/node-1/system-upgrade" locally
binary package gravitational.io/gravity:5.5.51 installed in /usr/bin/gravity
Fri Aug 21 17:24:40 UTC Rolling back "/masters/node-1/drain" locally
Fri Aug 21 17:24:46 UTC Rolling back "/coredns" locally
Fri Aug 21 17:24:50 UTC Rolling back "/bootstrap/node-1" locally
Fri Aug 21 17:24:56 UTC Rolling back "/pre-update" locally
Fri Aug 21 17:24:59 UTC Rolling back "/checks" locally
Fri Aug 21 17:25:05 UTC Rolling back "/init/node-1" locally
Fri Aug 21 17:25:10 UTC operation(update(a37b24b5-2d7b-44fa-b356-dbf058b8b95b), cluster=dev.test, created=2020-08-21 08:07) finished in 54 seconds
```

**Verify `gravity plan execute --phase=XXX` does not run agents check**
```
[vagrant@node-1 installer]$ sudo ./gravity plan execute --phase=/masters/node-1/drain --force
Fri Aug 21 17:21:24 UTC Executing "/masters/node-1/drain" locally
Fri Aug 21 17:21:30 UTC Executing phase "/masters/node-1/drain" finished in 6 seconds
```

**Verify `gravity agent status` still functions the same**
```
[vagrant@node-1 installer]$ sudo ./gravity agent status
Fri Aug 21 17:25:38 UTC Collecting RPC agent status
Hostname     Address            Status       Version
--------     -------            ------       -------
node-1       172.28.128.101     Deployed     5.5.52-dev.5
```