### PR TITLE
[5.5.x] ClusterConfiguration watcher

### DIFF
--- a/lib/ops/opsservice/clusterconfig.go
+++ b/lib/ops/opsservice/clusterconfig.go
@@ -17,12 +17,8 @@ limitations under the License.
 package opsservice
 
 import (
-	"context"
-	"encoding/json"
-
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
-	"github.com/gravitational/gravity/lib/kubernetes"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
@@ -82,35 +78,11 @@ func (o *Operator) GetClusterConfiguration(key ops.SiteKey) (config clusterconfi
 // UpdateClusterConfiguration updates the cluster configuration to the value given
 // in the specified request
 func (o *Operator) UpdateClusterConfiguration(req ops.UpdateClusterConfigRequest) error {
-	client, err := o.GetKubeClient()
+	cluster, err := o.openSite(req.ClusterKey)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	configmaps := client.CoreV1().ConfigMaps(defaults.KubeSystemNamespace)
-	configmap, err := getOrCreateClusterConfigMap(configmaps)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	var previousKeyValues []byte
-	if len(configmap.Data) != 0 {
-		var err error
-		previousKeyValues, err = json.Marshal(configmap.Data)
-		if err != nil {
-			return trace.Wrap(err, "failed to marshal previous key/values")
-		}
-		if configmap.Annotations == nil {
-			configmap.Annotations = make(map[string]string)
-		}
-		configmap.Annotations[constants.PreviousKeyValuesAnnotationKey] = string(previousKeyValues)
-	}
-	configmap.Data = map[string]string{
-		"spec": string(req.Config),
-	}
-	err = kubernetes.Retry(context.TODO(), func() error {
-		_, err := configmaps.Update(configmap)
-		return trace.Wrap(err)
-	})
-	return trace.Wrap(err)
+	return trace.Wrap(cluster.updateClusterConfiguration(req))
 }
 
 // NewConfigurationConfigMap creates the backing ConfigMap to host cluster configuration

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -630,6 +630,13 @@ func (r configCollection) WriteText(w io.Writer) error {
 		common.PrintCustomTableHeader(t, []string{"Kubelet"}, "-")
 		fmt.Fprintf(t, "%v\n", string(config.Config))
 	}
+	if config := r.GetGravityControllerServiceConfig(); config != nil {
+		common.PrintCustomTableHeader(t, []string{"GravityControllerService"}, "-")
+		fmt.Fprintf(t, "Type:\t%v\n", config.Type)
+		if len(config.Annotations) != 0 {
+			fmt.Fprintf(t, "Annotations:\t%v\n", formatAnnotations(config.Annotations))
+		}
+	}
 	config := r.GetGlobalConfig()
 	displayCloudConfig := config.CloudProvider != "" || config.CloudConfig != ""
 	if displayCloudConfig {
@@ -692,6 +699,14 @@ func formatFeatureGates(features map[string]bool) string {
 	result := make([]string, 0, len(features))
 	for feature, enabled := range features {
 		result = append(result, fmt.Sprintf("%v=%v", feature, enabled))
+	}
+	return strings.Join(result, ",")
+}
+
+func formatAnnotations(annotations map[string]string) string {
+	result := make([]string, 0, len(annotations))
+	for key, val := range annotations {
+		result = append(result, fmt.Sprintf("%v=%v", key, val))
 	}
 	return strings.Join(result, ",")
 }

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -1290,6 +1290,9 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		if err := p.startApplicationsSynchronizer(p.context); err != nil {
 			return trace.Wrap(err)
 		}
+		if err := p.startServiceConfigWatch(p.context, client); err != nil {
+			return trace.Wrap(err)
+		}
 
 		if err := p.startAutoscale(p.context); err != nil {
 			return trace.Wrap(err)

--- a/lib/process/watch.go
+++ b/lib/process/watch.go
@@ -25,10 +25,11 @@ import (
 	libkube "github.com/gravitational/gravity/lib/kubernetes"
 	"github.com/gravitational/gravity/lib/processconfig"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/trace"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
@@ -240,5 +241,143 @@ func (p *Process) startWatchingReloadEvents(ctx context.Context, client *kuberne
 			}
 		}
 	}()
+	return nil
+}
+
+// startServiceConfigWatch watches the clusterconfiguration configmap and updates
+// the gravity-site service configurations if the gravityControllerService has
+// been modified.
+func (p *Process) startServiceConfigWatch(ctx context.Context, client *kubernetes.Clientset) error {
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			err := p.watchServiceConfig(ctx, client)
+			if err != nil {
+				p.Errorf("Failed to start service config watch: %v.", trace.DebugReport(err))
+			}
+			select {
+			case <-ticker.C:
+			case <-ctx.Done():
+				p.Debug("Service config watcher stopped.")
+				return
+			}
+		}
+
+	}()
+	return nil
+}
+
+func (p *Process) watchServiceConfig(ctx context.Context, client *kubernetes.Clientset) error {
+	p.Debug("Restarting service config watch.")
+
+	watcher, err := client.CoreV1().ConfigMaps(defaults.KubeSystemNamespace).Watch(metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", constants.ClusterConfigurationMap).String(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				p.Debugf("Watcher channel closed: %v.", event)
+				return nil
+			}
+			if err := updateServiceConfiguration(client); err != nil {
+				p.Debug("Failed to update service config: %v.", trace.DebugReport(err))
+			}
+		case <-ctx.Done():
+			p.Debug("Stopping certificate watcher.")
+			return nil
+		}
+	}
+
+}
+
+// getServiceConfiguration returns the current gravityControllerService configuration
+// defined in the clusterconfiguration configmap.
+func getServiceConfiguration(client *kubernetes.Clientset) (*clusterconfig.GravityControllerService, error) {
+	configmap, err := client.CoreV1().ConfigMaps(defaults.KubeSystemNamespace).Get(constants.ClusterConfigurationMap, metav1.GetOptions{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	spec := configmap.Data["spec"]
+	if spec == "" {
+		return nil, trace.NotFound("clutserconfiguration spec is empty")
+	}
+
+	clusterConfig, err := clusterconfig.Unmarshal([]byte(spec))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return clusterConfig.GetGravityControllerServiceConfig(), nil
+}
+
+// updateServiceConfiguration updates the gravity-site service configuration.
+func updateServiceConfiguration(client *kubernetes.Clientset) error {
+	config, err := getServiceConfiguration(client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	services := client.CoreV1().Services(defaults.KubeSystemNamespace)
+
+	svc, err := services.Get(constants.GravityServiceName, metav1.GetOptions{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Set default service type and annotations.
+	svcType := v1.ServiceType(clusterconfig.LoadBalancer)
+	annotations := map[string]string{
+		clusterconfig.AWSIdleTimeoutKey: clusterconfig.AWSLoadBalancerIdleTimeout,
+		clusterconfig.AWSInternalKey:    clusterconfig.AWSLoadBalancerInternal,
+	}
+
+	if !config.IsEmpty() {
+		if config.Type != "" {
+			svcType = v1.ServiceType(config.Type)
+		}
+		for key, val := range config.Annotations {
+			annotations[key] = val
+		}
+	}
+
+	// shouldUpdate indicates that a change has been made to the service
+	// configuration and should be updated.
+	var shouldUpdate bool
+
+	if svc.Spec.Type != svcType {
+		svc.Spec.Type = svcType
+		shouldUpdate = true
+	}
+
+	if len(svc.Annotations) != len(annotations) {
+		svc.Annotations = annotations
+		shouldUpdate = true
+	} else {
+		for key, updatedVal := range annotations {
+			existingVal, exists := svc.Annotations[key]
+			if !exists || existingVal != updatedVal {
+				svc.Annotations = annotations
+				shouldUpdate = true
+				break
+			}
+		}
+	}
+
+	if !shouldUpdate {
+		return nil
+	}
+
+	if _, err := services.Update(svc); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }

--- a/lib/update/clusterconfig/plan.go
+++ b/lib/update/clusterconfig/plan.go
@@ -115,9 +115,9 @@ func shouldUpdateNodes(clusterConfig clusterconfig.Interface, numWorkerNodes int
 	if numWorkerNodes == 0 {
 		return false
 	}
-	var hasComponentUpdate, hasCIDRUpdate bool
 	config := clusterConfig.GetGlobalConfig()
-	hasComponentUpdate = len(config.FeatureGates) != 0
-	hasCIDRUpdate = len(config.PodCIDR) != 0 || len(config.ServiceCIDR) != 0
-	return !clusterConfig.GetKubeletConfig().IsEmpty() || hasComponentUpdate || hasCIDRUpdate
+	hasComponentUpdate := len(config.FeatureGates) != 0
+	hasCIDRUpdate := len(config.PodCIDR) != 0 || len(config.ServiceCIDR) != 0
+	kubeletUpdate := !clusterConfig.GetKubeletConfig().IsEmpty()
+	return kubeletUpdate || hasComponentUpdate || hasCIDRUpdate
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR adds a clusterconfiguration watcher that will watch for changes in `gravityControllerService` and update the gravity-site service. The clusterconfiguration can be used to modify the gravity-site service type and annotations.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1995

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Default gravity-site config:
```
[vagrant@node-1 ~]$ sudo kubectl describe svc gravity-site -n kube-system
Name:                     gravity-site
Namespace:                kube-system
Labels:                   app=gravity-site
Annotations:              service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: 3600
                          service.beta.kubernetes.op/aws-load-balancer-internal: 0.0.0.0/0
Selector:                 app=gravity-site
Type:                     LoadBalancer
IP:                       100.100.42.132
Port:                     web  3009/TCP
TargetPort:               3009/TCP
NodePort:                 web  32009/TCP
Endpoints:                172.28.128.101:3009
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>
```
cluster-config.yaml
```
kind: ClusterConfiguration
version: v1
spec:
  global:
    featureGates:
      AllAlpha: true
  gravityControllerService:
    type: NodePort
    annotations:
      "cloud.google.com/load-balancer-type": "Internal"
      "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "4000"
```

**Verify gravity-site service configuration is updated when updating cluster configuration**
**Verify gravity-site service configuration is updated on install**
**Verify gravity-site service configuration is updated on upgrade**