### PR TITLE
(5.5) Add check for http(-s) proxy format

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -204,6 +204,11 @@ const (
 	// If not empty, turns the preflight checks off
 	PreflightChecksOffEnvVar = "GRAVITY_CHECKS_OFF"
 
+	// HTTPProxyEnvVar is the HTTP_PROXY environment variable.
+	HTTPProxyEnvVar = "HTTP_PROXY"
+	// HTTPSProxyEnvVar is the HTTPS_PROXY environment variable.
+	HTTPSProxyEnvVar = "HTTPS_PROXY"
+
 	// DockerRegistry is a default name for private docker registry
 	DockerRegistry = "leader.telekube.local:5000"
 

--- a/lib/install/plan_test.go
+++ b/lib/install/plan_test.go
@@ -255,7 +255,7 @@ func (s *PlanSuite) verifyConfigurePhase(c *check.C, phase storage.OperationPhas
 		Data: &storage.OperationPhaseData{
 			Install: &storage.InstallOperationData{
 				Env: map[string]string{
-					"HTTP_PROXY": "example.com:8081",
+					"HTTP_PROXY": "http://example.com:8081",
 				},
 			},
 		},
@@ -471,7 +471,7 @@ func (s *PlanSuite) verifyResourcesPhase(c *check.C, phase storage.OperationPhas
     "creationTimestamp": null
   },
   "data": {
-    "HTTP_PROXY": "example.com:8081"
+    "HTTP_PROXY": "http://example.com:8081"
   }
 }
 	`)
@@ -762,7 +762,7 @@ version: v1
 kind: RuntimeEnvironment
 spec:
   data:
-    HTTP_PROXY: "example.com:8081"
+    HTTP_PROXY: "http://example.com:8081"
 ---
 version: v1
 kind: AlertTarget

--- a/lib/install/planbuilder.go
+++ b/lib/install/planbuilder.go
@@ -696,6 +696,9 @@ func addResources(builder *PlanBuilder, resourceBytes []byte, runtimeResources [
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			if err := env.CheckAndSetDefaults(); err != nil {
+				return trace.Wrap(err)
+			}
 			builder.env = env.GetKeyValues()
 			configmap := opsservice.NewEnvironmentConfigMap(env.GetKeyValues())
 			kubernetesResources = append(kubernetesResources, configmap)

--- a/lib/storage/environment.go
+++ b/lib/storage/environment.go
@@ -19,12 +19,12 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/utils"
 
 	teleservices "github.com/gravitational/teleport/lib/services"
 	teleutils "github.com/gravitational/teleport/lib/utils"
@@ -119,34 +119,26 @@ func (r *EnvironmentV1) CheckAndSetDefaults() error {
 	return trace.NewAggregate(errors...)
 }
 
-// checkHTTPProxy verifies HTTP_PROXY (if present) is valid a URL and has http:// scheme.
+// checkHTTPProxy verifies HTTP_PROXY (if present) is a valid proxy URL.
 func (r *EnvironmentV1) checkHTTPProxy() error {
 	httpProxy := r.getVariable(constants.HTTPProxyEnvVar)
 	if httpProxy == "" {
 		return nil
 	}
-	parsed, err := url.Parse(httpProxy)
-	if err != nil {
-		return trace.Wrap(err, "HTTP_PROXY must be a valid URL: %q", httpProxy)
-	}
-	if parsed.Scheme != "http" {
-		return trace.BadParameter("HTTP_PROXY URL must include http:// scheme: %q", httpProxy)
+	if _, err := utils.ParseProxy(httpProxy); err != nil {
+		return trace.Wrap(err, "failed to parse HTTP_PROXY")
 	}
 	return nil
 }
 
-// checkHTTPSProxy verifies HTTPS_PROXY (if present) is valid a URL and has https:// scheme.
+// checkHTTPSProxy verifies HTTPS_PROXY (if present) is a valid proxy URL.
 func (r *EnvironmentV1) checkHTTPSProxy() error {
 	httpsProxy := r.getVariable(constants.HTTPSProxyEnvVar)
 	if httpsProxy == "" {
 		return nil
 	}
-	parsed, err := url.Parse(httpsProxy)
-	if err != nil {
-		return trace.Wrap(err, "HTTPS_PROXY must be a valid URL: %q", httpsProxy)
-	}
-	if parsed.Scheme != "https" {
-		return trace.BadParameter("HTTPS_PROXY URL must include https:// scheme: %q", httpsProxy)
+	if _, err := utils.ParseProxy(httpsProxy); err != nil {
+		return trace.Wrap(err, "failed to parse HTTPS_PROXY")
 	}
 	return nil
 }

--- a/lib/storage/environment.go
+++ b/lib/storage/environment.go
@@ -110,35 +110,24 @@ func (r *EnvironmentV1) GetKeyValues() map[string]string {
 // CheckAndSetDefaults validates this resource and sets defaults
 func (r *EnvironmentV1) CheckAndSetDefaults() error {
 	var errors []error
-	if err := r.checkHTTPProxy(); err != nil {
+	if err := r.checkProxy(constants.HTTPProxyEnvVar); err != nil {
 		errors = append(errors, err)
 	}
-	if err := r.checkHTTPSProxy(); err != nil {
+	if err := r.checkProxy(constants.HTTPSProxyEnvVar); err != nil {
 		errors = append(errors, err)
 	}
 	return trace.NewAggregate(errors...)
 }
 
-// checkHTTPProxy verifies HTTP_PROXY (if present) is a valid proxy URL.
-func (r *EnvironmentV1) checkHTTPProxy() error {
-	httpProxy := r.getVariable(constants.HTTPProxyEnvVar)
+// checkProxy verifies the specified environment variable (HTTP_PROXY or
+// HTTPS_PROXY) is a valid proxy URL.
+func (r *EnvironmentV1) checkProxy(env string) error {
+	httpProxy := r.getVariable(env)
 	if httpProxy == "" {
 		return nil
 	}
 	if _, err := utils.ParseProxy(httpProxy); err != nil {
-		return trace.Wrap(err, "failed to parse HTTP_PROXY")
-	}
-	return nil
-}
-
-// checkHTTPSProxy verifies HTTPS_PROXY (if present) is a valid proxy URL.
-func (r *EnvironmentV1) checkHTTPSProxy() error {
-	httpsProxy := r.getVariable(constants.HTTPSProxyEnvVar)
-	if httpsProxy == "" {
-		return nil
-	}
-	if _, err := utils.ParseProxy(httpsProxy); err != nil {
-		return trace.Wrap(err, "failed to parse HTTPS_PROXY")
+		return trace.Wrap(err, "failed to parse %v", env)
 	}
 	return nil
 }

--- a/lib/storage/environment.go
+++ b/lib/storage/environment.go
@@ -110,11 +110,13 @@ func (r *EnvironmentV1) GetKeyValues() map[string]string {
 // CheckAndSetDefaults validates this resource and sets defaults
 func (r *EnvironmentV1) CheckAndSetDefaults() error {
 	var errors []error
-	if err := r.checkProxy(constants.HTTPProxyEnvVar); err != nil {
-		errors = append(errors, err)
-	}
-	if err := r.checkProxy(constants.HTTPSProxyEnvVar); err != nil {
-		errors = append(errors, err)
+	for _, env := range []string{
+		constants.HTTPProxyEnvVar, strings.ToLower(constants.HTTPProxyEnvVar),
+		constants.HTTPSProxyEnvVar, strings.ToLower(constants.HTTPSProxyEnvVar),
+	} {
+		if err := r.checkProxy(env); err != nil {
+			errors = append(errors, err)
+		}
 	}
 	return trace.NewAggregate(errors...)
 }
@@ -133,11 +135,9 @@ func (r *EnvironmentV1) checkProxy(env string) error {
 }
 
 // getVariable returns value of the specified environment variable or an empty string.
-//
-// The variable name is treated as case-insensitive.
 func (r *EnvironmentV1) getVariable(key string) string {
 	for k, v := range r.GetKeyValues() {
-		if strings.ToLower(k) == strings.ToLower(key) {
+		if k == key {
 			return v
 		}
 	}

--- a/lib/storage/environment_test.go
+++ b/lib/storage/environment_test.go
@@ -44,19 +44,29 @@ func (*EnvS) TestCheckAndSetDefaults(c *C) {
 			comment: "http proxy missing scheme",
 		},
 		{
+			vars:    `{"http_proxy": "proxy.example.com:8080"}`,
+			error:   true,
+			comment: "http proxy with port missing scheme",
+		},
+		{
 			vars:    `{"http_proxy": "http://proxy.example.com", "https_proxy": "proxy2.example.com"}`,
 			error:   true,
 			comment: "https proxy missing scheme",
 		},
 		{
-			vars:    `{"https_proxy": "http://proxy2.example.com"}`,
-			error:   true,
-			comment: "https proxy has incorrect scheme",
+			vars:    `{"https_proxy": "http://proxy2.example.com:1234"}`,
+			error:   false,
+			comment: "https proxy has http scheme",
 		},
 		{
 			vars:    `{"http_proxy": "http://proxy.example.com", "https_proxy": "https://proxy2.example.com"}`,
 			error:   false,
 			comment: "http and https proxies are ok",
+		},
+		{
+			vars:    `{"http_proxy": "ftp://proxy.example.com"}`,
+			error:   true,
+			comment: "invalid proxy scheme",
 		},
 		{
 			vars:    `{"http_proxy": "", "https_proxy": ""}`,

--- a/lib/storage/environment_test.go
+++ b/lib/storage/environment_test.go
@@ -49,6 +49,11 @@ func (*EnvS) TestCheckAndSetDefaults(c *C) {
 			comment: "http proxy with port missing scheme",
 		},
 		{
+			vars:    `{"HTTP_PROXY": "http://proxy.example.com", "http_proxy": "proxy.example.com"}`,
+			error:   true,
+			comment: "proxy environment variable case",
+		},
+		{
 			vars:    `{"http_proxy": "http://proxy.example.com", "https_proxy": "proxy2.example.com"}`,
 			error:   true,
 			comment: "https proxy missing scheme",

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -497,7 +497,7 @@ func ParseProxy(proxy string) (*url.URL, error) {
 		return nil, trace.Wrap(err, "failed to parse proxy address %q", proxy)
 	}
 	if !StringInSlice([]string{"http", "https", "socks5"}, proxyURL.Scheme) {
-		return nil, trace.BadParameter("proxy address %q must include a valid scheme (http, https or socks5)")
+		return nil, trace.BadParameter("proxy address %q must include a valid scheme (http, https or socks5)", proxy)
 	}
 	return proxyURL, nil
 }

--- a/lib/utils/parse.go
+++ b/lib/utils/parse.go
@@ -483,3 +483,21 @@ func ParseProxyAddr(proxyAddr, defaultWebPort, defaultSSHPort string) (host stri
 
 	return "", "", "", trace.BadParameter("unable to parse port: %v", port)
 }
+
+// ParseProxy parses the provided HTTP(-S) proxy address and returns it in
+// the parsed URL form. The proxy value is expected to be a complete URL
+// that includes a scheme (http, https or socks5).
+//
+// This function is loosely based on Go's proxy parsing method:
+//
+// https://github.com/golang/go/blob/release-branch.go1.15/src/vendor/golang.org/x/net/http/httpproxy/proxy.go#L149-L170
+func ParseProxy(proxy string) (*url.URL, error) {
+	proxyURL, err := url.Parse(proxy)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse proxy address %q", proxy)
+	}
+	if !StringInSlice([]string{"http", "https", "socks5"}, proxyURL.Scheme) {
+		return nil, trace.BadParameter("proxy address %q must include a valid scheme (http, https or socks5)")
+	}
+	return proxyURL, nil
+}

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -47,6 +47,7 @@ import (
 	"github.com/buger/goterm"
 	"github.com/coreos/go-semver/semver"
 	"github.com/fatih/color"
+	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/version"
 )
@@ -371,7 +372,43 @@ func (r *clusterInitializer) validatePreconditions(localEnv *localenv.LocalEnvir
 	if err := r.checkTiller(localEnv, updateApp.Manifest); err != nil {
 		return trace.Wrap(err)
 	}
+	if err := r.checkRuntimeEnvironment(localEnv, cluster, operator); err != nil {
+		return trace.Wrap(err)
+	}
 	r.updateLoc = updateApp.Package
+	return nil
+}
+
+func (r *clusterInitializer) checkRuntimeEnvironment(env *localenv.LocalEnvironment, cluster ops.Site, operator ops.Operator) error {
+	runtimeEnv, err := operator.GetClusterEnvironmentVariables(cluster.Key())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := runtimeEnv.CheckAndSetDefaults(); err != nil {
+		log.WithError(err).Error("Runtime environment variables validation failed.")
+		if r.force {
+			env.PrintStep(color.YellowString("Runtime environment variables validation failed: %v", err))
+			return nil
+		}
+		bytes, marshalErr := yaml.Marshal(runtimeEnv)
+		if marshalErr != nil {
+			return trace.Wrap(err)
+		}
+		return trace.BadParameter(`There was an issue detected with runtime environment variables:
+
+    %q
+
+This may cause problems during the upgrade. Please review configured environment
+variables using "gravity resource get runtimeenvironment" command and update it
+appropriately before proceeding with the upgrade:
+
+%s
+See https://gravitational.com/gravity/docs/config/#runtime-environment-variables
+for more information on managing runtime environment variables.
+
+This warning can be bypassed by providing a --force flag to the upgrade command.`, err, bytes)
+	}
+	log.Info("Runtime environment variables are valid.")
 	return nil
 }
 

--- a/tool/gravity/cli/resources.go
+++ b/tool/gravity/cli/resources.go
@@ -183,6 +183,9 @@ func (r clusterOperationHandler) UpdateResource(req resources.CreateRequest) err
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		if err := env.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
 		return trace.Wrap(updateEnviron(context.TODO(), localEnv, updateEnv,
 			env, req.Manual, req.Confirmed))
 	case storage.KindClusterConfiguration:


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This pull request makes sure that RuntimeEnvironment resource is validated, specifically that `HTTP_PROXY` and `HTTPS_PROXY` environment variables, when set, are valid URLs and have corresponding scheme.

There are really two parts to the fix:

* Validate `HTTP(-S)_PROXY` variables as mentioned above (case-insensitive) when user creates/updates RuntimeEnvironment resource.
* Add a pre-upgrade check to perform the same validation on the existing resource, to catch potentially invalid configurations before upgrade and let the user fix it (we've run into such problems before).

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Refs https://github.com/gravitational/gravity/issues/2021.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Install 5.5.40 and create a RuntimeEnvironment resource with invalid proxies format:

```yaml
kind: RuntimeEnvironment
version: v1
spec:
  data:
    HTTP_PROXY: abcdge
    HTTPS_PROXY: qweasd
    NO_PROXY: 0.0.0.0/0,*
```

```
ubuntu@node-1:~/resources$ sudo gravity resource get runtimeenvironment
Environment
-----------
HTTPS_PROXY=qweasd
HTTP_PROXY=abcdge
NO_PROXY=0.0.0.0/0,*
```

Try to upgrade to this branch and see a warning:

```
ubuntu@node-1:~/upgrade$ sudo ./gravity upgrade --manual
Fri Aug 21 23:36:07 UTC	Upgrading cluster from 5.5.40 to 5.5.52-dev.4
[ERROR]: There was an issue detected with runtime environment variables:

    "HTTP_PROXY URL must include http:// scheme, HTTPS_PROXY URL must include https:// scheme"

This may cause problems during the upgrade. Please review configured environment
variables using "gravity resource get runtimeenvironment" command and update it
appropriately before proceeding with the upgrade:

kind: runtimeenvironment
metadata:
  name: runtimeenvironment
spec:
  data:
    HTTP_PROXY: abcdge
    HTTPS_PROXY: qweasd
    NO_PROXY: 0.0.0.0/0,*
version: v1

See https://gravitational.com/gravity/docs/config/#runtime-environment-variables
for more information on managing runtime environment variables.

This warning can be bypassed by providing a --force flag to the upgrade command.
```

Fix the resource, upgrade and try to update to the incorrect resource again:

```
ubuntu@node-1:~/resources$ sudo gravity resource create runtimeenv.yaml
[ERROR]: HTTP_PROXY URL must include http:// scheme: "123s123", HTTPS_PROXY URL must include https:// scheme: "http://qweasd:20"
```

## Additional information
<!--Optional. Anything else that may be relevant.-->

Needs forward-ports.