### PR TITLE
(5.5) Add ability to override default install fsm spec

### DIFF
--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -29,9 +29,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// FSMSpec returns a function that returns an appropriate phase executor
-// based on the provided params
-func FSMSpec(config FSMConfig) fsm.FSMSpecFunc {
+// FSMSpecFunc defines a function that returns install FSM spec based on the config.
+type FSMSpecFunc func(FSMConfig) fsm.FSMSpecFunc
+
+// FSMSpec is the install FSM spec.
+//
+// It may be overriden by external implementations to support additional
+// install operation phases (e.g. by the enterprise version).
+var FSMSpec FSMSpecFunc = DefaultFSMSpec
+
+// DefaultFSMSpec returns a function that returns an the default install FSM
+// spec for the provided install FSM config.
+func DefaultFSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 	return func(p fsm.ExecutorParams, remote fsm.Remote) (fsm.PhaseExecutor, error) {
 		switch {
 		case p.Phase.ID == phases.ChecksPhase:


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

https://github.com/gravitational/gravity/pull/2037 backport.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/989, closes https://github.com/gravitational/gravity/issues/2036.
* Ports https://github.com/gravitational/gravity/pull/2037.
* Requires https://github.com/gravitational/gravity.e/pull/4332.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback
