### PR TITLE
Clean up the README.md distributed in our release tarball

### DIFF
--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -1,5 +1,6 @@
 Gravity
 =======
+
 Gravity is a Kubernetes packaging solution that takes the drama out of
 on-premises deployments.
 
@@ -11,9 +12,9 @@ Quick Start    :  https://gravitational.com/gravity/docs/quickstart/
 Blog           :  https://blog.gravitational.com
 Community Forum:  https://community.gravitational.com
 
-
 Introduction
 ============
+
 Gravity is an open source toolkit for creating "images" of Kubernetes
 clusters and the applications running inside the clusters. The resulting
 images are called *cluster or application images* and they are just `.tar` files.

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -9,6 +9,7 @@ Project Links
 
 Gravity Website:  https://gravitational.com/gravity/
 Quick Start    :  https://gravitational.com/gravity/docs/quickstart/
+Gravity Source :  https://github.com/gravitational/gravity
 Blog           :  https://blog.gravitational.com
 Community Forum:  https://community.gravitational.com
 

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -46,33 +46,6 @@ What are these binaries?
 See the quick start to learn how to use these tools:
 https://gravitational.com/gravity/docs/quickstart/
 
-Building from source
-====================
-Gravity is written in Go. There are two ways to build the Gravity tools from
-source: by using locally installed build tools or via Docker. In both cases
-you will need a Linux machine.
-
-**Building on MacOS, even with Docker, is possible but not currently supported**
-
-```bash
-$ git clone git@github.com:gravitational/gravity.git
-$ cd gravity
-
-# Running 'make' with the default target uses Docker.
-# The output will be stored in build/current/
-$ make
-
-# If you have Go 1.10+ installed, you can build without Docker which is faster.
-# The output will be stored in $GOPATH/bin/
-$ make install
-
-# To build tsh
-$ make build-tsh
-
-# To remove the build artifacts:
-$ make clean
-```
-
 Talk to us
 ==========
 

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -76,7 +76,7 @@ $ make clean
 Talk to us
 ==========
 
-* Want to join our team to hack on Gravity? https://gravitational.com/careers/systems-engineer/
+* Want to join our team to hack on Gravity? https://gravitational.com/careers/
 * Want to stop managing Kubernetes and have autonomous appliance-like clusters?
 * Want to take your complex SaaS application and convert it into a downloadable
   appliance so your customers can run it on their own AWS account or in a colo?


### PR DESCRIPTION
## Description
Clean up the README.md distributed in our release tarball.

This is some stuff I noticed while working on upcoming robotest changes in the `build.assets/` directory.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
N/A

## TODOs
- [x] Self-review the change
- [x] Address review feedback

## Testing done
I checked that https://gravitational.com/about/ goes somewhere sane. Although it isn't to our current lever site, that may also change (it was breezy when I was hired).  I trust the web team to keep `/careers/` redirecting somewhere relevant.