### PR TITLE
Do not set priorityClassName for hooks

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -129,11 +129,6 @@ func configureMetadata(job *batchv1.Job, p Params) error {
 		job.Spec.Template.Spec.SecurityContext = defaults.HookSecurityContext()
 	}
 
-	// if priorityClassName is not specified, set the default one
-	if job.Spec.Template.Spec.PriorityClassName == "" {
-		job.Spec.Template.Spec.PriorityClassName = defaults.HookPriorityClassName
-	}
-
 	return nil
 }
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1182,9 +1182,6 @@ const (
 
 	// GravityFileLabel specifies the file label for the gravity binary
 	GravityFileLabel = "system_u:object_r:gravity_exec_t:s0"
-
-	// HookPriorityClassName specifies the default priority class for hooks
-	HookPriorityClassName = "system-cluster-critical"
 )
 
 var (


### PR DESCRIPTION
----

## Description
<!--Required. Provide high-level overview of what the change is for.-->
Reverting previous changes for hooks. cluster-critical priority could
be set only for kube-system resources and this could break existing
pre-update hooks for applications.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->