### PR TITLE
[7.0.x] Verify agents active before upgrade resume or rollback

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -222,9 +222,6 @@ const (
 	// AgentStopTimeout is amount of time agent gets to gracefully shut down
 	AgentStopTimeout = 10 * time.Second
 
-	// AgentStatusTimeout specifies the timeout for agent status query
-	AgentStatusTimeout = 5 * time.Second
-
 	// PeerConnectTimeout is the timeout of an RPC agent connecting to its peer
 	PeerConnectTimeout = 10 * time.Second
 

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -226,6 +226,7 @@ func executeUpdatePhase(env *localenv.LocalEnvironment, environ LocalEnvironment
 	if operation.Type != ops.OperationUpdate {
 		return trace.NotFound("no active update operation found")
 	}
+
 	return executeUpdatePhaseForOperation(env, environ, params, operation.SiteOperation)
 }
 
@@ -246,6 +247,12 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 // executeOrForkPhase either directly executes the specified operation phase,
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
+	if params.isResume() {
+		if err := verifyAgentsActive(env); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	// If given the --block flag, we're running as a systemd unit (or a user
 	// requested the command to execute in foreground), so proceed to perform
 	// the command (resume or single phase) directly.

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -248,7 +248,7 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
 	if params.isResume() {
-		if err := verifyAgentsActive(env); err != nil {
+		if err := verifyOrDeployAgents(env); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -177,7 +177,7 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
 
-	if err := verifyAgentsActive(localEnv); err != nil {
+	if err := verifyOrDeployAgents(localEnv); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -176,6 +176,11 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 	default:
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
+
+	if err := verifyAgentsActive(localEnv); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if !confirmed && !params.DryRun {
 		localEnv.Printf(planRollbackWarning, operationList{*op}.formatTable())
 		if err := enforceConfirmation("Proceed?"); err != nil {

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -41,9 +41,7 @@ import (
 	"github.com/gravitational/gravity/lib/update"
 	clusterupdate "github.com/gravitational/gravity/lib/update/cluster"
 	"github.com/gravitational/gravity/lib/utils"
-	"github.com/gravitational/gravity/tool/common"
 
-	"github.com/buger/goterm"
 	"github.com/cenkalti/backoff"
 	teleclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/trace"
@@ -453,19 +451,36 @@ func rpcAgentShutdown(env *localenv.LocalEnvironment) error {
 func rpcAgentStatus(env *localenv.LocalEnvironment) error {
 	env.PrintStep("Collecting RPC agent status")
 
-	operator, err := env.SiteOperator()
+	statusList, err := collectAgentStatus(env)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	env.Println(statusList.String())
+
+	if !statusList.AgentsActive() {
+		return trace.BadParameter("some agents are offline")
+	}
+
+	return nil
+}
+
+// collectAgentStatus collects the gravity agent status from all members of the
+// cluster.
+func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusList, err error) {
+	operator, err := env.SiteOperator()
+	if err != nil {
+		return statusList, trace.Wrap(err)
 	}
 
 	creds, err := fsm.GetClientCredentials()
 	if err != nil {
-		return trace.Wrap(err)
+		return statusList, trace.Wrap(err)
 	}
 
 	timeout, err := utils.GetenvDuration(constants.AgentStatusTimeoutEnvVar)
 	if err != nil {
-		timeout = defaults.AgentStatusTimeout
+		timeout = defaults.AgentRequestTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -473,29 +488,23 @@ func rpcAgentStatus(env *localenv.LocalEnvironment) error {
 
 	cluster, err := operator.GetLocalSite(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return statusList, trace.Wrap(err)
 	}
 
-	statusList := rpc.CollectAgentStatus(ctx, cluster.ClusterState.Servers, fsm.NewAgentRunner(creds))
+	statusList = rpc.CollectAgentStatus(ctx, cluster.ClusterState.Servers, fsm.NewAgentRunner(creds))
+	return statusList, nil
+}
 
-	var errs []error
-
-	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	common.PrintTableHeader(t, []string{"Hostname", "Address", "Status", "Version"})
-	for _, status := range statusList {
-		fmt.Fprintf(t, "%s\t%s\t%s\t%s\n", status.Hostname, status.Address, status.Status, status.Version)
-		if status.Error != nil {
-			log.WithError(status.Error).Debugf("Failed to collect agent status on %s.", status.Address)
-			errs = append(errs, status.Error)
-		}
+// verifyAgentsActive verifies that all agents are active.
+func verifyAgentsActive(env *localenv.LocalEnvironment) error {
+	statusList, err := collectAgentStatus(env)
+	if err != nil {
+		return trace.Wrap(err, "failed to collect agent status")
 	}
-	env.Println(t.String())
-
-	if len(errs) > 0 {
-		log.Warn("Some agents are offline.")
-		return trace.BadParameter("some agents are offline")
+	if !statusList.AgentsActive() {
+		env.Println(statusList.String())
+		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
 	}
-
 	return nil
 }
 

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -495,13 +495,18 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 	return statusList, nil
 }
 
-// verifyAgentsActive verifies that all agents are active.
-func verifyAgentsActive(env *localenv.LocalEnvironment) error {
+// verifyOrDeployAgents verifies that all agents are active or attempts to
+// re-deploy agents.
+func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	statusList, err := collectAgentStatus(env)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect agent status")
 	}
-	if !statusList.AgentsActive() {
+	if statusList.AgentsActive() {
+		return nil
+	}
+	if err := rpcAgentDeploy(env, deployOptions{}); err != nil {
+		log.WithError(err).Error("Failed to deploy agents.")
 		env.Println(statusList.String())
 		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This change will make sure that all upgrade agents are online before resuming an upgrade or before rolling back an upgrade.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2017

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback


## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade and rollback will re-deploy agents if some are offline**