### PR TITLE
Fixed broken search in the docs

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -23,6 +23,11 @@
   {% include "footer.html" %}
   {% include "scripts.html" %}
   {%- block extrascripts %}{% endblock %}
+
+  <!-- search {{ base_url }} -->
+  <script src="/gravity/docs/search/main.js"></script>
+
+
 </body>
 </html>
 {% if page and page.is_homepage %}

--- a/docs/theme/scripts.html
+++ b/docs/theme/scripts.html
@@ -19,11 +19,6 @@
 <script src="{{ path|url }}/src/docs.js"></script>
 
 <script>var base_url = '{{ base_url }}';</script>
-
-{%- for path in extra_javascript %}
-<script src="{{ path|url }}"></script>
-{%- endfor %}
-
 <script src="{{ path|url }}/src/third-party.js"></script>
 
 


### PR DESCRIPTION
## Description

This is not a good fix!! The docs version switcher breaks {{ base_url }}
variable inside mkDocs, this leads to 404 error for `/search/main.js`

SEMRush complains about this.

Wolfe is redesigning the theme anyway, so it should be good enough for
now.

## Type of change

Documentation only

