### PR TITLE
[7.0.x] drop legacy case when uploading packages

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -778,10 +777,6 @@ var (
 		DockerStorageDriverOverlay,
 		DockerStorageDriverOverlay2,
 	}
-
-	// PlanetMultiRegistryVersion is the planet release starting from which registries
-	// are running on all master nodes
-	PlanetMultiRegistryVersion = semver.New("0.1.55")
 
 	// KubernetesServiceDomainName specifies the domain names of the kubernetes API service
 	KubernetesServiceDomainNames = []string{

--- a/tool/gravity/cli/ops.go
+++ b/tool/gravity/cli/ops.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 
 	libapp "github.com/gravitational/gravity/lib/app"
-	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/docker"
 	"github.com/gravitational/gravity/lib/install"
@@ -267,15 +266,7 @@ func getTarballEnvironForUpgrade(env *localenv.LocalEnvironment, stateDir string
 
 // getRegistries returns a list of registry addresses in the cluster
 func getRegistries(ctx context.Context, env *localenv.LocalEnvironment, servers []storage.Server) ([]string, error) {
-	// in planets before certain version registry was running only on active master
-	version, err := planetVersion(env)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if version.LessThan(*constants.PlanetMultiRegistryVersion) {
-		return []string{defaults.DockerRegistry}, nil
-	}
-	// otherwise return registry addresses on all masters
+	// return registry addresses on all masters
 	ips, err := getMasterNodes(ctx, servers)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -287,7 +278,6 @@ func getRegistries(ctx context.Context, env *localenv.LocalEnvironment, servers 
 	return registries, nil
 }
 
-// connectToOpsCenter
 func connectToOpsCenter(env *localenv.LocalEnvironment, opsCenterURL, username, password string) (err error) {
 	if username == "" || password == "" {
 		username, password, err = common.ReadUserPass()


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
When syncing application packages with cluster registries, do not consider the legacy case when only a single leader node had an active registry instance. First, the registry address using the local cluster domain (`leader.telekube.local`) will not resolve from the host unless the `resolv.conf` references the coredns (which isn't the case). Furthermore, this check is obsolete since 7.x can only upgrade 5.5.x which already runs an registry instance on each master node.

The actual problem this fixes is when a custom planet container has a tag (version) that compares before the legacy constant, `getRegistries` falls back to using the cluster local domain for registry which would not work.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/1993.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Set up environment

Create dummy planet package with a version before the sentinel (`0.1.55`) - e.g. `0.0.4` and label it appropriately as installed and runtime:

```
$ gravity package list
[gravitational.io]
------------------
...
* gravitational.io/custom-planet:0.0.4 591MB installed:installed,purpose:runtime
...
```

### Upload a version before the change

```
$ ./upload
Wed Sep  2 10:17:55 UTC	Importing application telekube v7.0.14
Wed Sep  2 10:20:13 UTC	Synchronizing application with Docker registry leader.telekube.local:5000
[ERROR]: failed to connect to registry at "leader.telekube.local:5000"
	failed to ping Docker registry: Get https://leader.telekube.local:5000/v2/: dial tcp: lookup leader.telekube.local: no such host
		Get https://leader.telekube.local:5000/v2/: dial tcp: lookup leader.telekube.local: no such host
```

### Upload a version after the change

```
$ ./upload 
Wed Sep  2 10:22:40 UTC	Importing application telekube v7.0.17-dev.4
Wed Sep  2 10:25:54 UTC	Synchronizing application with Docker registry 10.128.0.18:5000
Wed Sep  2 10:26:18 UTC	Verifying cluster health
Wed Sep  2 10:26:18 UTC	Application has been uploaded
```
