### PR TITLE
adjust pod subnet defaults

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -698,7 +698,7 @@ const (
 	// this seems like a sensible default. The setting can also be overridden at installation time.
 	ServiceSubnet = "100.100.0.0/16"
 	// PodSubnet is a subnet dedicated to the pods in the cluster
-	PodSubnet = "100.96.0.0/16"
+	PodSubnet = "100.96.0.0/14"
 
 	// MaxRouterIdleConnsPerHost defines tha maximum number of idle connections for "opsroute" transport
 	MaxRouterIdleConnsPerHost = 5

--- a/lib/validate/net.go
+++ b/lib/validate/net.go
@@ -36,11 +36,11 @@ func KubernetesSubnets(podCIDR, serviceCIDR string) error {
 				"invalid pod subnet: %q", podCIDR)
 		}
 
-		// the pod network should be /16 minimum so k8s can allocate /24 to each node
+		// the pod network should be /22 minimum so k8s can allocate /24 to each node (minimum 3 nodes)
 		ones, _ := podNet.Mask.Size()
-		if ones > 16 {
+		if ones > 22 {
 			return trace.BadParameter(
-				"pod subnet should be a minimum of /16: %q", podCIDR)
+				"pod subnet should be a minimum of /22: %q", podCIDR)
 		}
 	}
 

--- a/lib/validate/net_test.go
+++ b/lib/validate/net_test.go
@@ -53,7 +53,7 @@ func (*S) TestValidateKubernetesSubnets(c *check.C) {
 			description: "service subnet is not a valid CIDR",
 		},
 		{
-			podCIDR:     "10.200.0.0/20",
+			podCIDR:     "10.200.0.0/24",
 			ok:          false,
 			description: "pod subnet is too small",
 		},


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

- Updates default pod subnet to be 1023 /24's (flannel skips the first subnet). 
- Updates minimum subnet size to be a /22 (3 nodes)
  - This request has come up several times. The proper check should probably be a combination of app.yaml requirements for number of nodes + a satellite check at join time. 

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
  - Support for 1k node clusters
* This change has a user-facing impact
  - Default pod CIDR is now the range 100.96.0.0/14 - 100.99.255.0/14
  - Users can now specify smaller pod subnets.

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
  - Tested large subnet assignments
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
