### PR TITLE
[7.0.x] remove unneeded etcd upgrade steps (#2086)

### DIFF
--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -149,7 +149,7 @@ func (s *PlanSuite) TestPlanWithRuntimeAppsUpdate(c *check.C) {
 			params.coreDNS("/bootstrap"),
 			params.masters(leadMaster, updates[0:1], gravityPackage, "id", "/coredns"),
 			params.nodes(updates[2:], leadMaster.Server, gravityPackage, "id", "/masters"),
-			params.etcd(leadMaster.Server, updates[0:1], updates[2:], *params.targetStep.etcd),
+			params.etcd(leadMaster.Server, updates[0:1], *params.targetStep.etcd),
 			params.config("/etcd"),
 			params.runtime(runtimeUpdates, "/config"),
 			params.migration("/runtime"),
@@ -370,7 +370,6 @@ func (s *PlanSuite) TestPlanWithIntermediateRuntimeUpdate(c *check.C) {
 				params.nodes(intermediateNodes, intermediateLeadMaster.Server, intermediateGravityPackage, "id2", "/masters"),
 				params.etcd(intermediateLeadMaster.Server,
 					intermediateOtherMasters,
-					intermediateNodes,
 					*params.steps[0].etcd),
 				params.config("/etcd"),
 				params.runtime(intermediateRuntimeUpdates, "/config"),
@@ -380,7 +379,7 @@ func (s *PlanSuite) TestPlanWithIntermediateRuntimeUpdate(c *check.C) {
 				params.coreDNS("/bootstrap"),
 				params.masters(leadMaster, otherMasters, gravityPackage, "id", "/coredns"),
 				params.nodes(nodes, leadMaster.Server, gravityPackage, "id", "/masters"),
-				params.etcd(leadMaster.Server, otherMasters, nodes, *params.targetStep.etcd),
+				params.etcd(leadMaster.Server, otherMasters, *params.targetStep.etcd),
 				params.config("/etcd"),
 				params.runtime(runtimeUpdates, "/config"),
 			),
@@ -1000,7 +999,7 @@ func (r *params) bootstrapNodeVersioned(server storage.UpdateServer, version str
 	}
 }
 
-func (r params) etcd(leadMaster storage.Server, otherMasters, nodes []storage.UpdateServer, etcd etcdVersion) storage.OperationPhase {
+func (r params) etcd(leadMaster storage.Server, otherMasters []storage.UpdateServer, etcd etcdVersion) storage.OperationPhase {
 	return storage.OperationPhase{
 		ID:          "/etcd",
 		Description: fmt.Sprintf("Upgrade etcd %v to %v", etcd.installed, etcd.update),
@@ -1021,7 +1020,6 @@ func (r params) etcd(leadMaster storage.Server, otherMasters, nodes []storage.Up
 					r.etcdShutdownNode(leadMaster, true),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdShutdownNode(otherMasters[0].Server, false),
-					r.etcdShutdownWorkerNode(nodes[0].Server),
 				},
 			},
 			{
@@ -1031,8 +1029,6 @@ func (r params) etcd(leadMaster storage.Server, otherMasters, nodes []storage.Up
 					r.etcdUpgradeNode(leadMaster),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdUpgradeNode(otherMasters[0].Server),
-					// upgrade regular nodes
-					r.etcdUpgradeNode(nodes[0].Server),
 				},
 			},
 			{
@@ -1051,7 +1047,6 @@ func (r params) etcd(leadMaster storage.Server, otherMasters, nodes []storage.Up
 					r.etcdRestartLeaderNode(leadMaster),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdRestartNode(otherMasters[0].Server),
-					r.etcdRestartWorkerNode(nodes[0].Server),
 					r.etcdRestartGravity(leadMaster),
 				},
 			},


### PR DESCRIPTION
(cherry picked from commit 6ab482958a21c18329a0d2ed32b1b764798077bf)

## Description
<!--Required. Provide high-level overview of what the change is for.-->
Remove unneeded etcd upgrade steps from worker nodes. 

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact
  - Plans no longer include etcd step on worker nodes

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates https://github.com/gravitational/gravity/issues/2068

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
This simply removes etcd upgrade steps from plan creation. When used in conjunction with https://github.com/gravitational/planet/pull/738 the etcd gateway upgrades during the rolling restart of planet itself. 

etcd gateway is a stateless L4 proxy, and as such doesn't have any version compatibility concerns with the rest of the cluster.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->


## Additional information
<!--Optional. Anything else that may be relevant.-->
