### PR TITLE
[master] remove unneeded etcd upgrade steps (#2086)

### DIFF
--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -415,10 +415,6 @@ func (r phaseBuilder) etcdPlan(
 		p := r.etcdShutdownNode(server, shutdownEtcd, false)
 		shutdownEtcd.AddWithDependency(update.DependencyForServer(backupEtcd, server), p)
 	}
-	for _, server := range workers {
-		p := r.etcdShutdownNode(server, shutdownEtcd, false)
-		shutdownEtcd.Add(p)
-	}
 
 	root.Add(shutdownEtcd)
 
@@ -434,10 +430,6 @@ func (r phaseBuilder) etcdPlan(
 		r.etcdUpgrade(leadMaster, upgradeServers))
 
 	for _, server := range otherMasters {
-		p := r.etcdUpgrade(server, upgradeServers)
-		upgradeServers.AddWithDependency(update.DependencyForServer(shutdownEtcd, server), p)
-	}
-	for _, server := range workers {
 		p := r.etcdUpgrade(server, upgradeServers)
 		upgradeServers.AddWithDependency(update.DependencyForServer(shutdownEtcd, server), p)
 	}
@@ -467,10 +459,6 @@ func (r phaseBuilder) etcdPlan(
 		r.etcdRestart(leadMaster, leadMaster, restartMasters))
 
 	for _, server := range otherMasters {
-		p := r.etcdRestart(server, leadMaster, restartMasters)
-		restartMasters.AddWithDependency(update.DependencyForServer(upgradeServers, server), p)
-	}
-	for _, server := range workers {
 		p := r.etcdRestart(server, leadMaster, restartMasters)
 		restartMasters.AddWithDependency(update.DependencyForServer(upgradeServers, server), p)
 	}

--- a/lib/update/cluster/builder_test.go
+++ b/lib/update/cluster/builder_test.go
@@ -679,7 +679,6 @@ func (r params) etcd(otherMasters []storage.UpdateServer) storage.OperationPhase
 					r.etcdShutdownNode(r.leadMaster, true),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdShutdownNode(otherMasters[0], false),
-					r.etcdShutdownWorkerNode(updates[2]),
 				},
 			},
 			{
@@ -689,8 +688,6 @@ func (r params) etcd(otherMasters []storage.UpdateServer) storage.OperationPhase
 					r.etcdUpgradeNode(r.leadMaster),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdUpgradeNode(otherMasters[0]),
-					// upgrade regular nodes
-					r.etcdUpgradeNode(updates[2]),
 				},
 			},
 			{
@@ -709,8 +706,6 @@ func (r params) etcd(otherMasters []storage.UpdateServer) storage.OperationPhase
 					r.etcdRestartLeaderNode(),
 					// FIXME: assumes len(otherMasters) == 1
 					r.etcdRestartNode(otherMasters[0]),
-					// upgrade regular nodes
-					r.etcdRestartNode(updates[2]),
 					r.etcdRestartGravity(),
 				},
 			},


### PR DESCRIPTION
(cherry picked from commit 6ab482958a21c18329a0d2ed32b1b764798077bf)

## Description
<!--Required. Provide high-level overview of what the change is for.-->
Remove unneeded etcd upgrade steps from worker nodes. 

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact
  - Plans no longer include etcd step on worker nodes

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates https://github.com/gravitational/gravity/issues/2068

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
This simply removes etcd upgrade steps from plan creation. When used in conjunction with https://github.com/gravitational/planet/pull/738 the etcd gateway upgrades during the rolling restart of planet itself. 

etcd gateway is a stateless L4 proxy, and as such doesn't have any version compatibility concerns with the rest of the cluster.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->


## Additional information
<!--Optional. Anything else that may be relevant.-->
