### PR TITLE
Specify security context for robotest workload

### DIFF
--- a/assets/rbac-app/resources/resources.yaml
+++ b/assets/rbac-app/resources/resources.yaml
@@ -182,6 +182,7 @@ rules:
   - podsecuritypolicies
   resourceNames:
   - privileged
+  - restricted
   verbs:
   - use
 ---
@@ -225,25 +226,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: privileged-psp-user
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: telekube:controller-restricted-psp
-subjects:
-- kind: ServiceAccount
-  name: daemon-set-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: job-controller
-  namespace: kube-system
-- kind: ServiceAccount
-  name: generic-garbage-collector
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: restricted-psp-user
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/assets/robotest/resources/charts/echoserver/templates/echoserver-deployment.yaml
+++ b/assets/robotest/resources/charts/echoserver/templates/echoserver-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       containers:
       - name: echoserver
         image: {{.Values.echoserverRegistry}}/echoserver:1.10
+        securityContext:
+          runAsNonRoot: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Explicitly opt-out of running as non-root for echoserver test workload.
Remove spec redundancy in RBAC.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/2105

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

### Before the change
Cluster fails to install at `postInstall` hook step for `robotest` application. Both `echoserver` replicas are in `CreateContainerConfigError` state. As a test for this step, this [PR](https://github.com/gravitational/gravity/pull/2104) was used.

### After the change
Cluster installs successfully.
