### PR TITLE
set value for health_test to prevent runaway cpu usage

### DIFF
--- a/lib/install/phases/coredns.go
+++ b/lib/install/phases/coredns.go
@@ -234,7 +234,7 @@ const coreDNSTemplateText = `
   }{{end}}
   {{if .UpstreamNameservers}}forward . {{range $server := .UpstreamNameservers}}{{$server}} {{end}}{
     {{if .Rotate}}policy random{{else}}policy sequential{{end}}
-    health_check 0
+    health_check 1s
   }{{end}}
 }
 `

--- a/lib/install/phases/coredns_test.go
+++ b/lib/install/phases/coredns_test.go
@@ -74,7 +74,7 @@ func (*StartSuite) TestCoreDNSConf(c *check.C) {
   }
   forward . 1.1.1.1 8.8.8.8 {
     policy sequential
-    health_check 0
+    health_check 1s
   }
 }
 `,
@@ -103,7 +103,7 @@ func (*StartSuite) TestCoreDNSConf(c *check.C) {
   }
   forward . 1.1.1.1 {
     policy random
-    health_check 0
+    health_check 1s
   }
 }
 `,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Sets a value for coredns proxy health_check, as I was under the impression this disabled health checks which isn't the case. A value of CPU allows runaway CPU usage due to not properly backing off on queries. 

As discovered by Dima in https://github.com/gravitational/gravity/issues/613

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)


## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates https://github.com/gravitational/gravity/issues/613

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [ ] Address review feedback



## Additional information
<!--Optional. Anything else that may be relevant.-->

This does leave us open to the possibility that a customer deployment doesn't respond correctly to the health probes, but since this wasn't actually disabled, for the time being we should set a value. I've open a case upstream to see about having a way to disable health checks.

1s chosen as a reasonably aggressive probe that also shouldn't cause excessive load. I set this more aggressive than planet, as planet doesn't use the customers DNS for much other than docker. I'm open to other opinions though as this is really an estimate of the best behaviour. 
