### PR TITLE
gofmt entire project

### DIFF
--- a/lib/storage/keyval/backend.go
+++ b/lib/storage/keyval/backend.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
 )
 
 // backend implements storage interface, it also acts as a codec

--- a/lib/users/context.go
+++ b/lib/users/context.go
@@ -55,7 +55,7 @@ func NewActionsParser(ctx teleservices.RuleContext) (predicate.Parser, error) {
 	return predicate.NewParser(predicate.Def{
 		Operators: predicate.Operators{},
 		Functions: map[string]interface{}{
-			"log": teleservices.NewLogActionFn(ctx),
+			"log":                                  teleservices.NewLogActionFn(ctx),
 			constants.AssignKubernetesGroupsFnName: NewAssignKubernetesGroupsActionFn(ctx),
 		},
 		GetIdentifier: ctx.GetIdentifier,

--- a/lib/utils/bandwidth.go
+++ b/lib/utils/bandwidth.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/gravitational/gravity/lib/defaults"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/codahale/hdrhistogram"
 	"github.com/gravitational/trace"
 	"github.com/mailgun/timetools"
+	log "github.com/sirupsen/logrus"
 )
 
 // BandwidthWriter is a writer that calculates amount of traffic (bytes)

--- a/tool/gravity/cli/selinux.go
+++ b/tool/gravity/cli/selinux.go
@@ -94,7 +94,6 @@ func bootstrapSELinux(env *localenv.LocalEnvironment, path, stateDir string, vxl
 	return libselinux.WriteBootstrapScript(f, config)
 }
 
-
 func isSELinuxAlreadyBootstrapped() bool {
 	_, ok := os.LookupEnv(alreadyBootstrappedEnv)
 	return ok


### PR DESCRIPTION
This cleans up some stray non-`gofmt` files in the repo all at once, so the fixes don't trickle in as the files are touched. If that's the better way for this project to handle non-`gofmt`-compliant sources, then this PR should be closed.