### PR TITLE
[6.1.x] Degrade system status in case of offline nodes

### DIFF
--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -510,6 +510,15 @@ func fromPlanetAgent(ctx context.Context, local bool, servers []storage.Server) 
 		nodes = fromSystemStatus(*status)
 	}
 
+	// Collected system status may exclude the status of some nodes due to
+	// network partition. If offline nodes are detected, degrade system status.
+	for _, node := range nodes {
+		if node.Status != NodeHealthy {
+			status.Status = pb.SystemStatus_Degraded
+			break
+		}
+	}
+
 	return &Agent{
 		SystemStatus: SystemStatus(status.Status),
 		Nodes:        nodes,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the gravity status to report degraded status if any nodes are offline. Prior to this change, planet status could report an active cluster status while failing to collect the status of some nodes. This has been observed in #2100 when a serf node is partition off the cluster for too long and is eventually kicked out of the serf cluster.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2111

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify cluster status is degraded after a member leaves the serf cluster**
- Install 3-node cluster.
- On one of the nodes execute `serf force-leave -prune <another-node>`.
- Verify `serf members`.
```
[vagrant@node-1 ~]$ sudo gravity exec serf members
172_28_128_101.dev.test  172.28.128.101:7496  alive  role=master,publicip=172.28.128.101
172_28_128_102.dev.test  172.28.128.102:7496  alive  publicip=172.28.128.102,role=master
```
- Verify `gravity status` is degraded.
```
[vagrant@node-1 ~]$ sudo gravity status
Cluster name:           dev.test
Cluster status:         degraded
Application:            telekube, version 6.1.40-dev.1
Gravity version:        6.1.40-dev.1 (client) / 6.1.40-dev.1 (server)
[...]
Cluster nodes:
    Masters:
        * node-1 / 172.28.128.101 / node
            Status:             healthy
            Remote access:      online
        * node-2 / 172.28.128.102 / node
            Status:             healthy
            Remote access:      online
    Nodes:
        * node-3 / 172.28.128.103
            Status:             offline
            Remote access:      online
```