### PR TITLE
[6.1.x] fix wizard installation

### DIFF
--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -345,6 +345,10 @@ func (i *InstallConfig) CheckAndSetDefaults(validator resources.Validator) (err 
 	if i.SiteDomain == "" {
 		i.SiteDomain = generateClusterName()
 	}
+	// Avoid validating resources for wizard-driven installation or when the installer
+	// executes a remote install.
+	// In this case, the validation happens on the remote node where the cluster is
+	// being set up.
 	if !i.Remote {
 		err = i.validateResources(validator)
 		if err != nil {

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -345,9 +345,11 @@ func (i *InstallConfig) CheckAndSetDefaults(validator resources.Validator) (err 
 	if i.SiteDomain == "" {
 		i.SiteDomain = generateClusterName()
 	}
-	err = i.validateResources(validator)
-	if err != nil {
-		return trace.Wrap(err)
+	if !i.Remote {
+		err = i.validateResources(validator)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Fix a regression introduced in [this commit](https://github.com/gravitational/gravity/commit/b93cda478d63b154ae2aef1f4dc3eda4f3b946c3#diff-6b286661347d412609e65b03316d1842R348).
When installing in wizard mode, `remote` is on and no resource validation should take place.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Updates https://github.com/gravitational/gravity/issues/2134

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Installed a cluster with this branch in wizard mode.
