### PR TITLE
Fix containerized tele build image downloads

### DIFF
--- a/assets/robotest/Dockerfile
+++ b/assets/robotest/Dockerfile
@@ -1,0 +1,15 @@
+# resulting container image will contain `tele` tool and can be used
+# to create Cluster images from within a container.
+
+ARG BASE
+
+FROM $BASE
+
+RUN apt-get update && \
+    apt-get -y install apt-transport-https ca-certificates curl gnupg software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+
+RUN apt-get update && \
+    apt-get -y install docker-ce-cli

--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -32,9 +32,6 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 
 ROBOTEST_VERSION ?= 2.1.0
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
-# ROBOTEST_TELE_BUILD_DOCKER_IMAGE is an image used to sandbox tele builds. It could
-# be almost anything with dumb-init available.
-ROBOTEST_TELE_BUILD_DOCKER_IMAGE ?= quay.io/gravitational/debian-tall:buster-20200916
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build
 ROBOTEST_BUILDDIR ?= $(GRAVITY_BUILDDIR)/robotest
@@ -80,6 +77,13 @@ ROBOTEST_TELE_CACHE ?= $(ROBOTEST_CACHEDIR)/tele
 ROBOTEST_CACHES = $(ROBOTEST_GRAVITY_PKG_CACHE) $(ROBOTEST_TELE_CACHE)
 
 # Image configuration.
+
+TELE_BUILD_DOCKER_BASE_IMAGE = quay.io/gravitational/debian-grande:buster-20201001
+# TELE_BUILD_DOCKER_IMAGE is the base image with `tele build` prerequisites (such as the docker cli) added to it.
+TELE_BUILD_DOCKER_IMAGE = $(notdir $(TELE_BUILD_DOCKER_BASE_IMAGE))-tele-build
+# TELE_BUILD_DOCKER_IDDFILE is used to prevent make from constantly rebuilding the image.
+# subst because ':' in filenames breaks using them in make targets.
+TELE_BUILD_DOCKER_IIDFILE = $(ROBOTEST_BUILDDIR)/$(subst :,-,$(TELE_BUILD_DOCKER_IMAGE)).iid
 
 # ROBOTEST_IMAGEDIR is a store of robotest images used only for the current
 # robotest run. Expected to be populated on demand from the caches and mounted
@@ -167,6 +171,14 @@ $(ROBOTEST_BUILD_TMP):
 $(ROBOTEST_CACHE_TMP):
 	mkdir -p $(ROBOTEST_CACHE_TMP)
 
+.PHONY: docker-image-tele-build
+docker-image-tele-build: ## Build a docker image suitable to run `tele build`.
+docker-image-tele-build: $(TELE_BUILD_DOCKER_IIDFILE)
+
+$(TELE_BUILD_DOCKER_IIDFILE): $(TOP)/Dockerfile $(ROBOTEST_BUILDDIR)
+	docker build --tag $(TELE_BUILD_DOCKER_IMAGE) --build-arg BASE=$(TELE_BUILD_DOCKER_BASE_IMAGE) $(TOP)
+	touch $(TELE_BUILD_DOCKER_IIDFILE)
+
 .PHONY: images
 images: ## Build all images necessary to run robotest CI tests.
 images: image-telekube image-opscenter image-robotest image-robotest-upgrade
@@ -190,14 +202,14 @@ image-robotest: ## Build robotest cluster image using the current tele.
 image-robotest: $(ROBOTEST_IMAGE)
 
 $(ROBOTEST_IMAGE): export TARGET = $(ROBOTEST_IMAGE)
-$(ROBOTEST_IMAGE): export IMAGE = $(ROBOTEST_TELE_BUILD_DOCKER_IMAGE)
+$(ROBOTEST_IMAGE): export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGE): export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGE): export APP_MANIFEST = $(ROBOTEST_IMAGE_MANIFEST)
 $(ROBOTEST_IMAGE): export APP_SRCDIR = $(ROBOTEST_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGE): export VERSION = $(GRAVITY_VERSION)
 $(ROBOTEST_IMAGE): export TELE = $(TELE_OUT)
 $(ROBOTEST_IMAGE): export STATE_DIR = $(PACKAGES_DIR)
-$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
+$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh $(TELE_BUILD_DOCKER_IIDFILE) | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
 	$(TOP)/tele_build.sh
 
 # When using a shared state dir 7.0.x package syncing is prone to races
@@ -250,7 +262,7 @@ endif
 # .PRECIOUS because these need to be present through the run target.
 .PRECIOUS: $(ROBOTEST_IMAGEDIR)/robotest-%.tar
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TARGET = $@
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export IMAGE = $(ROBOTEST_TELE_BUILD_DOCKER_IMAGE)
+$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_MANIFEST = $(ROBOTEST_UPGRADE_BASE_IMAGE_MANIFEST)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_SRCDIR = $(ROBOTEST_UPGRADE_BASE_IMAGE_SRCDIR)

--- a/assets/robotest/tele_build.sh
+++ b/assets/robotest/tele_build.sh
@@ -32,8 +32,7 @@ TGT=$TMP/$(basename "$TARGET")
 
 NOROOT="--user=$(id -u):$(id -g) --group-add=$(getent group docker | cut -d: -f3)"
 VOLUMES="-v $TELE:$TELE -v $APP_SRCDIR:$APP_SRCDIR -v $STATE_DIR:$STATE_DIR -v $TMP:$TMP"
-VOLUMES="$VOLUMES -v /var/run/docker.sock:/var/run/docker.sock -v /run/docker.sock:/run/docker.sock"
-VOLUMES="$VOLUMES -v $HOME/.docker:/.docker:ro"
+VOLUMES="$VOLUMES -v /var/run/docker.sock:/var/run/docker.sock"
 VOLUMES="$VOLUMES --tmpfs /tmp"
 
 (

--- a/docs/4.x/pack.md
+++ b/docs/4.x/pack.md
@@ -133,15 +133,19 @@ The example below builds a Docker image called `tele-buildbox`. This image will 
 First, build docker image `tele-buildbox` with `tele` inside:
 
 ```Docker
-FROM quay.io/gravitational/debian-grande:0.0.1
+FROM quay.io/gravitational/debian-grande:buster
 
 ARG TELE_VERSION
-RUN apt-get update
-RUN apt-get -y install curl make git
+RUN apt-get update && \
+    apt-get -y install curl make git apt-transport-https ca-certificates gnupg software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+RUN apt-get update && \
+    apt-get -y install docker-ce-cli
 RUN curl https://get.gravitational.io/telekube/bin/${TELE_VERSION}/linux/x86_64/tele -o /usr/bin/tele && chmod 755 /usr/bin/tele
 ```
 
-Then build the image:
+Set the `TELE_VERSION` argument to the desired Gravity version, then build the docker image:
 
 ```bash
 docker build . -t tele-buildbox:latest
@@ -183,7 +187,7 @@ docker run -e OPS_URL=<opscenter url> \
         bash -c "cd /mnt/app && build.sh"
 ```
 
-!!! note 
+!!! note
     Notice that we are reusing tele loaded cache directory in between builds
     by setting `--state-dir`. You can use unique temporary directory
     to avoid sharing state between builds, or use parallel builds instead.

--- a/docs/5.x/pack.md
+++ b/docs/5.x/pack.md
@@ -133,15 +133,19 @@ The example below builds a Docker image called `tele-buildbox`. This image will 
 First, build docker image `tele-buildbox` with `tele` inside:
 
 ```bsh
-FROM quay.io/gravitational/debian-grande:stretch
+FROM quay.io/gravitational/debian-grande:buster
 
 ARG TELE_VERSION
-RUN apt-get update
-RUN apt-get -y install curl make git
+RUN apt-get update && \
+    apt-get -y install curl make git apt-transport-https ca-certificates gnupg software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+RUN apt-get update && \
+    apt-get -y install docker-ce-cli
 RUN curl https://get.gravitational.io/telekube/bin/${TELE_VERSION}/linux/x86_64/tele -o /usr/bin/tele && chmod 755 /usr/bin/tele
 ```
 
-Then build the image:
+Set the `TELE_VERSION` argument to the desired Gravity version, then build the docker image:
 
 ```bsh
 docker build . -t tele-buildbox:latest
@@ -183,7 +187,7 @@ docker run -e OPS_URL=<opscenter url> \
         bash -c "cd /mnt/app && build.sh"
 ```
 
-!!! note 
+!!! note
     Notice that we are reusing tele loaded cache directory in between builds
     by setting `--state-dir`. You can use unique temporary directory
     to avoid sharing state between builds, or use parallel builds instead.

--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -99,8 +99,12 @@ plugging them into a CI/CD pipeline.
 FROM quay.io/gravitational/debian-grande:buster
 
 ARG TELE_VERSION
-RUN apt-get update
-RUN apt-get -y install curl make git
+RUN apt-get update && \
+    apt-get -y install curl make git apt-transport-https ca-certificates gnupg software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+RUN apt-get update && \
+    apt-get -y install docker-ce-cli
 RUN curl https://get.gravitational.io/telekube/bin/${TELE_VERSION}/linux/x86_64/tele -o /usr/bin/tele && chmod 755 /usr/bin/tele
 ```
 
@@ -117,17 +121,17 @@ Now you should have `tele-buildbox` container on the build machine. Next, do the
   images referenced in the Image Manifest.
 * Expose the working directory with the Image Manifest to the container as `/mnt/cluster`
 
-The command below assumes that `build.sh` is located in the same working directory as the application:
+The command below assumes that the Image Manifest `app.yaml` is located in the current directory:
 
 ```bsh
 docker run \
        -v /tmp/tele-cache:/mnt/tele-cache \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       -v $(pwd):/mnt/app \
+       -v $(pwd):/mnt/cluster \
        -w /mnt/cluster \
-        --net=host \
-        tele-buildbox:latest \
-        bash -c "tele --state-dir=/mnt/tele-cache build -o cluster.tar"
+       --net=host \
+       tele-buildbox:latest \
+       dumb-init tele --state-dir=/mnt/tele-cache build app.yaml -o cluster.tar
 ```
 
 !!! note


### PR DESCRIPTION
## Description
@bernardjkim found a bug in #2133.  Specifically, if images specified in the application manifest were not already present, `tele_build.sh` would fail while trying to fetch them with the following error:

```
       Pulling remote image k8s.gcr.io/echoserver:1.10
Thu Sep 24 19:10:35 UTC Build finished in now
[ERROR]:
        exec: "docker": executable file not found in $PATH
```
The changes in this patchset fix the issue, update our documentation, and add a pre-emptive check to prevent others from making the same mistake.

## Type of change
* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
* Fixes an issue introduced in #2133

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Testing done
<details><summary>tele build before</summary>

```
walt@gcp:~/git/gravity$ make -C assets/robotest GRAVITY_VERSION=7.1.0-alpha.1.203 images                                                                                                      
make: Entering directory '/home/walt/git/gravity/assets/robotest'                           
/home/walt/git/gravity/assets/robotest/tele_build.sh                                         
+ docker run --rm=true --net=host --user=1000:1000 --group-add=998 -v /home/walt/git/gravity/build/7.1.0-alpha.1.203/tele:/home/walt/git/gravity/build/7.1.0-alpha.1.203/tele -v /home/walt/git/gravity/assets/robotest/current:/home/walt/git/gravity/assets/robotest/current -v /home/walt/git/gravity/build/7.1.0-alpha.1.203/packages:/home/walt/git/gravity/build/7.1.0-alpha.1.203/packages -v /home/walt/git/gravity/build/7.1.0-alpha.1.203/robotest/tmp/tmp.jrU9S9KOHl:/home/walt/git/gravity/build/7.1.0-alpha.1.203/robotest/tmp/tmp.jrU9S9KOHl -v /var/run/docker.sock:/var/run/docker.sock -v /run/docker.sock:/run/docker.sock --tmpfs /tmp -w /home/walt/git/gravity/build/7.1.0-alpha.1.203/robotest/tmp/tmp.jrU9S9KOHl quay.io/gravitational/debian-tall:buster-20200916 dumb-init /home/walt/git/gravity/build/7.1.0-alpha.1.203/tele build --debug /home/walt/git/gravity/assets/robotest/current/app.yaml --state-dir=/home/walt/git/gravity/build/7.1.0-alpha.1.203/packages --version=7.1.0-alpha.1.203 --output=/home/walt/git/gravity/build/7.1.0-alpha.1.203/robotest/tmp/tmp.jrU9S9KOHl/robotest-7.1.0-alpha.1.203.tar
INFO [BUILDER]   Using package cache from /home/walt/git/gravity/build/7.1.0-alpha.1.203/packages. builder/engine.go:357
DEBU [LOCAL]     Creating local environment. args:{/home/walt/git/gravity/build/7.1.0-alpha.1.203/packages /home/walt/git/gravity/build/7.1.0-alpha.1.203/packages false false false 0s 0s <nil> {[] 0} false false <nil> <nil>} localenv/localenv.go:140                                  
Thu Sep 24 20:30:42 UTC Building cluster image robotest 7.1.0-alpha.1.203 from manifest

// snip debug logs

        Using local image quay.io/gravitational/debian-tall:buster
INFO             Tagging image "quay.io/gravitational/debian-tall:buster": docker.TagImageOptions{Repo:"gravitational/debian-tall", Tag:"buster", Force:true}. image:quay.io/gravitational/debian-tall:buster service/docker.go:221
INFO             Pulling: k8s.gcr.io/echoserver:1.10. image:k8s.gcr.io/echoserver:1.10 service/docker.go:192
        Pulling remote image k8s.gcr.io/echoserver:1.10
INFO [SYSTEM]    docker pull k8s.gcr.io/echoserver:1.10 cmderr:true errmsg:exec: "docker": executable file not found in $PATH stderr: stdout: utils/exec.go:177
INFO             Pulling: quay.io/gravitational/debian-tall:buster. image:quay.io/gravitational/debian-tall:buster service/docker.go:192
INFO             Tagging image "quay.io/gravitational/debian-tall:buster": docker.TagImageOptions{Repo:"gravitational/debian-tall", Tag:"buster", Force:true}. image:quay.io/gravitational/debian-tall:buster service/docker.go:221
        Using local image quay.io/gravitational/debian-tall:buster
Thu Sep 24 20:30:42 UTC Build finished in now
ERRO             Command failed. error:[
ERROR REPORT:
Original Error: *exec.Error exec: &#34;docker&#34;: executable file not found in $PATH
Stack Trace:
        /gopath/src/github.com/gravitational/gravity/lib/utils/exec.go:188 github.com/gravitational/gravity/lib/utils.ExecWithInput
        /gopath/src/github.com/gravitational/gravity/lib/utils/exec.go:182 github.com/gravitational/gravity/lib/utils.Exec
        /gopath/src/github.com/gravitational/gravity/lib/utils/exec.go:170 github.com/gravitational/gravity/lib/utils.ExecL
        /gopath/src/github.com/gravitational/gravity/lib/docker/docker.go:47 github.com/gravitational/gravity/lib/docker.(*dockerPuller).Pull
        /gopath/src/github.com/gravitational/gravity/lib/app/service/docker.go:199 github.com/gravitational/gravity/lib/app/service.pullMissingRemoteImage
        /gopath/src/github.com/gravitational/gravity/lib/app/service/vendor.go:248 github.com/gravitational/gravity/lib/app/service.(*vendorer).VendorDir.func1
        /gopath/src/github.com/gravitational/gravity/lib/run/run.go:85 github.com/gravitational/gravity/lib/run.(*Group).Go.func1
        /go/src/runtime/asm_amd64.s:1357 runtime.goexit
User Message: 
        exec: &#34;docker&#34;: executable file not found in $PATH] tele/main.go:36
[ERROR]: 
        exec: "docker": executable file not found in $PATH
make: *** [Makefile:201: /home/walt/git/gravity/build/7.1.0-alpha.1.203/robotest/images/robotest-7.1.0-alpha.1.203.tar] Error 255
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
```
</details>

<details><summary>tele build after (updated after feedback)</summary>

```
walt@gcp:~/git/gravity$ make -C e/assets/robotest GRAVITY_BUILDDIR=$(pwd)/e/build/current image-robotest
make: Entering directory '/home/walt/git/gravity/e/assets/robotest'
/home/walt/git/gravity/assets/robotest/tele_build.sh                                                                                                                                          
+ docker run --rm=true --net=host --user=1000:1000 --group-add=998 -v /home/walt/git/gravity/e/build/current/tele:/home/walt/git/gravity/e/build/current/tele -v /home/walt/git/gravity/assets
/robotest/current:/home/walt/git/gravity/assets/robotest/current -v /home/walt/git/gravity/e/build/current/packages:/home/walt/git/gravity/e/build/current/packages -v /home/walt/git/gravity/
e/build/current/robotest/tmp/tmp.mN59VvrUsr:/home/walt/git/gravity/e/build/current/robotest/tmp/tmp.mN59VvrUsr -v /var/run/docker.sock:/var/run/docker.sock --tmpfs /tmp -w /home/walt/git/gra
vity/e/build/current/robotest/tmp/tmp.mN59VvrUsr quay.io/gravitational/debian-grande:buster-20201001 dumb-init /home/walt/git/gravity/e/build/current/tele build --debug /home/walt/git/gravit
y/assets/robotest/current/app.yaml --state-dir=/home/walt/git/gravity/e/build/current/packages --version=7.1.0-alpha.1.218 --output=/home/walt/git/gravity/e/build/current/robotest/tmp/tmp.mN
59VvrUsr/robotest-7.1.0-alpha.1.218.tar
ERRO [BUILDER]   Failed to validate docker binary. error:[
ERROR REPORT:
Original Error: *exec.Error exec: &#34;docker&#34;: executable file not found in $PATH
Stack Trace:
        /gopath/src/github.com/gravitational/gravity/lib/utils/exec.go:188 github.com/gravitational/gravity/lib/utils.ExecWithInput
        /gopath/src/github.com/gravitational/gravity/lib/utils/exec.go:182 github.com/gravitational/gravity/lib/utils.Exec
        /gopath/src/github.com/gravitational/gravity/lib/builder/util.go:80 github.com/gravitational/gravity/lib/builder.checkBuildEnv
        /gopath/src/github.com/gravitational/gravity/lib/builder/engine.go:120 github.com/gravitational/gravity/lib/builder.newEngine
        /gopath/src/github.com/gravitational/gravity/lib/builder/cluster.go:34 github.com/gravitational/gravity/lib/builder.NewClusterBuilder
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/cli/build.go:65 github.com/gravitational/gravity/e/tool/tele/cli.buildClusterImage
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/cli/run.go:52 github.com/gravitational/gravity/e/tool/tele/cli.Run
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/main.go:31 main.run
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/main.go:22 main.main
        /go/src/runtime/proc.go:203 runtime.main
        /go/src/runtime/asm_amd64.s:1357 runtime.goexit
User Message: exec: &#34;docker&#34;: executable file not found in $PATH] builder/util.go:82
ERRO             Command failed. error:[
ERROR REPORT:
Original Error: *trace.BadParameterError Docker does not seem to be available on this machine.
To resolve the issue:
  * Install Docker (https://docs.docker.com/engine/installation/).
  * Make sure it can be used by a non-root user (https://docs.docker.com/install/linux/linux-postinstall/).
Stack Trace:
        /gopath/src/github.com/gravitational/gravity/lib/builder/util.go:68 github.com/gravitational/gravity/lib/builder.checkBuildEnv
        /gopath/src/github.com/gravitational/gravity/lib/builder/engine.go:120 github.com/gravitational/gravity/lib/builder.newEngine
        /gopath/src/github.com/gravitational/gravity/lib/builder/cluster.go:34 github.com/gravitational/gravity/lib/builder.NewClusterBuilder
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/cli/build.go:65 github.com/gravitational/gravity/e/tool/tele/cli.buildClusterImage
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/cli/run.go:52 github.com/gravitational/gravity/e/tool/tele/cli.Run
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/main.go:31 main.run
        /gopath/src/github.com/gravitational/gravity/e/tool/tele/main.go:22 main.main
        /go/src/runtime/proc.go:203 runtime.main
        /go/src/runtime/asm_amd64.s:1357 runtime.goexit
User Message: Docker does not seem to be available on this machine.
To resolve the issue:
  * Install Docker (https://docs.docker.com/engine/installation/).
  * Make sure it can be used by a non-root user (https://docs.docker.com/install/linux/linux-postinstall/).] tele/main.go:23
[ERROR]: Docker does not seem to be available on this machine.
To resolve the issue:
  * Install Docker (https://docs.docker.com/engine/installation/).
  * Make sure it can be used by a non-root user (https://docs.docker.com/install/linux/linux-postinstall/).
make: *** [../../../assets/robotest/Makefile:213: /home/walt/git/gravity/e/build/current/robotest/images/robotest-7.1.0-alpha.1.218.tar] Error 255
make: Leaving directory '/home/walt/git/gravity/e/assets/robotest'
```
</details>


## Additional information
The use of docker pull dates back to https://github.com/gravitational/gravity.e/commit/19e710db505de1dd410fd6edbf3085d61ecb8d84 which is why I included the change in all docs versions.
