### PR TITLE
(6.1) Wait for operator

### DIFF
--- a/lib/install/process.go
+++ b/lib/install/process.go
@@ -50,11 +50,6 @@ func InitProcess(ctx context.Context, gravityConfig processconfig.Config, newPro
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = process.WaitForServiceStarted(ctx, p)
-	if err != nil {
-		shutdown(p)
-		return nil, trace.Wrap(err)
-	}
 	return p, nil
 }
 

--- a/lib/ops/opsclient/opsclient.go
+++ b/lib/ops/opsclient/opsclient.go
@@ -109,6 +109,15 @@ func WithLocalDialer(dialer httplib.Dialer) ClientParam {
 // ClientParam defines the API to override configuration on client c
 type ClientParam func(c *Client) error
 
+// Ping calls the operator service status endpoint.
+func (c *Client) Ping(ctx context.Context) error {
+	_, err := c.Get(c.Endpoint("status"), url.Values{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 func (c *Client) GetAccount(accountID string) (*ops.Account, error) {
 	out, err := c.Get(c.Endpoint("accounts", accountID), url.Values{})
 	if err != nil {

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -141,6 +141,10 @@ func newInstallerConfig(ctx context.Context, env *localenv.LocalEnvironment, con
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	err = wizard.WaitForOperator(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	installerConfig, err := config.NewInstallerConfig(env, wizard, process)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Backport https://github.com/gravitational/gravity/pull/1285 to make sure that installer waits for the process API to initialize, otherwise it may fail with the following error:

```
Thu Sep 24 22:33:51 UTC        Starting enterprise installer
[ERROR]: dial tcp 10.216.31.98:61009: connect: connection refused
```

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Requires https://github.com/gravitational/gravity.e/pull/4338.
* Ports https://github.com/gravitational/gravity/pull/1285.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Robotest should pass.