### PR TITLE
[5.5] Run robotest with regular user permissions.

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -27,6 +27,7 @@ export GCE_VM=${GCE_VM:-custom-4-8192}
 # Parallelism & retry, tuned for GCE
 export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
 export REPEAT_TESTS=${REPEAT_TESTS:-1}
+export DOCKER_RUN_FLAGS="--rm=true --user=$(id -u):$(id -g)"
 
 # set SUITE and UPGRADE_VERSIONS
 case $TARGET in

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -29,6 +29,12 @@ export PARALLEL_TESTS=${PARALLEL_TESTS:-4}
 export REPEAT_TESTS=${REPEAT_TESTS:-1}
 export DOCKER_RUN_FLAGS="--rm=true --user=$(id -u):$(id -g)"
 
+# Work around a bug in https://github.com/gravitational/robotest/blob/v2.1.0/docker/suite/run_suite.sh#L21-L30
+# which mounts a volume inside a volume, resulting in docker creating the inner mountpoint
+# owned by root:root if it does not already exist. See https://github.com/gravitational/gravity/issues/1915.
+INSTALLER_BINDIR="$(dirname ${INSTALLER_URL})/bin"
+mkdir -p "${INSTALLER_BINDIR}"
+
 # set SUITE and UPGRADE_VERSIONS
 case $TARGET in
   pr) source $(dirname $0)/pr_config.sh;;


### PR DESCRIPTION
## Description
This is a quick backport of the CI permissions fix to #1915, introduced in #2133.

I'm front-running because that port is large and won't necessarily go to all branches (still need to discuss this), and this one-liner provides excellent value in the interim.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Contributes to #1915.

## TODOs
- [x] Self-review the change
- [x] Verify the content of this PR build directory is 100% owned by Jenkins
- [x] Address review feedback

## Testing done
None, the PR build is sufficient.
