### PR TITLE
Continue operation in case gravity-site or etcd is down

### DIFF
--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -237,7 +237,9 @@ func executeUpdatePhaseForOperation(env *localenv.LocalEnvironment, environ Loca
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
 	if params.isResume() {
 		if err := verifyOrDeployAgents(env); err != nil {
-			return trace.Wrap(err)
+			// Continue operation in case gravity-site or etcd is down. In these
+			// cases the agent status may not be retrievable.
+			log.WithError(err).Warn("Failed to verify or deploy agents.")
 		}
 	}
 

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -184,7 +184,9 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 	}
 
 	if err := verifyOrDeployAgents(localEnv); err != nil {
-		return trace.Wrap(err)
+		// Continue operation in case gravity-site or etcd is down. In these
+		// cases the agent status may not be retrievable.
+		log.WithError(err).Warn("Failed to verify or deploy agents.")
 	}
 
 	if !confirmed && !params.DryRun {

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -476,15 +476,16 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	statusList, err := collectAgentStatus(env)
 	if err != nil {
+		env.Println("Failed to verify agents. Ensure gravity-site and etcd are up and running.")
 		return trace.Wrap(err, "failed to collect agent status")
 	}
 	if statusList.AgentsActive() {
 		return nil
 	}
 	if err := rpcAgentDeploy(env, deployOptions{}); err != nil {
-		log.WithError(err).Error("Failed to deploy agents.")
 		env.Println(statusList.String())
-		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
+		env.Println("Some agents are offline. Ensure all agents are deployed with `./gravity agent deploy`.")
+		return trace.Wrap(err, "failed to deploy agents")
 	}
 	return nil
 }

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/cenkalti/backoff"
+	"github.com/fatih/color"
 	teleclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/version"
@@ -476,7 +477,7 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	statusList, err := collectAgentStatus(env)
 	if err != nil {
-		env.Println("Failed to verify agents. Ensure gravity-site and etcd are up and running.")
+		env.Println(color.YellowString("Couldn't verify upgrade agents status. If some are offline, they won't be redeployed automatically"))
 		return trace.Wrap(err, "failed to collect agent status")
 	}
 	if statusList.AgentsActive() {
@@ -484,7 +485,7 @@ func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	}
 	if err := rpcAgentDeploy(env, deployOptions{}); err != nil {
 		env.Println(statusList.String())
-		env.Println("Some agents are offline. Ensure all agents are deployed with `./gravity agent deploy`.")
+		env.Println(color.YellowString("Some agents are offline. Ensure all agents are deployed with `./gravity agent deploy`"))
 		return trace.Wrap(err, "failed to deploy agents")
 	}
 	return nil


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Previous PR https://github.com/gravitational/gravity/pull/2017 added a check in upgrade resume and rollback operations that will abort if unable to verify agent status or re-deploy agents. This check made it impossible to resume/rollback if gravity-site or etcd is down. More details found in https://github.com/gravitational/gravity/issues/2156. This PR will allow resume/rollback continue operation in these situations.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2156, https://github.com/gravitational/gravity/pull/2017

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade resume executes if gravity-site or etcd is down**

**Verify rollback executes if gravity-site or etcd is down**