### PR TITLE
[5.5.x] Include gravity resources in debug report

### DIFF
--- a/lib/ops/opsservice/report.go
+++ b/lib/ops/opsservice/report.go
@@ -158,6 +158,9 @@ func (s *site) getReport(runner remoteRunner, servers []remoteServer, masters []
 		if err := s.collectStatusTimeline(reportWriter, serverRunner); err != nil {
 			logger.WithError(err).Error("Failed to collect status timeline.")
 		}
+		if err := s.collectResources(reportWriter, serverRunner); err != nil {
+			logger.WithError(err).Error("Failed to collect gravity resources.")
+		}
 	}
 
 	// use a pipe to avoid allocating a buffer
@@ -283,6 +286,21 @@ func (s *site) collectStatusTimeline(reportWriter report.FileWriter, runner *ser
 		fmt.Sprintf("--filter=%v", report.FilterTimeline), "--compressed")...)
 	if err != nil {
 		return trace.Wrap(err, "failed to collect status timeline: %s", stderr.String())
+	}
+	return nil
+}
+
+func (s *site) collectResources(reportWriter report.FileWriter, runner *serverRunner) error {
+	w, err := reportWriter.NewWriter("resources.tar.gz")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer w.Close()
+	var stderr bytes.Buffer
+	err = runner.RunStream(w, &stderr, s.gravityCommand("system", "report",
+		fmt.Sprintf("--filter=%v", report.FilterResources), "--compressed")...)
+	if err != nil {
+		return trace.Wrap(err, "failed to collect gravity resources: %s", stderr.String())
 	}
 	return nil
 }

--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -52,6 +52,8 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
+		case FilterResources:
+			collectors = append(collectors, ResourceCollectors()...)
 		}
 	}
 
@@ -124,7 +126,10 @@ const (
 
 	// FilterTimeline defines a report collection filter to fetch the status timeline
 	FilterTimeline = "timeline"
+
+	// FilterResources defines a report collection filter to fetch gravity resources
+	FilterResources = "resources"
 )
 
 // AllFilters lists all available collector filters
-var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd, FilterTimeline}
+var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd, FilterTimeline, FilterResources}

--- a/lib/report/resources.go
+++ b/lib/report/resources.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"fmt"
+
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
+)
+
+// ResourceCollectors returns gravity resource collectors.
+func ResourceCollectors() Collectors {
+	// Collect select gravity resources. More information on supported gravity
+	// resources found at https://gravitational.com/gravity/docs/config/
+	resources := []string{
+		storage.KindClusterConfiguration,
+		storage.KindRuntimeEnvironment,
+		storage.KindAuthGateway,
+		storage.KindSMTPConfig,
+		storage.KindAlertTarget,
+		storage.KindAlert,
+		storage.KindLogForwarder,
+	}
+
+	collectors := make(Collectors, len(resources))
+	for i, resource := range resources {
+		collectors[i] = Cmd(fmt.Sprintf("%s.yaml", resource), gravityResourceYAML(resource)...)
+	}
+	return collectors
+}
+
+// gravityResourceYAML returns the gravity command to output the specified
+// resource in YAML format.
+func gravityResourceYAML(resource string) []string {
+	return utils.Self("resource", "get", "--format", "yaml", resource)
+}

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -38,7 +38,7 @@ func NewSystemCollector(since time.Duration) Collectors {
 
 	add(basicSystemInfo()...)
 	add(systemStatus()...)
-	add(syslogExportLogs(since))
+	add(syslogExportLogs(since)...)
 	add(systemFileLogs()...)
 	add(planetLogs(since)...)
 	add(gravityCLILog(since))
@@ -118,15 +118,21 @@ func systemStatus() Collectors {
 }
 
 // syslogExportLogs fetches host journal logs
-func syslogExportLogs(since time.Duration) Collector {
+func syslogExportLogs(since time.Duration) Collectors {
 	var script = `
 #!/bin/bash
-/bin/journalctl --no-pager --output=export `
+/bin/journalctl --no-pager `
 	if since != 0 {
 		script = script + fmt.Sprintf(`--since="%s" `, time.Now().Add(-since).Format(JournalDateFormat))
 	}
-	script = script + "| /bin/gzip -f"
-	return Script("gravity-journal.log.gz", script)
+
+	plain := fmt.Sprintf("%s | /bin/gzip -f", script)
+	export := fmt.Sprintf("%s --output=export | /bin/gzip -f", script)
+
+	return Collectors{
+		Script("gravity-journal.log.gz", plain),
+		Script("gravity-journal-export.log.gz", export),
+	}
 }
 
 // systemFileLogs fetches gravity platform-related logs
@@ -146,12 +152,17 @@ cat %v 2> /dev/null || true`
 // planetLogs fetches planet syslog messages as well as the fresh journal entries
 func planetLogs(since time.Duration) Collectors {
 	return Collectors{
+		Self("planet-journal.log.gz",
+			"system", "export-runtime-journal",
+			"--since", since.String()),
 		// Fetch planet journal entries for the last two days
 		// The log can be imported as a journal with systemd-journal-remote:
 		//
 		// $ cat ./node-1-planet-journal-export.log | /lib/systemd/systemd-journal-remote -o ./journal/system.journal -
 		Self("planet-journal-export.log.gz",
-			"system", "export-runtime-journal", "--since", since.String()),
+			"system", "export-runtime-journal",
+			"--since", since.String(),
+			"--export"),
 	}
 }
 

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1639,6 +1639,8 @@ type SystemExportRuntimeJournalCmd struct {
 	// filter. Only log entries from the start of the time filter until now will
 	// be included in the report.
 	Since *time.Duration
+	// Export serializes the journal into a binary stream.
+	Export *bool
 }
 
 // SystemStreamRuntimeJournalCmd streams contents of the runtime journal
@@ -1648,6 +1650,8 @@ type SystemStreamRuntimeJournalCmd struct {
 	// filter. Only log entries from the start of the time filter until now will
 	// be included in the report.
 	Since *time.Duration
+	// Export serializes the journal into a binary stream.
+	Export *bool
 }
 
 // SystemGCJournalCmd manages cleanup of journal files

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -700,9 +700,11 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemExportRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("export-runtime-journal", "Export runtime journal logs to a file").Hidden()
 	g.SystemExportRuntimeJournalCmd.OutputFile = g.SystemExportRuntimeJournalCmd.Flag("output", "Name of resulting tarball. Output to stdout if unspecified").String()
 	g.SystemExportRuntimeJournalCmd.Since = g.SystemExportRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
+	g.SystemExportRuntimeJournalCmd.Export = g.SystemExportRuntimeJournalCmd.Flag("export", "Serializes the journal into a binary stream").Bool()
 
 	g.SystemStreamRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("stream-runtime-journal", "Stream runtime journal to stdout").Hidden()
 	g.SystemStreamRuntimeJournalCmd.Since = g.SystemStreamRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
+	g.SystemStreamRuntimeJournalCmd.Export = g.SystemStreamRuntimeJournalCmd.Flag("export", "Serializes the journal into a binary stream").Bool()
 
 	// pruning cluster resources
 	g.GarbageCollectCmd.CmdClause = g.Command("gc", "Prune cluster resources")

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -881,9 +881,12 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 	case g.SystemExportRuntimeJournalCmd.FullCommand():
 		return exportRuntimeJournal(localEnv,
 			*g.SystemExportRuntimeJournalCmd.OutputFile,
-			*g.SystemExportRuntimeJournalCmd.Since)
+			*g.SystemExportRuntimeJournalCmd.Since,
+			*g.SystemExportRuntimeJournalCmd.Export)
 	case g.SystemStreamRuntimeJournalCmd.FullCommand():
-		return streamRuntimeJournal(localEnv, *g.SystemStreamRuntimeJournalCmd.Since)
+		return streamRuntimeJournal(localEnv,
+			*g.SystemStreamRuntimeJournalCmd.Since,
+			*g.SystemStreamRuntimeJournalCmd.Export)
 	case g.GarbageCollectCmd.FullCommand():
 		return garbageCollect(localEnv, *g.GarbageCollectCmd.Manual, *g.GarbageCollectCmd.Confirmed)
 	case g.SystemGCJournalCmd.FullCommand():


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Gravity debug report now includes the gravity resources in yaml format.
- Journal logs are now also collected as a plain text file.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2148

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify `gravity report` command includes `<node>-resources.tar.gz`**

**Verify `gravity-journal.log` and `planet-journal.log` are formatted as a plain text file**
