### PR TITLE
[6.1.x] Include gravity resources in debug report

### DIFF
--- a/lib/report/report.go
+++ b/lib/report/report.go
@@ -51,6 +51,8 @@ func Collect(ctx context.Context, config Config, w io.Writer) error {
 			collectors = append(collectors, etcdMetrics()...)
 		case FilterTimeline:
 			collectors = append(collectors, NewTimelineCollector())
+		case FilterResources:
+			collectors = append(collectors, ResourceCollectors()...)
 		}
 	}
 
@@ -123,7 +125,10 @@ const (
 
 	// FilterTimeline defines a report collection filter to fetch the status timeline
 	FilterTimeline = "timeline"
+
+	// FilterResources defines a report collection filter to fetch gravity resources
+	FilterResources = "resources"
 )
 
 // AllFilters lists all available collector filters
-var AllFilters = []string{FilterSystem, FilterKubernetes, FilterTimeline}
+var AllFilters = []string{FilterSystem, FilterKubernetes, FilterEtcd, FilterTimeline, FilterResources}

--- a/lib/report/resources.go
+++ b/lib/report/resources.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package report
+
+import (
+	"fmt"
+
+	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
+)
+
+// ResourceCollectors returns gravity resource collectors.
+func ResourceCollectors() Collectors {
+	// Collect select gravity resources. More information on supported gravity
+	// resources found at https://gravitational.com/gravity/docs/config/
+	resources := []string{
+		storage.KindClusterConfiguration,
+		storage.KindRuntimeEnvironment,
+		storage.KindAuthGateway,
+		storage.KindOperation,
+		storage.KindSMTPConfig,
+		storage.KindAlertTarget,
+		storage.KindAlert,
+		storage.KindLogForwarder,
+	}
+
+	collectors := make(Collectors, len(resources))
+	for i, resource := range resources {
+		collectors[i] = Cmd(fmt.Sprintf("%s.yaml", resource), gravityResourceYAML(resource)...)
+	}
+	return collectors
+}
+
+// gravityResourceYAML returns the gravity command to output the specified
+// resource in YAML format.
+func gravityResourceYAML(resource string) []string {
+	return utils.Self("resource", "get", "--format", "yaml", resource)
+}

--- a/lib/report/system.go
+++ b/lib/report/system.go
@@ -35,7 +35,7 @@ func NewSystemCollector(since time.Duration) Collectors {
 
 	add(basicSystemInfo()...)
 	add(systemStatus()...)
-	add(syslogExportLogs(since))
+	add(syslogExportLogs(since)...)
 	add(systemFileLogs()...)
 	add(planetLogs(since)...)
 	add(gravityCLILog(since))
@@ -119,15 +119,21 @@ func systemStatus() Collectors {
 
 // syslogExportLogs fetches logs for gravity binary invocations
 // (including installation logs)
-func syslogExportLogs(since time.Duration) Collector {
+func syslogExportLogs(since time.Duration) Collectors {
 	var script = `
 #!/bin/bash
-/bin/journalctl --no-pager --output=export`
+/bin/journalctl --no-pager `
 	if since != 0 {
 		script = fmt.Sprintf(`%s --since="%s" `, script, time.Now().Add(-since).Format(JournalDateFormat))
 	}
-	script = fmt.Sprintf("%s | /bin/gzip -f", script)
-	return Script("gravity-system.log.gz", script)
+
+	plain := fmt.Sprintf("%s | /bin/gzip -f", script)
+	export := fmt.Sprintf("%s --output=export | /bin/gzip -f", script)
+
+	return Collectors{
+		Script("gravity-journal.log.gz", plain),
+		Script("gravity-journal-export.log.gz", export),
+	}
 }
 
 // systemFileLogs fetches gravity platform-related logs
@@ -146,12 +152,17 @@ cat %v 2> /dev/null || true`
 // planetLogs fetches planet syslog messages as well as the fresh journal entries
 func planetLogs(since time.Duration) Collectors {
 	return Collectors{
+		Self("planet-journal.log.gz",
+			"system", "export-runtime-journal",
+			"--since", since.String()),
 		// Fetch planet journal entries for the last two days
 		// The log can be imported as a journal with systemd-journal-remote:
 		//
 		// $ cat ./node-1-planet-journal-export.log | /lib/systemd/systemd-journal-remote -o ./journal/system.journal -
 		Self("planet-journal-export.log.gz",
-			"system", "export-runtime-journal", "--since", since.String()),
+			"system", "export-runtime-journal",
+			"--since", since.String(),
+			"--export"),
 	}
 }
 

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -1643,6 +1643,8 @@ type SystemExportRuntimeJournalCmd struct {
 	// filter. Only log entries from the start of the time filter until now will
 	// be included in the report.
 	Since *time.Duration
+	// Export serializes the journal into a binary stream.
+	Export *bool
 }
 
 // SystemStreamRuntimeJournalCmd streams contents of the runtime journal
@@ -1652,6 +1654,8 @@ type SystemStreamRuntimeJournalCmd struct {
 	// filter. Only log entries from the start of the time filter until now will
 	// be included in the report.
 	Since *time.Duration
+	// Export serializes the journal into a binary stream.
+	Export *bool
 }
 
 // SystemGCJournalCmd manages cleanup of journal files

--- a/tool/gravity/cli/journal.go
+++ b/tool/gravity/cli/journal.go
@@ -40,7 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string, since time.Duration) error {
+func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string, since time.Duration, export bool) error {
 	stateDir, err := state.GetStateDir()
 	if err != nil {
 		return trace.Wrap(err)
@@ -92,15 +92,21 @@ func exportRuntimeJournal(env *localenv.LocalEnvironment, outputFile string, sin
 
 	zip := gzip.NewWriter(w)
 	defer zip.Close()
-	cmd := exec.CommandContext(ctx, utils.Exe.Path,
+
+	args := []string{
 		"system", "stream-runtime-journal",
-		"--since", since.String())
+		"--since", since.String(),
+	}
+	if export {
+		args = append(args, "--export")
+	}
+	cmd := exec.CommandContext(ctx, utils.Exe.Path, args...)
 	cmd.Stdout = zip
 	cmd.Stderr = zip
 	return trace.Wrap(cmd.Run())
 }
 
-func streamRuntimeJournal(env *localenv.LocalEnvironment, since time.Duration) error {
+func streamRuntimeJournal(env *localenv.LocalEnvironment, since time.Duration, export bool) error {
 	runtimePackage, err := pack.FindRuntimePackage(env.Packages)
 	if err != nil {
 		return trace.Wrap(err)
@@ -124,8 +130,10 @@ func streamRuntimeJournal(env *localenv.LocalEnvironment, since time.Duration) e
 	const cmd = defaults.JournalctlBin
 	args := []string{
 		cmd,
-		"--output", "export",
 		"-D", journalDir,
+	}
+	if export {
+		args = append(args, "--output", "export")
 	}
 	if since != 0 {
 		args = append(args, "--since", time.Now().Add(-since).Format(report.JournalDateFormat))

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -705,9 +705,11 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.SystemExportRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("export-runtime-journal", "Export runtime journal logs to a file").Hidden()
 	g.SystemExportRuntimeJournalCmd.OutputFile = g.SystemExportRuntimeJournalCmd.Flag("output", "Name of resulting tarball. Output to stdout if unspecified").String()
 	g.SystemExportRuntimeJournalCmd.Since = g.SystemExportRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
+	g.SystemExportRuntimeJournalCmd.Export = g.SystemExportRuntimeJournalCmd.Flag("export", "Serializes the journal into a binary stream").Bool()
 
 	g.SystemStreamRuntimeJournalCmd.CmdClause = g.SystemCmd.Command("stream-runtime-journal", "Stream runtime journal to stdout").Hidden()
 	g.SystemStreamRuntimeJournalCmd.Since = g.SystemStreamRuntimeJournalCmd.Flag("since", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Default is 336h (14 days). Specify 0s to collect all logs.").Default("336h").Duration()
+	g.SystemStreamRuntimeJournalCmd.Export = g.SystemStreamRuntimeJournalCmd.Flag("export", "Serializes the journal into a binary stream").Bool()
 
 	// pruning cluster resources
 	g.GarbageCollectCmd.CmdClause = g.Command("gc", "Prune cluster resources")

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -864,9 +864,12 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 	case g.SystemExportRuntimeJournalCmd.FullCommand():
 		return exportRuntimeJournal(localEnv,
 			*g.SystemExportRuntimeJournalCmd.OutputFile,
-			*g.SystemExportRuntimeJournalCmd.Since)
+			*g.SystemExportRuntimeJournalCmd.Since,
+			*g.SystemExportRuntimeJournalCmd.Export)
 	case g.SystemStreamRuntimeJournalCmd.FullCommand():
-		return streamRuntimeJournal(localEnv, *g.SystemStreamRuntimeJournalCmd.Since)
+		return streamRuntimeJournal(localEnv,
+			*g.SystemStreamRuntimeJournalCmd.Since,
+			*g.SystemStreamRuntimeJournalCmd.Export)
 	case g.GarbageCollectCmd.FullCommand():
 		return garbageCollect(localEnv, *g.GarbageCollectCmd.Manual, *g.GarbageCollectCmd.Confirmed)
 	case g.SystemGCJournalCmd.FullCommand():


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
- Gravity debug report now includes the gravity resources in yaml format.
- Journal logs are now also collected as a plain text file.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2148

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify `gravity report` command includes `<node>-resources.tar.gz`**

**Verify `gravity-journal.log` and `planet-journal.log` are formatted as a plain text file**
