### PR TITLE
(7.0) Disable source/dest check for instances

### DIFF
--- a/lib/autoscale/aws/autoscaler.go
+++ b/lib/autoscale/aws/autoscaler.go
@@ -160,6 +160,27 @@ func (a *Autoscaler) DescribeInstance(ctx context.Context, instanceID string) (*
 	return resp.Reservations[0].Instances[0], nil
 }
 
+// DescribeInstancesWithSourceDestinationCheck returns all instances from the
+// specified list that have source/destination check enabled.
+func (a *Autoscaler) DescribeInstancesWithSourceDestinationCheck(ctx context.Context, instanceIDs []string) (result []*ec2.Instance, err error) {
+	resp, err := a.Cloud.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice(instanceIDs),
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("source-dest-check"),
+				Values: aws.StringSlice([]string{"true"}),
+			},
+		},
+	})
+	if err != nil {
+		return nil, utils.ConvertEC2Error(err)
+	}
+	for _, reservation := range resp.Reservations {
+		result = append(result, reservation.Instances...)
+	}
+	return result, nil
+}
+
 // WaitUntilInstanceTerminated blocks until the instance with the specified ID
 // is terminated.
 //

--- a/lib/autoscale/aws/discovery.go
+++ b/lib/autoscale/aws/discovery.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/ops"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/gravitational/trace"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,10 +35,11 @@ func (a *Autoscaler) PublishDiscovery(ctx context.Context, operator ops.Operator
 	a.Info("Start publishing discovery info.")
 	err := a.syncDiscovery(ctx, operator, true)
 	if err != nil {
-		a.Errorf("Failed to publish discovery: %v.", trace.DebugReport(err))
+		a.WithError(err).Error("Failed to publish discovery.")
 	}
 	publishTicker := time.NewTicker(defaults.DiscoveryPublishInterval)
 	resyncTicker := time.NewTicker(defaults.DiscoveryResyncInterval)
+	sourceDestTicker := time.NewTicker(defaults.SourceDestinationCheckInterval)
 	for {
 		select {
 		case <-ctx.Done():
@@ -46,15 +48,50 @@ func (a *Autoscaler) PublishDiscovery(ctx context.Context, operator ops.Operator
 		case <-publishTicker.C:
 			err = a.syncDiscovery(ctx, operator, false)
 			if err != nil {
-				a.Errorf("Failed to publish discovery: %v.", trace.DebugReport(err))
+				a.WithError(err).Error("Failed to publish discovery.")
 			}
 		case <-resyncTicker.C:
 			err = a.syncDiscovery(ctx, operator, true)
 			if err != nil {
-				a.Errorf("Failed to publish discovery: %v.", trace.DebugReport(err))
+				a.WithError(err).Error("Failed to publish discovery.")
+			}
+		case <-sourceDestTicker.C:
+			err = a.checkSourceDestination(ctx, operator)
+			if err != nil {
+				a.WithError(err).Error("Failed to ensure source/dest check is disabled.")
 			}
 		}
 	}
+}
+
+// checkSourceDestination makes sure source/destination check is disabled for
+// the cluster instances.
+func (a *Autoscaler) checkSourceDestination(ctx context.Context, operator ops.Operator) error {
+	cluster, err := operator.GetLocalSite(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	var instanceIDs []string
+	for _, node := range cluster.ClusterState.Servers {
+		if node.InstanceID != "" {
+			instanceIDs = append(instanceIDs, node.InstanceID)
+		} else {
+			a.Warnf("%v doesn't have cloud instance id.", node)
+		}
+	}
+	instances, err := a.DescribeInstancesWithSourceDestinationCheck(ctx, instanceIDs)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, instance := range instances {
+		a.Infof("Instance %v has source/dest check enabled, disabling.",
+			aws.StringValue(instance.InstanceId))
+		err := a.TurnOffSourceDestinationCheck(ctx, aws.StringValue(instance.InstanceId))
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
 }
 
 // syncDiscovery syncs cluster discovery information in the SSM

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1153,6 +1153,9 @@ const (
 	DiscoveryPublishInterval = 5 * time.Second
 	// DiscoveryResyncInterval specifies the frequency to force publish cluster discovery details
 	DiscoveryResyncInterval = 10 * time.Minute
+	// SourceDestinationCheckInterval is how often Gravity will check if any of
+	// the instances have source/dest check enabled and try to disable it.
+	SourceDestinationCheckInterval = 10 * time.Minute
 
 	// CACertificateExpiry is the validity period of self-signed CA generated
 	// for clusters during installation

--- a/lib/utils/strings.go
+++ b/lib/utils/strings.go
@@ -108,3 +108,15 @@ func CombineLabels(labels ...map[string]string) (result map[string]string) {
 	}
 	return result
 }
+
+// SplitSlice splits the provided string slice into batches of specified size.
+func SplitSlice(slice []string, batchSize int) (result [][]string) {
+	for i := 0; i < len(slice); i += batchSize {
+		batchEnd := i + batchSize
+		if batchEnd > len(slice) {
+			batchEnd = len(slice)
+		}
+		result = append(result, slice[i:batchEnd])
+	}
+	return result
+}

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -287,3 +287,40 @@ func (s *UtilsSuite) TestTrimPathPrefix(c *C) {
 		c.Assert(TrimPathPrefix(t.path, t.prefix...), Equals, t.result)
 	}
 }
+
+func (s *UtilsSuite) TestSplitSlice(c *C) {
+	tests := []struct {
+		slice  []string
+		size   int
+		result [][]string
+	}{
+		{
+			slice:  []string{"a", "b", "c", "d", "e"},
+			size:   1,
+			result: [][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}},
+		},
+		{
+			slice:  []string{"a", "b", "c", "d", "e"},
+			size:   2,
+			result: [][]string{{"a", "b"}, {"c", "d"}, {"e"}},
+		},
+		{
+			slice:  []string{"a", "b", "c", "d", "e"},
+			size:   3,
+			result: [][]string{{"a", "b", "c"}, {"d", "e"}},
+		},
+		{
+			slice:  []string{"a", "b", "c", "d", "e"},
+			size:   5,
+			result: [][]string{{"a", "b", "c", "d", "e"}},
+		},
+		{
+			slice:  []string{"a", "b", "c", "d", "e"},
+			size:   250,
+			result: [][]string{{"a", "b", "c", "d", "e"}},
+		},
+	}
+	for _, test := range tests {
+		c.Assert(SplitSlice(test.slice, test.size), DeepEquals, test.result)
+	}
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Update our AWS autoscaler controller loop with additional responsibility to periodically check if any of the cluster instances have source/destination check enabled and disable it. The check should be disabled in AWS cloud integration mode.

Our autoscaler actually already disables this parameter for new instances that come up when it receives events from ASG, but it doesn't work for pre-existing instances or those created outside of auto-scaling groups.

I kept scaling in mind when adding this, there should not be any downsides in that regard because I'm using a single "describe instances" call with filters (once every 10 minutes) to get information specifically about instances that have that check enabled which should not be many.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature) 

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Provisioned instances using our terraform and made sure that gravity-site disables source/dest check. Also, manually enabled it back and made sure it was disabled again.
