### PR TITLE
[5.5.x] Continue operation in case gravity-site or etcd is down

### DIFF
--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -200,8 +200,10 @@ const gravityResumeServiceName = "gravity-resume.service"
 // or launches a one-shot systemd service that executes it in the background.
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
 	if params.IsResume() {
-		if err := verifyAgentsActive(env); err != nil {
-			return trace.Wrap(err)
+		if err := verifyOrDeployAgents(env); err != nil {
+			// Continue operation in case gravity-site or etcd is down. In these
+			// cases the agent status may not be retrievable.
+			log.WithError(err).Warn("Failed to verify or deploy agents.")
 		}
 	}
 

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -119,8 +119,10 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 		return trace.BadParameter(unsupportedRollbackWarning, op.TypeString())
 	}
 
-	if err := verifyAgentsActive(localEnv); err != nil {
-		return trace.Wrap(err)
+	if err := verifyOrDeployAgents(localEnv); err != nil {
+		// Continue operation in case gravity-site or etcd is down. In these
+		// cases the agent status may not be retrievable.
+		log.WithError(err).Warn("Failed to verify or deploy agents.")
 	}
 
 	if !confirmed && !params.DryRun {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Previous PR added a check in upgrade resume and rollback operations that will abort if unable to verify agent status or re-deploy agents. This check made it impossible to resume/rollback if gravity-site or etcd is down. This PR will allow resume/rollback continue operation in these situations.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/2157

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade resume executes if gravity-site or etcd is down**

**Verify rollback executes if gravity-site or etcd is down**