### PR TITLE
[6.1.x] Continue operation in case gravity-site or etcd is down

### DIFF
--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -200,7 +200,9 @@ const gravityResumeServiceName = "gravity-resume.service"
 func executeOrForkPhase(env *localenv.LocalEnvironment, updater updater, params PhaseParams, operation ops.SiteOperation) error {
 	if params.isResume() {
 		if err := verifyOrDeployAgents(env); err != nil {
-			return trace.Wrap(err)
+			// Continue operation in case gravity-site or etcd is down. In these
+			// cases the agent status may not be retrievable.
+			log.WithError(err).Warn("Failed to verify or deploy agents.")
 		}
 	}
 

--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -178,7 +178,9 @@ func rollbackPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentF
 	}
 
 	if err := verifyOrDeployAgents(localEnv); err != nil {
-		return trace.Wrap(err)
+		// Continue operation in case gravity-site or etcd is down. In these
+		// cases the agent status may not be retrievable.
+		log.WithError(err).Warn("Failed to verify or deploy agents.")
 	}
 
 	if !confirmed && !params.DryRun {

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/cenkalti/backoff"
+	"github.com/fatih/color"
 	teleclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/version"
@@ -502,15 +503,16 @@ func collectAgentStatus(env *localenv.LocalEnvironment) (statusList rpc.StatusLi
 func verifyOrDeployAgents(env *localenv.LocalEnvironment) error {
 	statusList, err := collectAgentStatus(env)
 	if err != nil {
+		env.Println(color.YellowString("Couldn't verify upgrade agents status. If some are offline, they won't be redeployed automatically"))
 		return trace.Wrap(err, "failed to collect agent status")
 	}
 	if statusList.AgentsActive() {
 		return nil
 	}
 	if err := rpcAgentDeploy(env, deployOptions{}); err != nil {
-		log.WithError(err).Error("Failed to deploy agents.")
 		env.Println(statusList.String())
-		return trace.BadParameter("some agents are offline; ensure all agents are deployed with `./gravity agent deploy`")
+		env.Println(color.YellowString("Some agents are offline. Ensure all agents are deployed with `./gravity agent deploy`"))
+		return trace.Wrap(err, "failed to deploy agents")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Previous PR added a check in upgrade resume and rollback operations that will abort if unable to verify agent status or re-deploy agents. This check made it impossible to resume/rollback if gravity-site or etcd is down. This PR will allow resume/rollback continue operation in these situations.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/2157

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify upgrade resume executes if gravity-site or etcd is down**

**Verify rollback executes if gravity-site or etcd is down**