### PR TITLE
[6.1.x] take mount overrides into account in preflight checks

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -70,7 +70,8 @@ func (r *ManifestValidator) Validate(ctx context.Context) (failedProbes []*agent
 	failed, err := schema.ValidateRequirements(ctx, requirements, r.StateDir)
 	if err != nil {
 		errors = append(errors, trace.Wrap(err,
-			"error validating profile requirements, see log file for details"))
+			"error validating profile requirements, see log file (%v) for details",
+			defaults.GravitySystemLogPath))
 	}
 	failedProbes = append(failedProbes, failed...)
 
@@ -82,7 +83,8 @@ func (r *ManifestValidator) Validate(ctx context.Context) (failedProbes []*agent
 	failed, err = schema.ValidateDocker(ctx, dockerSchema, r.StateDir)
 	if err != nil {
 		errors = append(errors, trace.Wrap(err,
-			"error validating docker requirements, see log file for details"))
+			"error validating docker requirements, see log file (%v) for details",
+			defaults.GravitySystemLogPath))
 	}
 	failedProbes = append(failedProbes, failed...)
 
@@ -130,7 +132,7 @@ type LocalChecksRequest struct {
 	Options *validationpb.ValidateOptions
 	// Docker specifies Docker configuration overrides (if any)
 	Docker storage.DockerConfig
-	// Mounts specidies optional mount overrides as name -> source path pairs
+	// Mounts specifies optional mount overrides as name -> source path pairs
 	Mounts map[string]string
 	// AutoFix when set to true attempts to fix some common problems
 	AutoFix bool

--- a/lib/checks/checks_test.go
+++ b/lib/checks/checks_test.go
@@ -40,13 +40,13 @@ func (s *ChecksSuite) SetUpSuite(c *check.C) {
 	sysinfo := storage.NewSystemInfo(storage.SystemSpecV2{
 		Hostname: "foo",
 		Filesystems: []storage.Filesystem{
-			storage.Filesystem{
+			{
 				DirName: "/foo/bar",
 				Type:    "tmpfs",
 			},
 		},
 		FilesystemStats: map[string]storage.FilesystemUsage{
-			"/foo/bar": storage.FilesystemUsage{
+			"/foo/bar": {
 				TotalKB: 2,
 				FreeKB:  1,
 			},

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -721,6 +721,7 @@ func (p *Peer) runLocalChecks(ctx operationContext) error {
 		Manifest: ctx.Cluster.App.Manifest,
 		Role:     p.Role,
 		Docker:   ctx.Cluster.ClusterState.Docker,
+		Mounts:   mountsFromProto(p.PeerConfig.RuntimeConfig.Mounts),
 		Options: &validationpb.ValidateOptions{
 			VxlanPort: int32(installOperation.GetVars().OnPrem.VxlanPort),
 			DnsAddrs:  ctx.Cluster.DNSConfig.Addrs,
@@ -1350,4 +1351,12 @@ type connectResult struct {
 type closeResponse struct {
 	doneC chan struct{}
 	resp  *installpb.ProgressResponse
+}
+
+func mountsFromProto(mounts []*pb.Mount) (result map[string]string) {
+	result = make(map[string]string, len(mounts))
+	for _, mount := range mounts {
+		result[mount.Name] = mount.Source
+	}
+	return result
 }

--- a/lib/schema/checks.go
+++ b/lib/schema/checks.go
@@ -55,7 +55,7 @@ var (
 // ValidateDocker validates Docker requirements.
 // The specified directory is expected to be on the same filesystem
 // as the Docker graph directory (which might not exist at this point).
-func ValidateDocker(d Docker, dir string) (failed []*pb.Probe, err error) {
+func ValidateDocker(ctx context.Context, d Docker, dir string) (failed []*pb.Probe, err error) {
 	var checkers []health.Checker
 
 	checkers = append(checkers,
@@ -72,12 +72,12 @@ func ValidateDocker(d Docker, dir string) (failed []*pb.Probe, err error) {
 	all := monitoring.NewCompositeChecker("docker", checkers)
 	var probes health.Probes
 
-	all.Check(context.TODO(), &probes)
+	all.Check(ctx, &probes)
 	return probes.GetFailed(), nil
 }
 
 // ValidateKubelet will check kubelet configuration
-func ValidateKubelet(profile NodeProfile, manifest Manifest) (failed []*pb.Probe) {
+func ValidateKubelet(ctx context.Context, profile NodeProfile, manifest Manifest) (failed []*pb.Probe) {
 	checkers := append([]health.Checker{},
 		DefaultKernelModuleChecker,
 		monitoring.NewCGroupChecker("cpu", "cpuacct", "cpuset", "memory"),
@@ -85,12 +85,12 @@ func ValidateKubelet(profile NodeProfile, manifest Manifest) (failed []*pb.Probe
 	checker := monitoring.NewCompositeChecker("kubelet", checkers)
 
 	var probes health.Probes
-	checker.Check(context.TODO(), &probes)
+	checker.Check(ctx, &probes)
 	return probes.GetFailed()
 }
 
 // ValidateRequirements will assess local node to match requirements
-func ValidateRequirements(reqs Requirements, stateDir string) (failed []*pb.Probe, err error) {
+func ValidateRequirements(ctx context.Context, reqs Requirements, stateDir string) (failed []*pb.Probe, err error) {
 	var checkers []health.Checker
 	checkers = append(checkers, monitoring.NewHostChecker(
 		monitoring.HostConfig{
@@ -157,7 +157,7 @@ func ValidateRequirements(reqs Requirements, stateDir string) (failed []*pb.Prob
 	all := monitoring.NewCompositeChecker("common requirements", checkers)
 	var probes health.Probes
 
-	all.Check(context.TODO(), &probes)
+	all.Check(ctx, &probes)
 	return probes.GetFailed(), nil
 }
 

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -478,6 +478,7 @@ func (i *InstallConfig) RunLocalChecks() error {
 		Manifest: app.Manifest,
 		Role:     role,
 		Docker:   i.Docker,
+		Mounts:   i.Mounts,
 		Options: &validationpb.ValidateOptions{
 			VxlanPort: int32(i.VxlanPort),
 			DnsAddrs:  i.DNSConfig.Addrs,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Take mount overrides into account when running local pre-flight checks during expand and install.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs github.com/gravitational/gravity/issues/2167

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Edited the application manifest to add a volume and tested with a modified `check` that accepted a list of mount overrides:
```
$ ./gravity check -p node --mounts=data=/path/to/new/volume
```
