### PR TITLE
Take mount overrides into account in preflight checks.

### DIFF
--- a/lib/checks/checks.go
+++ b/lib/checks/checks.go
@@ -59,32 +59,52 @@ func New(config Config) (*checker, error) {
 	return &checker{Config: config}, nil
 }
 
-// ValidateManifest verifies the specified manifest against the host environment.
+// Validate verifies the specified manifest against the host environment.
 // Returns list of failed health probes.
-func ValidateManifest(
-	manifest schema.Manifest,
-	profile schema.NodeProfile,
-	dockerConfig storage.DockerConfig,
-	stateDir string,
-) (failedProbes []*agentpb.Probe, err error) {
+func (r *ManifestValidator) Validate(ctx context.Context) (failedProbes []*agentpb.Probe, err error) {
 	var errors []error
-	failed, err := schema.ValidateRequirements(profile.Requirements, stateDir)
+	requirements := r.Profile.Requirements
+	if len(r.Mounts) != 0 {
+		requirements = overrideMounts(requirements, r.Mounts)
+	}
+	failed, err := schema.ValidateRequirements(ctx, requirements, r.StateDir)
 	if err != nil {
 		errors = append(errors, trace.Wrap(err,
-			"error validating profile requirements, see syslog for details"))
+			"error validating profile requirements, see log file (%v) for details",
+			defaults.GravitySystemLogPath))
 	}
 	failedProbes = append(failedProbes, failed...)
 
+	dockerConfig := r.Manifest.Docker(r.Profile)
+	if r.Docker != nil {
+		dockerConfig.StorageDriver = r.Docker.StorageDriver
+	}
 	dockerSchema := schema.Docker{StorageDriver: dockerConfig.StorageDriver}
-	failed, err = schema.ValidateDocker(dockerSchema, stateDir)
+	failed, err = schema.ValidateDocker(ctx, dockerSchema, r.StateDir)
 	if err != nil {
 		errors = append(errors, trace.Wrap(err,
-			"error validating docker requirements, see syslog for details"))
+			"error validating docker requirements, see log file (%v) for details",
+			defaults.GravitySystemLogPath))
 	}
 	failedProbes = append(failedProbes, failed...)
 
-	failedProbes = append(failedProbes, schema.ValidateKubelet(profile, manifest)...)
+	failedProbes = append(failedProbes, schema.ValidateKubelet(ctx, r.Profile, r.Manifest)...)
 	return failedProbes, trace.NewAggregate(errors...)
+}
+
+// ManifestValidator describes a manifest validator
+type ManifestValidator struct {
+	// Manifest specifies the manifest to validate against
+	Manifest schema.Manifest
+	// Profile specifies the node profile to validate against
+	Profile schema.NodeProfile
+	// StateDir specifies the state directory on the local node
+	StateDir string
+	// Docker specifies optional docker configuration.
+	// If specified, overrides the system docker configuration
+	Docker *storage.DockerConfig
+	// Mounts specifies the mount overrides as name -> source path pairs
+	Mounts map[string]string
 }
 
 // RunBasicChecks executes a set of additional health checks.
@@ -112,6 +132,8 @@ type LocalChecksRequest struct {
 	Options *validationpb.ValidateOptions
 	// Docker specifies Docker configuration overrides (if any)
 	Docker storage.DockerConfig
+	// Mounts specifies optional mount overrides as name -> source path pairs
+	Mounts map[string]string
 	// AutoFix when set to true attempts to fix some common problems
 	AutoFix bool
 	// Progress is used to report information about auto-fixed problems
@@ -170,7 +192,16 @@ func ValidateLocal(ctx context.Context, req LocalChecksRequest) (*LocalChecksRes
 
 	dockerConfig := DockerConfigFromSchemaValue(req.Manifest.SystemDocker())
 	OverrideDockerConfig(&dockerConfig, req.Docker)
-	failedProbes, err := ValidateManifest(req.Manifest, *profile, dockerConfig, stateDir)
+
+	v := ManifestValidator{
+		Manifest: req.Manifest,
+		Profile:  *profile,
+		StateDir: stateDir,
+		Docker:   &dockerConfig,
+		Mounts:   req.Mounts,
+	}
+
+	failedProbes, err := v.Validate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -951,6 +982,21 @@ func ifTestsDisabled() bool {
 	disabled, _ := strconv.ParseBool(envVar)
 	return disabled
 
+}
+
+func overrideMounts(requirements schema.Requirements, mounts map[string]string) schema.Requirements {
+	var result []schema.Volume
+	for _, volume := range requirements.Volumes {
+		if path, ok := mounts[volume.Name]; !ok {
+			result = append(result, volume)
+		} else {
+			v := volume
+			v.Path = path
+			result = append(result, v)
+		}
+	}
+	requirements.Volumes = result
+	return requirements
 }
 
 // RunStream executes the specified command on r.server.

--- a/lib/checks/checks_test.go
+++ b/lib/checks/checks_test.go
@@ -40,13 +40,13 @@ func (s *ChecksSuite) SetUpSuite(c *check.C) {
 	sysinfo := storage.NewSystemInfo(storage.SystemSpecV2{
 		Hostname: "foo",
 		Filesystems: []storage.Filesystem{
-			storage.Filesystem{
+			{
 				DirName: "/foo/bar",
 				Type:    "tmpfs",
 			},
 		},
 		FilesystemStats: map[string]storage.FilesystemUsage{
-			"/foo/bar": storage.FilesystemUsage{
+			"/foo/bar": {
 				TotalKB: 2,
 				FreeKB:  1,
 			},

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -720,6 +720,7 @@ func (p *Peer) runLocalChecks(ctx operationContext) error {
 		Manifest: ctx.Cluster.App.Manifest,
 		Role:     p.Role,
 		Docker:   ctx.Cluster.ClusterState.Docker,
+		Mounts:   mountsFromProto(p.PeerConfig.RuntimeConfig.Mounts),
 		Options: &validationpb.ValidateOptions{
 			VxlanPort: int32(installOperation.GetVars().OnPrem.VxlanPort),
 			DnsAddrs:  ctx.Cluster.DNSConfig.Addrs,
@@ -1362,4 +1363,12 @@ type connectResult struct {
 type closeResponse struct {
 	doneC chan struct{}
 	resp  *installpb.ProgressResponse
+}
+
+func mountsFromProto(mounts []*pb.Mount) (result map[string]string) {
+	result = make(map[string]string, len(mounts))
+	for _, mount := range mounts {
+		result[mount.Name] = mount.Source
+	}
+	return result
 }

--- a/lib/network/validation/validation.go
+++ b/lib/network/validation/validation.go
@@ -139,15 +139,20 @@ func (_ *Server) Validate(ctx context.Context, req *pb.ValidateRequest) (resp *p
 		return nil, trace.Wrap(err)
 	}
 
-	var failedProbes []*agentpb.Probe
-	dockerConfig := storage.DockerConfig{
-		StorageDriver: req.Docker.StorageDriver,
+	v := checks.ManifestValidator{
+		Manifest: manifest,
+		Profile:  *profile,
+		StateDir: stateDir,
 	}
+	var failedProbes []*agentpb.Probe
 	if req.FullRequirements {
-		failedProbes, err = checks.ValidateManifest(manifest, *profile, dockerConfig, stateDir)
+		v.Docker = &storage.DockerConfig{
+			StorageDriver: req.Docker.StorageDriver,
+		}
+		failedProbes, err = v.Validate(ctx)
 		failedProbes = append(failedProbes, checks.RunBasicChecks(ctx, req.Options)...)
 	} else {
-		failedProbes, err = validateManifest(*profile, manifest, stateDir)
+		failedProbes, err = validateManifest(ctx, v)
 		failedProbes = append(failedProbes, runLocalChecks(ctx)...)
 	}
 
@@ -188,16 +193,16 @@ func computeDiff(expected []*pb.Addr, actual []*pb.ServerResult) (diff []*pb.Add
 // validateManifest validates the node against the specified profile.
 // The profile requirements are skipped as these are only meaningful during
 // installation.
-func validateManifest(profile schema.NodeProfile, manifest schema.Manifest, stateDir string) (failedProbes []*agentpb.Probe, err error) {
+func validateManifest(ctx context.Context, v checks.ManifestValidator) (failedProbes []*agentpb.Probe, err error) {
 	var errors []error
-	failed, err := schema.ValidateDocker(manifest.SystemDocker(), stateDir)
+	failed, err := schema.ValidateDocker(ctx, v.Manifest.Docker(v.Profile), v.StateDir)
 	if err != nil {
 		errors = append(errors, trace.Wrap(err,
 			"error validating docker requirements, see syslog for details"))
 	}
 	failedProbes = append(failedProbes, failed...)
 
-	failedProbes = append(failedProbes, schema.ValidateKubelet(profile, manifest)...)
+	failedProbes = append(failedProbes, schema.ValidateKubelet(ctx, v.Profile, v.Manifest)...)
 	return failedProbes, trace.NewAggregate(errors...)
 }
 

--- a/lib/schema/checks.go
+++ b/lib/schema/checks.go
@@ -55,7 +55,7 @@ var (
 // ValidateDocker validates Docker requirements.
 // The specified directory is expected to be on the same filesystem
 // as the Docker graph directory (which might not exist at this point).
-func ValidateDocker(d Docker, dir string) (failed []*pb.Probe, err error) {
+func ValidateDocker(ctx context.Context, d Docker, dir string) (failed []*pb.Probe, err error) {
 	var checkers []health.Checker
 
 	checkers = append(checkers,
@@ -72,12 +72,12 @@ func ValidateDocker(d Docker, dir string) (failed []*pb.Probe, err error) {
 	all := monitoring.NewCompositeChecker("docker", checkers)
 	var probes health.Probes
 
-	all.Check(context.TODO(), &probes)
+	all.Check(ctx, &probes)
 	return probes.GetFailed(), nil
 }
 
 // ValidateKubelet will check kubelet configuration
-func ValidateKubelet(profile NodeProfile, manifest Manifest) (failed []*pb.Probe) {
+func ValidateKubelet(ctx context.Context, profile NodeProfile, manifest Manifest) (failed []*pb.Probe) {
 	checkers := append([]health.Checker{},
 		DefaultKernelModuleChecker,
 		monitoring.NewCGroupChecker("cpu", "cpuacct", "cpuset", "memory"),
@@ -85,12 +85,12 @@ func ValidateKubelet(profile NodeProfile, manifest Manifest) (failed []*pb.Probe
 	checker := monitoring.NewCompositeChecker("kubelet", checkers)
 
 	var probes health.Probes
-	checker.Check(context.TODO(), &probes)
+	checker.Check(ctx, &probes)
 	return probes.GetFailed()
 }
 
 // ValidateRequirements will assess local node to match requirements
-func ValidateRequirements(reqs Requirements, stateDir string) (failed []*pb.Probe, err error) {
+func ValidateRequirements(ctx context.Context, reqs Requirements, stateDir string) (failed []*pb.Probe, err error) {
 	var checkers []health.Checker
 	checkers = append(checkers, monitoring.NewHostChecker(
 		monitoring.HostConfig{
@@ -157,7 +157,7 @@ func ValidateRequirements(reqs Requirements, stateDir string) (failed []*pb.Prob
 	all := monitoring.NewCompositeChecker("common requirements", checkers)
 	var probes health.Probes
 
-	all.Check(context.TODO(), &probes)
+	all.Check(ctx, &probes)
 	return probes.GetFailed(), nil
 }
 

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -531,6 +531,7 @@ func (i *InstallConfig) RunLocalChecks() error {
 		Manifest: app.Manifest,
 		Role:     role,
 		Docker:   i.Docker,
+		Mounts:   i.Mounts,
 		Options: &validationpb.ValidateOptions{
 			VxlanPort: int32(i.VxlanPort),
 			DnsAddrs:  i.DNSConfig.Addrs,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Take mount overrides into account when running local pre-flight checks during expand and install.
Port of https://github.com/gravitational/gravity/pull/2168.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs github.com/gravitational/gravity/issues/2167
* Ports https://github.com/gravitational/gravity/pull/2168

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Edited the application manifest to add a volume and tested with a modified `check` that accepted a list of mount overrides:
```
$ ./gravity check -p node --mounts=data=/path/to/new/volume
```
