### PR TITLE
[6.1.x] explicit control over gRPC logging

### DIFF
--- a/lib/rpc/server/peers.go
+++ b/lib/rpc/server/peers.go
@@ -227,7 +227,6 @@ func (r *peers) reconnectPeer(p Peer, reqCh <-chan chan clientUpdate, doneCh cha
 			err := utils.RetryWithInterval(r.ctx, r.Backoff(), func() (err error) {
 				clt, err = p.Reconnect(r.ctx)
 				if err != nil {
-					log.WithError(err).Warn("Unable to reconnect.")
 					return r.ShouldReconnect(err)
 				}
 				return nil

--- a/lib/rpc/server/peers.go
+++ b/lib/rpc/server/peers.go
@@ -227,6 +227,7 @@ func (r *peers) reconnectPeer(p Peer, reqCh <-chan chan clientUpdate, doneCh cha
 			err := utils.RetryWithInterval(r.ctx, r.Backoff(), func() (err error) {
 				clt, err = p.Reconnect(r.ctx)
 				if err != nil {
+					log.WithError(err).Warn("Unable to reconnect.")
 					return r.ShouldReconnect(err)
 				}
 				return nil

--- a/lib/utils/env.go
+++ b/lib/utils/env.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gravitational/gravity/lib/defaults"
+
 	"github.com/gravitational/trace"
 )
 

--- a/lib/utils/logging.go
+++ b/lib/utils/logging.go
@@ -20,23 +20,70 @@ import (
 	"io/ioutil"
 	"log/syslog"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/gravitational/gravity/lib/defaults"
 
 	log "github.com/sirupsen/logrus"
 	syslogrus "github.com/sirupsen/logrus/hooks/syslog"
+	"google.golang.org/grpc/grpclog"
 )
 
 // InitLogging initalizes logging to log both to syslog and to a file
-func InitLogging(logFile string) {
+func InitLogging(level log.Level, logFile string) {
 	log.StandardLogger().Hooks.Add(&Hook{
 		path: logFile,
 	})
-	setLoggingOptions()
+	setLoggingOptions(level)
 }
 
-func setLoggingOptions() {
-	log.SetLevel(log.DebugLevel)
+// InitGRPCLoggerFromEnvironment configures the GRPC logger if any of the related environment variables
+// are set.
+func InitGRPCLoggerFromEnvironment() {
+	const (
+		envSeverityLevel  = "GRPC_GO_LOG_SEVERITY_LEVEL"
+		envVerbosityLevel = "GRPC_GO_LOG_VERBOSITY_LEVEL"
+	)
+	severityLevel := os.Getenv(envSeverityLevel)
+	verbosityLevel := os.Getenv(envVerbosityLevel)
+	var verbosity int
+	if verbosityOverride, err := strconv.Atoi(verbosityLevel); err == nil {
+		verbosity = verbosityOverride
+	}
+	if severityLevel == "" && verbosityLevel == "" {
+		// Nothing to do
+		return
+	}
+	InitGRPCLogger(severityLevel, verbosity)
+}
+
+// InitGRPCLoggerWithDefaults configures the GRPC logger with debug defaults.
+func InitGRPCLoggerWithDefaults() {
+	InitGRPCLogger("info", 10)
+}
+
+// Severity level is one of `info`, `warning` or `error` and defaults to error if unspecified.
+// Verbosity is a non-negative integer.
+func InitGRPCLogger(severityLevel string, verbosity int) {
+	errorW := ioutil.Discard
+	warningW := ioutil.Discard
+	infoW := ioutil.Discard
+
+	switch strings.ToLower(severityLevel) {
+	case "", "error": // If env is unset, set level to `error`.
+		errorW = os.Stderr
+	case "warning":
+		warningW = os.Stderr
+	case "info":
+		infoW = os.Stderr
+	}
+
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(infoW, warningW, errorW, verbosity))
+}
+
+func setLoggingOptions(level log.Level) {
+	log.SetLevel(level)
 	log.SetOutput(ioutil.Discard)
 }
 

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -70,11 +70,11 @@ func Run(g *Application) (err error) {
 		return trace.Wrap(err)
 	}
 
+	var grpcSeverity, grpcVerbosity string
 	if *g.Debug {
-		utils.InitGRPCLoggerWithDefaults()
-	} else {
-		utils.InitGRPCLoggerFromEnvironment()
+		grpcSeverity, grpcVerbosity = utils.DebugGRPCEnvironment()
 	}
+	utils.InitGRPCLoggerFromEnvironment(grpcSeverity, grpcVerbosity)
 
 	if *g.UID != -1 || *g.GID != -1 {
 		return SwitchPrivileges(*g.UID, *g.GID)

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -70,6 +70,12 @@ func Run(g *Application) (err error) {
 		return trace.Wrap(err)
 	}
 
+	if *g.Debug {
+		utils.InitGRPCLoggerWithDefaults()
+	} else {
+		utils.InitGRPCLoggerFromEnvironment()
+	}
+
 	if *g.UID != -1 || *g.GID != -1 {
 		return SwitchPrivileges(*g.UID, *g.GID)
 	}
@@ -142,20 +148,20 @@ func InitAndCheck(g *Application, cmd string) error {
 		g.ResourceCreateCmd.FullCommand(),
 		g.ResourceRemoveCmd.FullCommand(),
 		g.OpsAgentCmd.FullCommand():
-		utils.InitLogging(*g.SystemLogFile)
+		utils.InitLogging(level, *g.SystemLogFile)
 		// install and join command also duplicate their logs to the file in
 		// the current directory for convenience, unless the user set their
 		// own location
 		switch cmd {
 		case g.InstallCmd.FullCommand(), g.JoinCmd.FullCommand():
 			if *g.SystemLogFile == defaults.GravitySystemLogPath {
-				utils.InitLogging(defaults.GravitySystemLogFile)
+				utils.InitLogging(level, defaults.GravitySystemLogFile)
 			}
 		}
 	default:
 		if systemLogSet {
 			// For all commands, use the system log file explicitly set on command line
-			utils.InitLogging(*g.SystemLogFile)
+			utils.InitLogging(level, *g.SystemLogFile)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Expose control over gRPC logging which is implicitly disabled by the etcd client package. The logging is on if a gravity command is executed with `--debug`, otherwise - the logging can be turned on using these environment variables:
 * `GRPC_GO_LOG_SEVERITY_LEVEL` - control the severity level, takes one of `error`, `warning` or `info`
 * `GRPC_GO_LOG_VERBOSITY_LEVEL` - arbitrary verbosity level as an integer
See https://pkg.go.dev/google.golang.org/grpc@v1.32.0/grpclog#pkg-overview for details.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Requires https://github.com/gravitational/gravity.e/pull/4340

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
