### PR TITLE
[5.5.x] use etcd quorum reads for querying the operation plan

### DIFF
--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -498,15 +497,6 @@ func (h *WebHandler) exportApp(w http.ResponseWriter, req *http.Request,
 	if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
 		return trace.Wrap(err)
 	}
-	_, _, err = net.SplitHostPort(config.RegistryHostPort)
-	if config.RegistryHostPort == "" || err != nil {
-		message := "invalid host:port value"
-		if err != nil {
-			message = err.Error()
-		}
-		return trace.BadParameter("registryHostPort: %v", message)
-	}
-
 	if err = context.applications.ExportApp(app.ExportAppRequest{
 		Package:         *locator,
 		RegistryAddress: config.RegistryHostPort,

--- a/lib/app/suite/suite.go
+++ b/lib/app/suite/suite.go
@@ -209,7 +209,7 @@ spec:
 	c.Assert(err, IsNil)
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf("%v:5000", constants.APIServerDomainName),
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -269,7 +269,7 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf(constants.DockerRegistry),
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 	apps := r.NewService(c, dockerClient, imageService)
@@ -278,14 +278,15 @@ func (r *AppsSuite) ExportsApplication(c *C) {
 	c.Assert(err, IsNil)
 	application := r.importApplication(apps, vendorer, c)
 
+	registryAddr := registryAddr(registry.Addr())
 	c.Assert(apps.ExportApp(app.ExportAppRequest{
 		Package:         application.Package,
-		RegistryAddress: registry.Addr(),
+		RegistryAddress: registryAddr,
 	}), IsNil)
 
 	remoteRegistry, err := docker.ConnectRegistry(context.TODO(),
 		docker.RegistryConnectionRequest{
-			RegistryAddress: registry.Addr(),
+			RegistryAddress: registryAddr,
 		})
 	c.Assert(err, IsNil)
 	repos := make([]string, 3)
@@ -635,7 +636,7 @@ func (r *AppsSuite) Charts(c *C) {
 	defer registry.Close()
 
 	imageService, err := docker.NewImageService(docker.RegistryConnectionRequest{
-		RegistryAddress: fmt.Sprintf(constants.DockerRegistry),
+		RegistryAddress: defaults.DockerRegistry,
 	})
 	c.Assert(err, IsNil)
 
@@ -700,19 +701,20 @@ registry:
 	c.Assert(files["resources/charts/mattermost/values.yaml"], Equals, valuesBytes)
 	c.Assert(files["resources/charts/mattermost/templates/pod.yaml"], Equals, templateBytes)
 
+	registryAddr := registryAddr(registry.Addr())
 	// alpine was referenced as a part of helm template,
 	// but make sure helm template has captured it
 	// and added to the list of vendored apps
 	c.Assert(apps.ExportApp(app.ExportAppRequest{
 		Package:         application.Package,
-		RegistryAddress: registry.Addr(),
+		RegistryAddress: registryAddr,
 	}), IsNil)
 
 	ctx := context.Background()
 	remoteRegistry, err := docker.ConnectRegistry(
 		ctx,
 		docker.RegistryConnectionRequest{
-			RegistryAddress: registry.Addr(),
+			RegistryAddress: registryAddr,
 		})
 	c.Assert(err, IsNil)
 	repos := make([]string, 2)
@@ -898,4 +900,8 @@ spec:
 	defer reader.Close()
 	archive.AssertArchiveHasFiles(c, reader, []string{"registry"}, "resources", "resources/resource-0.yaml", "resources/app.yaml")
 	return importedApplication
+}
+
+func registryAddr(addr string) string {
+	return fmt.Sprintf("http://%v", addr)
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1177,6 +1177,9 @@ var (
 
 	// TeleportVersion specifies the version of the bundled teleport package as a semver
 	TeleportVersion = semver.New(TeleportVersionString)
+
+	// DockerRegistry is a default name for private docker registry
+	DockerRegistry = DockerRegistryAddr("leader.telekube.local")
 )
 
 // HookSecurityContext returns default securityContext for hook pods

--- a/lib/fsm/format.go
+++ b/lib/fsm/format.go
@@ -59,6 +59,7 @@ func FormatOperationPlanJSON(w io.Writer, plan storage.OperationPlan) error {
 func FormatOperationPlanText(w io.Writer, plan storage.OperationPlan) {
 	var t tabwriter.Writer
 	t.Init(w, 0, 10, 5, ' ', 0)
+	fmt.Fprintln(&t, "Operation: ", OperationString(plan))
 	common.PrintTableHeader(&t, []string{"Phase", "Description", "State", "Node", "Requires", "Updated"})
 	for _, phase := range plan.Phases {
 		printPhase(&t, phase, 0)

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fsm
 
 import (
+	"fmt"
+
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/schema"
@@ -285,6 +287,14 @@ func ClusterKey(plan storage.OperationPlan) ops.SiteKey {
 		AccountID:  plan.AccountID,
 		SiteDomain: plan.ClusterName,
 	}
+}
+
+// OperationString returns the textual representation of this operation
+func OperationString(plan storage.OperationPlan) string {
+	return fmt.Sprintf("%v(%v), cluster=%v",
+		ops.OperationTypeString(plan.OperationType),
+		plan.OperationID,
+		plan.ClusterName)
 }
 
 // CompleteOrFailOperation completes or fails the operation given by the plan in the specified operator.

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/gravity/lib/ops/opsservice"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/pack/localpack"
-	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
 	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/users"
@@ -75,7 +74,7 @@ func (r *LocalEnvironment) NewClusterEnvironment(opts ...ClusterEnvironmentOptio
 // ClusterEnvironment provides access to local cluster services
 type ClusterEnvironment struct {
 	// Backend is the cluster etcd backend
-	Backend storage.Backend
+	Backend keyval.EtcdBackend
 	// Packages is the package service that talks to local storage
 	Packages pack.PackageService
 	// ClusterPackages is the package service that talks to cluster API

--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -1044,7 +1044,13 @@ func (s *SiteOperation) String() string {
 
 // TypeString returns the textual representation of the operation's type
 func (s *SiteOperation) TypeString() string {
-	switch s.Type {
+	return OperationTypeString(s.Type)
+}
+
+// OperationTypeString formats the specified operation type
+// as readable text
+func OperationTypeString(typ string) string {
+	switch typ {
 	case OperationInstall:
 		return "install"
 	case OperationExpand:
@@ -1062,7 +1068,7 @@ func (s *SiteOperation) TypeString() string {
 	case OperationUpdateConfig:
 		return "update configuration"
 	default:
-		return s.Type
+		return typ
 	}
 }
 

--- a/lib/storage/keyval/backend.go
+++ b/lib/storage/keyval/backend.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
 )
 
 // backend implements storage interface, it also acts as a codec

--- a/lib/storage/keyval/etcd.go
+++ b/lib/storage/keyval/etcd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/state"
+	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/cenkalti/backoff"
@@ -59,13 +60,15 @@ func NewETCD(cfg ETCDConfig) (*electingBackend, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	backend := &backend{
+		Clock:    clock,
+		kvengine: engine,
+	}
 	return &electingBackend{
-		Backend: &backend{
-			Clock:    clock,
-			kvengine: engine,
-		},
-		Leader: leader,
-		client: engine.client,
+		Backend: backend,
+		Leader:  leader,
+		backend: backend,
+		engine:  engine,
 	}, nil
 }
 
@@ -101,6 +104,30 @@ func LocalEtcdConfig(retryTimeout time.Duration) (*ETCDConfig, error) {
 	}, nil
 }
 
+// EtcdBackend enables access to etcd-specific features
+type EtcdBackend interface {
+	storage.Backend
+	// CloneWithOptions creates a shallow copy of this backend
+	// with the specified options applied
+	CloneWithOptions(opts ...EtcdOption) storage.Backend
+}
+
+// EtcdOption is a functional option to configure an etcd backend
+type EtcdOption func(*etcdOptions)
+
+// WithReadQuorum specifies that reads should go through the quorum,
+// e.g. return the latest committed value applied in a quorum of members
+func WithReadQuorum(quorum bool) EtcdOption {
+	return func(config *etcdOptions) {
+		config.GetOptions.Quorum = quorum
+	}
+}
+
+type etcdOptions struct {
+	// GetOptions specifies the options for Get API
+	GetOptions client.GetOptions
+}
+
 // Check checks if all the parameters are valid and sets defaults
 func (cfg *ETCDConfig) Check() error {
 	if len(cfg.Key) == 0 {
@@ -124,11 +151,9 @@ func newEngine(cfg ETCDConfig, codec Codec) (*engine, error) {
 		return nil, trace.Wrap(err)
 	}
 	e := &engine{
-		cfg:     cfg,
+		config:  cfg,
 		nodes:   cfg.Nodes,
 		etcdKey: strings.Split(cfg.Key, "/"),
-		cancelC: make(chan bool, 1),
-		stopC:   make(chan bool, 1),
 		codec:   codec,
 	}
 	if err := e.reconnect(); err != nil {
@@ -141,11 +166,21 @@ type engine struct {
 	client.KeysAPI
 	nodes   []string
 	codec   Codec
-	cfg     ETCDConfig
+	config  ETCDConfig
 	etcdKey []string
 	client  client.Client
-	cancelC chan bool
-	stopC   chan bool
+	options etcdOptions
+}
+
+func (e *engine) copyWithOptions(opts ...EtcdOption) *engine {
+	options := e.options
+	for _, opt := range opts {
+		opt(&options)
+	}
+	// Create a shallow copy of the engine
+	engine := *e
+	engine.options = options
+	return &engine
 }
 
 func (e *engine) key(prefix string, keys ...string) key {
@@ -171,9 +206,9 @@ func (e *engine) Close() error {
 
 func (e *engine) reconnect() error {
 	info := transport.TLSInfo{
-		CAFile:   e.cfg.TLSCAFile,
-		CertFile: e.cfg.TLSCertFile,
-		KeyFile:  e.cfg.TLSKeyFile,
+		CAFile:   e.config.TLSCAFile,
+		CertFile: e.config.TLSCertFile,
+		KeyFile:  e.config.TLSKeyFile,
 	}
 	cfg, err := info.ClientConfig()
 	if err != nil {
@@ -201,7 +236,7 @@ func (e *engine) reconnect() error {
 	e.client = clt
 	e.KeysAPI = retryApi{
 		api:      client.NewKeysAPI(e.client),
-		interval: e.cfg.RetryInterval,
+		interval: e.config.RetryInterval,
 	}
 
 	return nil
@@ -360,7 +395,7 @@ func (e *engine) compareAndSwapBytes(key key, val, prevVal []byte, outVal *[]byt
 }
 
 func (e *engine) getValBytes(key key) ([]byte, error) {
-	re, err := e.Get(context.TODO(), ekey(key), nil)
+	re, err := e.Get(context.TODO(), ekey(key), &e.options.GetOptions)
 	if err != nil {
 		return nil, convertErr(err)
 	}
@@ -371,7 +406,7 @@ func (e *engine) getValBytes(key key) ([]byte, error) {
 }
 
 func (e *engine) getVal(key key, val interface{}) error {
-	re, err := e.Get(context.TODO(), ekey(key), nil)
+	re, err := e.Get(context.TODO(), ekey(key), &e.options.GetOptions)
 	if err != nil {
 		return convertErr(err)
 	}
@@ -435,7 +470,7 @@ func (e *engine) releaseLock(key key) error {
 
 func (e *engine) getKeys(key key) ([]string, error) {
 	var vals []string
-	re, err := e.Get(context.TODO(), ekey(key), nil)
+	re, err := e.Get(context.TODO(), ekey(key), &e.options.GetOptions)
 	err = convertErr(err)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -572,11 +607,11 @@ func (r retryApi) retry(ctx context.Context, fn apiCall) (resp *client.Response,
 	err = backoff.Retry(func() (err error) {
 		resp, err = fn()
 		if utils.IsTransientClusterError(err) {
-			log.Debugf("retrying on transient etcd error: %v", err)
+			log.WithField("err", trace.UserMessage(err)).Debug("Retry on transient etcd error.")
 			return trace.Wrap(err)
 		}
 		if err != nil {
-			return &backoff.PermanentError{err}
+			return &backoff.PermanentError{Err: err}
 		}
 		return nil
 	}, b)

--- a/lib/storage/keyval/leader.go
+++ b/lib/storage/keyval/leader.go
@@ -27,7 +27,9 @@ import (
 type electingBackend struct {
 	storage.Backend
 	storage.Leader
-	client etcd.Client
+
+	backend *backend
+	engine  *engine
 }
 
 // AddWatch starts watching the key for changes and sending them
@@ -48,7 +50,18 @@ func (b *electingBackend) StepDown() {
 	b.Leader.StepDown()
 }
 
+// CloneWithOptions returns a shallow copy of this backend with the specified options applied
+func (b *electingBackend) CloneWithOptions(opts ...EtcdOption) storage.Backend {
+	engine := b.engine.copyWithOptions(opts...)
+	return &electingBackend{
+		Backend: b.backend,
+		Leader:  b.Leader,
+		backend: b.backend,
+		engine:  engine,
+	}
+}
+
 // api returns etcd API client used by tests
 func (b *electingBackend) api() etcd.KeysAPI {
-	return etcd.NewKeysAPI(b.client)
+	return etcd.NewKeysAPI(b.engine.client)
 }

--- a/lib/update/cluster/engine.go
+++ b/lib/update/cluster/engine.go
@@ -315,9 +315,12 @@ func (f *engine) reconcilePlan(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 	f.plan = *plan
+	// Use a type alias and not the string type directly as a workaround to
+	// log the plan unescaped.
 	var buf bytes.Buffer
+	type s string
 	fsm.FormatOperationPlanText(&buf, f.plan)
-	f.Debugf("Reconciled plan: %v.", buf.String())
+	f.WithField("plan", s(buf.String())).Debug("Reconciled plan.")
 	return nil
 }
 

--- a/lib/update/reconciler.go
+++ b/lib/update/reconciler.go
@@ -87,14 +87,7 @@ func (r *reconciler) trySyncChangelogFromEtcd(ctx context.Context) error {
 	}
 
 	if shouldSync {
-		r.Debug("Use quorum reads for plan sync.")
-		// Use consistent reads when querying the operation plan to avoid
-		// reading stale values.
-		// TODO(v3): This is only required for etcd client v2 as client v3 defaults
-		// to quorum reads and offers clientv3.WithSerializable() as an opt-out.
-		// See https://etcd.io/docs/v2/faq/ and https://github.com/etcd-io/etcd/issues/6829 for details
-		consistentSrc := r.backend.CloneWithOptions(keyval.WithReadQuorum(true))
-		return trace.Wrap(r.syncChangelog(ctx, consistentSrc, r.localBackend))
+		return trace.Wrap(r.syncChangelog(ctx, r.backend, r.localBackend))
 	}
 
 	return nil

--- a/lib/update/updater.go
+++ b/lib/update/updater.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/storage/keyval"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -202,7 +203,7 @@ func (r *Updater) executePlan(ctx context.Context) error {
 		addrs = append(addrs, server.AdvertiseIP)
 	}
 	if errShutdown := rpc.ShutdownAgents(ctx, addrs, r.FieldLogger, r.Runner); errShutdown != nil {
-		r.Warnf("Failed to shutdown agents: %v.", trace.DebugReport(errShutdown))
+		r.WithError(errShutdown).Warn("Failed to shutdown agents.")
 	}
 	return nil
 }
@@ -250,7 +251,7 @@ type Config struct {
 	// Operator is the cluster operator service
 	Operator ops.Operator
 	// Backend specifies the cluster backend
-	Backend storage.Backend
+	Backend keyval.EtcdBackend
 	// LocalBackend specifies the authoritative source for operation state
 	LocalBackend storage.Backend
 	// Runner specifies the runner for remote commands

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -517,6 +518,25 @@ func getGravityPackage() loc.Locator {
 		Name:       constants.GravityPackage,
 		Version:    strings.Split(ver.Version, "+")[0],
 	}
+}
+
+// String returns a textual representation of this request suitable
+// for logging
+func (r deployAgentsRequest) String() string {
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, "deploy(cluster=", r.cluster.Domain)
+	if r.leader != nil {
+		fmt.Fprint(&buf, ",leader(addr=", r.leader.AdvertiseIP, ",params=", r.leaderParams, ")")
+	}
+	if r.version != "" {
+		fmt.Fprint(&buf, ",version=", r.version)
+	}
+	fmt.Fprint(&buf, ",servers(")
+	for _, s := range r.cluster.ClusterState.Servers {
+		fmt.Fprint(&buf, "addr=", s.AdvertiseIP, ",")
+	}
+	fmt.Fprint(&buf, "))")
+	return buf.String()
 }
 
 type deployAgentsRequest struct {

--- a/tool/gravity/cli/update.go
+++ b/tool/gravity/cli/update.go
@@ -125,7 +125,7 @@ func newUpdater(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironm
 	})
 	deployCtx, cancel := context.WithTimeout(ctx, defaults.AgentDeployTimeout)
 	defer cancel()
-	logger.WithField("request", req).Debug("Deploying agents on cluster nodes.")
+	logger.WithField("request", req.String()).Debug("Deploying agents on cluster nodes.")
 	localEnv.PrintStep("Deploying agents on cluster nodes")
 	creds, err := deployAgents(deployCtx, localEnv, req)
 	if err != nil {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Use consistent (quorum) reads when querying the operation plan to avoid reading stale values.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2140
* Ports https://github.com/gravitational/gravity/pull/2144

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
TODO