### PR TITLE
[6.1.x] backport smaller pod cidr

### DIFF
--- a/lib/validate/net.go
+++ b/lib/validate/net.go
@@ -55,11 +55,11 @@ func KubernetesSubnetsFromStrings(podCIDR, serviceCIDR string) error {
 func KubernetesSubnets(podNet, serviceNet *net.IPNet) (err error) {
 	if podNet != nil {
 		// make sure the pod subnet is valid
-		// the pod network should be /16 minimum so k8s can allocate /24 to each node
+		// the pod network should be /22 minimum so k8s can allocate /24 to each node (minimum 3 nodes)
 		ones, _ := podNet.Mask.Size()
-		if ones > 16 {
+		if ones > 22 {
 			return trace.BadParameter(
-				"pod subnet should be a minimum of /16: %q", podNet.String())
+				"pod subnet should be a minimum of /22: %q", podNet.String())
 		}
 	}
 	if podNet != nil && serviceNet != nil {

--- a/lib/validate/net_test.go
+++ b/lib/validate/net_test.go
@@ -53,7 +53,7 @@ func (*S) TestValidateKubernetesSubnets(c *check.C) {
 			description: "service subnet is not a valid CIDR",
 		},
 		{
-			podCIDR:     "10.200.0.0/20",
+			podCIDR:     "10.200.0.0/24",
 			ok:          false,
 			description: "pod subnet is too small",
 		},


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

- Updates minimum subnet size to be a /22 (3 nodes)
  - This request has come up several times. The proper check should probably be a combination of app.yaml requirements for number of nodes + a satellite check at join time. 

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact
  - Users can now specify smaller pod subnets.

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Partial Port: https://github.com/gravitational/gravity/pull/2095
- We don't want to change the default value mid-release, but still be more flexible in the subnet assignments.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
