### PR TITLE
[5.5.x] Add check for rollback of latest unstarted phase

### DIFF
--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -257,12 +257,14 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = CanRollback(plan, p.PhaseID, p.DryRun)
-	if err != nil {
-		if !p.Force {
-			return trace.Wrap(err)
+	if !p.DryRun {
+		err = CanRollback(plan, p.PhaseID)
+		if err != nil {
+			if !p.Force {
+				return trace.Wrap(err)
+			}
+			f.WithError(err).Warn("Forcing rollback.")
 		}
-		f.WithError(err).Warn("Forcing rollback.")
 	}
 	phase, err := FindPhase(plan, p.PhaseID)
 	if err != nil {

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -257,6 +257,7 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	// No need to verify if phase can be rolled back during dry runs.
 	if !p.DryRun {
 		err = CanRollback(plan, p.PhaseID)
 		if err != nil {

--- a/lib/fsm/fsm.go
+++ b/lib/fsm/fsm.go
@@ -257,7 +257,7 @@ func (f *FSM) RollbackPhase(ctx context.Context, p Params) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = CanRollback(plan, p.PhaseID)
+	err = CanRollback(plan, p.PhaseID, p.DryRun)
 	if err != nil {
 		if !p.Force {
 			return trace.Wrap(err)

--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -33,11 +33,11 @@ import (
 // rollbackDependentsErrorMsg returns an error message for when a phase is being
 // rolled back, but has dependent phases that have not yet been rolled back.
 func rollbackDependentsErrorMsg(phaseID string, dependents []string) string {
-	const msg = `phase %[1]s cannot be rolled back because some phases that depend on it haven't been rolled back yet. Please rollback the following phases first:
+	const msg = `Phase %[1]s cannot be rolled back because some phases that depend on it haven't been rolled back yet. Please rollback the following phases first:
 
 	%[2]s
 
-you can pass --force flag to override this check and force phase %[1]s rollback`
+You can pass --force flag to override this check and force phase %[1]s rollback.`
 	return fmt.Sprintf(msg, phaseID, strings.Join(dependents, "\n\t"))
 }
 

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -249,7 +249,32 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 			expected: `rollback subsequent phases before rolling back phase "/init"`,
 		},
 		{
-			comment: "Rollback leaf phase",
+			comment: "Rollback after a later phase has been executed out of band",
+			plan: &storage.OperationPlan{
+				Phases: []storage.OperationPhase{
+					{
+						ID:    "/init",
+						State: storage.OperationPhaseStateCompleted,
+					},
+					{
+						ID:    "/startAgent",
+						State: storage.OperationPhaseStateUnstarted,
+					},
+					{
+						ID:    "/checks",
+						State: storage.OperationPhaseStateCompleted,
+					},
+					{
+						ID:    "/test",
+						State: storage.OperationPhaseStateRolledBack,
+					},
+				},
+			},
+			phaseID:  "/init",
+			expected: `rollback subsequent phases before rolling back phase "/init"`,
+		},
+		{
+			comment: "Rollback subphase",
 			plan: &storage.OperationPlan{
 				Phases: []storage.OperationPhase{
 					{
@@ -271,7 +296,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 			phaseID: "/masters/node-2",
 		},
 		{
-			comment: "Rollback top level phase that has sub phases",
+			comment: "Rollback non-leaf phase",
 			plan: &storage.OperationPlan{
 				Phases: []storage.OperationPhase{
 					{
@@ -290,7 +315,8 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID: "/masters",
+			phaseID:  "/masters",
+			expected: `attempting to rollback non-leaf phase "/masters"`,
 		},
 	}
 	for _, tc := range tests {

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -172,8 +172,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID:  "/startAgent",
-			expected: "",
+			phaseID: "/startAgent",
 		},
 		{
 			comment: "A subsequent phase is in progress",
@@ -206,8 +205,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID:  "/init",
-			expected: "",
+			phaseID: "/init",
 		},
 		{
 			comment: "All later phases have been rolled back or are unstarted",
@@ -227,8 +225,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID:  "/init",
-			expected: "",
+			phaseID: "/init",
 		},
 		{
 			comment: "Rollback after a previously forced rollback",
@@ -271,8 +268,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID:  "/masters/node-2",
-			expected: "",
+			phaseID: "/masters/node-2",
 		},
 		{
 			comment: "Rollback top level phase that has sub phases",
@@ -294,8 +290,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 					},
 				},
 			},
-			phaseID:  "/masters",
-			expected: "",
+			phaseID: "/masters",
 		},
 	}
 	for _, tc := range tests {

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -328,7 +328,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/masters",
-			expected: "unable to rollback non-leaf phase, only leaf phases can be rolled back",
+			expected: "rolling back phases that have sub-phases is not supported. Please rollback individual phases",
 		},
 		{
 			comment: "Top level phase has dependent phases that have not been rolled back",
@@ -355,7 +355,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 							{
 								ID:       "/nodes/node-3",
 								State:    storage.OperationPhaseStateCompleted,
-								Requires: []string{"/nodes-node-2"},
+								Requires: []string{"/nodes/node-2"},
 							},
 						},
 						Requires: []string{"/masters"},

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -365,6 +365,28 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 			phaseID:  "/masters/node-1",
 			expected: `rollback subsequent phases before rolling back phase "/masters/node-1"`,
 		},
+		{
+			comment: "Rollback parallel phase",
+			plan: &storage.OperationPlan{
+				Phases: []storage.OperationPhase{
+					{
+						ID:    "/parallel",
+						State: storage.OperationPhaseStateCompleted,
+						Phases: []storage.OperationPhase{
+							{
+								ID:    "/parallel/masters",
+								State: storage.OperationPhaseStateCompleted,
+							},
+							{
+								ID:    "/parallel/nodes",
+								State: storage.OperationPhaseStateCompleted,
+							},
+						},
+					},
+				},
+			},
+			phaseID: "/parallel/masters",
+		},
 	}
 	for _, tc := range tests {
 		comment := check.Commentf(tc.comment)

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -316,7 +316,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/masters",
-			expected: `attempting to rollback non-leaf phase "/masters"`,
+			expected: "unable to rollback non-leaf phase, only leaf phases can be rolled back",
 		},
 	}
 	for _, tc := range tests {

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -191,7 +191,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/init",
-			expected: `rollback subsequent phases before rolling back phase "/init"`,
+			expected: rollbackDependentsErrorMsg("/init", []string{"/startAgent"}),
 		},
 		{
 			comment: "All later phases have been rolled back",
@@ -253,7 +253,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/init",
-			expected: `rollback subsequent phases before rolling back phase "/init"`,
+			expected: rollbackDependentsErrorMsg("/init", []string{"/checks"}),
 		},
 		{
 			comment: "Rollback after a later phase has been executed out of band",
@@ -281,7 +281,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/init",
-			expected: `rollback subsequent phases before rolling back phase "/init"`,
+			expected: rollbackDependentsErrorMsg("/init", []string{"/checks"}),
 		},
 		{
 			comment: "Rollback subphase",
@@ -363,7 +363,7 @@ func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
 				},
 			},
 			phaseID:  "/masters/node-1",
-			expected: `rollback subsequent phases before rolling back phase "/masters/node-1"`,
+			expected: rollbackDependentsErrorMsg("/masters/node-1", []string{"/nodes"}),
 		},
 		{
 			comment: "Rollback parallel phase",

--- a/lib/storage/plan_test.go
+++ b/lib/storage/plan_test.go
@@ -41,3 +41,69 @@ func (*PlanSuite) TestGetLeafPhases(c *check.C) {
 	compare.DeepCompare(c, plan.GetLeafPhases(), []OperationPhase{
 		initPhase, bootstrapPhase1, bootstrapPhase2, upgradePhase})
 }
+
+func (*PlanSuite) TestGetState(c *check.C) {
+	tests := []struct {
+		comment  string
+		expected string
+		phase    OperationPhase
+	}{
+		{
+			comment:  "Phase unstarted",
+			expected: OperationPhaseStateUnstarted,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{
+						State: OperationPhaseStateUnstarted,
+					},
+				},
+			},
+		},
+		{
+			comment:  "Phase completed",
+			expected: OperationPhaseStateCompleted,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+				},
+			},
+		},
+		{
+			comment:  "Phase failed",
+			expected: OperationPhaseStateFailed,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+					{State: OperationPhaseStateFailed},
+					{State: OperationPhaseStateRolledBack},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+		{
+			comment:  "Phase rolled back",
+			expected: OperationPhaseStateRolledBack,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateRolledBack},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+		{
+			comment:  "Phase in progress",
+			expected: OperationPhaseStateInProgress,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+					{State: OperationPhaseStateInProgress},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		comment := check.Commentf(tc.comment)
+		c.Assert(tc.phase.GetState(), check.Equals, tc.expected, comment)
+	}
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the check for `gravity plan rollback` command. The check now ensures that phases of an operation are being rolled back in order. This check can be bypassed by providing the `--force` flag.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/2184

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify rollback phase fails if out of order and `--force` flag is not provided**

**Verify rollback phase executes if out of order and `--force` flag is provided**

**Verify latest phase can still be rolled back**

**Verify plan can be rolled back completely**
