### PR TITLE
Mark robotest volumes readonly

### DIFF
--- a/assets/robotest/run.sh
+++ b/assets/robotest/run.sh
@@ -35,7 +35,7 @@ ALWAYS_COLLECT_LOGS=${ALWAYS_COLLECT_LOGS:-true}
 DESTROY_ON_SUCCESS=${DESTROY_ON_SUCCESS:-true}
 DESTROY_ON_FAILURE=${DESTROY_ON_FAILURE:-true}
 
-EXTRA_VOLUME_MOUNTS="-v $IMAGEDIR:$IMAGEDIR_MOUNTPOINT"
+EXTRA_VOLUME_MOUNTS="-v $IMAGEDIR:$IMAGEDIR_MOUNTPOINT:ro"
 
 export INSTALLER_URL TELEKUBE_URL OPSCENTER_URL IMAGEDIR_MOUNTPOINT
 SUITE=$($TARGET configuration)
@@ -43,7 +43,7 @@ SUITE=$($TARGET configuration)
 # GRAVITY_FILE/GRAVITY_URL specify the location of the up-to-date gravity binary
 if [ -d $(dirname ${GRAVITY_URL}) ]; then
   GRAVITY_FILE='/robotest-bin/'$(basename ${GRAVITY_URL})
-  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${GRAVITY_URL}):$(dirname ${GRAVITY_FILE})
+  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${GRAVITY_URL}):$(dirname ${GRAVITY_FILE}:ro)
 fi
 
 check_files () {
@@ -102,10 +102,10 @@ set -o xtrace
 exec docker run \
     $NOROOT \
 	-v ${STATEDIR}:/robotest/state \
-	-v ${SSH_KEY}:/robotest/config/ops.pem \
-	${GCE_CONFIG:+'-v' "${SSH_PUB}:/robotest/config/ops_rsa.pub"} \
-	${GCE_CONFIG:+'-v' "${GOOGLE_APPLICATION_CREDENTIALS}:/robotest/config/creds.json"} \
-	${GCL_PROJECT_ID:+'-v' "${GOOGLE_APPLICATION_CREDENTIALS}:/robotest/config/gcp.json" '-e' 'GOOGLE_APPLICATION_CREDENTIALS=/robotest/config/gcp.json'} \
+	-v ${SSH_KEY}:/robotest/config/ops.pem:ro \
+	${GCE_CONFIG:+'-v' "${SSH_PUB}:/robotest/config/ops_rsa.pub:ro"} \
+	${GCE_CONFIG:+'-v' "${GOOGLE_APPLICATION_CREDENTIALS}:/robotest/config/creds.json:ro"} \
+	${GCL_PROJECT_ID:+'-v' "${GOOGLE_APPLICATION_CREDENTIALS}:/robotest/config/gcp.json:ro" '-e' 'GOOGLE_APPLICATION_CREDENTIALS=/robotest/config/gcp.json'} \
 	${EXTRA_VOLUME_MOUNTS:-} \
 	${DOCKER_IMAGE} \
 	dumb-init robotest-suite -test.timeout=48h \

--- a/assets/robotest/tele_build.sh
+++ b/assets/robotest/tele_build.sh
@@ -31,7 +31,7 @@ TGT=$TMP/$(basename "$TARGET")
 
 
 NOROOT="--user=$(id -u):$(id -g) --group-add=$(getent group docker | cut -d: -f3)"
-VOLUMES="-v $TELE:$TELE -v $APP_SRCDIR:$APP_SRCDIR -v $STATE_DIR:$STATE_DIR -v $TMP:$TMP"
+VOLUMES="-v $TELE:$TELE:ro -v $APP_SRCDIR:$APP_SRCDIR:ro -v $STATE_DIR:$STATE_DIR -v $TMP:$TMP"
 VOLUMES="$VOLUMES -v /var/run/docker.sock:/var/run/docker.sock"
 VOLUMES="$VOLUMES --tmpfs /tmp"
 


### PR DESCRIPTION
## Description
These robotest image volumes shouldn't be written to, they're only
source data.

This is a bit of unrelated cleanup I pulled out of another patch in progress.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
N/A

## TODOs
- [x] Self-review the change
- [x] Address review feedback

## Testing done
The PR build is sufficient.
