### PR TITLE
Migrate jenkinsfiles to use unified robotest-run target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ def robotest() {
           file(credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'),
           file(credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'),
         ]) {
-          sh 'make -C e robotest-run-suite'
+          sh 'make -C e robotest-run'
         }
       } else {
         echo 'skipping robotest execution'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -115,7 +115,7 @@ timestamps {
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_KEY', variable: 'SSH_KEY'],
                   [$class: 'FileBinding', credentialsId:'OPS_SSH_PUB', variable: 'SSH_PUB'],
                   ]) {
-                    sh 'make -C e robotest-run-nightly'
+                    sh 'make -C e robotest-run ROBOTEST_CONFIG=nightly'
               }
             } else {
               echo 'skipped system tests'

--- a/Makefile
+++ b/Makefile
@@ -522,13 +522,12 @@ $(TELEKUBE_OUT): packages
 		--skip-version-check \
 		-o $(TELEKUBE_OUT)
 
-.PHONY: robotest-run-suite
-robotest-run-suite: # depends on: telekube opscenter $(TELE_OUT) $(GRAVITY_OUT)
-	$(MAKE) -C assets/robotest run ROBOTEST_CONFIG=pr
-
-.PHONY: robotest-run-nightly
-robotest-run-nightly: # depends on: telekube opscenter $(TELE_OUT) $(GRAVITY_OUT)
-	$(MAKE) -C assets/robotest run ROBOTEST_CONFIG=nightly
+#
+# runs robotest integration tests
+#
+.PHONY: robotest-run
+robotest-run: # depends on: telekube opscenter $(TELE_OUT) $(GRAVITY_OUT)
+	$(MAKE) -C assets/robotest run
 
 #
 # builds wormhole installer

--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -23,7 +23,7 @@ ROBOTEST_DOWNLOAD_TELE_SCRIPT ?= $(TOP)/download_tele.sh
 # (e.g. enterprise) cache.
 ROBOTEST_CACHE_FLAVOR ?= oss
 # ROBOTEST_CONFIG is the desired robotest configuration (pr, nightly)
-ROBOTEST_CONFIG = pr
+ROBOTEST_CONFIG ?= pr
 # ROBOTEST_CONFIG_SCRIPT is full path to the scrip that will generate robotest configurations
 ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 


### PR DESCRIPTION
## Description
This will allow us to use the common Jenkinsfile for both nightly and PR
builds, as well as other configurations.

Once this is merged and our nightly job has been shifted to use Jenkinsfile,
I will delete Jenkinsfile.nightly.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Depends on https://github.com/gravitational/gravity.e/pull/4342

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Testing done
The PR build shows that this change is safe for PR CI.

For nightly, I've run a gravity try build with a complete nightly run using `ROBOTEST_CONFIG=nightly` as a Jenkins parameter:

https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/85/console