### PR TITLE
Add RHEL 8.2 and CentOS 8.2 to Gravity 5.5's supported distros

### DIFF
--- a/docs/5.x/requirements.md
+++ b/docs/5.x/requirements.md
@@ -10,8 +10,8 @@ Gravity supports the following distributions:
 | Linux Distribution       | Version          | Docker Storage Drivers                 |
 |--------------------------|------------------|----------------------------------------|
 | Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
+| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.2 | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.7, 8.0-8.2 | `devicemapper`*, `overlay`, `overlay2` |
 | Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu                   | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
@@ -33,8 +33,8 @@ Following table lists all the supported distributions and how they can be specif
 
 | Distribution Name        | ID                         | Version          |
 |--------------------------|----------------------------|------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.1 |
-| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.2 |
+| CentOS                   | centos                     | 7.2-7.7, 8.0-8.2 |
 | Debian                   | debian                     | 8-9              |
 | Ubuntu                   | ubuntu                     | 16.04            |
 | Ubuntu-Core              | ubuntu                     | 16.04            |


### PR DESCRIPTION
## Description
Add RHEL 8.2 and CentOS 8.2 to Gravity 5.5's supported distros.

## Type of change
* Documentation
* This change has a user-facing impact

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
Redhat 8.2 3 node install: [logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22c5bb7a8a-40e2-449b-9d3e-9f6b945a86d3%22%0Alabels.__suite__%3D%227d8f04bb-30e5-4f4f-9273-ab372c275b34%22;timeRange=2020-10-07T17:27:45Z%2F2020-10-07T18:27:45Z?project=kubeadm-167321)

CentOS 8.2 3 node install: [logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22ea69fe80-350c-445a-bfce-854ddb2b2615%22%0Alabels.__suite__%3D%2216db9334-6727-4aa9-b29d-ca62ca15e61c%22;timeRange=2020-10-07T17:46:14Z%2F2020-10-07T18:46:14Z?project=kubeadm-167321)
