### PR TITLE
adjust base value of expand concurrency to allow more joins

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1305,7 +1305,7 @@ var (
 	HelmRegistryVar = fmt.Sprintf("%v=%v/", ImageRegistryVar, DockerRegistry)
 
 	// MaxExpandConcurrency is the number of servers that can be joining the cluster concurrently
-	MaxExpandConcurrency = (runtime.NumCPU() / 3) + 1
+	MaxExpandConcurrency = (runtime.NumCPU() / 3) + 4
 )
 
 // HookSecurityContext returns default securityContext for hook pods


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Adjust the base value for joins to allow more joins on clusters with limited CPU cores. 

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

In large cluster testing, somewhere between 1/2 and 1/3 appeared to be safe, so increasing the base value should have no impact. This was requested by customer M.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

N/A

## Additional information
<!--Optional. Anything else that may be relevant.-->
