### PR TITLE
[7.1/master] Remove Support for Debian 8 "Jessie"

### DIFF
--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -55,7 +55,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["9"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -87,7 +87,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["9"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -16,7 +16,7 @@ Gravity officially supports the following Linux distributions:
 |--------------------------|------------------|---------------------------------------|
 | Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.2 | `overlay`, `overlay2`                 |
 | CentOS                   | 7.2-7.7, 8.0-8.1 | `overlay`, `overlay2`                 |
-| Debian                   | 8-9              | `overlay`, `overlay2`                 |
+| Debian                   | 9                | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04     | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04            | `overlay`, `overlay2`                 |
 | openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                 |
@@ -38,7 +38,7 @@ specified in the manifest:
 |--------------------------|----------------------------|------------------|
 | Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.2 |
 | CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
-| Debian                   | debian                     | 8-9              |
+| Debian                   | debian                     | 9                |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04     |
 | Ubuntu-Core              | ubuntu                     | 16.04            |
 | openSuse                 | suse, opensuse, opensuse-* | 12-SP2 to 12-SP5 |
@@ -260,7 +260,7 @@ Gravity requires that these modules are loaded prior to installation.
 | CentOS                               | 7.2              | bridge, ebtable_filter, iptables, overlay       |
 | CentOS                               | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
 | RedHat Linux                         | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
-| Debian                               | 8-9              | br_netfilter, ebtable_filter, iptables, overlay |
+| Debian                               | 9                | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu                               | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu-Core                          | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
 | Suse Linux (openSUSE and Enterprise) | 12-SP2 to 12-SP5 | br_netfilter, ebtable_filter, iptables, overlay |

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -255,14 +255,14 @@ root$ modprobe iptable_nat
 Following table summarizes the required kernel modules per OS distribution.
 Gravity requires that these modules are loaded prior to installation.
 
-| Linux Distribution                     | Version | Modules |
-|--------------------------|-----------|---------------------------|
-| CentOS                    | 7.2     | bridge, ebtable_filter, iptables, overlay  |
-| CentOS                  | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay  |
-| RedHat Linux | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay     |
-| Debian | 8-9 | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu-Core | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
+| Linux Distribution                   | Version          | Modules                                         |
+|--------------------------------------|------------------|-------------------------------------------------|
+| CentOS                               | 7.2              | bridge, ebtable_filter, iptables, overlay       |
+| CentOS                               | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
+| Debian                               | 8-9              | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu                               | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu-Core                          | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
 | Suse Linux (openSUSE and Enterprise) | 12-SP2 to 12-SP5 | br_netfilter, ebtable_filter, iptables, overlay |
 
 ### Inotify watches


### PR DESCRIPTION
## Description
This patchset removes publicly stated support of Debian 8 "Jessie".  This is predominantly because Jessie defaults to an old kernel (3.16) that does not include overlay support.  Attempting a gravity 7.0.18 install on an Jessie image with all of the [system requirements](https://gravitational.com/gravity/docs/requirements/) steps taken  results in:

```
gke-97685a70aa778af1d173@walt-deb8-node-0:~$ sudo ~/7.0.18/gravity install ~/7.0.18 --debug --flavor=one --cloud-provider=generic --cluster=walt-deb8
Thu Oct  8 18:11:08 UTC Starting enterprise installer
[ERROR]: The following pre-flight checks failed:
        [×] kernel module "overlay" not loaded
        [×] kernel module "br_netfilter" not loaded
        [×] kernel module "overlay" not loaded
        [×] required kernel boot config parameter CONFIG_OVERLAY_FS missing
        [×] Following CGroups have not been mounted: ["memory"]
        [×] required kernel boot config parameter CONFIG_IP_NF_NAT missing
```

Several of these can be fixed:
* The memory cgroup can be mounted (should be documented if we want to continue support)
* `br_netfilter` is available as `bridge` in 3.16, it was enabled before the install above (maybe a satellite bug if we want to continue support)
* `CONFIG_IP_NF_NAT` is `CONFIG_NF_NAT_IPV4` as discussed at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=762458 (also satellite work)

However the lack of overlay means a newer kernel will need to be installed.  Given these various troubles, and the fact that [Jessie no longer receives security updates](https://www.debian.org/News/2020/20200709), I say we remove support for it in future Gravity releases (7.1 +).

## Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change has a user-facing impact

## Linked tickets and other PRs
* Refs https://github.com/gravitational/gravity/pull/212 (devicemapper -> overlay switch)
* Refs https://github.com/gravitational/gravity/pull/1376 (removal of alternate storage driver testing)

* Affects the prioritization of the following robotest tickets:
  * https://github.com/gravitational/robotest/issues/182
  * https://github.com/gravitational/robotest/issues/269

## TODOs
- [x] Self-review the change
- [ ] Figure out if there are other places this support needs to be removed
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Testing done
I attempted to install 7.0.18 on Jessie [here](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2241ec1956-2b33-4b35-ae33-9f0543e4fe60%22%0Alabels.__suite__%3D%225557d297-cdcf-4b32-90fc-ca6643960138%22;timeRange=2020-10-08T01:32:11Z%2F2020-10-08T02:32:11Z?project=kubeadm-167321) as part of some opportunistic work on https://github.com/gravitational/robotest/issues/182.

I also invested several hours tinkering with various GCP images, seeing if I could successfully install 7.0.18 on any of them following our [public documentation](https://gravitational.com/gravity/docs/requirements/).  Ultimately, I was unable to do so quickly, and I stopped trying because it didn't seem high ROI.  I believe it is possible, but it would require a significant amount of _undocumented_ customization compared to newer distros.

## Additional Questions
If we take this, should it also be backported to 7.0.x?  Typically I'd say "no" to backporting intentionally breaking changes to a LTS release.  However I wonder if intentionally saying Jessie is unsupported is better than "broken by default and untested", which is the current situation.

If we don't backport, we may have a docs mismatch (something latent for a while) -- our docs vary on major version, where realistically we can have structural differences between minor versions (e.g. 7.1 doesn't support distros that 7.0 does).  If we choose to take this pach and not backport, it may be time that we split our docs to be versioned at the minor version, instead of only at the major version.

Also to be considered: Should we drop support for CentOS 7.2 and 7.3 (prior to kernel version 3.18 where br_netfilter & overlay landed).  We already don't publicly support RHEL prior to 7.4, and CentOS 7.2 has several special cases ins the docs because of its old kernel.

