### PR TITLE
[7.0.x] tele sync packages

### DIFF
--- a/build.assets/Dockerfile.testbox
+++ b/build.assets/Dockerfile.testbox
@@ -1,0 +1,23 @@
+FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
+
+RUN set -ex && adduser jenkins --uid=995 --disabled-password --system
+RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity && \
+     chown -R jenkins /gopath && \
+     mkdir -p /.cache && \
+     chmod 777 /.cache)
+
+RUN set -ex && apt-get update && \
+    apt-get -y install apt-transport-https ca-certificates curl gnupg software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable" && \
+    apt-get update && \
+    apt-get -y install docker-ce-cli
+
+ENV LANGUAGE="en_US.UTF-8" \
+     LANG="en_US.UTF-8" \
+     LC_ALL="en_US.UTF-8" \
+     LC_CTYPE="en_US.UTF-8" \
+     GOPATH="/gopath" \
+     PATH="$PATH:/opt/go/bin:/gopath/bin"
+
+VOLUME ["/gopath/src/github.com/gravitational/gravity"]

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -13,7 +13,8 @@ LOCAL_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build
 LOCAL_GRAVITY_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build/$(GRAVITY_VERSION)
 
 DOCKER_ARGS ?= --pull
-BBOX = gravity-buildbox:latest
+BUILDBOX = gravity-buildbox:7.0.x
+TESTBOX ?= gravity-testbox:7.0.x
 
 GRAVITY_WEB_APP_DIR ?= $(abspath $(LOCALDIR)/../web)/
 
@@ -122,12 +123,14 @@ endif
 # Runs tests inside a build container
 #
 .PHONY: test
-test: buildbox test-etcd
+test: testbox test-etcd
 	docker run --net=host --rm=true $(NOROOT) \
 		-v $(TOP):$(SRCDIR) \
-		-e "GRAVITY_PKG_PATH=$(GRAVITY_PKG_PATH)" \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		--tmpfs /tmp:rw,nosuid,nodev,exec,relatime \
+		-e "GRAVITY_PKG_PATH=$(GRAVITY_PK,_PATH)" \
 		-e "TEST_PACKAGES=$(TEST_PACKAGES)" \
-		-t $(BBOX) \
+		-t $(TESTBOX) \
 		dumb-init make -C $(SRCDIR)/build.assets FLAGS='-cover -race' TEST_ETCD=true TEST_K8S=$(TEST_K8S) test-inside-container
 
 
@@ -196,7 +199,7 @@ grpc: $(GRPC_PROTO_OUTPUTS)
 $(GRPC_PROTO_OUTPUTS): buildbox $(GRPC_PROTOS)
 	docker run --rm=true -u $$(id -u) \
 		   -v $(TOP):$(SRCDIR) \
-		   $(BBOX) \
+		   $(BUILDBOX) \
 		   dumb-init make -C $(subst $(TOP),$(SRCDIR),$(@D))
 
 #
@@ -211,7 +214,7 @@ validate-deps: buildbox
 	docker run --rm=true \
 		   -v $(GITHUB_SSH_KEY):/root/.ssh/id_rsa \
 		   -v $(TMP):$(SRCDIR) \
-		   $(BBOX) \
+		   $(BUILDBOX) \
 		   dumb-init make -C $(SRCDIR) validate-deps
 
 #
@@ -231,7 +234,7 @@ build-in-container: buildbox
 		   -e "GRAVITY_BUILDTAGS=$(GRAVITY_BUILDTAGS)" \
 		   -e "TARGETS=$(TARGETS)" \
 		   $(GOCACHE_DOCKER_OPTIONS) \
-		   $(BBOX) \
+		   $(BUILDBOX) \
 		   dumb-init make -C $(SRCDIR)/build.assets -j $(TARGETS)
 
 #
@@ -472,7 +475,7 @@ build-tsh-in-container: clone-teleport
 		   -e "GRAVITY_VERSION=$(GRAVITY_VERSION)" \
 		   -e "GRAVITY_TAG=$(GRAVITY_TAG)" \
 		   -e "LOCAL_GRAVITY_BUILDDIR=$(LOCAL_GRAVITY_BUILDDIR)" \
-		   $(BBOX) \
+		   $(BUILDBOX) \
 		   dumb-init make -C $(SRCDIR)/build.assets build-tsh-inside-container
 
 #
@@ -582,7 +585,7 @@ build-fio-sub: clone-fio
 	docker run --rm=true -u $$(id -u) \
 	    -v $(TOP):$(SRCDIR) \
 	    -v $(FIO_BUILDDIR):/fio \
-	    $(BBOX) \
+	    $(BUILDBOX) \
 	    dumb-init make -C $(SRCDIR)/build.assets build-fio-in-buildbox
 
 .PHONY: build-fio-in-buildbox
@@ -657,7 +660,7 @@ push-storage-app: $(STORAGE_APP_OUT)
 #
 .PHONY: enter
 enter:
-	docker run -ti --rm=true $(BBOX) /bin/bash
+	docker run -ti --rm=true $(BUILDBOX) /bin/bash
 
 .PHONY: selinux
 selinux: $(SELINUX_ASSETS)
@@ -696,4 +699,10 @@ buildbox:
 		--build-arg GRPC_GATEWAY_TAG=$(GRPC_GATEWAY_TAG) \
 		--build-arg GODEP_TAG=$(GODEP_TAG) \
 		--build-arg VERSION_TAG=$(VERSION_TAG) \
-		$(DOCKER_ARGS) --tag $(BBOX) .
+		$(DOCKER_ARGS) --tag $(BUILDBOX) .
+#
+# testbox container: container used for tests
+#
+.PHONY: testbox
+testbox:
+	docker build $(DOCKER_ARGS) --tag $(TESTBOX) -f Dockerfile.testbox .

--- a/lib/app/service/test/builder.go
+++ b/lib/app/service/test/builder.go
@@ -198,6 +198,7 @@ func CreateApplicationFromBinaryData(apps app.Applications, locator loc.Locator,
 	app, err := apps.CreateApp(locator, &data, labels)
 	c.Assert(err, IsNil)
 	c.Assert(app, NotNil)
+	c.Logf("Created app %v.", app.Package)
 	return app
 }
 

--- a/lib/builder/builder_test.go
+++ b/lib/builder/builder_test.go
@@ -128,6 +128,51 @@ func (s *InstallerBuilderSuite) TestBuildInstallerWithDefaultPlanetPackage(c *ch
 	if !checkDockerAvailable() {
 		c.Skip("test requires docker")
 	}
+
+	var (
+		manifestBytes = []byte(`
+apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+metadata:
+  name: app
+  resourceVersion: "0.0.1"
+dependencies:
+  apps:
+    - gravitational.io/app-dependency:0.0.1
+installer:
+  flavors:
+    items:
+      - name: "one"
+        nodes:
+          - profile: master
+            count: 1
+      - name: "three"
+        nodes:
+          - profile: master
+            count: 1
+          - profile: node
+            count: 2
+nodeProfiles:
+  - name: master
+    labels:
+      node-role.kubernetes.io/master: "true"
+  - name: node
+    labels:
+      node-role.kubernetes.io/node: "true"
+systemOptions:
+  runtime:
+    version: 0.0.1
+`)
+
+		dependencyManifestBytes = []byte(`
+apiVersion: bundle.gravitational.io/v2
+kind: SystemApplication
+metadata:
+  name: app-dependency
+  resourceVersion: "0.0.1"
+`)
+	)
+
 	// setup
 	remoteEnv := newEnviron(c)
 	defer remoteEnv.Close()
@@ -135,7 +180,36 @@ func (s *InstallerBuilderSuite) TestBuildInstallerWithDefaultPlanetPackage(c *ch
 	defer buildEnv.Close()
 	appDir := c.MkDir()
 	manifestPath := filepath.Join(appDir, defaults.ManifestFileName)
-	manifestBytes := []byte(`
+
+	writeFile(manifestPath, manifestBytes, c)
+	b, err := New(Config{
+		FieldLogger:      logrus.WithField(trace.Component, "test"),
+		Progress:         utils.DiscardProgress,
+		Env:              buildEnv,
+		OutPath:          filepath.Join(buildEnv.StateDir, "app.tar"),
+		ManifestPath:     manifestPath,
+		SkipVersionCheck: true,
+		Repository:       "repository",
+		Syncer:           NewPackSyncer(remoteEnv.Packages, remoteEnv.Apps),
+	})
+	c.Assert(err, check.IsNil)
+
+	createRuntimeApplication(remoteEnv, c)
+	createApp(dependencyManifestBytes, remoteEnv.Apps, c)
+	createApp(manifestBytes, remoteEnv.Apps, c)
+
+	// verify
+	err = b.Build(context.TODO())
+	c.Assert(err, check.IsNil)
+}
+
+func (s *InstallerBuilderSuite) TestBuildInstallerWithIntermediateHops(c *check.C) {
+	if !checkDockerAvailable() {
+		c.Skip("test requires docker")
+	}
+
+	var (
+		manifestBytes = []byte(`
 apiVersion: cluster.gravitational.io/v2
 kind: Cluster
 metadata:
@@ -163,30 +237,63 @@ nodeProfiles:
       node-role.kubernetes.io/node: "true"
 systemOptions:
   runtime:
-    version: 0.0.1
+    version: 0.0.2
 `)
+	)
+
+	// setup
+	remoteEnv := newEnviron(c)
+	defer remoteEnv.Close()
+	buildEnv := newEnviron(c)
+	defer buildEnv.Close()
+	appDir := c.MkDir()
+	manifestPath := filepath.Join(appDir, defaults.ManifestFileName)
+
 	writeFile(manifestPath, manifestBytes, c)
+	outputPath := filepath.Join(buildEnv.StateDir, "app.tar")
 	b, err := New(Config{
 		FieldLogger:      logrus.WithField(trace.Component, "test"),
 		Progress:         utils.DiscardProgress,
 		Env:              buildEnv,
-		OutPath:          filepath.Join(buildEnv.StateDir, "app.tar"),
+		OutPath:          outputPath,
 		ManifestPath:     manifestPath,
 		SkipVersionCheck: true,
 		Repository:       "repository",
 		Syncer:           NewPackSyncer(remoteEnv.Packages, remoteEnv.Apps),
+		UpgradeVia:       []string{"0.0.1"},
 	})
 	c.Assert(err, check.IsNil)
 
-	createRuntimeApplication(remoteEnv, c)
+	createRuntimeApplicationWithVersion(remoteEnv, "0.0.1", c)
+	createRuntimeApplicationWithVersion(remoteEnv, "0.0.2", c)
 	createApp(manifestBytes, remoteEnv.Apps, c)
 
 	// verify
 	err = b.Build(context.TODO())
 	c.Assert(err, check.IsNil)
+
+	unpackDir := c.MkDir()
+	tarballEnv := unpackTarball(outputPath, unpackDir, c)
+	defer tarballEnv.Close()
+
+	verifyPackagesWithLabels(tarballEnv.Packages, packagesWithLabels{
+		newPackage("gravitational.io/planet:0.0.2"),
+		newPackage("gravitational.io/planet:0.0.1",
+			pack.PurposeRuntimeUpgrade, "0.0.1",
+		),
+		newPackage("gravitational.io/app:0.0.1"),
+		newPackage("gravitational.io/gravity:0.0.1",
+			pack.PurposeRuntimeUpgrade, "0.0.1",
+		),
+		newPackage("gravitational.io/gravity:0.0.2"),
+		newPackage("gravitational.io/kubernetes:0.0.1",
+			pack.PurposeRuntimeUpgrade, "0.0.1",
+		),
+		newPackage("gravitational.io/kubernetes:0.0.2"),
+	}, c)
 }
 
-func (s *BuilderSuite) TestBuildInstallerWithDefaultPlanetPackageFromHub(c *check.C) {
+func (s *BuilderSuite) TestBuildInstallerWithDefaultPlanetPackageFromLegacyHub(c *check.C) {
 	if !checkDockerAvailable() {
 		c.Skip("test requires docker")
 	}
@@ -429,36 +536,39 @@ func newEnviron(c *check.C) *localenv.LocalEnvironment {
 }
 
 func createRuntimeApplication(env *localenv.LocalEnvironment, c *check.C) {
-	runtimePackage := loc.MustParseLocator("gravitational.io/planet:0.0.1")
+	createRuntimeApplicationWithVersion(env, "0.0.1", c)
+}
+
+func createRuntimeApplicationWithVersion(env *localenv.LocalEnvironment, version string, c *check.C) {
+	runtimePackage := loc.Planet.WithLiteralVersion(version)
+	gravityPackage := loc.Gravity.WithLiteralVersion(version)
 	items := []*archive.Item{
 		archive.ItemFromString("planet", "planet"),
 	}
 	apptest.CreatePackage(env.Packages, runtimePackage, items, c)
-	gravityPackage := loc.MustParseLocator("gravitational.io/gravity:0.0.1")
 	items = []*archive.Item{
 		archive.ItemFromString("gravity", "gravity"),
 	}
 	apptest.CreatePackage(env.Packages, gravityPackage, items, c)
-	manifestBytes := `apiVersion: bundle.gravitational.io/v2
+	manifestBytes := fmt.Sprintf(`apiVersion: bundle.gravitational.io/v2
 kind: Runtime
 metadata:
   name: kubernetes
-  resourceVersion: 0.0.1
+  resourceVersion: %[1]v
 dependencies:
   packages:
-  - gravitational.io/planet:0.0.1
-  - gravitational.io/gravity:0.0.1
+  - gravitational.io/planet:%[1]v
+  - gravitational.io/gravity:%[1]v
 systemOptions:
   dependencies:
-    runtimePackage: gravitational.io/planet:0.0.1
-`
-	locator := loc.MustParseLocator(
-		fmt.Sprintf("%v/%v:0.0.1", defaults.SystemAccountOrg, defaults.Runtime))
+    runtimePackage: gravitational.io/planet:%[1]v
+`, version)
+	runtimeAppLoc := loc.Runtime.WithLiteralVersion(version)
 	items = []*archive.Item{
 		archive.DirItem("resources"),
 		archive.ItemFromString("resources/app.yaml", manifestBytes),
 	}
-	apptest.CreateApplicationFromData(env.Apps, locator, items, c)
+	apptest.CreateApplicationFromData(env.Apps, runtimeAppLoc, items, c)
 }
 
 func createApp(manifestBytes []byte, apps libapp.Applications, c *check.C) *libapp.Application {
@@ -481,10 +591,10 @@ func writeFile(path string, contents []byte, c *check.C) {
 }
 
 func newHubApps(apps libapp.Applications) libapp.Applications {
-	return hubApps{Applications: apps}
+	return legacyHubApps{Applications: apps}
 }
 
-func (r hubApps) GetApp(loc loc.Locator) (*libapp.Application, error) {
+func (r legacyHubApps) GetApp(loc loc.Locator) (*libapp.Application, error) {
 	app, err := r.Applications.GetApp(loc)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -497,7 +607,11 @@ func (r hubApps) GetApp(loc loc.Locator) (*libapp.Application, error) {
 	return app, nil
 }
 
-type hubApps struct {
+// legacyHubApps implements the libapp.Applications interface but replaces
+// the GetApp API to mimick the behavior of the legacy enterprise hub - namely,
+// that it does not understand the recent versions of the manifest and strips
+// away SystemOptions which is used to detect the planet package
+type legacyHubApps struct {
 	libapp.Applications
 }
 
@@ -525,6 +639,24 @@ func buildDockerImage(dir, tag string, c *check.C) {
 
 func removeDockerImage(tag string) {
 	exec.Command("docker", "rmi", tag).Run()
+}
+
+func verifyPackagesWithLabels(packages pack.PackageService, expected packagesWithLabels, c *check.C) {
+	var obtained packagesWithLabels
+	pack.ForeachPackage(packages, func(e pack.PackageEnvelope) error {
+		labels := e.RuntimeLabels
+		if labels == nil {
+			// To compensate for package envelopes with nil labels
+			// when comparing
+			labels = make(map[string]string)
+		}
+		obtained = append(obtained, packageWithLabels{
+			loc:    e.Locator,
+			labels: labels,
+		})
+		return nil
+	})
+	c.Assert(obtained, compare.SortedSliceEquals, expected)
 }
 
 func verifyPackages(packages pack.PackageService, expected []string, c *check.C) {
@@ -576,3 +708,30 @@ metadata:
 	planetTag      = "quay.io/gravitational/planet:0.0.2"
 	planetPlainTag = "gravitational/planet:0.0.2"
 )
+
+func newPackage(s string, labels ...string) packageWithLabels {
+	if len(labels)%2 != 0 {
+		panic("number of labels must be even")
+	}
+	var m map[string]string
+	m = make(map[string]string)
+	for i := 0; i < len(labels); i += 2 {
+		m[labels[i]] = labels[i+1]
+	}
+	return packageWithLabels{loc: loc.MustParseLocator(s), labels: m}
+}
+
+func (r packagesWithLabels) Len() int { return len(r) }
+func (r packagesWithLabels) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+func (r packagesWithLabels) Less(i, j int) bool {
+	return r[i].loc.String() < r[j].loc.String()
+}
+
+type packagesWithLabels []packageWithLabels
+
+type packageWithLabels struct {
+	loc    loc.Locator
+	labels map[string]string
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
When building an (cluster) image, tele syncs the local cache with packages/applications from a remote hub if any are missing.
The recent work on intermediate upgrades introduced a change that stopped syncing direct application dependencies - instead it only synced the dependencies of the base (runtime) applications.
This went unnoticed since the development workflow does not exercise this path.

Additionally added the relevant tests to exercise both direct dependency synchronization as well handling intermediate hops (which were not tested before).

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2214

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Added new integration tests in lib/builder for:
  * intermediate hops
  * building an application with additional dependencies
