### PR TITLE
[7.0.x] More info in gravity status and remove nodes by cloud instance id (#2202)

### DIFF
--- a/lib/ops/ops.go
+++ b/lib/ops/ops.go
@@ -718,7 +718,7 @@ type Node struct {
 	Profile string `json:"profile"`
 	// Role is the node service role
 	Role string `json:"role"`
-	// InstanceType is the node instance type
+	// InstanceType is the node cloud specific instance type
 	InstanceType string `json:"instance_type"`
 }
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -135,7 +135,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.LeaveCmd.Confirm = g.LeaveCmd.Flag("confirm", "Do not ask for confirmation.").Bool()
 
 	g.RemoveCmd.CmdClause = g.Command("remove", "Remove a node from the cluster.")
-	g.RemoveCmd.Node = g.RemoveCmd.Arg("node", "Node to remove: can be IP address, hostname or name from `kubectl get nodes` output).").
+	g.RemoveCmd.Node = g.RemoveCmd.Arg("node", "Node to remove: can be IP address, hostname, cloud specific instance ID or name from `kubectl get nodes` output).").
 		Required().String()
 	g.RemoveCmd.Force = g.RemoveCmd.Flag("force", "Force removal of an offline node.").Bool()
 	g.RemoveCmd.Confirm = g.RemoveCmd.Flag("confirm", "Do not ask for confirmation.").Bool()

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -306,6 +306,9 @@ func printClusterStatus(cluster statusapi.Cluster, w io.Writer) {
 		fmt.Fprintf(w, "Cluster image:\t%v, version %v\n", cluster.App.Name,
 			cluster.App.Version)
 	}
+	if cluster.CloudProvider != "" {
+		fmt.Fprintf(w, "Cloud provider:\t%v\n", cluster.CloudProvider)
+	}
 	fmt.Fprintf(w, "Gravity version:\t%v (client) / %v (server)\n",
 		cluster.ClientVersion.Version, formatVersion(cluster.ServerVersion))
 	if cluster.Token.Token != "" {
@@ -385,6 +388,12 @@ func printNodeStatus(node statusapi.ClusterServer, w io.Writer) {
 		description = fmt.Sprintf("%v / %v", description, node.Profile)
 	}
 	fmt.Fprintf(w, "        * %v / %v\n", unknownFallback(node.Hostname), description)
+	if node.InstanceID != "" {
+		fmt.Fprintf(w, "            Instance ID:\t%v\n", node.InstanceID)
+	}
+	if node.InstanceType != "" {
+		fmt.Fprintf(w, "            Instance Type:\t%v\n", node.InstanceType)
+	}
 	if node.SELinux != nil && *node.SELinux {
 		fmt.Fprintf(w, "            SELinux:\t%v\n", formatSELinuxStatus(*node.SELinux))
 	}

--- a/tool/gravity/cli/utils.go
+++ b/tool/gravity/cli/utils.go
@@ -216,7 +216,7 @@ func findLocalServer(servers storage.Servers) (*storage.Server, error) {
 }
 
 // findServer searches the provided cluster's state for a server that matches one of the provided
-// tokens, where a token can be the server's advertise IP, hostname or AWS internal DNS name
+// tokens, where a token can be the server's advertise IP, hostname, cloud specific InstanceID or AWS internal DNS name
 func findServer(servers storage.Servers, tokens []string) (*storage.Server, error) {
 	for _, server := range servers {
 		for _, token := range tokens {
@@ -224,7 +224,7 @@ func findServer(servers storage.Servers, tokens []string) (*storage.Server, erro
 				continue
 			}
 			switch token {
-			case server.AdvertiseIP, server.Hostname, server.Nodename:
+			case server.AdvertiseIP, server.Hostname, server.Nodename, server.InstanceID:
 				return &server, nil
 			}
 		}

--- a/tool/gravity/cli/utils_test.go
+++ b/tool/gravity/cli/utils_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/gravitational/gravity/lib/compare"
+	"github.com/gravitational/gravity/lib/storage"
+
+	"gopkg.in/check.v1"
+)
+
+func TestUtils(t *testing.T) { check.TestingT(t) }
+
+type UtilsSuite struct{}
+
+var _ = check.Suite(&UtilsSuite{})
+
+func (s *UtilsSuite) TestFindServer(c *check.C) {
+	server1 := storage.Server{
+		AdvertiseIP: "10.0.0.1",
+		Hostname:    "hostName1",
+		Nodename:    "nodeName1",
+		InstanceID:  "i-sdfkwerjal_1",
+	}
+
+	server2 := storage.Server{
+		AdvertiseIP: "10.0.0.2",
+		Hostname:    "hostName2",
+		Nodename:    "nodeName2",
+		InstanceID:  "i-sdfkwerjal_2",
+	}
+
+	server3 := storage.Server{
+		AdvertiseIP: "10.0.0.3",
+		Hostname:    "hostName3",
+		Nodename:    "nodeName3",
+		InstanceID:  "i-sdfkwerjal_3",
+	}
+
+	servers := []storage.Server{server1, server2, server3}
+
+	tokens := []string{server1.AdvertiseIP}
+	out, err := findServer(servers, tokens)
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, out, &server1)
+
+	tokens = []string{server1.Hostname}
+	out, err = findServer(servers, tokens)
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, out, &server1)
+
+	tokens = []string{server1.Nodename}
+	out, err = findServer(servers, tokens)
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, out, &server1)
+
+	tokens = []string{server1.InstanceID}
+	out, err = findServer(servers, tokens)
+	c.Assert(err, check.IsNil)
+	compare.DeepCompare(c, out, &server1)
+}
+
+func (s *UtilsSuite) TestFindServerNotFound(c *check.C) {
+	server1 := storage.Server{
+		AdvertiseIP: "10.0.0.1",
+		Hostname:    "hostName1",
+		Nodename:    "nodeName1",
+		InstanceID:  "i-sdfkwerjal_1",
+	}
+
+	server2 := storage.Server{
+		AdvertiseIP: "10.0.0.2",
+		Hostname:    "hostName2",
+		Nodename:    "nodeName2",
+		InstanceID:  "i-sdfkwerjal_2",
+	}
+
+	server3 := storage.Server{
+		AdvertiseIP: "10.0.0.3",
+		Hostname:    "hostName3",
+		Nodename:    "nodeName3",
+		InstanceID:  "i-sdfkwerjal_3",
+	}
+
+	servers := []storage.Server{server1, server2, server3}
+
+	tokens := []string{"110.0.0.7"}
+	out, err := findServer(servers, tokens)
+	c.Assert(out, check.IsNil)
+	c.Assert(err.Error(), check.Equals, "no server matching [110.0.0.7] found among registered cluster nodes")
+}


### PR DESCRIPTION
Port extra info in status command changes to the 7.0.x branch. [(2202)](https://github.com/gravitational/gravity/pull/2202)

(cherry picked from commit bd663b56e44b6651e3e1bd55681a1745aa473cff)
