### PR TITLE
[6.1.x] Add check for rollback phases in reverse order

### DIFF
--- a/lib/fsm/utils.go
+++ b/lib/fsm/utils.go
@@ -19,6 +19,7 @@ package fsm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/ops"
@@ -29,6 +30,17 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 )
+
+// rollbackDependentsErrorMsg returns an error message for when a phase is being
+// rolled back, but has dependent phases that have not yet been rolled back.
+func rollbackDependentsErrorMsg(phaseID string, dependents []string) string {
+	const msg = `Phase %[1]s cannot be rolled back because some phases that depend on it haven't been rolled back yet. Please rollback the following phases first:
+
+	%[2]s
+
+You can pass --force flag to override this check and force phase %[1]s rollback.`
+	return fmt.Sprintf(msg, phaseID, strings.Join(dependents, "\n\t"))
+}
 
 // CanRollback checks if specified phase can be rolled back
 func CanRollback(plan *storage.OperationPlan, phaseID string) error {
@@ -44,7 +56,98 @@ func CanRollback(plan *storage.OperationPlan, phaseID string) error {
 		return trace.BadParameter(
 			"phase %q has already been rolled back", phase.ID)
 	}
+
+	// TODO: Rollback of non-leaf phases is not currently supported.
+	// Rollback starts top-down, and not in reverse order.
+	if phase.HasSubphases() {
+		return trace.BadParameter(
+			"rolling back phases that have sub-phases is not supported. Please rollback individual phases").
+			AddField("phase", phase.ID)
+	}
+
+	requiresRollback := getRequiresRollback(plan, phase.ID)
+	if len(requiresRollback) != 0 {
+		return trace.BadParameter(rollbackDependentsErrorMsg(phase.ID, requiresRollback))
+	}
+
 	return nil
+}
+
+// getRequired constructs the initial set of required phases. This set includes
+// the phase specified by phaseID and its parent phases. Returns nil if phases
+// does not contain a phase with phaseID.
+//
+// Given a list of phases like:
+//
+//	/init
+//	/masters
+//		* /node-1
+//			* /system-upgrade
+//		* /node-2
+//
+// and a phaseID "/masters/node-1/system-upgrade" will return the set:
+//
+// {"/masters", "/masters/node-1", "/masters/node-1/system-upgrade"}
+func getRequired(phases []storage.OperationPhase, phaseID string) map[string]struct{} {
+	for _, phase := range phases {
+		if phase.ID == phaseID {
+			return map[string]struct{}{
+				phaseID: {},
+			}
+		}
+		required := getRequired(phase.Phases, phaseID)
+		if required != nil {
+			required[phase.ID] = struct{}{}
+			return required
+		}
+	}
+	return nil
+}
+
+// getRequiresRollback returns a list of phases that need to be rolled back
+// before the phase specified by phaseID can be rolled back.
+func getRequiresRollback(plan *storage.OperationPlan, phaseID string) (dependents []string) {
+	// required will be nil if an invalid phaseID is provided.
+	required := getRequired(plan.Phases, phaseID)
+	if required == nil {
+		return dependents
+	}
+	return getRequiresRollbackHelper(required, plan.Phases)
+}
+
+// getRequiresRollbackHelper is a recursive helper function that returns a list
+// of dependent phases that have been started and have not been rolled back.
+func getRequiresRollbackHelper(required map[string]struct{}, phases []storage.OperationPhase) (dependents []string) {
+	if len(phases) == 0 {
+		return dependents
+	}
+
+	for _, phase := range phases {
+		if isDependent(required, phase) {
+			if !phase.IsUnstarted() && !phase.IsRolledBack() {
+				// Append phase to list of dependents that need to be rolled back.
+				dependents = append(dependents, phase.ID)
+			}
+			// Add phase to the required set. Phases dependent on this phase are
+			// also dependents of the original set of required phases.
+			required[phase.ID] = struct{}{}
+		}
+		// Append any dependent sub phases that need to be rolled back.
+		dependents = append(dependents, getRequiresRollbackHelper(required, phase.Phases)...)
+	}
+
+	return dependents
+}
+
+// isDependent returns true if the phase requires any of the phases contained in
+// the required set.
+func isDependent(required map[string]struct{}, phase storage.OperationPhase) bool {
+	for _, phaseID := range phase.Requires {
+		if _, exists := required[phaseID]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 // IsCompleted returns true if all phases of the provided plan are completed

--- a/lib/fsm/utils_test.go
+++ b/lib/fsm/utils_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package fsm
 
 import (
+	"fmt"
+
 	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/storage"
 
+	"github.com/gravitational/trace"
 	"gopkg.in/check.v1"
 )
 
@@ -147,4 +150,305 @@ func (s *FSMUtilsSuite) TestDiffPlanNoPrevious(c *check.C) {
 			NewState:   storage.OperationPhaseStateFailed,
 		},
 	})
+}
+
+func (s *FSMUtilsSuite) TestNonLeafRollback(c *check.C) {
+	tests := []struct {
+		comment    string
+		phases     []*phaseBuilder
+		rollbackID string
+		expected   string
+	}{
+		{
+			comment: "Rollback non-leaf phase",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/non-leaf").
+					withSubphases(
+						s.phaseBuilder("/leaf").withState(storage.OperationPhaseStateCompleted)),
+			},
+			rollbackID: "/non-leaf",
+			expected:   "rolling back phases that have sub-phases is not supported. Please rollback individual phases",
+		},
+	}
+	for _, tc := range tests {
+		comment := check.Commentf(tc.comment)
+
+		// build plan
+		phases := make([]storage.OperationPhase, len(tc.phases))
+		for i, phase := range tc.phases {
+			phases[i] = phase.build()
+		}
+		plan := &storage.OperationPlan{Phases: phases}
+
+		err := CanRollback(plan, tc.rollbackID)
+		c.Assert(trace.UserMessage(err), check.Equals, tc.expected, comment)
+	}
+
+}
+
+func (s *FSMUtilsSuite) TestCanRollback(c *check.C) {
+	tests := []struct {
+		comment    string
+		phases     []*phaseBuilder
+		rollbackID string
+		expected   string
+	}{
+		{
+			comment: "Rollback latest phase",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+			},
+			rollbackID: "/init",
+		},
+		{
+			comment: "A subsequent phase is in progress",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/startAgent").withState(storage.OperationPhaseStateInProgress).
+					withRequires("/init"),
+			},
+			rollbackID: "/init",
+			expected:   rollbackDependentsErrorMsg("/init", []string{"/startAgent"}),
+		},
+		{
+			comment: "All dependent phases have been rolled back or are unstarted",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/startAgent").withState(storage.OperationPhaseStateRolledBack).
+					withRequires("/init"),
+				s.phaseBuilder("/checks").withState(storage.OperationPhaseStateUnstarted).
+					withRequires("/startAgent"),
+			},
+			rollbackID: "/init",
+		},
+		{
+			comment: "Phase is considered rolled back if all subphases are unstarted or rolled back",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/masters").
+					withRequires("/init").
+					withSubphases(
+						s.phaseBuilder("/node-1").withState(storage.OperationPhaseStateRolledBack),
+						s.phaseBuilder("/node-2").withState(storage.OperationPhaseStateUnstarted).
+							withRequires("/masters/node-1"),
+					),
+			},
+			rollbackID: "/init",
+		},
+		{
+			comment: "Rollback after a dependent phase was previously rolled back forcefully",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/startAgent").withState(storage.OperationPhaseStateRolledBack).
+					withRequires("/init"),
+				s.phaseBuilder("/checks").withState(storage.OperationPhaseStateFailed).
+					withRequires("/startAgent"),
+			},
+			rollbackID: "/init",
+			expected:   rollbackDependentsErrorMsg("/init", []string{"/checks"}),
+		},
+		{
+			comment: "Rollback after a dependent phase has been executed out of band",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/startAgent").withState(storage.OperationPhaseStateUnstarted).
+					withRequires("/init"),
+				s.phaseBuilder("/checks").withState(storage.OperationPhaseStateCompleted).
+					withRequires("/startAgent"),
+			},
+			rollbackID: "/init",
+			expected:   rollbackDependentsErrorMsg("/init", []string{"/checks"}),
+		},
+		{
+			comment: "Top level phase has dependent phases that have not been rolled back",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/masters").
+					withSubphases(
+						s.phaseBuilder("/node-1").withState(storage.OperationPhaseStateCompleted)),
+				s.phaseBuilder("/nodes").
+					withRequires("/masters").
+					withSubphases(
+						s.phaseBuilder("node-2").withState(storage.OperationPhaseStateCompleted),
+						s.phaseBuilder("node-3").withState(storage.OperationPhaseStateCompleted).
+							withRequires("/nodes/node-2")),
+			},
+			rollbackID: "/masters/node-1",
+			expected:   rollbackDependentsErrorMsg("/masters/node-1", []string{"/nodes"}),
+		},
+		{
+			comment: "Rollback parallel phase",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/parallel").
+					withSubphases(
+						s.phaseBuilder("/masters").withState(storage.OperationPhaseStateCompleted),
+						s.phaseBuilder("/nodes").withState(storage.OperationPhaseStateCompleted)),
+			},
+			rollbackID: "/parallel/masters",
+		},
+		{
+			comment: "Rollback with multiple requires",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").
+					withSubphases(
+						s.phaseBuilder("/node-1").withState(storage.OperationPhaseStateCompleted),
+						s.phaseBuilder("/node-2").withState(storage.OperationPhaseStateCompleted),
+						s.phaseBuilder("/node-3").withState(storage.OperationPhaseStateCompleted),
+					),
+				s.phaseBuilder("/checks").withState(storage.OperationPhaseStateCompleted).
+					withRequires("/init"),
+				s.phaseBuilder("/pre-update").withState(storage.OperationPhaseStateCompleted).
+					withRequires("/init", "/checks"),
+			},
+			rollbackID: "/init/node-1",
+			expected:   rollbackDependentsErrorMsg("/init/node-1", []string{"/checks", "/pre-update"}),
+		},
+		{
+			comment: "Invalid rollback with multi-level deep subphases",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/masters").
+					withRequires("/init").
+					withSubphases(
+						s.phaseBuilder("/node-1").
+							withSubphases(
+								s.phaseBuilder("/drain").withState(storage.OperationPhaseStateCompleted),
+								s.phaseBuilder("/system-upgrade").withState(storage.OperationPhaseStateCompleted).
+									withRequires("/masters/node-1/drain")),
+						s.phaseBuilder("/node-2").
+							withRequires("/masters/node-1").
+							withSubphases(
+								s.phaseBuilder("/drain").withState(storage.OperationPhaseStateCompleted),
+								s.phaseBuilder("/system-upgrade").withState(storage.OperationPhaseStateCompleted).
+									withRequires("/masters/node-2/drain"))),
+				s.phaseBuilder("/nodes").
+					withRequires("/masters").
+					withSubphases(
+						s.phaseBuilder("node-3").
+							withSubphases(
+								s.phaseBuilder("/drain").withState(storage.OperationPhaseStateCompleted),
+								s.phaseBuilder("/system-upgrade").withState(storage.OperationPhaseStateCompleted).
+									withRequires("/nodes/node-3/drain"))),
+				s.phaseBuilder("/etcd").
+					withSubphases(
+						s.phaseBuilder("/backup").withState(storage.OperationPhaseStateCompleted)),
+				s.phaseBuilder("/runtime").
+					withRequires("/masters").
+					withSubphases(
+						s.phaseBuilder("/monitoring").withState(storage.OperationPhaseStateCompleted),
+						s.phaseBuilder("/site").withState(storage.OperationPhaseStateCompleted)),
+				s.phaseBuilder("/gc").withState(storage.OperationPhaseStateCompleted).
+					withRequires("/runtime"),
+			},
+			rollbackID: "/masters/node-1/drain",
+			expected: rollbackDependentsErrorMsg("/masters/node-1/drain", []string{
+				"/masters/node-1/system-upgrade",
+				"/masters/node-2",
+				"/nodes",
+				"/runtime",
+				"/gc",
+			}),
+		},
+		{
+			comment: "Valid rollback with multi-level deep subphases",
+			phases: []*phaseBuilder{
+				s.phaseBuilder("/init").withState(storage.OperationPhaseStateCompleted),
+				s.phaseBuilder("/masters").
+					withRequires("/init").
+					withSubphases(
+						s.phaseBuilder("/node-1").
+							withSubphases(
+								s.phaseBuilder("/drain").
+									withState(storage.OperationPhaseStateCompleted),
+								s.phaseBuilder("/system-upgrade").
+									withState(storage.OperationPhaseStateRolledBack).
+									withRequires("/masters/node-1/drain")),
+						s.phaseBuilder("/node-2").
+							withRequires("/masters/node-1").
+							withSubphases(
+								s.phaseBuilder("/drain").withState(storage.OperationPhaseStateRolledBack),
+								s.phaseBuilder("/system-upgrade").withState(storage.OperationPhaseStateRolledBack).
+									withRequires("/masters/node-2/drain"))),
+				s.phaseBuilder("/nodes").
+					withRequires("/masters").
+					withSubphases(
+						s.phaseBuilder("node-3").
+							withSubphases(
+								s.phaseBuilder("/drain").withState(storage.OperationPhaseStateRolledBack),
+								s.phaseBuilder("/system-upgrade").withState(storage.OperationPhaseStateRolledBack).
+									withRequires("/nodes/node-3/drain"))),
+				s.phaseBuilder("/etcd").
+					withSubphases(
+						s.phaseBuilder("/backup").withState(storage.OperationPhaseStateCompleted)),
+				s.phaseBuilder("/runtime").
+					withRequires("/masters").
+					withSubphases(
+						s.phaseBuilder("/monitoring").withState(storage.OperationPhaseStateRolledBack),
+						s.phaseBuilder("/site").withState(storage.OperationPhaseStateRolledBack)),
+				s.phaseBuilder("/gc").withState(storage.OperationPhaseStateUnstarted).
+					withRequires("/runtime"),
+			},
+			rollbackID: "/masters/node-1/drain",
+		},
+	}
+	for _, tc := range tests {
+		comment := check.Commentf(tc.comment)
+
+		// build plan
+		phases := make([]storage.OperationPhase, len(tc.phases))
+		for i, phase := range tc.phases {
+			phases[i] = phase.build()
+		}
+		plan := &storage.OperationPlan{Phases: phases}
+
+		err := CanRollback(plan, tc.rollbackID)
+		c.Assert(trace.UserMessage(err), check.Equals, tc.expected, comment)
+	}
+}
+
+// phaseBuilder returns a new phaseBuilder.
+func (s *FSMUtilsSuite) phaseBuilder(id string) *phaseBuilder {
+	return &phaseBuilder{
+		id: id,
+	}
+}
+
+// phaseBuilder builds storage.OperationPhase to be used in test cases.
+type phaseBuilder struct {
+	id       string
+	state    string
+	phases   []*phaseBuilder
+	requires []string
+}
+
+// withState sets the phase state.
+func (r *phaseBuilder) withState(state string) *phaseBuilder {
+	r.state = state
+	return r
+}
+
+// withSubphases appends the provided subphases.
+func (r *phaseBuilder) withSubphases(subphases ...*phaseBuilder) *phaseBuilder {
+	r.phases = append(r.phases, subphases...)
+	return r
+}
+
+// withRequires appends the provided required phases.
+func (r *phaseBuilder) withRequires(requires ...string) *phaseBuilder {
+	r.requires = append(r.requires, requires...)
+	return r
+}
+
+// build builds the phase.
+func (r *phaseBuilder) build() storage.OperationPhase {
+	phase := storage.OperationPhase{
+		ID:       r.id,
+		State:    r.state,
+		Phases:   make([]storage.OperationPhase, len(r.phases)),
+		Requires: r.requires,
+	}
+	for i, subphase := range r.phases {
+		subphase.id = fmt.Sprintf("%s%s", r.id, subphase.id)
+		phase.Phases[i] = subphase.build()
+	}
+	return phase
 }

--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -369,7 +369,7 @@ func (p OperationPhase) GetState() string {
 		}
 		return p.State
 	}
-	// otherwise collect states of all subphases
+	// otherwise collect the set of states of all subphases
 	states := utils.NewStringSet()
 	for _, phase := range p.Phases {
 		states.Add(phase.GetState())
@@ -378,10 +378,24 @@ func (p OperationPhase) GetState() string {
 	if len(states) == 1 {
 		return states.Slice()[0]
 	}
-	// if any of the subphases is failed or rolled back then this phase is failed
-	if states.Has(OperationPhaseStateFailed) || states.Has(OperationPhaseStateRolledBack) {
+
+	// if any of the subphases are in a failed state, then this phase is also failed.
+	if states.Has(OperationPhaseStateFailed) {
 		return OperationPhaseStateFailed
 	}
+
+	// an in_progress state means that the phase has at least one subphase
+	// in_progress and no failed subphases.
+	if states.Has(OperationPhaseStateInProgress) {
+		return OperationPhaseStateInProgress
+	}
+
+	// If all subphases are either unstarted or rolled back, this phase is also
+	// considered to be rolled back.
+	if !states.Has(OperationPhaseStateCompleted) && states.Has(OperationPhaseStateRolledBack) {
+		return OperationPhaseStateRolledBack
+	}
+
 	// otherwise we consider the whole phase to be in progress because it hasn't
 	// converged to a single state yet
 	return OperationPhaseStateInProgress

--- a/lib/storage/plan_test.go
+++ b/lib/storage/plan_test.go
@@ -41,3 +41,69 @@ func (*PlanSuite) TestGetLeafPhases(c *check.C) {
 	compare.DeepCompare(c, plan.GetLeafPhases(), []OperationPhase{
 		initPhase, bootstrapPhase1, bootstrapPhase2, upgradePhase})
 }
+
+func (*PlanSuite) TestGetState(c *check.C) {
+	tests := []struct {
+		comment  string
+		expected string
+		phase    OperationPhase
+	}{
+		{
+			comment:  "Phase unstarted",
+			expected: OperationPhaseStateUnstarted,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{
+						State: OperationPhaseStateUnstarted,
+					},
+				},
+			},
+		},
+		{
+			comment:  "Phase completed",
+			expected: OperationPhaseStateCompleted,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+				},
+			},
+		},
+		{
+			comment:  "Phase failed",
+			expected: OperationPhaseStateFailed,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+					{State: OperationPhaseStateFailed},
+					{State: OperationPhaseStateRolledBack},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+		{
+			comment:  "Phase rolled back",
+			expected: OperationPhaseStateRolledBack,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateRolledBack},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+		{
+			comment:  "Phase in progress",
+			expected: OperationPhaseStateInProgress,
+			phase: OperationPhase{
+				Phases: []OperationPhase{
+					{State: OperationPhaseStateCompleted},
+					{State: OperationPhaseStateInProgress},
+					{State: OperationPhaseStateUnstarted},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		comment := check.Commentf(tc.comment)
+		c.Assert(tc.phase.GetState(), check.Equals, tc.expected, comment)
+	}
+}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the check for `gravity plan rollback` command. The check now ensures that phases of an operation are being rolled back in order. This check can be bypassed by providing the `--force` flag.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/2184

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
**Verify rollback phase fails if dependent phase is not rolled back**

**Verify rollback phase executes if `--force` flag is provided**

**Verify latest phase can still be rolled back**

**Verify plan can be rolled back completely**