### PR TITLE
Release notes for 6.1.43

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -12,7 +12,7 @@ Find the latest Open Source Gravity releases at [Gravity Downloads](https://grav
 | Version             | Latest Patch | LTS | Release Date         | Latest Patch Date    | End of Support *        | Kubernetes Version   | Teleport Version |
 | ------------------- | ------------ | --- | -------------------- | -------------------- | ----------------------- | -------------------- | ---------------- |
 | [7.0](#70-releases) | 7.0.20       | Yes | April 3, 2020        | October 9th, 2020    | July 9, 2022            | 1.17.9               | 3.2.14-gravity   |
-| [6.1](#61-releases) | 6.1.42       | Yes | August 2, 2019       | October 6th, 2020    | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
+| [6.1](#61-releases) | 6.1.43       | Yes | August 2, 2019       | October 13th, 2020   | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
 | [5.5](#55-releases) | 5.5.54       | Yes | March 8, 2019        | October 12th, 2020   | March 8, 2021           | 1.13.11              | 3.0.7-gravity    |
 
 Gravity offers one Long Term Support (LTS) version for every 2nd Kubernetes
@@ -621,6 +621,12 @@ to learn how to gain insight into how the cluster status changes over time.
 * Upgrade Kubernetes to `v1.16.0`.
 
 ## 6.1 Releases
+
+### 6.1.43 LTS (October 13th, 2020)
+
+#### Improvements
+* Tune gravity to support up to 1000 nodes ([#2220](https://github.com/gravitational/gravity/pull/2220)).
+* Add check that phases are rolled back in the correct order ([#2218](https://github.com/gravitational/gravity/pull/2218)).
 
 ### 6.1.42 LTS (October 6th, 2020)
 

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -625,7 +625,7 @@ to learn how to gain insight into how the cluster status changes over time.
 ### 6.1.43 LTS (October 13th, 2020)
 
 #### Improvements
-* Tune gravity to support up to 1000 nodes ([#2220](https://github.com/gravitational/gravity/pull/2220)).
+* Tune gravity to support larger clusters ([#2220](https://github.com/gravitational/gravity/pull/2220)).
 * Add check that phases are rolled back in the correct order ([#2218](https://github.com/gravitational/gravity/pull/2218)).
 
 ### 6.1.42 LTS (October 6th, 2020)


### PR DESCRIPTION
I'm not sure how we want to communicate that we don't intend to support the 1k node support through the entire 6.1 lifecycle. 