### PR TITLE
[7.0.x] Check for conflicts between host and overlay or service networks (#2204)

### DIFF
--- a/lib/validate/net.go
+++ b/lib/validate/net.go
@@ -22,6 +22,25 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// NetworkOverlap verifies that ipAddr is not in the range of the subnetCIDR
+func NetworkOverlap(ipAddr, subnetCIDR, errMsg string) error {
+	_, subNet, err := net.ParseCIDR(subnetCIDR)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	ip := net.ParseIP(ipAddr)
+	if ip == nil {
+		return trace.BadParameter("invalid IP address (%v)", ipAddr)
+	}
+
+	if subNet.Contains(ip) {
+		return trace.BadParameter(errMsg)
+	}
+
+	return nil
+}
+
 // KubernetesSubnetsFromStrings makes sure that the provided CIDR ranges are valid and can be used as
 // pod/service Kubernetes subnets
 func KubernetesSubnetsFromStrings(podCIDR, serviceCIDR string) error {

--- a/lib/validate/net_test.go
+++ b/lib/validate/net_test.go
@@ -73,3 +73,40 @@ func (*S) TestValidateKubernetesSubnets(c *check.C) {
 		}
 	}
 }
+
+func (*S) TestNetworkOverlap(c *check.C) {
+	type testCase struct {
+		ipAddr      string
+		subnetCIDR  string
+		ok          bool
+		description string
+	}
+	testCases := []testCase{
+		{
+			ipAddr:      "10.100.0.0",
+			subnetCIDR:  "10.100.0.0/16",
+			ok:          false,
+			description: "At the edge of the range.",
+		},
+		{
+			ipAddr:      "10.100.0.111",
+			subnetCIDR:  "10.100.0.0/16",
+			ok:          false,
+			description: "Inside the range.",
+		},
+		{
+			ipAddr:      "11.100.0.111",
+			subnetCIDR:  "10.100.0.0/16",
+			ok:          true,
+			description: "Outside the range.",
+		},
+	}
+	for _, tc := range testCases {
+		err := NetworkOverlap(tc.ipAddr, tc.subnetCIDR, "errMsg")
+		if tc.ok {
+			c.Assert(err, check.IsNil, check.Commentf(tc.description))
+		} else {
+			c.Assert(err, check.ErrorMatches, "errMsg")
+		}
+	}
+}

--- a/tool/gravity/cli/clusterconfig.go
+++ b/tool/gravity/cli/clusterconfig.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/gravity/lib/fsm"
 	libfsm "github.com/gravitational/gravity/lib/fsm"
@@ -276,7 +277,34 @@ func validateClusterConfig(localEnv *localenv.LocalEnvironment, update libcluste
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return validate.ClusterConfiguration(existing, update)
+	err = validate.ClusterConfiguration(existing, update)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	server, err := findLocalServer(cluster.ClusterState.Servers)
+	if err != nil {
+		return trace.NotFound("unable to find local node among cluster state servers: %v",
+			cluster.ClusterState.Servers)
+	}
+
+	if update.GetGlobalConfig().ServiceCIDR != "" {
+		message := fmt.Sprintf("The advertise address %v conflicts with the global service network CIDR range %v. "+
+			"Please specify a different service CIDR.", server.AdvertiseIP, update.GetGlobalConfig().ServiceCIDR)
+		if err := validate.NetworkOverlap(server.AdvertiseIP, update.GetGlobalConfig().ServiceCIDR, message); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if update.GetGlobalConfig().PodCIDR != "" {
+		message := fmt.Sprintf("The advertise address %v conflicts with the global pod network CIDR range %v. "+
+			"Please specify a different pod CIDR.", server.AdvertiseIP, update.GetGlobalConfig().PodCIDR)
+		if err := validate.NetworkOverlap(server.AdvertiseIP, update.GetGlobalConfig().PodCIDR, message); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
 }
 
 const (

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -731,6 +731,19 @@ func (i *InstallConfig) updateClusterConfig(resources []storage.UnknownResource)
 	if err != nil {
 		return nil, trace.Wrap(err, "invalid service subnet: %v", globalConfig.ServiceCIDR)
 	}
+
+	message := fmt.Sprintf("The selected advertise address %v conflicts with the service network CIDR range %v. "+
+		"Please specify a different service CIDR.", i.AdvertiseAddr, globalConfig.ServiceCIDR)
+	if err := validate.NetworkOverlap(i.AdvertiseAddr, globalConfig.ServiceCIDR, message); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	message = fmt.Sprintf("The selected advertise address %v conflicts with the pod network CIDR range %v. "+
+		"Please specify a different pod CIDR.", i.AdvertiseAddr, globalConfig.PodCIDR)
+	if err := validate.NetworkOverlap(i.AdvertiseAddr, globalConfig.PodCIDR, message); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	config.SetGlobalConfig(globalConfig)
 	// Serialize the cluster configuration and add to resources
 	configResource, err := clusterconfig.ToUnknown(config)


### PR DESCRIPTION
Port of the changes for network conflicts validation [2204](https://github.com/gravitational/gravity/pull/2204)

(cherry picked from commit c9c2fbe31f9d4586c717d5110166bcda43dcba6f)
