### PR TITLE
Fix robotest tele build caching

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -165,6 +165,12 @@ $(ROBOTEST_TELE_CACHE):
 $(ROBOTEST_GRAVITY_PKG_CACHE):
 	mkdir -p $(ROBOTEST_GRAVITY_PKG_CACHE)
 
+# .PRECIOUS because this is a pattern rule. As such these caches would otherwise be marked intermediate
+# and make would try to delete them.
+.PRECIOUS: $(ROBOTEST_GRAVITY_PKG_CACHE)/%
+$(ROBOTEST_GRAVITY_PKG_CACHE)/%:
+	mkdir -p $@
+
 $(ROBOTEST_BUILD_TMP):
 	mkdir -p $(ROBOTEST_BUILD_TMP)
 
@@ -268,8 +274,8 @@ $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_MANIFEST = $(ROBOTEST_UPGRADE_BA
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_SRCDIR = $(ROBOTEST_UPGRADE_BASE_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export VERSION = $*
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TELE = $<
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export STATE_DIR = $(ROBOTEST_GRAVITY_PKG_CACHE)
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: $(ROBOTEST_TELE_CACHE)/tele-% $(ROBOTEST_UPGRADE_BASE_IMAGE_SRC) $(TOP)/tele_build.sh | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP) $(ROBOTEST_GRAVITY_PKG_CACHE)
+$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export STATE_DIR = $(ROBOTEST_GRAVITY_PKG_CACHE)/$*
+$(ROBOTEST_IMAGEDIR)/robotest-%.tar: $(ROBOTEST_TELE_CACHE)/tele-% $(ROBOTEST_UPGRADE_BASE_IMAGE_SRC) $(TOP)/tele_build.sh | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP) $(ROBOTEST_GRAVITY_PKG_CACHE)/%
 	$(TOP)/tele_build.sh
 
 # The following target is a pattern rule for populating the tele binary cache.

--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -239,21 +239,19 @@ $(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh $(TELE
 # Benchmarks:
 #  a) parallel builds with common unseeded state dirs (races & fails often)
 # *b) parallel builds with independent unseeded state dirs (4-5 mins)
-#  c) parallel builds with common seeded state dir (~2 mins)
-# *d) serial builds with common unseeded state dir (5-7 mins)
-#  e) serial builds with independent unseeded state dirs (didn't bother testing)
-#  f) serial builds with common seeded state dir (3-4 mins)
+#  c) parallel builds with common seeded state dir (~2 mins, determinism suffers, see #2229)
+# *d) parallel builds with independent seeded state dirs (~2 mins)
+# *e) serial builds with common unseeded state dir (5-7 mins)
+#  f) serial builds with independent unseeded state dirs (didn't bother testing)
+#  g) serial builds with common seeded state dir (3-4 mins)
 #
 # *   Recommended strategies
 #
 # Benchmarked on GCP e2-standard-8 with 30MB/s & 200 sustained random IOPS disks.
 # Code at PR #2133, with 4 7.0.x upgrade base images.
 #
-# For now, I've implemented: d) serial builds with common unseeded state dir.  This has
-# two nice properties:
-#  1) The build output is linear and easy to read
-#  2) Jenkins PR builds & local builds effectively have a semaphore, allowing f) seeded state
-#     dir to kick in and bring the 2+ build time lower than b) parallel independent unseeded.
+# I've implemented: d) parallel builds with independent seeded state dirs. This is fast and
+# benefits from caching on subsequent runs but the parallel build output can get confusing.
 #
 # Lastly, some test configs don't require upgrades, so the sub-make invocation can be skipped.
 #
@@ -261,7 +259,7 @@ $(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh $(TELE
 .PHONY: image-robotest-upgrade
 image-robotest-upgrade: ## Build robotest cluster images needed for upgrade testing.
 ifneq ($(ROBOTEST_TELE_BINARIES),)
-	$(MAKE) $(ROBOTEST_UPGRADE_IMAGES)
+	$(MAKE) -j $(ROBOTEST_UPGRADE_IMAGES)
 endif
 
 # The following rule builds all upgrade base images. It fulfills the $(ROBOTEST_UPGRADE_IMAGES) targets.


### PR DESCRIPTION
## Description
While debugging test failures in the 7.0 robotest backports (#2224) I found that we were not performing the expected upgrades because tele build was occasionally choosing a too-recent baseImage (#2229).

This patch stack does two things:
1) Have each upgrade tele build use a independent `--state-dir`
2) As these are now independent, we can parallelize the upgrade image builds, saving a couple minutes of build time.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* No ports needed as nightly configs only exist in master

## Linked tickets and other PRs

<!--This PR addresses the following issues.-->
* Contributes to #2229
* Needs to be ported as part of #2224, several of the CI failures are a result of #2229

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback

## Implementation
I considered some sort of `sed` or templating to dynamically insert `baseImage` into the robotest image manifest.  However, I felt this added more complexity than the proposed changes in this stack, and it didn't build towards the 2nd commit (parallelism).  On the other hand, this approach is probably closer to what our customers do, and is more robust to a shared packaged cache at some point in the future.

## Testing done
<details><summary>building two upgrade images, out of order, checking the resulting versions</summary>

```
walt@gcp:~/git/gravity$ make -C e/assets/robotest /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images/robotest-7.0.19.tar
make: Entering directory '/home/walt/git/gravity/e/assets/robotest'
mkdir -p /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images
mkdir -p /home/walt/.cache/robotest/ent/gravity-state/7.0.19
/home/walt/git/gravity/assets/robotest/tele_build.sh
+ docker run --rm=true --net=host --user=1000:1000 --group-add=998 -v /home/walt/.cache/robotest/ent/tele/tele-7.0.19:/home/walt/.cache/robotest/ent/tele/tele-7.0.19:ro -v /home/walt/git/gravity/assets/robotest/upgrade-base:/home/walt/git/gravity/assets/robotest/upgrade-base:ro -v /home/walt/.cache/robotest/ent/gravity-state/7.0.19:/home/walt/.cache/robotest/ent/gravity-state/7.0.19 -v /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i:/home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i -v /var/run/docker.sock:/var/run/docker.sock --tmpfs /tmp -w /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i debian-grande:buster-20201001-tele-build dumb-init /home/walt/.cache/robotest/ent/tele/tele-7.0.19 build /home/walt/git/gravity/assets/robotest/upgrade-base/app.yaml --state-dir=/home/walt/.cache/robotest/ent/gravity-state/7.0.19 --version=7.0.19 --output=/home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i/robotest-7.0.19.tar
Wed Oct 14 23:33:15 UTC Building cluster image robotest 7.0.19
Wed Oct 14 23:33:15 UTC Selecting base image version
        Will use base image version 7.0.19
Wed Oct 14 23:33:15 UTC Syncing packages for 7.0.19
Wed Oct 14 23:33:15 UTC Downloading dependencies from https://get.gravitational.io
        Still downloading dependencies from https://get.gravitational.io (10 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (20 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (30 seconds elapsed)
Wed Oct 14 23:33:53 UTC Embedding application container images
        Using local image quay.io/gravitational/debian-tall:buster
        Using local image quay.io/gravitational/debian-tall:buster
        Using local image k8s.gcr.io/echoserver:1.0
time="2020-10-14T23:33:53Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." source=local-docker-registry
time="2020-10-14T23:33:53Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:59bb830684e5e31745c4db7945063ad636397e37ce39cfc0a22b1fa1b98a865a" err.message="blob unknown to registry" http.request.host="127.0.0.1:43223" http.request.id=22cd6d13-019e-44be-8fb8-949554c68800 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38030" http.request.uri="/v2/gravitational/debian-tall/blobs/sha256:59bb830684e5e31745c4db7945063ad636397e37ce39cfc0a22b1fa1b98a865a" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.402201ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:59bb830684e5e31745c4db7945063ad636397e37ce39cfc0a22b1fa1b98a865a" vars.name=gravitational/debian-tall
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:a853f8c65b4045823a00cc81f4691d23e1b6cbcc6b4cf5042341427f3226504e" err.message="blob unknown to registry" http.request.host="127.0.0.1:43223" http.request.id=86e3b700-10af-42d5-9c14-95697c7e780a http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38042" http.request.uri="/v2/gravitational/debian-tall/blobs/sha256:a853f8c65b4045823a00cc81f4691d23e1b6cbcc6b4cf5042341427f3226504e" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.282422ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:a853f8c65b4045823a00cc81f4691d23e1b6cbcc6b4cf5042341427f3226504e" vars.name=gravitational/debian-tall
        Vendored image gravitational/debian-tall:buster
time="2020-10-14T23:33:54Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." source=local-docker-registry
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:a00312a509935e6514ef751cc3ec80381bf4a41c144c013d2e99329861c83e1e" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=8b982abe-8a98-4aad-af5d-7bed2f68afd7 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:37970" http.request.uri="/v2/echoserver/blobs/sha256:a00312a509935e6514ef751cc3ec80381bf4a41c144c013d2e99329861c83e1e" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=7.21011ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:a00312a509935e6514ef751cc3ec80381bf4a41c144c013d2e99329861c83e1e" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:fbb99d21be8a6fd71f5e9bba7780ee209b560fa960351e94145b6e3661262969" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=183b46fb-b41a-4b51-a342-4e9bedd6fabf http.request.method=HEAD http.request.remoteaddr="127.0.0.1:37974" http.request.uri="/v2/echoserver/blobs/sha256:fbb99d21be8a6fd71f5e9bba7780ee209b560fa960351e94145b6e3661262969" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=4.576377ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:fbb99d21be8a6fd71f5e9bba7780ee209b560fa960351e94145b6e3661262969" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:7691202a33cec6e98c2fd4576d9d11a365be23c14f53ec5c3afef50f19c7b829" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=b80bc38e-2fa9-46e6-a96f-a37f75f40dff http.request.method=HEAD http.request.remoteaddr="127.0.0.1:37968" http.request.uri="/v2/echoserver/blobs/sha256:7691202a33cec6e98c2fd4576d9d11a365be23c14f53ec5c3afef50f19c7b829" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=7.176476ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:7691202a33cec6e98c2fd4576d9d11a365be23c14f53ec5c3afef50f19c7b829" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:0d8ec01080f177d17fdbe2caa51f136ce1416681ede9174d23e9109e9c7f8270" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=f1b8e849-32b6-4514-9b5d-78ae0cd9df3b http.request.method=HEAD http.request.remoteaddr="127.0.0.1:37972" http.request.uri="/v2/echoserver/blobs/sha256:0d8ec01080f177d17fdbe2caa51f136ce1416681ede9174d23e9109e9c7f8270" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=7.221828ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:0d8ec01080f177d17fdbe2caa51f136ce1416681ede9174d23e9109e9c7f8270" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=1687ccf4-c8a1-406e-9801-19b6b88ee859 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:37966" http.request.uri="/v2/echoserver/blobs/sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=4.93197ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:885b4cd557ff041bd2213948373e15cf7ee999a0a3048e513625b2f673991b55" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=28e296d6-3290-4351-820f-cd19248d6490 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38024" http.request.uri="/v2/echoserver/blobs/sha256:885b4cd557ff041bd2213948373e15cf7ee999a0a3048e513625b2f673991b55" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.447386ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:885b4cd557ff041bd2213948373e15cf7ee999a0a3048e513625b2f673991b55" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:d6ab7acb097a8143ecce21e7b3d7ed5a28e692ff52f752de5a00e3ab1b0d048e" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=cc4ea31f-1a62-469e-a5b3-039945500b80 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38040" http.request.uri="/v2/echoserver/blobs/sha256:d6ab7acb097a8143ecce21e7b3d7ed5a28e692ff52f752de5a00e3ab1b0d048e" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.795337ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:d6ab7acb097a8143ecce21e7b3d7ed5a28e692ff52f752de5a00e3ab1b0d048e" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:532730a33a2969b92d354b63bb1ec45ad2f29671505e08d674d35cf97b76890e" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=dc537ed0-7ebd-4b57-95cb-079ad9eb52b6 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38038" http.request.uri="/v2/echoserver/blobs/sha256:532730a33a2969b92d354b63bb1ec45ad2f29671505e08d674d35cf97b76890e" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.731887ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:532730a33a2969b92d354b63bb1ec45ad2f29671505e08d674d35cf97b76890e" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:12b878835004f7f33794e0d802ddd7e01c5588c6ab1e74cf8877bb9c4cff38a1" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=3b4264a3-a897-4888-8e73-f4121768497c http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38050" http.request.uri="/v2/echoserver/blobs/sha256:12b878835004f7f33794e0d802ddd7e01c5588c6ab1e74cf8877bb9c4cff38a1" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.769207ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:12b878835004f7f33794e0d802ddd7e01c5588c6ab1e74cf8877bb9c4cff38a1" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:77c3e89ab3ce8817139ad4c2d7e8caa96dddadc864b35f51947188214f122386" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=5f00dae7-5bc3-4863-bb21-db3371db19d5 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38052" http.request.uri="/v2/echoserver/blobs/sha256:77c3e89ab3ce8817139ad4c2d7e8caa96dddadc864b35f51947188214f122386" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=1.495144ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:77c3e89ab3ce8817139ad4c2d7e8caa96dddadc864b35f51947188214f122386" vars.name=echoserver
time="2020-10-14T23:33:54Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:4ba2dce22d748fda5f5dd2178a94aad8528b6461cc7fd2b53a5246fd365b3a43" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=938d7047-85c8-4fd1-afa3-3a639eef10b5 http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38066" http.request.uri="/v2/echoserver/blobs/sha256:4ba2dce22d748fda5f5dd2178a94aad8528b6461cc7fd2b53a5246fd365b3a43" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=2.291189ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:4ba2dce22d748fda5f5dd2178a94aad8528b6461cc7fd2b53a5246fd365b3a43" vars.name=echoserver
        Still embedding application container images (10 seconds elapsed)
        Still embedding application container images (20 seconds elapsed)
time="2020-10-14T23:34:14Z" level=error msg="response completed with error" err.code="blob unknown" err.detail="sha256:a3724de5980c71064d5b3f543e3babbf0195590b41a7c8e1cdb420bbf0d34b3a" err.message="blob unknown to registry" http.request.host="127.0.0.1:32979" http.request.id=bee0ef83-590f-4db5-859d-2ebd49fa3c1e http.request.method=HEAD http.request.remoteaddr="127.0.0.1:38092" http.request.uri="/v2/echoserver/blobs/sha256:a3724de5980c71064d5b3f543e3babbf0195590b41a7c8e1cdb420bbf0d34b3a" http.request.useragent="docker/19.03.13 go/go1.13.15 git-commit/4484c46d9d kernel/5.4.0-1025-gcp os/linux arch/amd64 UpstreamClient(go-dockerclient)" http.response.contenttype="application/json; charset=utf-8" http.response.duration=2.002345ms http.response.status=404 http.response.written=157 source=local-docker-registry vars.digest="sha256:a3724de5980c71064d5b3f543e3babbf0195590b41a7c8e1cdb420bbf0d34b3a" vars.name=echoserver
        Vendored image k8s.gcr.io/echoserver:1.0
Wed Oct 14 23:34:14 UTC Creating application
        Still creating application (10 seconds elapsed)
Wed Oct 14 23:34:29 UTC Generating the cluster image
        Still generating the cluster image (10 seconds elapsed)
Wed Oct 14 23:34:46 UTC Saving the image as /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i/robotest-7.0.19.tar
        Still saving the image as /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i/robotest-7.0.19.tar (10 seconds elapsed)
Wed Oct 14 23:34:56 UTC Build finished in 1 minute
+ mv /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.L3tt82aA4i/robotest-7.0.19.tar /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images/robotest-7.0.19.tar
make: Leaving directory '/home/walt/git/gravity/e/assets/robotest'
walt@gcp:~/git/gravity$ make -C e/assets/robotest /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images/robotest-7.0.12.tar
make: Entering directory '/home/walt/git/gravity/e/assets/robotest'
mkdir -p /home/walt/.cache/robotest/ent/gravity-state/7.0.12
/home/walt/git/gravity/assets/robotest/tele_build.sh
+ docker run --rm=true --net=host --user=1000:1000 --group-add=998 -v /home/walt/.cache/robotest/ent/tele/tele-7.0.12:/home/walt/.cache/robotest/ent/tele/tele-7.0.12:ro -v /home/walt/git/gravity/assets/robotest/upgrade-base:/home/walt/git/gravity/assets/robotest/upgrade-base:ro -v /home/walt/.cache/robotest/ent/gravity-state/7.0.12:/home/walt/.cache/robotest/ent/gravity-state/7.0.12 -v /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u:/home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u -v /var/run/docker.sock:/var/run/docker.sock --tmpfs /tmp -w /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u debian-grande:buster-20201001-tele-build dumb-init /home/walt/.cache/robotest/ent/tele/tele-7.0.12 build /home/walt/git/gravity/assets/robotest/upgrade-base/app.yaml --state-dir=/home/walt/.cache/robotest/ent/gravity-state/7.0.12 --version=7.0.12 --output=/home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u/robotest-7.0.12.tar
Wed Oct 14 23:35:18 UTC Building cluster image robotest 7.0.12
Wed Oct 14 23:35:18 UTC Selecting base image version
        Will use base image version 7.0.12
Wed Oct 14 23:35:18 UTC Downloading dependencies from https://get.gravitational.io
        Still downloading dependencies from https://get.gravitational.io (10 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (20 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (30 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (40 seconds elapsed)
        Still downloading dependencies from https://get.gravitational.io (50 seconds elapsed)
Wed Oct 14 23:36:17 UTC Embedding application container images
        Using local image quay.io/gravitational/debian-tall:buster
        Using local image quay.io/gravitational/debian-tall:buster
        Using local image k8s.gcr.io/echoserver:1.0
time="2020-10-14T23:36:17Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." source=local-docker-registry
        Vendored image gravitational/debian-tall:buster
time="2020-10-14T23:36:18Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." source=local-docker-registry
        Still embedding application container images (10 seconds elapsed)
        Still embedding application container images (20 seconds elapsed)
        Vendored image k8s.gcr.io/echoserver:1.0
Wed Oct 14 23:36:38 UTC Creating application
        Still creating application (10 seconds elapsed)
Wed Oct 14 23:36:52 UTC Generating the cluster image
        Still generating the cluster image (10 seconds elapsed)
Wed Oct 14 23:37:02 UTC Saving the image as /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u/robotest-7.0.12.tar
Wed Oct 14 23:37:11 UTC Build finished in 1 minute
+ mv /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/tmp/tmp.lnFJYRCH4u/robotest-7.0.12.tar /home/walt/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images/robotest-7.0.12.tar
make: Leaving directory '/home/walt/git/gravity/e/assets/robotest'
walt@gcp:~/git/gravity$ cd e/build/7.1.0-alpha.1.235/robotest/images
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ ls
robotest-7.0.12.tar  robotest-7.0.19.tar
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ mkdir 7.0.12 7.0.19
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ tar -xf robotest-7.0.12.tar -C 7.0.12
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ tar -xf robotest-7.0.19.tar -C 7.0.19
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ ./7.0.12/gravity version
Edition:        enterprise
Version:        7.0.12
Git Commit:     8a1dbd9c0cfa4ae4ce11a63e3b4a8d6c7b9226e7
Helm Version:   v2.15
walt@gcp:~/git/gravity/e/build/7.1.0-alpha.1.235/robotest/images$ ./7.0.19/gravity version
Edition:        enterprise
Version:        7.0.19
Git Commit:     9932b6291888c2667d936b32646804ded937273f
Helm Version:   v2.15
```
</details>

The PR build should cover the rest.
