### PR TITLE
Incremental upgrades

### DIFF
--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -201,10 +201,10 @@ hooks:
     job: file://preUpdate.yaml
 ingress:
   nginx:
-    enabled: false
+    enabled: true
 storage:
   openebs:
-    enabled: false
+    enabled: true
 systemOptions:
   runtime:
     version: "0.0.0+latest"

--- a/assets/telekube/resources/app.yaml
+++ b/assets/telekube/resources/app.yaml
@@ -201,10 +201,10 @@ hooks:
     job: file://preUpdate.yaml
 ingress:
   nginx:
-    enabled: true
+    enabled: false
 storage:
   openebs:
-    enabled: true
+    enabled: false
 systemOptions:
   runtime:
     version: "0.0.0+latest"

--- a/examples/robot-shop-app/resources/app.yaml
+++ b/examples/robot-shop-app/resources/app.yaml
@@ -49,7 +49,7 @@ installer:
         count: 3
 
 # This section allows to define what flavors of servers are required for
-# this cluster. 
+# this cluster.
 #
 #
 nodeProfiles:
@@ -112,3 +112,6 @@ hooks:
   update:
     job: file://upgrade.yaml
 
+extensions:
+  monitoring:
+    disabled: true

--- a/examples/robot-shop-app/resources/app.yaml
+++ b/examples/robot-shop-app/resources/app.yaml
@@ -111,7 +111,3 @@ hooks:
 # the helm call to upgrade.
   update:
     job: file://upgrade.yaml
-
-extensions:
-  monitoring:
-    disabled: true

--- a/examples/robot-shop-app/resources/charts/robot-shop/templates/redis-statefulset.yaml
+++ b/examples/robot-shop-app/resources/charts/robot-shop/templates/redis-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
       {{ end }}
       containers:
       - name: redis
-        image:  {{ .Values.registry }}redis:4.0.6
+        image:  {{ .Values.registry }}redis:{{ .Values.redis.image.version }}
         ports:
         - containerPort: 6379
         volumeMounts:
@@ -48,4 +48,3 @@ spec:
         resources:
           requests:
             storage: 1Gi
-

--- a/examples/robot-shop-app/resources/charts/robot-shop/templates/web-deployment.yaml
+++ b/examples/robot-shop-app/resources/charts/robot-shop/templates/web-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{ end }}
       containers:
       - name: web
-        image: {{ .Values.registry }}{{ .Values.image.repo }}/rs-web:{{ .Values.image.version }}
+        image: {{ .Values.registry }}{{ .Values.image.repo }}/rs-web:{{ .Values.robotshop.web.image.version }}
         {{- if .Values.eum.key }}
         env:
         - name: INSTANA_EUM_KEY

--- a/examples/robot-shop-app/resources/charts/robot-shop/values.yaml
+++ b/examples/robot-shop-app/resources/charts/robot-shop/values.yaml
@@ -42,3 +42,14 @@ securitySettingIstio: false
 
 # web deployment replicas
 numberWebReplicas: 3
+
+# redis
+redis:
+  image:
+    version: 4.0.6
+
+# robotshop
+robotshop:
+  web:
+    image:
+      version: 0.4.20

--- a/examples/robot-shop-app/resources/charts/robot-shop/values.yaml
+++ b/examples/robot-shop-app/resources/charts/robot-shop/values.yaml
@@ -43,12 +43,12 @@ securitySettingIstio: false
 # web deployment replicas
 numberWebReplicas: 3
 
-# redis
+# Image variables for Redis
 redis:
   image:
     version: 4.0.6
 
-# robotshop
+# Image variables for Robotest application components
 robotshop:
   web:
     image:

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/garyburd/redigo v0.0.0-20151029235527-6ece6e0a09f2 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
 	github.com/gizak/termui v2.3.0+incompatible
+	github.com/go-delve/delve v1.5.0 // indirect
 	github.com/go-ini/ini v1.30.0 // indirect
 	github.com/go-openapi/runtime v0.19.4
 	github.com/gobuffalo/packr v1.30.1 // indirect
@@ -51,7 +52,6 @@ require (
 	github.com/gogo/protobuf v1.3.0
 	github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b
 	github.com/golang/protobuf v1.3.2
-	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/gops v0.3.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/handlers v0.0.0-20151124211609-e96366d97736 // indirect
@@ -136,8 +136,9 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3
+	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
+	golang.org/x/tools/gopls v0.5.0 // indirect
 	gonum.org/v1/gonum v0.6.1 // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -205,9 +205,11 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/prometheus-operator v0.32.0 h1:6ZVpCM4t+gPmAhZhaMoYZbn5/1BSuWZl1EZuU0xpo2g=
 github.com/coreos/prometheus-operator v0.32.0/go.mod h1:Bk/PShB4YYCX7sIRLuFv2/d8WA8P2gpj8RahsGGPfy0=
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
+github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
 github.com/cpuguy83/go-md2man v1.0.4/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299 h1:2pOMM/RaFhI52FyCITl8aTf5HZ9LoHD8SkjbghAEG1E=
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
@@ -223,6 +225,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v17.12.1-ce-rc2+incompatible h1:ESUycEAqvFuLglAHkUW66rCc2djYtd3i1x231svLq9o=
 github.com/docker/distribution v0.0.0-20170726174610-edc3ab29cdff/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.6.0-rc.1.0.20170726174610-edc3ab29cdff+incompatible h1:357nGVUC8gSpeSc2Axup8HfrfTLLUfWfCsCUhiQSKIg=
 github.com/docker/distribution v2.6.0-rc.1.0.20170726174610-edc3ab29cdff+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -257,7 +260,9 @@ github.com/emicklei/go-restful v2.6.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.11.0+incompatible h1:XfJYmBrweXijz6u2n8jWVAH10Vt7AsYahtOAZepjmGA=
 github.com/emicklei/go-restful v2.11.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473 h1:4cmBvAEBNJaGARUEs3/suWRyfyBfhf7I60WBZq+bv2w=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v3.0.0+incompatible h1:l91aby7TzBXBdmF8heZqjskeH9f3g7ZOL8/sSe+vTlU=
@@ -300,6 +305,8 @@ github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-bindata/go-bindata v3.1.1+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540/go.mod h1:+sE8vrLDS2M0pZkBk0wy6+nLdKexVDrl/jBqQOTDThA=
+github.com/go-delve/delve v1.5.0 h1:gQsRvFdR0BGk19NROQZsAv6iG4w5QIZoJlxJeEUBb0c=
+github.com/go-delve/delve v1.5.0/go.mod h1:c6b3a1Gry6x8a4LGCe/CWzrocrfaHvkUxCj3k4bvSUQ=
 github.com/go-ini/ini v1.21.1/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ini/ini v1.30.0 h1:bcFeUQUA+99t1cZPXmtc7HpGv2KTlZGIFeBDWQh2DRw=
 github.com/go-ini/ini v1.30.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
@@ -419,6 +426,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v0.0.0-20160127222235-bd3c8e81be01/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.0.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -461,6 +469,9 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-dap v0.2.0/go.mod h1:5q8aYQFnHOAZEMP+6vmq25HKYAEwE+LF5yh7JKrrhSQ=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20150304233714-bbcb9da2d746 h1:M6d2zDTA4cKXT6OwFsJxlo5tWrAukj3KfvJ1zcBatnA=
@@ -805,6 +816,7 @@ github.com/marstr/guid v0.0.0-20170427235115-8bdf7d1a087c/go.mod h1:74gB1z2wpxxI
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/maruel/panicparse v1.1.2-0.20180806203336-f20d4c4d746f h1:mtX2D0ta3lWxCvv276VVIH6mMYzm4jhSfYP70ZJSOQU=
 github.com/maruel/panicparse v1.1.2-0.20180806203336-f20d4c4d746f/go.mod h1:nty42YY5QByNC5MM7q/nj938VbgPU7avs45z6NClpxI=
+github.com/mattn/go-colorable v0.0.0-20170327083344-ded68f7a9561/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
@@ -944,6 +956,7 @@ github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1/go.mod h1:uqqh8
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
+github.com/peterh/liner v0.0.0-20170317030525-88609521dc4b/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/petermattis/goid v0.0.0-20170504144140-0ded85884ba5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -990,6 +1003,9 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.5.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rubenv/sql-migrate v0.0.0-20190902133344-8926f37f0bc1 h1:G7j/gxkXAL80NMLOWi6EEctDET1Iuxl3sBMJXDnu2z0=
 github.com/rubenv/sql-migrate v0.0.0-20190902133344-8926f37f0bc1/go.mod h1:WS0rl9eEliYI8DPnr3TOwz4439pay+qNgzJoVya/DmY=
@@ -1018,6 +1034,8 @@ github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -1060,6 +1078,7 @@ github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec/go.mod h1:
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1134,6 +1153,8 @@ github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6Ut
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xtgo/set v1.0.0 h1:6BCNBRv3ORNDQ7fyoJXRv+tstJz3m1JVFQErfeZz2pY=
 github.com/xtgo/set v1.0.0/go.mod h1:d3NHzGzSa0NmB2NhFyECA+QdRp29oEn2xbT+TpeFoM8=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v0.0.0-20180815031001-58bb2bc0302a/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20180829180805-c2393a5d54f2 h1:6kLV7zzkF4LbOhuztGPIJjd/u7csij6t3GXRz/1hu2Y=
 github.com/zclconf/go-cty v0.0.0-20180829180805-c2393a5d54f2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
@@ -1153,6 +1174,7 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+go.starlark.net v0.0.0-20190702223751-32f345186213/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569 h1:nSQar3Y0E3VQF/VdZ8PTAilaXpER+d7ypdABCrpwMdg=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -1167,6 +1189,8 @@ go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15/go.mod h1:vwi/ZaCAaUcBkycHslx
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
+golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4 h1:QlVATYS7JBoZMVaf+cNjb90WD/beKVHnIxFKT4QaHVI=
+golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/build v0.0.0-20190927031335-2835ba2e683f/go.mod h1:fYw7AShPAhGMdXqA9gRadk/CcMsvLlClpE5oBwnS3dM=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774 h1:a4tQYYYuK9QdeO/+kEvNYyuR21S+7ve5EANok6hABhI=
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1175,6 +1199,7 @@ golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495 h1:I6A9Ag9FpEKOjcKrRNjQkPHawoXIhKyTGfvvjFAiiAk=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
+golang.org/x/exp v0.0.0-20200513190911-00229845015e h1:rMqLP+9XLy+LdbCXHjJHAmTfXCr93W7oruWA6Hq1Alc=
 golang.org/x/exp v0.0.0-20200821190819-94841d0725da h1:vfV2BR+q1+/jmgJR30Ms3RHbryruQ3Yd83lLAAue9cs=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1186,6 +1211,7 @@ golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170915142106-8351a756f30f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1219,6 +1245,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrS
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced h1:4oqSq7eft7MdPKBGQK11X9WYUxmj6ZLgGTqYIbY1kyw=
 golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
@@ -1230,6 +1258,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5 h1:x6r4Jo0KNzOOzYd8lbcRsqjuqEASK6ob3auvWYM4/8U=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f h1:A601OM5nBnC8+2gkdd3/VyRPfpcZvSehZCmiBDBQ9xU=
@@ -1272,11 +1302,23 @@ golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c h1:KfpJVdWhuRqNk4XVXzjXf2K
 golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190909030654-5b82db07426d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191127201027-ecd32218bd7f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191212051200-825cb0626375/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191224055732-dd894d0a8a40 h1:UyP2XDSgSc8ldYCxAK735zQxeH3Gd81sK7Iy7AoaVxk=
 golang.org/x/tools v0.0.0-20191224055732-dd894d0a8a40/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200914163123-ea50a3c84940 h1:151ExL+g/k/wnhOqV+O1OliaTi0FR2UxQEEcpAhzzw8=
+golang.org/x/tools v0.0.0-20200914163123-ea50a3c84940/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20201001104356-43ebab892c4c h1:9BSeO6440XJVa2mxIcRAndAol4g4g2KflCVGcHx9Yu8=
+golang.org/x/tools/gopls v0.5.0 h1:XEmO9RylgmaXp33iGrWfCGopVYDGBmLy+KmsIsfIo8Y=
+golang.org/x/tools/gopls v0.5.0/go.mod h1:bm7s/5W/faSLxWyOWFtTI+5lZQQVdtksvEXdIfkFE74=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/gonum v0.6.1/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
@@ -1355,6 +1397,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75k=
+honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 howett.net/plist v0.0.0-20180609054337-500bd5b9081b/go.mod h1:jInWmjR7JRkkon4jlLXDZGVEeY/wo3kOOJEWYhNE+9Y=
 k8s.io/api v0.15.7 h1:Qoun2090uLk9jvaXX6I5b02mh8bKrluPcbvsGrOfAKE=
 k8s.io/api v0.15.7/go.mod h1:a/tUxscL+UxvYyA7Tj5DRc8ivYqJIO1Y5KDdlI6wSvo=
@@ -1477,9 +1521,12 @@ modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
+mvdan.cc/gofumpt v0.0.0-20200802201014-ab5a8192947d h1:t8TAw9WgTLghti7RYkpPmqk4JtQ3+wcP5GgZqgWeWLQ=
+mvdan.cc/gofumpt v0.0.0-20200802201014-ab5a8192947d/go.mod h1:bzrjFmaD6+xqohD3KYP0H2FEuxknnBmyyOxdhLdaIws=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
+mvdan.cc/xurls/v2 v2.2.0/go.mod h1:EV1RMtya9D6G5DMYPGD8zTQzaHet6Jh8gFlRgGRJeO8=
 rsc.io/goversion v1.0.0/go.mod h1:Eih9y/uIBS3ulggl7KNJ09xGSLcuNaLgmvvqa07sgfo=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=

--- a/lib/app/app.go
+++ b/lib/app/app.go
@@ -274,6 +274,9 @@ type InstallerRequest struct {
 	CACert string `json:"ca_cert,omitempty"`
 	// EncryptionKey is encryption key to encrypt installer packages with
 	EncryptionKey string `json:"encryption_key,omitempty"`
+	// Incremental indicates that incremental upgrade image is being built
+	// so no runtime packages will be included.
+	Incremental bool `json:"patch,omitempty"`
 }
 
 // Check validates this request
@@ -417,6 +420,19 @@ func (a Application) RequiresLicense() bool {
 		return false
 	}
 	return true
+}
+
+// LabelAsLocator returns the specified label as a parsed locator.
+func (a Application) LabelAsLocator(label string) (*loc.Locator, error) {
+	locatorS, ok := a.PackageEnvelope.RuntimeLabels[label]
+	if !ok {
+		return nil, trace.NotFound("%v doesn't have label %v", a, label)
+	}
+	locator, err := loc.ParseLocator(locatorS)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return locator, nil
 }
 
 // Logger defines an interface to log messages

--- a/lib/app/service/app.go
+++ b/lib/app/service/app.go
@@ -230,7 +230,7 @@ func syncWithRegistry(ctx context.Context, registryDir string, imageService dock
 	if empty {
 		return trace.BadParameter("registry directory %v is empty", registryDir)
 	}
-	if _, err = imageService.Sync(ctx, registryDir, utils.DiscardPrinter); err != nil {
+	if _, err = imageService.SyncFrom(ctx, registryDir, utils.DiscardPrinter); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/app/service/fixtures/test-app/app.yaml
+++ b/lib/app/service/fixtures/test-app/app.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.gravitational.io/v2
+kind: Cluster
+metadata:
+  name: test-app
+  resourceVersion: "0.0.1"
+hooks:
+  install:
+    job: file://install.yaml

--- a/lib/app/service/fixtures/test-app/charts/test-chart/Chart.yaml
+++ b/lib/app/service/fixtures/test-app/charts/test-chart/Chart.yaml
@@ -1,0 +1,2 @@
+name: test-chart
+version: 0.0.1 

--- a/lib/app/service/fixtures/test-app/charts/test-chart/templates/mysql-deployment.yaml
+++ b/lib/app/service/fixtures/test-app/charts/test-chart/templates/mysql-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-mysql
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wordpress
+    tier: mysql
+  clusterIP: None
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim3
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  storageClassName: {{.Values.storageClassType}}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.wordpressStorageSize}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: {{.Values.registry}}mysql:{{.Values.mysqlTag}}
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim3
+      nodeSelector:
+        db: "true" # runs on a node designated as a db 
+

--- a/lib/app/service/fixtures/test-app/charts/test-chart/templates/wordpress-deployment.yaml
+++ b/lib/app/service/fixtures/test-app/charts/test-chart/templates/wordpress-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: wordpress
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: {{.Values.registry}}wordpress:{{.Values.wordpressTag}}
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim3
+      nodeSelector:
+        front: "true" # uses this to determine which node to attach to
+

--- a/lib/app/service/fixtures/test-app/charts/test-chart/values.yaml
+++ b/lib/app/service/fixtures/test-app/charts/test-chart/values.yaml
@@ -1,0 +1,4 @@
+registry: ""
+wordpressNamespace: default
+wordpressTag: 5.4-apache
+mysqlTag: 5.7

--- a/lib/app/service/fixtures/test-app/install.yaml
+++ b/lib/app/service/fixtures/test-app/install.yaml
@@ -1,0 +1,12 @@
+ apiVersion: batch/v1
+ kind: Job
+ metadata:
+   name: install
+ spec:
+   template:
+     metadata:
+       name: install
+     spec:
+       containers:
+         - name: install
+           image: install-hook:latest

--- a/lib/app/service/fixtures/test-app/resources.yaml
+++ b/lib/app/service/fixtures/test-app/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx

--- a/lib/app/service/fixtures/test-app/resources/charts/test-chart/templates/mysql-deployment.yaml
+++ b/lib/app/service/fixtures/test-app/resources/charts/test-chart/templates/mysql-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  namespace: {{.Values.wordpressNamespace}}
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: {{.Values.registry}}mysql:{{.Values.mysqlTag}}
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim3
+      nodeSelector:
+        db: "true" # runs on a node designated as a db 

--- a/lib/app/service/layer.go
+++ b/lib/app/service/layer.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/blob/fs"
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/pack/layerpack"
+	"github.com/gravitational/gravity/lib/pack/localpack"
+	"github.com/gravitational/gravity/lib/storage/keyval"
+
+	"github.com/gravitational/trace"
+)
+
+// LayeredApps contains layered package and application services.
+type LayeredApps struct {
+	// Package is a layered package service.
+	Packages pack.PackageService
+	// Apps is app service based on the layered package service.
+	Apps app.Applications
+	// dir is the directory with the new write layer data.
+	dir string
+}
+
+// Cleanup removes the write layer directory.
+func (l LayeredApps) Cleanup() error {
+	if l.dir != "" {
+		return os.RemoveAll(l.dir)
+	}
+	return nil
+}
+
+// NewLayeredApps returns layered package and application services where
+// the provided package service serves as a read-only layer.
+func NewLayeredApps(readPackages pack.PackageService) (*LayeredApps, error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	backend, err := keyval.NewBolt(keyval.BoltConfig{
+		Path:  filepath.Join(dir, defaults.GravityDBFile),
+		Multi: true,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	objects, err := fs.New(filepath.Join(dir, defaults.PackagesDir))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	packages, err := localpack.New(localpack.Config{
+		Backend:     backend,
+		UnpackedDir: filepath.Join(dir, defaults.PackagesDir, defaults.UnpackedDir),
+		Objects:     objects,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	layeredPackages := layerpack.New(readPackages, packages)
+	layeredApps, err := New(Config{
+		StateDir:    filepath.Join(dir, defaults.ImportDir),
+		Backend:     backend,
+		Packages:    layeredPackages,
+		UnpackedDir: filepath.Join(dir, defaults.PackagesDir, defaults.UnpackedDir),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &LayeredApps{
+		Packages: layeredPackages,
+		Apps:     layeredApps,
+		dir:      dir,
+	}, nil
+}

--- a/lib/app/service/restore.go
+++ b/lib/app/service/restore.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/gravity/lib/app"
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/docker"
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/gravitational/trace"
+)
+
+// RestoreRequest describes a request to restore the application integrity
+// by downloading missing Docker images from the cluster registry.
+type RestoreRequest struct {
+	// Packages is a package service where the application resides.
+	Packages pack.PackageService
+	// Apps is the app service based on the above package service.
+	Apps app.Applications
+	// ClusterPackages is the cluster's package service.
+	ClusterPackages pack.PackageService
+	// ClusterApps is the cluster's app service.
+	ClusterApps app.Applications
+	// Images is the cluster registry interface.
+	Images docker.ImageService
+	// Locator is the application locator to restore.
+	Locator loc.Locator
+	// Progress is the progress printer.
+	Progress utils.Printer
+}
+
+// RestoreApp downloads Docker images that application depends on but does not
+// vendor and returns package and app services containing the new application.
+//
+// It is used to restore integrity of the cluster/application images built as
+// an incremental upgrade before uploading them to the cluster storage, since
+// they only contain a subset of required images.
+func RestoreApp(ctx context.Context, req RestoreRequest) (*LayeredApps, error) {
+	application, err := req.Apps.GetApp(req.Locator)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Unpack the application to a temporary directory.
+	dir, err := ioutil.TempDir("", fmt.Sprintf("%v-%v-unpacked", req.Locator.Name, req.Locator.Version))
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	defer os.RemoveAll(dir)
+	req.Progress.PrintStep("Unpacking application to %v", dir)
+	err = pack.Unpack(req.Packages, req.Locator, dir, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Download images that the application doesn't vendor from the cluster
+	// registry to the application's registry directory.
+	registryDir := filepath.Join(dir, defaults.RegistryDir)
+	req.Progress.PrintStep("Resyncing Docker images from the cluster registry")
+	err = req.Images.SyncTo(ctx, registryDir, getMissingImages(*application), req.Progress)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Now that the application's "registry" directory contains all images,
+	// re-import it again.
+	stream, err := archive.Tar(dir, archive.Uncompressed)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	layered, err := NewLayeredApps(req.ClusterPackages)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.Progress.PrintStep("Importing restored application in %v", layered.dir)
+	_, err = app.ImportApplication(stream, layered.Packages, layered.Apps)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return layered, nil
+}
+
+// getMissingImages returns a list of Docker images that the application
+// depends on but does not vendor e.g. in case of an incremental upgrade
+// image).
+func getMissingImages(application app.Application) (result []docker.Image) {
+	images := application.Manifest.Status.DockerImages
+	for _, image := range images.All {
+		if !images.Vendored.Has(image.Repository, image.Tag) {
+			result = append(result, docker.Image{
+				Repository: image.Repository,
+				Tags:       []string{image.Tag},
+			})
+		}
+	}
+	return result
+}

--- a/lib/app/service/restore.go
+++ b/lib/app/service/restore.go
@@ -89,11 +89,13 @@ func RestoreApp(ctx context.Context, req RestoreRequest) (*LayeredApps, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	layered, err := NewLayeredApps(req.ClusterPackages)
+	layered, err := NewLayeredApps(LayeredAppsConfig{
+		Packages: req.ClusterPackages,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	req.Progress.PrintStep("Importing restored application in %v", layered.dir)
+	req.Progress.PrintStep("Importing restored application in %v", layered.Dir)
 	_, err = app.ImportApplication(stream, layered.Packages, layered.Apps)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/app/service/sync.go
+++ b/lib/app/service/sync.go
@@ -60,8 +60,12 @@ func SyncApp(ctx context.Context, req SyncRequest) error {
 	}
 
 	application, err := req.AppService.GetApp(req.Package)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
+	}
+	if trace.IsNotFound(err) {
+		log.Warnf("App %v not found, skipping registry sync.", req.Package)
+		return nil
 	}
 
 	// sync base app
@@ -136,7 +140,7 @@ func SyncApp(ctx context.Context, req SyncRequest) error {
 
 	log.Infof("Syncing %v.", req.Package)
 
-	if _, err = req.ImageService.Sync(ctx, syncPath, req.Progress); err != nil {
+	if _, err = req.ImageService.SyncFrom(ctx, syncPath, req.Progress); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/builder/application.go
+++ b/lib/builder/application.go
@@ -87,7 +87,7 @@ func (b *applicationBuilder) Build(ctx context.Context, req ApplicationRequest) 
 			return trace.Wrap(err)
 		}
 		req.Vendor.SkipImages = response.Images
-		upgradeFrom = response.Manifest.LocatorP()
+		upgradeFrom = response.Manifest.LocatorPtr()
 	}
 
 	vendorDir, err := ioutil.TempDir("", "vendor")

--- a/lib/builder/generator.go
+++ b/lib/builder/generator.go
@@ -27,15 +27,13 @@ import (
 type Generator interface {
 	// Generate generates an installer tarball for the specified application
 	// using the provided builder and returns its data as a stream
-	Generate(*Engine, *schema.Manifest, app.Application) (io.ReadCloser, error)
+	Generate(*Engine, *schema.Manifest, app.InstallerRequest) (io.ReadCloser, error)
 }
 
 type generator struct{}
 
 // Generate generates an installer tarball for the specified application
 // using the provided builder and returns its data as a stream
-func (g *generator) Generate(engine *Engine, manifest *schema.Manifest, application app.Application) (io.ReadCloser, error) {
-	return engine.Apps.GetAppInstaller(app.InstallerRequest{
-		Application: application.Package,
-	})
+func (g *generator) Generate(engine *Engine, manifest *schema.Manifest, req app.InstallerRequest) (io.ReadCloser, error) {
+	return engine.Apps.GetAppInstaller(req)
 }

--- a/lib/builder/inspector.go
+++ b/lib/builder/inspector.go
@@ -100,7 +100,7 @@ func InspectCluster(ctx context.Context, path string, vendor service.VendorReque
 	}, nil
 }
 
-// InspectImage returns information about the specified tarball image.
+// InspectImage returns information about the tarball image specified with path.
 func InspectImage(ctx context.Context, path string) (*InspectResponse, error) {
 	// Cluster and application images built with recent versions of tele include
 	// Docker images information in the application metadata.

--- a/lib/builder/inspector.go
+++ b/lib/builder/inspector.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/docker"
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/localenv"
+	"github.com/gravitational/gravity/lib/pack"
+	"github.com/gravitational/gravity/lib/schema"
+
+	"github.com/gravitational/trace"
+	"k8s.io/helm/pkg/chartutil"
+)
+
+// InspectResponse contains information about inspected cluster/application images.
+type InspectResponse struct {
+	// Manifest is the image manifest.
+	Manifest *schema.Manifest
+	// Images is a list of Docker images vendored in the image.
+	Images loc.DockerImages
+}
+
+// ImagesAsStrings returns a list of images as strings without registry.
+func (r InspectResponse) ImagesAsStrings() (result []string) {
+	for _, image := range r.Images {
+		result = append(result, fmt.Sprintf("%v:%v", image.Repository, image.Tag))
+	}
+	return result
+}
+
+// InspectChart returns information about the specified Helm chart.
+func InspectChart(ctx context.Context, path string, vendor service.VendorRequest) (*InspectResponse, error) {
+	chart, err := chartutil.Load(path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	manifest, err := generateApplicationImageManifest(chart)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vendorer, err := service.NewVendorer(service.VendorerConfig{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	images, err := vendorer.Images(path, vendor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InspectResponse{
+		Manifest: manifest,
+		Images:   images,
+	}, nil
+}
+
+// InspectCluster returns information about the specified cluster image source.
+func InspectCluster(ctx context.Context, path string, vendor service.VendorRequest) (*InspectResponse, error) {
+	source, err := GetClusterImageSource(path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	manifest, err := source.Manifest()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vendorer, err := service.NewVendorer(service.VendorerConfig{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	vendor.ManifestPath = path
+	images, err := vendorer.Images(source.Dir(), vendor)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InspectResponse{
+		Manifest: manifest,
+		Images:   images,
+	}, nil
+}
+
+// InspectImage returns information about the specified tarball image.
+func InspectImage(ctx context.Context, path string) (*InspectResponse, error) {
+	// Cluster and application images built with recent versions of tele include
+	// Docker images information in the application metadata.
+	response, err := getImagesFromAppMetadata(path)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	if response != nil {
+		return response, nil
+	}
+	// For older images fallback to extracting image references directly from
+	// the registry layers (which is much slower).
+	response, err = getImagesFromRegistry(ctx, path)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return response, nil
+}
+
+// getImagesFromAppMetadata returns Docker images information from the metadata
+// of the application packaged in the specified image.
+func getImagesFromAppMetadata(path string) (*InspectResponse, error) {
+	env, err := localenv.NewImageEnvironment(localenv.ImageEnvironmentConfig{
+		Path:   path,
+		DBOnly: true,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer env.Close()
+	if len(env.Manifest.Status.DockerImages.Vendored) == 0 {
+		return nil, trace.NotFound("%v metadata doesn't contain image references",
+			env.Manifest.Locator())
+	}
+	return &InspectResponse{
+		Manifest: env.Manifest,
+		Images:   env.Manifest.Status.DockerImages.Vendored,
+	}, nil
+}
+
+// getImagesFromRegistry returns Docker images information from the registry
+// layers of the application packaged in the specified image.
+func getImagesFromRegistry(ctx context.Context, path string) (*InspectResponse, error) {
+	env, err := localenv.NewImageEnvironment(localenv.ImageEnvironmentConfig{
+		Path: path,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer env.Close()
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer os.RemoveAll(dir)
+	err = pack.Unpack(env.Packages, env.Manifest.Locator(), dir, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	images, err := docker.ListImages(ctx, filepath.Join(dir, defaults.RegistryDir))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &InspectResponse{
+		Manifest: env.Manifest,
+		Images:   images,
+	}, nil
+}

--- a/lib/docker/api.go
+++ b/lib/docker/api.go
@@ -48,9 +48,12 @@ type DockerInterface interface {
 
 // ImageService defines an interface to a private docker registry
 type ImageService interface {
-	// Sync synchronizes the contents of dir with this private docker registry
+	// SyncFrom synchronizes the contents of dir with this private docker registry
 	// Returns the list of images synced
-	Sync(ctx context.Context, dir string, progress utils.Printer) ([]TagSpec, error)
+	SyncFrom(ctx context.Context, dir string, progress utils.Printer) ([]TagSpec, error)
+
+	// SyncTo pulls the specified images from this image service into the specified directory.
+	SyncTo(ctx context.Context, dir string, images []Image, progress utils.Printer) error
 
 	// Wrap translates the specified image name to point to the private registry.
 	Wrap(image string) string

--- a/lib/docker/scanningimageservice.go
+++ b/lib/docker/scanningimageservice.go
@@ -128,7 +128,7 @@ func (r *scanningImageService) Sync(ctx context.Context, dir string, progress ut
 					Actions:    []string{"push"},
 				})
 			}
-			if err = r.remoteStore.updateRepo(ctx, remoteRepo, localRepo, localManifest, tagSpec.Version); err != nil {
+			if _, err = r.remoteStore.updateRepo(ctx, remoteRepo, localRepo, localManifest, tagSpec.Version); err != nil {
 				return nil, trace.Wrap(err, "failed to update remote for tag %q: %v", tagSpec, err)
 			}
 

--- a/lib/docker/testhelpers.go
+++ b/lib/docker/testhelpers.go
@@ -1,0 +1,84 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/utils"
+
+	dockerapi "github.com/fsouza/go-dockerclient"
+)
+
+// MockDocker is a mock Docker client implementation used in unit tests.
+type MockDocker struct{}
+
+// InspectImage retrieves metadata for the specified image
+func (d *MockDocker) InspectImage(name string) (*dockerapi.Image, error) {
+	return nil, nil
+}
+
+// TagImage tags the image specified with name
+func (d *MockDocker) TagImage(name string, opt dockerapi.TagImageOptions) error {
+	return nil
+}
+
+// PushImage pushes the image specified with opts using the specified
+// authentication configuration
+func (d *MockDocker) PushImage(opts dockerapi.PushImageOptions, auth dockerapi.AuthConfiguration) error {
+	return nil
+}
+
+// RemoveImage removes the specified image
+func (d *MockDocker) RemoveImage(image string) error {
+	return nil
+}
+
+// CreateContainer creates a container instance based on the given configuration
+func (d *MockDocker) CreateContainer(opts dockerapi.CreateContainerOptions) (*dockerapi.Container, error) {
+	return nil, nil
+}
+
+// RemoveContainer removes the container given with opts
+func (d *MockDocker) RemoveContainer(opts dockerapi.RemoveContainerOptions) error {
+	return nil
+}
+
+// ExportContainer exports the contents of the running container given with opts
+// as a tarball
+func (d *MockDocker) ExportContainer(opts dockerapi.ExportContainerOptions) error {
+	return nil
+}
+
+// Version returns version information about the docker server.
+func (d *MockDocker) Version() (*dockerapi.Env, error) {
+	return nil, nil
+}
+
+// MockImageService is a mock image service implementation used in unit tests.
+type MockImageService struct{}
+
+// SyncFrom synchronizes the contents of dir with this private docker registry
+// Returns the list of images synced
+func (s *MockImageService) SyncFrom(ctx context.Context, dir string, progress utils.Printer) ([]TagSpec, error) {
+	return nil, nil
+}
+
+// SyncTo pulls the specified images from this image service into the specified directory.
+func (s *MockImageService) SyncTo(ctx context.Context, dir string, images []Image, progress utils.Printer) error {
+	return nil
+}
+
+// Wrap translates the specified image name to point to the private registry.
+func (s *MockImageService) Wrap(image string) string {
+	return image
+}
+
+// Unwrap translates the specified image name to point to the original repository
+// if it's prefixed with this registry address - functional inverse of Wrap
+func (s *MockImageService) Unwrap(image string) string {
+	return image
+}
+
+// List fetches a list of all images from the registry
+func (s *MockImageService) List(context.Context) ([]Image, error) {
+	return nil, nil
+}

--- a/lib/install/phases/export.go
+++ b/lib/install/phases/export.go
@@ -151,7 +151,7 @@ func (p *exportExecutor) exportApp(ctx context.Context, locator loc.Locator) err
 		locator.Name, locator.Version)
 	p.Infof("Exporting application %v:%v to local registry.",
 		locator.Name, locator.Version)
-	_, err := p.ImageService.Sync(ctx, p.registryPath(locator), utils.DiscardPrinter)
+	_, err := p.ImageService.SyncFrom(ctx, p.registryPath(locator), utils.DiscardPrinter)
 	return trace.Wrap(err)
 }
 

--- a/lib/loc/cli.go
+++ b/lib/loc/cli.go
@@ -58,6 +58,46 @@ func LocatorSlice(s kingpin.Settings) *Locators {
 // DockerImages represent a slice of DockerImage.
 type DockerImages []DockerImage
 
+// Images returns a list of images as strings.
+func (d *DockerImages) Images() (result []string) {
+	for _, image := range *d {
+		result = append(result, image.String())
+	}
+	return result
+}
+
+// Tags returns a list of tags for the specified repository from these images.
+func (i DockerImages) Tags(repository string) (tags []string) {
+	for _, image := range i {
+		if image.Repository == repository {
+			tags = append(tags, image.Tag)
+		}
+	}
+	return tags
+}
+
+// Repositories returns a list of repositories from these images.
+func (i DockerImages) Repositories() (repositories []string) {
+	repositoriesMap := map[string]struct{}{}
+	for _, image := range i {
+		repositoriesMap[image.Repository] = struct{}{}
+	}
+	for repository := range repositoriesMap {
+		repositories = append(repositories, repository)
+	}
+	return repositories
+}
+
+// Has returns true if this list contains the image with specified repository and tag.
+func (i DockerImages) Has(repository, tag string) bool {
+	for _, image := range i {
+		if image.Repository == repository && image.Tag == tag {
+			return true
+		}
+	}
+	return false
+}
+
 // IsCumulative indicates that DockerImages is a cumulative argument.
 func (*DockerImages) IsCumulative() bool {
 	return true

--- a/lib/loc/diff.go
+++ b/lib/loc/diff.go
@@ -51,23 +51,11 @@ func DiffDockerImages(left, right DockerImages) (results []RepositoryDiff) {
 		sort.Strings(repoTags)
 		result := RepositoryDiff{Repository: repo}
 		for _, tag := range repoTags {
-			if left.Has(repo, tag) && right.Has(repo, tag) {
-				result.Tags = append(result.Tags, TagDiff{
-					Tag:   tag,
-					Left:  true,
-					Right: true,
-				})
-			} else if left.Has(repo, tag) {
-				result.Tags = append(result.Tags, TagDiff{
-					Tag:  tag,
-					Left: true,
-				})
-			} else if right.Has(repo, tag) {
-				result.Tags = append(result.Tags, TagDiff{
-					Tag:   tag,
-					Right: true,
-				})
-			}
+			result.Tags = append(result.Tags, TagDiff{
+				Tag:   tag,
+				Left:  left.Has(repo, tag),
+				Right: right.Has(repo, tag),
+			})
 		}
 		results = append(results, result)
 	}

--- a/lib/loc/diff.go
+++ b/lib/loc/diff.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loc
+
+import (
+	"sort"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// RepositoryDiff represents the difference in Docker images for a particular repository.
+type RepositoryDiff struct {
+	// Repository is the Docker image repository.
+	Repository string
+	// Tags are the tags for this repository.
+	Tags []TagDiff
+}
+
+// TagDiff represents the particular tag presence in the compared lists.
+type TagDiff struct {
+	// Tag is the Docker image tag.
+	Tag string
+	// Left is true if the tag is present in the "left" images list.
+	Left bool
+	// Right is true if the tag is present in the "right" images list.
+	Right bool
+}
+
+// DiffDockerImages returns the difference between the provided Docker images.
+func DiffDockerImages(left, right DockerImages) (results []RepositoryDiff) {
+	allRepos := append(left.Repositories(), right.Repositories()...)
+	allRepos = utils.Deduplicate(allRepos)
+	sort.Strings(allRepos)
+	for _, repo := range allRepos {
+		repoTags := append(left.Tags(repo), right.Tags(repo)...)
+		repoTags = utils.Deduplicate(repoTags)
+		sort.Strings(repoTags)
+		result := RepositoryDiff{Repository: repo}
+		for _, tag := range repoTags {
+			if left.Has(repo, tag) && right.Has(repo, tag) {
+				result.Tags = append(result.Tags, TagDiff{
+					Tag:   tag,
+					Left:  true,
+					Right: true,
+				})
+			} else if left.Has(repo, tag) {
+				result.Tags = append(result.Tags, TagDiff{
+					Tag:  tag,
+					Left: true,
+				})
+			} else if right.Has(repo, tag) {
+				result.Tags = append(result.Tags, TagDiff{
+					Tag:   tag,
+					Right: true,
+				})
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}

--- a/lib/loc/diff_test.go
+++ b/lib/loc/diff_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loc
+
+import (
+	"gopkg.in/check.v1"
+)
+
+type DiffSuite struct{}
+
+var _ = check.Suite(&DiffSuite{})
+
+func (s *DiffSuite) TestDiffDockerImages(c *check.C) {
+	c.Assert(DiffDockerImages(DockerImages{
+		{
+			Repository: "gravitational/debian-tall",
+			Tag:        "0.0.1",
+		},
+		{
+			Repository: "redis",
+			Tag:        "4.0.0",
+		},
+		{
+			Repository: "mongodb",
+			Tag:        "6.0.0",
+		},
+		{
+			Repository: "robotshop/rs-user",
+			Tag:        "latest",
+		},
+	}, DockerImages{
+		{
+			Repository: "gravitational/debian-tall",
+			Tag:        "0.0.1",
+		},
+		{
+			Repository: "gravitational/debian-tall",
+			Tag:        "buster",
+		},
+		{
+			Repository: "redis",
+			Tag:        "5.0.0",
+		},
+		{
+			Repository: "postgresql",
+			Tag:        "11.0.0",
+		},
+		{
+			Repository: "robotshop/rs-user",
+			Tag:        "latest",
+		},
+	}), check.DeepEquals, []RepositoryDiff{
+		{
+			Repository: "gravitational/debian-tall",
+			Tags: []TagDiff{
+				{Tag: "0.0.1", Left: true, Right: true},
+				{Tag: "buster", Left: false, Right: true},
+			},
+		},
+		{
+			Repository: "mongodb",
+			Tags: []TagDiff{
+				{Tag: "6.0.0", Left: true, Right: false},
+			},
+		},
+		{
+			Repository: "postgresql",
+			Tags: []TagDiff{
+				{Tag: "11.0.0", Left: false, Right: true},
+			},
+		},
+		{
+			Repository: "redis",
+			Tags: []TagDiff{
+				{Tag: "4.0.0", Left: true, Right: false},
+				{Tag: "5.0.0", Left: false, Right: true},
+			},
+		},
+		{
+			Repository: "robotshop/rs-user",
+			Tags: []TagDiff{
+				{Tag: "latest", Left: true, Right: true},
+			},
+		},
+	})
+}

--- a/lib/loc/docker.go
+++ b/lib/loc/docker.go
@@ -23,7 +23,7 @@ import (
 )
 
 type DockerImage struct {
-	Registry   string `json:"registry"`
+	Registry   string `json:"registry,omitempty"`
 	Repository string `json:"repository"`
 	Tag        string `json:"tag"`
 }
@@ -43,6 +43,14 @@ func (d *DockerImage) String() string {
 	return out
 }
 
+// WithoutRegistry returns the same Docker image without the registry part.
+func (d *DockerImage) WithoutRegistry() *DockerImage {
+	return &DockerImage{
+		Repository: d.Repository,
+		Tag:        d.Tag,
+	}
+}
+
 // ParseDockerImage parses docker image
 func ParseDockerImage(image string) (*DockerImage, error) {
 	if image == "" {
@@ -57,6 +65,18 @@ func ParseDockerImage(image string) (*DockerImage, error) {
 		return &DockerImage{Registry: "", Repository: strings.Join(parts, "/"), Tag: tag}, nil
 	}
 	return &DockerImage{Registry: parts[0], Repository: strings.Join(parts[1:], "/"), Tag: tag}, nil
+}
+
+// ParseDockerImages parses a list of Docker images.
+func ParseDockerImages(images []string) (result []DockerImage, err error) {
+	for _, image := range images {
+		parsed, err := ParseDockerImage(image)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		result = append(result, *parsed)
+	}
+	return result, nil
 }
 
 // Get a repos name and returns the right reposName + tag|digest

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -172,8 +172,8 @@ func (l Locator) String() string {
 	return str
 }
 
-// Human returns user-friendly string representation of the locator.
-func (l Locator) Human() string {
+// Description returns user-friendly string representation of the locator.
+func (l Locator) Description() string {
 	return fmt.Sprintf("%v v%v", l.Name, l.Version)
 }
 

--- a/lib/loc/loc.go
+++ b/lib/loc/loc.go
@@ -172,6 +172,11 @@ func (l Locator) String() string {
 	return str
 }
 
+// Human returns user-friendly string representation of the locator.
+func (l Locator) Human() string {
+	return fmt.Sprintf("%v v%v", l.Name, l.Version)
+}
+
 // WithVersion returns a copy of this locator with version set to the specified one
 func (l Locator) WithVersion(version *semver.Version) Locator {
 	return Locator{

--- a/lib/pack/constants.go
+++ b/lib/pack/constants.go
@@ -29,6 +29,9 @@ const (
 	AdvertiseIPLabel = "advertise-ip"
 	// OperationIDLabel contains ID of the operation the package was configured for
 	OperationIDLabel = "operation-id"
+	// UpgradeFromLabel contains locator of the application the incremental
+	// installer was built off of.
+	UpgradeFromLabel = "upgrade-from"
 
 	// PurposeCA marks the planet certificate authority package
 	PurposeCA = "ca"

--- a/lib/pack/options.go
+++ b/lib/pack/options.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package pack
 
-import "github.com/gravitational/gravity/lib/storage"
+import (
+	"github.com/gravitational/gravity/lib/storage"
+)
 
 // WithLabels adds the specified labels as runtime labels to a package
 func WithLabels(labels map[string]string) PackageOption {

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -168,8 +168,8 @@ func (m Manifest) Locator() loc.Locator {
 	}
 }
 
-// LocatorP returns a pointer to the manifest's app locator.
-func (m Manifest) LocatorP() *loc.Locator {
+// LocatorPtr returns a pointer to the manifest's app locator.
+func (m Manifest) LocatorPtr() *loc.Locator {
 	locator := m.Locator()
 	return &locator
 }

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -77,6 +77,22 @@ type Manifest struct {
 	Extensions *Extensions `json:"extensions,omitempty"`
 	// WebConfig allows to specify config.js used by UI to customize installer
 	WebConfig string `json:"webConfig,omitempty"`
+	// Status contains runtime cluster or application image information
+	Status Status `json:"status,omitempty"`
+}
+
+// Status contains runtime cluster or application image information.
+type Status struct {
+	// DockerImages contains information about the application's Docker images.
+	DockerImages DockerImages `json:"dockerImages,omitempty"`
+}
+
+// DockerImages contains information about the application's Docker images.
+type DockerImages struct {
+	// All is a list of all Docker images the application depends on.
+	All loc.DockerImages `json:"all,omitempty"`
+	// Vendored is a list of Docker images vendored in the tarball.
+	Vendored loc.DockerImages `json:"vendored,omitempty"`
 }
 
 // BaseImage defines a base image type which is basically a locator with
@@ -150,6 +166,12 @@ func (m Manifest) Locator() loc.Locator {
 		Name:       m.Metadata.Name,
 		Version:    m.Metadata.ResourceVersion,
 	}
+}
+
+// LocatorP returns a pointer to the manifest's app locator.
+func (m Manifest) LocatorP() *loc.Locator {
+	locator := m.Locator()
+	return &locator
 }
 
 // SetBase sets a runtime application to the provided locator

--- a/lib/schema/schema.go
+++ b/lib/schema/schema.go
@@ -350,6 +350,18 @@ const manifestSchema = `
             "type": {"type": "string", "default": "certificate"}
           }
         },
+        "status": {
+          "type": "object",
+          "properties": {
+            "dockerImages": {
+              "type": "object",
+              "properties": {
+                "all": {"$ref": "#/definitions/dockerImages"},
+                "vendored": {"$ref": "#/definitions/dockerImages"}
+              }
+            }
+          }
+        },
         "hooks": {
           "type": "object",
           "additionalProperties": false,
@@ -729,6 +741,17 @@ const manifestSchema = `
       "properties": {
         "disabled": {"type": "boolean"}
       }
+    },
+    "dockerImages": {
+      "type": "array",
+      "items": {  
+        "type": "object",
+        "properties": {
+          "registry": {"type": "string"},
+          "repository": {"type": "string"},
+          "tag": {"type": "string"}
+        }
+      } 
     }
   }
 }

--- a/tool/gravity/cli/clusterupdate.go
+++ b/tool/gravity/cli/clusterupdate.go
@@ -445,10 +445,8 @@ func (r *clusterInitializer) checkAppIntegrity(env *localenv.LocalEnvironment, u
 	err = app.VerifyDependencies(upgradeApp, apps, packages)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to verify %v dependencies.", upgradeApp)
-		return trace.BadParameter(`There was an issue trying to verify %v cluster image integrity.
-
-Some required dependencies are missing from the cluster store. Check logs for more details.`,
-			upgradeApp.Package.Human())
+		return trace.BadParameter("Some required dependencies are missing from the cluster store for image %v. Check logs for more details.",
+			upgradeApp.Package.Description())
 	}
 	log.Infof("All required dependencies for %v are present.", upgradeApp)
 	return nil

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -654,8 +654,9 @@ type UpdateUploadCmd struct {
 	*kingpin.CmdClause
 	// OpsCenterURL is cluster URL
 	OpsCenterURL *string
-	// Force allows to override certain preconditions.
-	Force *bool
+	// SkipVersionCheck overrides the installed version check when uploading
+	// an incremental upgrade image.
+	SkipVersionCheck *bool
 }
 
 // UpdateCompleteCmd marks update operation as completed

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -654,6 +654,8 @@ type UpdateUploadCmd struct {
 	*kingpin.CmdClause
 	// OpsCenterURL is cluster URL
 	OpsCenterURL *string
+	// Force allows to override certain preconditions.
+	Force *bool
 }
 
 // UpdateCompleteCmd marks update operation as completed

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -591,7 +591,7 @@ func (i *InstallConfig) validateApplication() error {
 	if upgradeFrom != nil {
 		return trace.BadParameter("This cluster image was built as an incremental "+
 			"upgrade from %v. It cannot be used to perform full installation as "+
-			"only contains a subset of Docker images.", upgradeFrom.Human())
+			"it only contains a subset of Docker images.", upgradeFrom.Description())
 	}
 	return nil
 }

--- a/tool/gravity/cli/helm.go
+++ b/tool/gravity/cli/helm.go
@@ -157,7 +157,9 @@ func releaseInstall(env *localenv.LocalEnvironment, conf releaseInstallConfig) e
 		conf.Image = result.Path
 		defer result.Close() // Remove downloaded tarball after install.
 	}
-	imageEnv, err := localenv.NewImageEnvironment(conf.Image)
+	imageEnv, err := localenv.NewImageEnvironment(localenv.ImageEnvironmentConfig{
+		Path: conf.Image,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -264,7 +266,9 @@ func releaseUpgrade(env *localenv.LocalEnvironment, conf releaseUpgradeConfig) e
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	imageEnv, err := localenv.NewImageEnvironment(conf.Image)
+	imageEnv, err := localenv.NewImageEnvironment(localenv.ImageEnvironmentConfig{
+		Path: conf.Image,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -223,7 +223,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.UpdateUploadCmd.CmdClause = g.UpdateCmd.Command("upload", "Upload update package to locally running site").Hidden()
 	g.UpdateUploadCmd.OpsCenterURL = g.UpdateUploadCmd.Flag("ops-url", "Optional Gravity Hub URL to upload new packages to (defaults to local gravity site)").Default(defaults.GravityServiceURL).String()
-	g.UpdateUploadCmd.Force = g.UpdateUploadCmd.Flag("force", "Bypass checks that would have otherwise resulted in the rejected upload").Bool()
+	g.UpdateUploadCmd.SkipVersionCheck = g.UpdateUploadCmd.Flag("skip-version-check", "Suppress the installed application version check when uploading an incremental upgrade image").Bool()
 
 	// manual update flow commands
 	g.UpdateCompleteCmd.CmdClause = g.UpdateCmd.Command("complete", "Mark update operation as completed").Hidden()

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -223,6 +223,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 
 	g.UpdateUploadCmd.CmdClause = g.UpdateCmd.Command("upload", "Upload update package to locally running site").Hidden()
 	g.UpdateUploadCmd.OpsCenterURL = g.UpdateUploadCmd.Flag("ops-url", "Optional Gravity Hub URL to upload new packages to (defaults to local gravity site)").Default(defaults.GravityServiceURL).String()
+	g.UpdateUploadCmd.Force = g.UpdateUploadCmd.Flag("force", "Bypass checks that would have otherwise resulted in the rejected upload").Bool()
 
 	// manual update flow commands
 	g.UpdateCompleteCmd.CmdClause = g.UpdateCmd.Command("complete", "Mark update operation as completed").Hidden()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -534,7 +534,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 		}
 		return uploadUpdate(context.Background(), tarballEnv, localEnv,
 			*g.UpdateUploadCmd.OpsCenterURL,
-			*g.UpdateUploadCmd.Force)
+			*g.UpdateUploadCmd.SkipVersionCheck)
 	case g.AppPackageCmd.FullCommand():
 		return appPackage(localEnv)
 		// app commands

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -533,7 +533,8 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			return trace.Wrap(err)
 		}
 		return uploadUpdate(context.Background(), tarballEnv, localEnv,
-			*g.UpdateUploadCmd.OpsCenterURL)
+			*g.UpdateUploadCmd.OpsCenterURL,
+			*g.UpdateUploadCmd.Force)
 	case g.AppPackageCmd.FullCommand():
 		return appPackage(localEnv)
 		// app commands

--- a/tool/gravity/cli/sync.go
+++ b/tool/gravity/cli/sync.go
@@ -83,7 +83,9 @@ func (c registryConfig) imageService() (docker.ImageService, error) {
 }
 
 func appSync(env *localenv.LocalEnvironment, conf appSyncConfig) error {
-	imageEnv, err := localenv.NewImageEnvironment(conf.Image)
+	imageEnv, err := localenv.NewImageEnvironment(localenv.ImageEnvironmentConfig{
+		Path: conf.Image,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tele/cli/build.go
+++ b/tool/tele/cli/build.go
@@ -93,8 +93,8 @@ func printDiff(oldImage, newImage *builder.InspectResponse) {
 	diffResults := loc.DiffDockerImages(oldImage.Images, newImage.Images)
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
 	common.PrintTableHeader(t, []string{"",
-		oldImage.Manifest.Locator().Human(),
-		newImage.Manifest.Locator().Human()})
+		oldImage.Manifest.Locator().Description(),
+		newImage.Manifest.Locator().Description()})
 	for _, diff := range diffResults {
 		var oldTags, newTags []string
 		for _, tag := range diff.Tags {

--- a/tool/tele/cli/buildparameters.go
+++ b/tool/tele/cli/buildparameters.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cli
+
+import (
+	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/builder"
+	"github.com/gravitational/gravity/lib/helm"
+	"github.com/gravitational/gravity/lib/utils"
+)
+
+// BuildParameters represents the arguments provided for building an application
+type BuildParameters struct {
+	// StateDir is build state directory, if was specified
+	StateDir string
+	// SourcePath is the path to a manifest file or a Helm chart to build image from
+	SourcePath string
+	// OutPath holds the path to the installer tarball to be output
+	OutPath string
+	// Overwrite indicates whether or not to overwrite an existing installer file
+	Overwrite bool
+	// SkipVersionCheck indicates whether or not to perform the version check of the tele binary with the application's runtime at build time
+	SkipVersionCheck bool
+	// Silent is whether builder should report progress to the console
+	Silent bool
+	// Verbose turns on more detailed progress output
+	Verbose bool
+	// Insecure turns on insecure verify mode
+	Insecure bool
+	// Vendor combines vendoring parameters
+	Vendor service.VendorRequest
+	// BaseImage sets base image for the cluster image
+	BaseImage string
+	// UpgradeFrom is the path to the base image when building incremental upgrade image.
+	UpgradeFrom string
+	// SkipBaseCheck bypasses base image version check when building incremental image.
+	SkipBaseCheck bool
+}
+
+// Level returns level at which the progress should be reported based on the CLI parameters.
+func (p BuildParameters) Level() utils.ProgressLevel {
+	if p.Silent { // No output.
+		return utils.ProgressLevelNone
+	} else if p.Verbose { // Detailed output.
+		return utils.ProgressLevelDebug
+	}
+	return utils.ProgressLevelInfo // Normal output.
+}
+
+// BuilderConfig makes builder config from CLI parameters.
+func (p BuildParameters) BuilderConfig() builder.Config {
+	return builder.Config{
+		StateDir:         p.StateDir,
+		Insecure:         p.Insecure,
+		SkipVersionCheck: p.SkipVersionCheck,
+		Parallel:         p.Vendor.Parallel,
+		Level:            p.Level(),
+	}
+}
+
+// BuildCommandParameters returns build parameters for the tele build command.
+func BuildCommandParameters(tele Application) BuildParameters {
+	return BuildParameters{
+		StateDir:         *tele.StateDir,
+		SourcePath:       *tele.BuildCmd.Path,
+		OutPath:          *tele.BuildCmd.OutFile,
+		Overwrite:        *tele.BuildCmd.Overwrite,
+		SkipVersionCheck: *tele.BuildCmd.SkipVersionCheck,
+		Silent:           *tele.BuildCmd.Quiet,
+		Verbose:          *tele.BuildCmd.Verbose,
+		BaseImage:        *tele.BuildCmd.BaseImage,
+		Insecure:         *tele.Insecure,
+		UpgradeFrom:      *tele.BuildCmd.UpgradeFrom,
+		SkipBaseCheck:    *tele.BuildCmd.SkipBaseCheck,
+		Vendor: service.VendorRequest{
+			PackageName:            *tele.BuildCmd.Name,
+			PackageVersion:         *tele.BuildCmd.Version,
+			ResourcePatterns:       *tele.BuildCmd.VendorPatterns,
+			IgnoreResourcePatterns: *tele.BuildCmd.VendorIgnorePatterns,
+			SetImages:              *tele.BuildCmd.SetImages,
+			SetDeps:                *tele.BuildCmd.SetDeps,
+			Parallel:               *tele.BuildCmd.Parallel,
+			VendorRuntime:          true,
+			Helm: helm.RenderParameters{
+				Values: *tele.BuildCmd.Values,
+				Set:    *tele.BuildCmd.Set,
+			},
+			Pull: *tele.BuildCmd.Pull,
+		},
+	}
+}
+
+// HelmBuildCommandParameters returns build parameters for the tele helm build command.
+func HelmBuildCommandParameters(tele Application) BuildParameters {
+	return BuildParameters{
+		StateDir:    *tele.StateDir,
+		SourcePath:  *tele.HelmBuildCmd.Path,
+		OutPath:     *tele.HelmBuildCmd.OutFile,
+		Overwrite:   *tele.HelmBuildCmd.Overwrite,
+		Silent:      *tele.HelmBuildCmd.Quiet,
+		Verbose:     *tele.HelmBuildCmd.Verbose,
+		Insecure:    *tele.Insecure,
+		UpgradeFrom: *tele.HelmBuildCmd.UpgradeFrom,
+		Vendor: service.VendorRequest{
+			ResourcePatterns:       *tele.HelmBuildCmd.VendorPatterns,
+			IgnoreResourcePatterns: *tele.HelmBuildCmd.VendorIgnorePatterns,
+			SetImages:              *tele.HelmBuildCmd.SetImages,
+			Parallel:               *tele.HelmBuildCmd.Parallel,
+			Helm: helm.RenderParameters{
+				Values: *tele.HelmBuildCmd.Values,
+				Set:    *tele.HelmBuildCmd.Set,
+			},
+			Pull: *tele.HelmBuildCmd.Pull,
+		},
+	}
+}

--- a/tool/tele/cli/buildparameters.go
+++ b/tool/tele/cli/buildparameters.go
@@ -30,7 +30,7 @@ type BuildParameters struct {
 	SourcePath string
 	// OutPath holds the path to the installer tarball to be output
 	OutPath string
-	// Overwrite indicates whether or not to overwrite an existing installer file
+	// Overwrite indicates whether to overwrite an existing installer file
 	Overwrite bool
 	// SkipVersionCheck indicates whether or not to perform the version check of the tele binary with the application's runtime at build time
 	SkipVersionCheck bool
@@ -38,7 +38,7 @@ type BuildParameters struct {
 	Silent bool
 	// Verbose turns on more detailed progress output
 	Verbose bool
-	// Insecure turns on insecure verify mode
+	// Insecure turns off TLS verification
 	Insecure bool
 	// Vendor combines vendoring parameters
 	Vendor service.VendorRequest

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -86,6 +86,10 @@ type HelmBuildCmd struct {
 	Values *[]string
 	// Pull allows to force-pull Docker images even if they're already present.
 	Pull *bool
+	// UpgradeFrom is a path to the image to build an incremental image off of.
+	UpgradeFrom *string
+	// Diff shows differences between two images without building the image.
+	Diff *bool
 }
 
 // BuildCmd builds app installer tarball
@@ -125,6 +129,12 @@ type BuildCmd struct {
 	Pull *bool
 	// BaseImage allows to specify base image on the CLI.
 	BaseImage *string
+	// UpgradeFrom is a path to the image to build an incremental image off of.
+	UpgradeFrom *string
+	// Diff shows differences between two images without building the image.
+	Diff *bool
+	// SkipBaseCheck allows to skip base version check when building incremental image.
+	SkipBaseCheck *bool
 }
 
 type ListCmd struct {

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -58,6 +58,9 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.Values = tele.BuildCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 	tele.BuildCmd.Pull = tele.BuildCmd.Flag("pull", "Always attempt to pull newer versions of Docker images.").Bool()
 	tele.BuildCmd.BaseImage = tele.BuildCmd.Flag("with-base-image", "Specify base image to use, for example 'gravity:7.0.0'.").String()
+	tele.BuildCmd.UpgradeFrom = tele.BuildCmd.Flag("upgrade-from", "Build an incremental upgrade image from the specified cluster image. Only new Docker images will be vendored.").String()
+	tele.BuildCmd.Diff = tele.BuildCmd.Flag("diff", "Print Docker image differences between the image being built and the image specified with --upgrade-from flag.").Bool()
+	tele.BuildCmd.SkipBaseCheck = tele.BuildCmd.Flag("skip-base-check", "Bypass base image check when building an incremental upgrade image.").Bool()
 
 	tele.HelmCmd.CmdClause = app.Command("helm", "Operations with Helm charts.").Alias("app")
 
@@ -74,6 +77,8 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.HelmBuildCmd.Set = tele.HelmBuildCmd.Flag("set", "Set Helm chart values on the command line. Can be specified multiple times and/or as comma-separated values: key1=val1,key2=val2.").Strings()
 	tele.HelmBuildCmd.Values = tele.HelmBuildCmd.Flag("values", "Set Helm chart values from the provided YAML file. Can be specified multiple times.").Strings()
 	tele.HelmBuildCmd.Pull = tele.HelmBuildCmd.Flag("pull", "Always attempt to pull newer versions of Docker images.").Bool()
+	tele.HelmBuildCmd.UpgradeFrom = tele.HelmBuildCmd.Flag("upgrade-from", "Build an incremental image from the specified application image. Only new Docker images will be vendored.").String()
+	tele.HelmBuildCmd.Diff = tele.HelmBuildCmd.Flag("diff", "Print Docker image differences between the image being built and the image specified with --upgrade-from flag.").Bool()
 
 	tele.ListCmd.CmdClause = app.Command("ls", "List cluster and application images published to Gravity Hub.")
 	tele.ListCmd.Runtimes = tele.ListCmd.Flag("runtimes", "Show only runtimes.").Short('r').Hidden().Bool()

--- a/vendor/github.com/google/go-cmp/cmp/compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare.go
@@ -6,6 +6,10 @@
 //
 // This package is intended to be a more powerful and safer alternative to
 // reflect.DeepEqual for comparing whether two values are semantically equal.
+// It is intended to only be used in tests, as performance is not a goal and
+// it may panic if it cannot compare the values. Its propensity towards
+// panicking means that its unsuitable for production environments where a
+// spurious panic may be fatal.
 //
 // The primary features of cmp are:
 //
@@ -22,8 +26,8 @@
 // equality is determined by recursively comparing the primitive kinds on both
 // values, much like reflect.DeepEqual. Unlike reflect.DeepEqual, unexported
 // fields are not compared by default; they result in panics unless suppressed
-// by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly compared
-// using the AllowUnexported option.
+// by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly
+// compared using the Exporter option.
 package cmp
 
 import (
@@ -62,8 +66,8 @@ import (
 //
 // Structs are equal if recursively calling Equal on all fields report equal.
 // If a struct contains unexported fields, Equal panics unless an Ignore option
-// (e.g., cmpopts.IgnoreUnexported) ignores that field or the AllowUnexported
-// option explicitly permits comparing the unexported field.
+// (e.g., cmpopts.IgnoreUnexported) ignores that field or the Exporter option
+// explicitly permits comparing the unexported field.
 //
 // Slices are equal if they are both nil or both non-nil, where recursively
 // calling Equal on all non-ignored slice or array elements report equal.
@@ -80,7 +84,58 @@ import (
 // Pointers and interfaces are equal if they are both nil or both non-nil,
 // where they have the same underlying concrete type and recursively
 // calling Equal on the underlying values reports equal.
+//
+// Before recursing into a pointer, slice element, or map, the current path
+// is checked to detect whether the address has already been visited.
+// If there is a cycle, then the pointed at values are considered equal
+// only if both addresses were previously visited in the same path step.
 func Equal(x, y interface{}, opts ...Option) bool {
+	s := newState(opts)
+	s.compareAny(rootStep(x, y))
+	return s.result.Equal()
+}
+
+// Diff returns a human-readable report of the differences between two values.
+// It returns an empty string if and only if Equal returns true for the same
+// input values and options.
+//
+// The output is displayed as a literal in pseudo-Go syntax.
+// At the start of each line, a "-" prefix indicates an element removed from x,
+// a "+" prefix to indicates an element added to y, and the lack of a prefix
+// indicates an element common to both x and y. If possible, the output
+// uses fmt.Stringer.String or error.Error methods to produce more humanly
+// readable outputs. In such cases, the string is prefixed with either an
+// 's' or 'e' character, respectively, to indicate that the method was called.
+//
+// Do not depend on this output being stable. If you need the ability to
+// programmatically interpret the difference, consider using a custom Reporter.
+func Diff(x, y interface{}, opts ...Option) string {
+	s := newState(opts)
+
+	// Optimization: If there are no other reporters, we can optimize for the
+	// common case where the result is equal (and thus no reported difference).
+	// This avoids the expensive construction of a difference tree.
+	if len(s.reporters) == 0 {
+		s.compareAny(rootStep(x, y))
+		if s.result.Equal() {
+			return ""
+		}
+		s.result = diff.Result{} // Reset results
+	}
+
+	r := new(defaultReporter)
+	s.reporters = append(s.reporters, reporter{r})
+	s.compareAny(rootStep(x, y))
+	d := r.String()
+	if (d == "") != s.result.Equal() {
+		panic("inconsistent difference and equality results")
+	}
+	return d
+}
+
+// rootStep constructs the first path step. If x and y have differing types,
+// then they are stored within an empty interface type.
+func rootStep(x, y interface{}) PathStep {
 	vx := reflect.ValueOf(x)
 	vy := reflect.ValueOf(y)
 
@@ -103,33 +158,7 @@ func Equal(x, y interface{}, opts ...Option) bool {
 		t = vx.Type()
 	}
 
-	s := newState(opts)
-	s.compareAny(&pathStep{t, vx, vy})
-	return s.result.Equal()
-}
-
-// Diff returns a human-readable report of the differences between two values.
-// It returns an empty string if and only if Equal returns true for the same
-// input values and options.
-//
-// The output is displayed as a literal in pseudo-Go syntax.
-// At the start of each line, a "-" prefix indicates an element removed from x,
-// a "+" prefix to indicates an element added to y, and the lack of a prefix
-// indicates an element common to both x and y. If possible, the output
-// uses fmt.Stringer.String or error.Error methods to produce more humanly
-// readable outputs. In such cases, the string is prefixed with either an
-// 's' or 'e' character, respectively, to indicate that the method was called.
-//
-// Do not depend on this output being stable. If you need the ability to
-// programmatically interpret the difference, consider using a custom Reporter.
-func Diff(x, y interface{}, opts ...Option) string {
-	r := new(defaultReporter)
-	eq := Equal(x, y, Options(opts), Reporter(r))
-	d := r.String()
-	if (d == "") != eq {
-		panic("inconsistent difference and equality results")
-	}
-	return d
+	return &pathStep{t, vx, vy}
 }
 
 type state struct {
@@ -137,6 +166,7 @@ type state struct {
 	// Calling statelessCompare must not result in observable changes to these.
 	result    diff.Result // The current result of comparison
 	curPath   Path        // The current path in the value tree
+	curPtrs   pointerPath // The current set of visited pointers
 	reporters []reporter  // Optional reporters
 
 	// recChecker checks for infinite cycles applying the same set of
@@ -148,13 +178,14 @@ type state struct {
 	dynChecker dynChecker
 
 	// These fields, once set by processOption, will not change.
-	exporters map[reflect.Type]bool // Set of structs with unexported field visibility
-	opts      Options               // List of all fundamental and filter options
+	exporters []exporter // List of exporters for structs with unexported fields
+	opts      Options    // List of all fundamental and filter options
 }
 
 func newState(opts []Option) *state {
 	// Always ensure a validator option exists to validate the inputs.
 	s := &state{opts: Options{validator{}}}
+	s.curPtrs.Init()
 	s.processOption(Options(opts))
 	return s
 }
@@ -174,13 +205,8 @@ func (s *state) processOption(opt Option) {
 			panic(fmt.Sprintf("cannot use an unfiltered option: %v", opt))
 		}
 		s.opts = append(s.opts, opt)
-	case visibleStructs:
-		if s.exporters == nil {
-			s.exporters = make(map[reflect.Type]bool)
-		}
-		for t := range opt {
-			s.exporters[t] = true
-		}
+	case exporter:
+		s.exporters = append(s.exporters, opt)
 	case reporter:
 		s.reporters = append(s.reporters, opt)
 	default:
@@ -192,9 +218,9 @@ func (s *state) processOption(opt Option) {
 // This function is stateless in that it does not alter the current result,
 // or output to any registered reporters.
 func (s *state) statelessCompare(step PathStep) diff.Result {
-	// We do not save and restore the curPath because all of the compareX
-	// methods should properly push and pop from the path.
-	// It is an implementation bug if the contents of curPath differs from
+	// We do not save and restore curPath and curPtrs because all of the
+	// compareX methods should properly push and pop from them.
+	// It is an implementation bug if the contents of the paths differ from
 	// when calling this function to when returning from it.
 
 	oldResult, oldReporters := s.result, s.reporters
@@ -216,9 +242,17 @@ func (s *state) compareAny(step PathStep) {
 	}
 	s.recChecker.Check(s.curPath)
 
-	// Obtain the current type and values.
+	// Cycle-detection for slice elements (see NOTE in compareSlice).
 	t := step.Type()
 	vx, vy := step.Values()
+	if si, ok := step.(SliceIndex); ok && si.isSlice && vx.IsValid() && vy.IsValid() {
+		px, py := vx.Addr(), vy.Addr()
+		if eq, visited := s.curPtrs.Push(px, py); visited {
+			s.report(eq, reportByCycle)
+			return
+		}
+		defer s.curPtrs.Pop(px, py)
+	}
 
 	// Rule 1: Check whether an option applies on this node in the value tree.
 	if s.tryOptions(t, vx, vy) {
@@ -342,7 +376,7 @@ func detectRaces(c chan<- reflect.Value, f reflect.Value, vs ...reflect.Value) {
 // assuming that T is assignable to R.
 // Otherwise, it returns the input value as is.
 func sanitizeValue(v reflect.Value, t reflect.Type) reflect.Value {
-	// TODO(dsnet): Workaround for reflect bug (https://golang.org/issue/22143).
+	// TODO(≥go1.10): Workaround for reflect bug (https://golang.org/issue/22143).
 	if !flags.AtLeastGo110 {
 		if v.Kind() == reflect.Interface && v.IsNil() && v.Type() != t {
 			return reflect.New(t).Elem()
@@ -352,8 +386,10 @@ func sanitizeValue(v reflect.Value, t reflect.Type) reflect.Value {
 }
 
 func (s *state) compareStruct(t reflect.Type, vx, vy reflect.Value) {
+	var addr bool
 	var vax, vay reflect.Value // Addressable versions of vx and vy
 
+	var mayForce, mayForceInit bool
 	step := StructField{&structField{}}
 	for i := 0; i < t.NumField(); i++ {
 		step.typ = t.Field(i).Type
@@ -372,10 +408,18 @@ func (s *state) compareStruct(t reflect.Type, vx, vy reflect.Value) {
 				// For retrieveUnexportedField to work, the parent struct must
 				// be addressable. Create a new copy of the values if
 				// necessary to make them addressable.
+				addr = vx.CanAddr() || vy.CanAddr()
 				vax = makeAddressable(vx)
 				vay = makeAddressable(vy)
 			}
-			step.mayForce = s.exporters[t]
+			if !mayForceInit {
+				for _, xf := range s.exporters {
+					mayForce = mayForce || xf(t)
+				}
+				mayForceInit = true
+			}
+			step.mayForce = mayForce
+			step.paddr = addr
 			step.pvx = vax
 			step.pvy = vay
 			step.field = t.Field(i)
@@ -391,9 +435,21 @@ func (s *state) compareSlice(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// NOTE: It is incorrect to call curPtrs.Push on the slice header pointer
+	// since slices represents a list of pointers, rather than a single pointer.
+	// The pointer checking logic must be handled on a per-element basis
+	// in compareAny.
+	//
+	// A slice header (see reflect.SliceHeader) in Go is a tuple of a starting
+	// pointer P, a length N, and a capacity C. Supposing each slice element has
+	// a memory size of M, then the slice is equivalent to the list of pointers:
+	//	[P+i*M for i in range(N)]
+	//
+	// For example, v[:0] and v[:1] are slices with the same starting pointer,
+	// but they are clearly different values. Using the slice pointer alone
+	// violates the assumption that equal pointers implies equal values.
 
-	step := SliceIndex{&sliceIndex{pathStep: pathStep{typ: t.Elem()}}}
+	step := SliceIndex{&sliceIndex{pathStep: pathStep{typ: t.Elem()}, isSlice: isSlice}}
 	withIndexes := func(ix, iy int) SliceIndex {
 		if ix >= 0 {
 			step.vx, step.xkey = vx.Index(ix), ix
@@ -470,7 +526,12 @@ func (s *state) compareMap(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// Cycle-detection for maps.
+	if eq, visited := s.curPtrs.Push(vx, vy); visited {
+		s.report(eq, reportByCycle)
+		return
+	}
+	defer s.curPtrs.Pop(vx, vy)
 
 	// We combine and sort the two map keys so that we can perform the
 	// comparisons in a deterministic order.
@@ -507,7 +568,12 @@ func (s *state) comparePtr(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// Cycle-detection for pointers.
+	if eq, visited := s.curPtrs.Push(vx, vy); visited {
+		s.report(eq, reportByCycle)
+		return
+	}
+	defer s.curPtrs.Pop(vx, vy)
 
 	vx, vy = vx.Elem(), vy.Elem()
 	s.compareAny(Indirect{&indirect{pathStep{t.Elem(), vx, vy}}})

--- a/vendor/github.com/google/go-cmp/cmp/export_panic.go
+++ b/vendor/github.com/google/go-cmp/cmp/export_panic.go
@@ -8,8 +8,8 @@ package cmp
 
 import "reflect"
 
-const supportAllowUnexported = false
+const supportExporters = false
 
-func retrieveUnexportedField(reflect.Value, reflect.StructField) reflect.Value {
-	panic("retrieveUnexportedField is not implemented")
+func retrieveUnexportedField(reflect.Value, reflect.StructField, bool) reflect.Value {
+	panic("no support for forcibly accessing unexported fields")
 }

--- a/vendor/github.com/google/go-cmp/cmp/export_unsafe.go
+++ b/vendor/github.com/google/go-cmp/cmp/export_unsafe.go
@@ -11,13 +11,25 @@ import (
 	"unsafe"
 )
 
-const supportAllowUnexported = true
+const supportExporters = true
 
 // retrieveUnexportedField uses unsafe to forcibly retrieve any field from
 // a struct such that the value has read-write permissions.
 //
 // The parent struct, v, must be addressable, while f must be a StructField
-// describing the field to retrieve.
-func retrieveUnexportedField(v reflect.Value, f reflect.StructField) reflect.Value {
-	return reflect.NewAt(f.Type, unsafe.Pointer(v.UnsafeAddr()+f.Offset)).Elem()
+// describing the field to retrieve. If addr is false,
+// then the returned value will be shallowed copied to be non-addressable.
+func retrieveUnexportedField(v reflect.Value, f reflect.StructField, addr bool) reflect.Value {
+	ve := reflect.NewAt(f.Type, unsafe.Pointer(uintptr(unsafe.Pointer(v.UnsafeAddr()))+f.Offset)).Elem()
+	if !addr {
+		// A field is addressable if and only if the struct is addressable.
+		// If the original parent value was not addressable, shallow copy the
+		// value to make it non-addressable to avoid leaking an implementation
+		// detail of how forcibly exporting a field works.
+		if ve.Kind() == reflect.Interface && ve.IsNil() {
+			return reflect.Zero(f.Type)
+		}
+		return reflect.ValueOf(ve.Interface()).Convert(f.Type)
+	}
+	return ve
 }

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/name.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/name.go
@@ -1,0 +1,157 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package value
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// TypeString is nearly identical to reflect.Type.String,
+// but has an additional option to specify that full type names be used.
+func TypeString(t reflect.Type, qualified bool) string {
+	return string(appendTypeName(nil, t, qualified, false))
+}
+
+func appendTypeName(b []byte, t reflect.Type, qualified, elideFunc bool) []byte {
+	// BUG: Go reflection provides no way to disambiguate two named types
+	// of the same name and within the same package,
+	// but declared within the namespace of different functions.
+
+	// Named type.
+	if t.Name() != "" {
+		if qualified && t.PkgPath() != "" {
+			b = append(b, '"')
+			b = append(b, t.PkgPath()...)
+			b = append(b, '"')
+			b = append(b, '.')
+			b = append(b, t.Name()...)
+		} else {
+			b = append(b, t.String()...)
+		}
+		return b
+	}
+
+	// Unnamed type.
+	switch k := t.Kind(); k {
+	case reflect.Bool, reflect.String, reflect.UnsafePointer,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		b = append(b, k.String()...)
+	case reflect.Chan:
+		if t.ChanDir() == reflect.RecvDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, "chan"...)
+		if t.ChanDir() == reflect.SendDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, ' ')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Func:
+		if !elideFunc {
+			b = append(b, "func"...)
+		}
+		b = append(b, '(')
+		for i := 0; i < t.NumIn(); i++ {
+			if i > 0 {
+				b = append(b, ", "...)
+			}
+			if i == t.NumIn()-1 && t.IsVariadic() {
+				b = append(b, "..."...)
+				b = appendTypeName(b, t.In(i).Elem(), qualified, false)
+			} else {
+				b = appendTypeName(b, t.In(i), qualified, false)
+			}
+		}
+		b = append(b, ')')
+		switch t.NumOut() {
+		case 0:
+			// Do nothing
+		case 1:
+			b = append(b, ' ')
+			b = appendTypeName(b, t.Out(0), qualified, false)
+		default:
+			b = append(b, " ("...)
+			for i := 0; i < t.NumOut(); i++ {
+				if i > 0 {
+					b = append(b, ", "...)
+				}
+				b = appendTypeName(b, t.Out(i), qualified, false)
+			}
+			b = append(b, ')')
+		}
+	case reflect.Struct:
+		b = append(b, "struct{ "...)
+		for i := 0; i < t.NumField(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			sf := t.Field(i)
+			if !sf.Anonymous {
+				if qualified && sf.PkgPath != "" {
+					b = append(b, '"')
+					b = append(b, sf.PkgPath...)
+					b = append(b, '"')
+					b = append(b, '.')
+				}
+				b = append(b, sf.Name...)
+				b = append(b, ' ')
+			}
+			b = appendTypeName(b, sf.Type, qualified, false)
+			if sf.Tag != "" {
+				b = append(b, ' ')
+				b = strconv.AppendQuote(b, string(sf.Tag))
+			}
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	case reflect.Slice, reflect.Array:
+		b = append(b, '[')
+		if k == reflect.Array {
+			b = strconv.AppendUint(b, uint64(t.Len()), 10)
+		}
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Map:
+		b = append(b, "map["...)
+		b = appendTypeName(b, t.Key(), qualified, false)
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Ptr:
+		b = append(b, '*')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Interface:
+		b = append(b, "interface{ "...)
+		for i := 0; i < t.NumMethod(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			m := t.Method(i)
+			if qualified && m.PkgPath != "" {
+				b = append(b, '"')
+				b = append(b, m.PkgPath...)
+				b = append(b, '"')
+				b = append(b, '.')
+			}
+			b = append(b, m.Name...)
+			b = appendTypeName(b, m.Type, qualified, true)
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	default:
+		panic("invalid kind: " + k.String())
+	}
+	return b
+}

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_purego.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_purego.go
@@ -21,3 +21,13 @@ func PointerOf(v reflect.Value) Pointer {
 	// assumes that the GC implementation does not use a moving collector.
 	return Pointer{v.Pointer(), v.Type()}
 }
+
+// IsNil reports whether the pointer is nil.
+func (p Pointer) IsNil() bool {
+	return p.p == 0
+}
+
+// Uintptr returns the pointer as a uintptr.
+func (p Pointer) Uintptr() uintptr {
+	return p.p
+}

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_unsafe.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_unsafe.go
@@ -24,3 +24,13 @@ func PointerOf(v reflect.Value) Pointer {
 	// which is necessary if the GC ever uses a moving collector.
 	return Pointer{unsafe.Pointer(v.Pointer()), v.Type()}
 }
+
+// IsNil reports whether the pointer is nil.
+func (p Pointer) IsNil() bool {
+	return p.p == nil
+}
+
+// Uintptr returns the pointer as a uintptr.
+func (p Pointer) Uintptr() uintptr {
+	return uintptr(p.p)
+}

--- a/vendor/github.com/google/go-cmp/cmp/path.go
+++ b/vendor/github.com/google/go-cmp/cmp/path.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp/internal/value"
 )
 
 // Path is a list of PathSteps describing the sequence of operations to get
@@ -41,7 +43,7 @@ type PathStep interface {
 	// In some cases, one or both may be invalid or have restrictions:
 	//	• For StructField, both are not interface-able if the current field
 	//	is unexported and the struct type is not explicitly permitted by
-	//	AllowUnexported to traverse unexported fields.
+	//	an Exporter to traverse unexported fields.
 	//	• For SliceIndex, one may be invalid if an element is missing from
 	//	either the x or y slice.
 	//	• For MapIndex, one may be invalid if an entry is missing from
@@ -175,7 +177,8 @@ type structField struct {
 	// pvx, pvy, and field are only valid if unexported is true.
 	unexported bool
 	mayForce   bool                // Forcibly allow visibility
-	pvx, pvy   reflect.Value       // Parent values
+	paddr      bool                // Was parent addressable?
+	pvx, pvy   reflect.Value       // Parent values (always addressible)
 	field      reflect.StructField // Field information
 }
 
@@ -187,8 +190,8 @@ func (sf StructField) Values() (vx, vy reflect.Value) {
 
 	// Forcibly obtain read-write access to an unexported struct field.
 	if sf.mayForce {
-		vx = retrieveUnexportedField(sf.pvx, sf.field)
-		vy = retrieveUnexportedField(sf.pvy, sf.field)
+		vx = retrieveUnexportedField(sf.pvx, sf.field, sf.paddr)
+		vy = retrieveUnexportedField(sf.pvy, sf.field, sf.paddr)
 		return vx, vy // CanInterface reports true
 	}
 	return sf.vx, sf.vy // CanInterface reports false
@@ -207,6 +210,7 @@ type SliceIndex struct{ *sliceIndex }
 type sliceIndex struct {
 	pathStep
 	xkey, ykey int
+	isSlice    bool // False for reflect.Array
 }
 
 func (si SliceIndex) Type() reflect.Type             { return si.typ }
@@ -300,6 +304,72 @@ func (tf Transform) Func() reflect.Value { return tf.trans.fnc }
 // Option returns the originally constructed Transformer option.
 // The == operator can be used to detect the exact option used.
 func (tf Transform) Option() Option { return tf.trans }
+
+// pointerPath represents a dual-stack of pointers encountered when
+// recursively traversing the x and y values. This data structure supports
+// detection of cycles and determining whether the cycles are equal.
+// In Go, cycles can occur via pointers, slices, and maps.
+//
+// The pointerPath uses a map to represent a stack; where descension into a
+// pointer pushes the address onto the stack, and ascension from a pointer
+// pops the address from the stack. Thus, when traversing into a pointer from
+// reflect.Ptr, reflect.Slice element, or reflect.Map, we can detect cycles
+// by checking whether the pointer has already been visited. The cycle detection
+// uses a seperate stack for the x and y values.
+//
+// If a cycle is detected we need to determine whether the two pointers
+// should be considered equal. The definition of equality chosen by Equal
+// requires two graphs to have the same structure. To determine this, both the
+// x and y values must have a cycle where the previous pointers were also
+// encountered together as a pair.
+//
+// Semantically, this is equivalent to augmenting Indirect, SliceIndex, and
+// MapIndex with pointer information for the x and y values.
+// Suppose px and py are two pointers to compare, we then search the
+// Path for whether px was ever encountered in the Path history of x, and
+// similarly so with py. If either side has a cycle, the comparison is only
+// equal if both px and py have a cycle resulting from the same PathStep.
+//
+// Using a map as a stack is more performant as we can perform cycle detection
+// in O(1) instead of O(N) where N is len(Path).
+type pointerPath struct {
+	// mx is keyed by x pointers, where the value is the associated y pointer.
+	mx map[value.Pointer]value.Pointer
+	// my is keyed by y pointers, where the value is the associated x pointer.
+	my map[value.Pointer]value.Pointer
+}
+
+func (p *pointerPath) Init() {
+	p.mx = make(map[value.Pointer]value.Pointer)
+	p.my = make(map[value.Pointer]value.Pointer)
+}
+
+// Push indicates intent to descend into pointers vx and vy where
+// visited reports whether either has been seen before. If visited before,
+// equal reports whether both pointers were encountered together.
+// Pop must be called if and only if the pointers were never visited.
+//
+// The pointers vx and vy must be a reflect.Ptr, reflect.Slice, or reflect.Map
+// and be non-nil.
+func (p pointerPath) Push(vx, vy reflect.Value) (equal, visited bool) {
+	px := value.PointerOf(vx)
+	py := value.PointerOf(vy)
+	_, ok1 := p.mx[px]
+	_, ok2 := p.my[py]
+	if ok1 || ok2 {
+		equal = p.mx[px] == py && p.my[py] == px // Pointers paired together
+		return equal, true
+	}
+	p.mx[px] = py
+	p.my[py] = px
+	return false, false
+}
+
+// Pop ascends from pointers vx and vy.
+func (p pointerPath) Pop(vx, vy reflect.Value) {
+	delete(p.mx, value.PointerOf(vx))
+	delete(p.my, value.PointerOf(vy))
+}
 
 // isExported reports whether the identifier is exported.
 func isExported(id string) bool {

--- a/vendor/github.com/google/go-cmp/cmp/report.go
+++ b/vendor/github.com/google/go-cmp/cmp/report.go
@@ -41,7 +41,10 @@ func (r *defaultReporter) String() string {
 	if r.root.NumDiff == 0 {
 		return ""
 	}
-	return formatOptions{}.FormatDiff(r.root).String()
+	ptrs := new(pointerReferences)
+	text := formatOptions{}.FormatDiff(r.root, ptrs)
+	resolveReferences(text)
+	return text.String()
 }
 
 func assert(ok bool) {

--- a/vendor/github.com/google/go-cmp/cmp/report_compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_compare.go
@@ -11,14 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp/internal/value"
 )
 
-// TODO: Enforce limits?
-//	* Enforce maximum number of records to print per node?
-//	* Enforce maximum size in bytes allowed?
-//	* As a heuristic, use less verbosity for equal nodes than unequal nodes.
-// TODO: Enforce unique outputs?
-//	* Avoid Stringer methods if it results in same output?
-//	* Print pointer address if outputs still equal?
-
 // numContextRecords is the number of surrounding equal records to print.
 const numContextRecords = 2
 
@@ -71,14 +63,56 @@ func (opts formatOptions) WithTypeMode(t typeMode) formatOptions {
 	opts.TypeMode = t
 	return opts
 }
+func (opts formatOptions) WithVerbosity(level int) formatOptions {
+	opts.VerbosityLevel = level
+	opts.LimitVerbosity = true
+	return opts
+}
+func (opts formatOptions) verbosity() uint {
+	switch {
+	case opts.VerbosityLevel < 0:
+		return 0
+	case opts.VerbosityLevel > 16:
+		return 16 // some reasonable maximum to avoid shift overflow
+	default:
+		return uint(opts.VerbosityLevel)
+	}
+}
+
+const maxVerbosityPreset = 3
+
+// verbosityPreset modifies the verbosity settings given an index
+// between 0 and maxVerbosityPreset, inclusive.
+func verbosityPreset(opts formatOptions, i int) formatOptions {
+	opts.VerbosityLevel = int(opts.verbosity()) + 2*i
+	if i > 0 {
+		opts.AvoidStringer = true
+	}
+	if i >= maxVerbosityPreset {
+		opts.PrintAddresses = true
+		opts.QualifiedNames = true
+	}
+	return opts
+}
 
 // FormatDiff converts a valueNode tree into a textNode tree, where the later
 // is a textual representation of the differences detected in the former.
-func (opts formatOptions) FormatDiff(v *valueNode) textNode {
+func (opts formatOptions) FormatDiff(v *valueNode, ptrs *pointerReferences) (out textNode) {
+	if opts.DiffMode == diffIdentical {
+		opts = opts.WithVerbosity(1)
+	} else {
+		opts = opts.WithVerbosity(3)
+	}
+
 	// Check whether we have specialized formatting for this node.
 	// This is not necessary, but helpful for producing more readable outputs.
 	if opts.CanFormatDiffSlice(v) {
 		return opts.FormatDiffSlice(v)
+	}
+
+	var parentKind reflect.Kind
+	if v.parent != nil && v.parent.TransformerName == "" {
+		parentKind = v.parent.Type.Kind()
 	}
 
 	// For leaf nodes, format the value based on the reflect.Values alone.
@@ -87,8 +121,8 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 		case diffUnknown, diffIdentical:
 			// Format Equal.
 			if v.NumDiff == 0 {
-				outx := opts.FormatValue(v.ValueX, visitedPointers{})
-				outy := opts.FormatValue(v.ValueY, visitedPointers{})
+				outx := opts.FormatValue(v.ValueX, parentKind, ptrs)
+				outy := opts.FormatValue(v.ValueY, parentKind, ptrs)
 				if v.NumIgnored > 0 && v.NumSame == 0 {
 					return textEllipsis
 				} else if outx.Len() < outy.Len() {
@@ -101,8 +135,13 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 			// Format unequal.
 			assert(opts.DiffMode == diffUnknown)
 			var list textList
-			outx := opts.WithTypeMode(elideType).FormatValue(v.ValueX, visitedPointers{})
-			outy := opts.WithTypeMode(elideType).FormatValue(v.ValueY, visitedPointers{})
+			outx := opts.WithTypeMode(elideType).FormatValue(v.ValueX, parentKind, ptrs)
+			outy := opts.WithTypeMode(elideType).FormatValue(v.ValueY, parentKind, ptrs)
+			for i := 0; i <= maxVerbosityPreset && outx != nil && outy != nil && outx.Equal(outy); i++ {
+				opts2 := verbosityPreset(opts, i).WithTypeMode(elideType)
+				outx = opts2.FormatValue(v.ValueX, parentKind, ptrs)
+				outy = opts2.FormatValue(v.ValueY, parentKind, ptrs)
+			}
 			if outx != nil {
 				list = append(list, textRecord{Diff: '-', Value: outx})
 			}
@@ -111,34 +150,57 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 			}
 			return opts.WithTypeMode(emitType).FormatType(v.Type, list)
 		case diffRemoved:
-			return opts.FormatValue(v.ValueX, visitedPointers{})
+			return opts.FormatValue(v.ValueX, parentKind, ptrs)
 		case diffInserted:
-			return opts.FormatValue(v.ValueY, visitedPointers{})
+			return opts.FormatValue(v.ValueY, parentKind, ptrs)
 		default:
 			panic("invalid diff mode")
 		}
 	}
 
+	// Register slice element to support cycle detection.
+	if parentKind == reflect.Slice {
+		ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, true)
+		defer ptrs.Pop()
+		defer func() { out = wrapTrunkReferences(ptrRefs, out) }()
+	}
+
 	// Descend into the child value node.
 	if v.TransformerName != "" {
-		out := opts.WithTypeMode(emitType).FormatDiff(v.Value)
-		out = textWrap{"Inverse(" + v.TransformerName + ", ", out, ")"}
+		out := opts.WithTypeMode(emitType).FormatDiff(v.Value, ptrs)
+		out = &textWrap{Prefix: "Inverse(" + v.TransformerName + ", ", Value: out, Suffix: ")"}
 		return opts.FormatType(v.Type, out)
 	} else {
 		switch k := v.Type.Kind(); k {
-		case reflect.Struct, reflect.Array, reflect.Slice, reflect.Map:
-			return opts.FormatType(v.Type, opts.formatDiffList(v.Records, k))
+		case reflect.Struct, reflect.Array, reflect.Slice:
+			out = opts.formatDiffList(v.Records, k, ptrs)
+			out = opts.FormatType(v.Type, out)
+		case reflect.Map:
+			// Register map to support cycle detection.
+			ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, false)
+			defer ptrs.Pop()
+
+			out = opts.formatDiffList(v.Records, k, ptrs)
+			out = wrapTrunkReferences(ptrRefs, out)
+			out = opts.FormatType(v.Type, out)
 		case reflect.Ptr:
-			return textWrap{"&", opts.FormatDiff(v.Value), ""}
+			// Register pointer to support cycle detection.
+			ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, false)
+			defer ptrs.Pop()
+
+			out = opts.FormatDiff(v.Value, ptrs)
+			out = wrapTrunkReferences(ptrRefs, out)
+			out = &textWrap{Prefix: "&", Value: out}
 		case reflect.Interface:
-			return opts.WithTypeMode(emitType).FormatDiff(v.Value)
+			out = opts.WithTypeMode(emitType).FormatDiff(v.Value, ptrs)
 		default:
 			panic(fmt.Sprintf("%v cannot have children", k))
 		}
+		return out
 	}
 }
 
-func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) textNode {
+func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind, ptrs *pointerReferences) textNode {
 	// Derive record name based on the data structure kind.
 	var name string
 	var formatKey func(reflect.Value) string
@@ -154,7 +216,17 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 	case reflect.Map:
 		name = "entry"
 		opts = opts.WithTypeMode(elideType)
-		formatKey = formatMapKey
+		formatKey = func(v reflect.Value) string { return formatMapKey(v, false, ptrs) }
+	}
+
+	maxLen := -1
+	if opts.LimitVerbosity {
+		if opts.DiffMode == diffIdentical {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+		} else {
+			maxLen = (1 << opts.verbosity()) << 1 // 2, 4, 8, 16, 32, 64, etc...
+		}
+		opts.VerbosityLevel--
 	}
 
 	// Handle unification.
@@ -163,6 +235,11 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 		var list textList
 		var deferredEllipsis bool // Add final "..." to indicate records were dropped
 		for _, r := range recs {
+			if len(list) == maxLen {
+				deferredEllipsis = true
+				break
+			}
+
 			// Elide struct fields that are zero value.
 			if k == reflect.Struct {
 				var isZero bool
@@ -186,23 +263,31 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 				}
 				continue
 			}
-			if out := opts.FormatDiff(r.Value); out != nil {
+			if out := opts.FormatDiff(r.Value, ptrs); out != nil {
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
 			}
 		}
 		if deferredEllipsis {
 			list.AppendEllipsis(diffStats{})
 		}
-		return textWrap{"{", list, "}"}
+		return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 	case diffUnknown:
 	default:
 		panic("invalid diff mode")
 	}
 
 	// Handle differencing.
+	var numDiffs int
 	var list textList
+	var keys []reflect.Value // invariant: len(list) == len(keys)
 	groups := coalesceAdjacentRecords(name, recs)
+	maxGroup := diffStats{Name: name}
 	for i, ds := range groups {
+		if maxLen >= 0 && numDiffs >= maxLen {
+			maxGroup = maxGroup.Append(ds)
+			continue
+		}
+
 		// Handle equal records.
 		if ds.NumDiff() == 0 {
 			// Compute the number of leading and trailing records to print.
@@ -226,16 +311,21 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 
 			// Format the equal values.
 			for _, r := range recs[:numLo] {
-				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value)
+				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 			if numEqual > numLo+numHi {
 				ds.NumIdentical -= numLo + numHi
 				list.AppendEllipsis(ds)
+				for len(keys) < len(list) {
+					keys = append(keys, reflect.Value{})
+				}
 			}
 			for _, r := range recs[numEqual-numHi : numEqual] {
-				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value)
+				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 			recs = recs[numEqual:]
 			continue
@@ -247,24 +337,70 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 			case opts.CanFormatDiffSlice(r.Value):
 				out := opts.FormatDiffSlice(r.Value)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			case r.Value.NumChildren == r.Value.MaxDepth:
-				outx := opts.WithDiffMode(diffRemoved).FormatDiff(r.Value)
-				outy := opts.WithDiffMode(diffInserted).FormatDiff(r.Value)
+				outx := opts.WithDiffMode(diffRemoved).FormatDiff(r.Value, ptrs)
+				outy := opts.WithDiffMode(diffInserted).FormatDiff(r.Value, ptrs)
+				for i := 0; i <= maxVerbosityPreset && outx != nil && outy != nil && outx.Equal(outy); i++ {
+					opts2 := verbosityPreset(opts, i)
+					outx = opts2.WithDiffMode(diffRemoved).FormatDiff(r.Value, ptrs)
+					outy = opts2.WithDiffMode(diffInserted).FormatDiff(r.Value, ptrs)
+				}
 				if outx != nil {
 					list = append(list, textRecord{Diff: diffRemoved, Key: formatKey(r.Key), Value: outx})
+					keys = append(keys, r.Key)
 				}
 				if outy != nil {
 					list = append(list, textRecord{Diff: diffInserted, Key: formatKey(r.Key), Value: outy})
+					keys = append(keys, r.Key)
 				}
 			default:
-				out := opts.FormatDiff(r.Value)
+				out := opts.FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 		}
 		recs = recs[ds.NumDiff():]
+		numDiffs += ds.NumDiff()
 	}
-	assert(len(recs) == 0)
-	return textWrap{"{", list, "}"}
+	if maxGroup.IsZero() {
+		assert(len(recs) == 0)
+	} else {
+		list.AppendEllipsis(maxGroup)
+		for len(keys) < len(list) {
+			keys = append(keys, reflect.Value{})
+		}
+	}
+	assert(len(list) == len(keys))
+
+	// For maps, the default formatting logic uses fmt.Stringer which may
+	// produce ambiguous output. Avoid calling String to disambiguate.
+	if k == reflect.Map {
+		var ambiguous bool
+		seenKeys := map[string]reflect.Value{}
+		for i, currKey := range keys {
+			if currKey.IsValid() {
+				strKey := list[i].Key
+				prevKey, seen := seenKeys[strKey]
+				if seen && prevKey.CanInterface() && currKey.CanInterface() {
+					ambiguous = prevKey.Interface() != currKey.Interface()
+					if ambiguous {
+						break
+					}
+				}
+				seenKeys[strKey] = currKey
+			}
+		}
+		if ambiguous {
+			for i, k := range keys {
+				if k.IsValid() {
+					list[i].Key = formatMapKey(k, true, ptrs)
+				}
+			}
+		}
+	}
+
+	return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 }
 
 // coalesceAdjacentRecords coalesces the list of records into groups of

--- a/vendor/github.com/google/go-cmp/cmp/report_references.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_references.go
@@ -1,0 +1,264 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp/internal/flags"
+	"github.com/google/go-cmp/cmp/internal/value"
+)
+
+const (
+	pointerDelimPrefix = "⟪"
+	pointerDelimSuffix = "⟫"
+)
+
+// formatPointer prints the address of the pointer.
+func formatPointer(p value.Pointer, withDelims bool) string {
+	v := p.Uintptr()
+	if flags.Deterministic {
+		v = 0xdeadf00f // Only used for stable testing purposes
+	}
+	if withDelims {
+		return pointerDelimPrefix + formatHex(uint64(v)) + pointerDelimSuffix
+	}
+	return formatHex(uint64(v))
+}
+
+// pointerReferences is a stack of pointers visited so far.
+type pointerReferences [][2]value.Pointer
+
+func (ps *pointerReferences) PushPair(vx, vy reflect.Value, d diffMode, deref bool) (pp [2]value.Pointer) {
+	if deref && vx.IsValid() {
+		vx = vx.Addr()
+	}
+	if deref && vy.IsValid() {
+		vy = vy.Addr()
+	}
+	switch d {
+	case diffUnknown, diffIdentical:
+		pp = [2]value.Pointer{value.PointerOf(vx), value.PointerOf(vy)}
+	case diffRemoved:
+		pp = [2]value.Pointer{value.PointerOf(vx), value.Pointer{}}
+	case diffInserted:
+		pp = [2]value.Pointer{value.Pointer{}, value.PointerOf(vy)}
+	}
+	*ps = append(*ps, pp)
+	return pp
+}
+
+func (ps *pointerReferences) Push(v reflect.Value) (p value.Pointer, seen bool) {
+	p = value.PointerOf(v)
+	for _, pp := range *ps {
+		if p == pp[0] || p == pp[1] {
+			return p, true
+		}
+	}
+	*ps = append(*ps, [2]value.Pointer{p, p})
+	return p, false
+}
+
+func (ps *pointerReferences) Pop() {
+	*ps = (*ps)[:len(*ps)-1]
+}
+
+// trunkReferences is metadata for a textNode indicating that the sub-tree
+// represents the value for either pointer in a pair of references.
+type trunkReferences struct{ pp [2]value.Pointer }
+
+// trunkReference is metadata for a textNode indicating that the sub-tree
+// represents the value for the given pointer reference.
+type trunkReference struct{ p value.Pointer }
+
+// leafReference is metadata for a textNode indicating that the value is
+// truncated as it refers to another part of the tree (i.e., a trunk).
+type leafReference struct{ p value.Pointer }
+
+func wrapTrunkReferences(pp [2]value.Pointer, s textNode) textNode {
+	switch {
+	case pp[0].IsNil():
+		return &textWrap{Value: s, Metadata: trunkReference{pp[1]}}
+	case pp[1].IsNil():
+		return &textWrap{Value: s, Metadata: trunkReference{pp[0]}}
+	case pp[0] == pp[1]:
+		return &textWrap{Value: s, Metadata: trunkReference{pp[0]}}
+	default:
+		return &textWrap{Value: s, Metadata: trunkReferences{pp}}
+	}
+}
+func wrapTrunkReference(p value.Pointer, printAddress bool, s textNode) textNode {
+	var prefix string
+	if printAddress {
+		prefix = formatPointer(p, true)
+	}
+	return &textWrap{Prefix: prefix, Value: s, Metadata: trunkReference{p}}
+}
+func makeLeafReference(p value.Pointer, printAddress bool) textNode {
+	out := &textWrap{Prefix: "(", Value: textEllipsis, Suffix: ")"}
+	var prefix string
+	if printAddress {
+		prefix = formatPointer(p, true)
+	}
+	return &textWrap{Prefix: prefix, Value: out, Metadata: leafReference{p}}
+}
+
+// resolveReferences walks the textNode tree searching for any leaf reference
+// metadata and resolves each against the corresponding trunk references.
+// Since pointer addresses in memory are not particularly readable to the user,
+// it replaces each pointer value with an arbitrary and unique reference ID.
+func resolveReferences(s textNode) {
+	var walkNodes func(textNode, func(textNode))
+	walkNodes = func(s textNode, f func(textNode)) {
+		f(s)
+		switch s := s.(type) {
+		case *textWrap:
+			walkNodes(s.Value, f)
+		case textList:
+			for _, r := range s {
+				walkNodes(r.Value, f)
+			}
+		}
+	}
+
+	// Collect all trunks and leaves with reference metadata.
+	var trunks, leaves []*textWrap
+	walkNodes(s, func(s textNode) {
+		if s, ok := s.(*textWrap); ok {
+			switch s.Metadata.(type) {
+			case leafReference:
+				leaves = append(leaves, s)
+			case trunkReference, trunkReferences:
+				trunks = append(trunks, s)
+			}
+		}
+	})
+
+	// No leaf references to resolve.
+	if len(leaves) == 0 {
+		return
+	}
+
+	// Collect the set of all leaf references to resolve.
+	leafPtrs := make(map[value.Pointer]bool)
+	for _, leaf := range leaves {
+		leafPtrs[leaf.Metadata.(leafReference).p] = true
+	}
+
+	// Collect the set of trunk pointers that are always paired together.
+	// This allows us to assign a single ID to both pointers for brevity.
+	// If a pointer in a pair ever occurs by itself or as a different pair,
+	// then the pair is broken.
+	pairedTrunkPtrs := make(map[value.Pointer]value.Pointer)
+	unpair := func(p value.Pointer) {
+		if !pairedTrunkPtrs[p].IsNil() {
+			pairedTrunkPtrs[pairedTrunkPtrs[p]] = value.Pointer{} // invalidate other half
+		}
+		pairedTrunkPtrs[p] = value.Pointer{} // invalidate this half
+	}
+	for _, trunk := range trunks {
+		switch p := trunk.Metadata.(type) {
+		case trunkReference:
+			unpair(p.p) // standalone pointer cannot be part of a pair
+		case trunkReferences:
+			p0, ok0 := pairedTrunkPtrs[p.pp[0]]
+			p1, ok1 := pairedTrunkPtrs[p.pp[1]]
+			switch {
+			case !ok0 && !ok1:
+				// Register the newly seen pair.
+				pairedTrunkPtrs[p.pp[0]] = p.pp[1]
+				pairedTrunkPtrs[p.pp[1]] = p.pp[0]
+			case ok0 && ok1 && p0 == p.pp[1] && p1 == p.pp[0]:
+				// Exact pair already seen; do nothing.
+			default:
+				// Pair conflicts with some other pair; break all pairs.
+				unpair(p.pp[0])
+				unpair(p.pp[1])
+			}
+		}
+	}
+
+	// Correlate each pointer referenced by leaves to a unique identifier,
+	// and print the IDs for each trunk that matches those pointers.
+	var nextID uint
+	ptrIDs := make(map[value.Pointer]uint)
+	newID := func() uint {
+		id := nextID
+		nextID++
+		return id
+	}
+	for _, trunk := range trunks {
+		switch p := trunk.Metadata.(type) {
+		case trunkReference:
+			if print := leafPtrs[p.p]; print {
+				id, ok := ptrIDs[p.p]
+				if !ok {
+					id = newID()
+					ptrIDs[p.p] = id
+				}
+				trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id))
+			}
+		case trunkReferences:
+			print0 := leafPtrs[p.pp[0]]
+			print1 := leafPtrs[p.pp[1]]
+			if print0 || print1 {
+				id0, ok0 := ptrIDs[p.pp[0]]
+				id1, ok1 := ptrIDs[p.pp[1]]
+				isPair := pairedTrunkPtrs[p.pp[0]] == p.pp[1] && pairedTrunkPtrs[p.pp[1]] == p.pp[0]
+				if isPair {
+					var id uint
+					assert(ok0 == ok1) // must be seen together or not at all
+					if ok0 {
+						assert(id0 == id1) // must have the same ID
+						id = id0
+					} else {
+						id = newID()
+						ptrIDs[p.pp[0]] = id
+						ptrIDs[p.pp[1]] = id
+					}
+					trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id))
+				} else {
+					if print0 && !ok0 {
+						id0 = newID()
+						ptrIDs[p.pp[0]] = id0
+					}
+					if print1 && !ok1 {
+						id1 = newID()
+						ptrIDs[p.pp[1]] = id1
+					}
+					switch {
+					case print0 && print1:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id0)+","+formatReference(id1))
+					case print0:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id0))
+					case print1:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id1))
+					}
+				}
+			}
+		}
+	}
+
+	// Update all leaf references with the unique identifier.
+	for _, leaf := range leaves {
+		if id, ok := ptrIDs[leaf.Metadata.(leafReference).p]; ok {
+			leaf.Prefix = updateReferencePrefix(leaf.Prefix, formatReference(id))
+		}
+	}
+}
+
+func formatReference(id uint) string {
+	return fmt.Sprintf("ref#%d", id)
+}
+
+func updateReferencePrefix(prefix, ref string) string {
+	if prefix == "" {
+		return pointerDelimPrefix + ref + pointerDelimSuffix
+	}
+	suffix := strings.TrimPrefix(prefix, pointerDelimPrefix)
+	return pointerDelimPrefix + ref + ": " + suffix
+}

--- a/vendor/github.com/google/go-cmp/cmp/report_reflect.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_reflect.go
@@ -5,13 +5,14 @@
 package cmp
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
-	"github.com/google/go-cmp/cmp/internal/flags"
 	"github.com/google/go-cmp/cmp/internal/value"
 )
 
@@ -20,14 +21,22 @@ type formatValueOptions struct {
 	// methods like error.Error or fmt.Stringer.String.
 	AvoidStringer bool
 
-	// ShallowPointers controls whether to avoid descending into pointers.
-	// Useful when printing map keys, where pointer comparison is performed
-	// on the pointer address rather than the pointed-at value.
-	ShallowPointers bool
-
 	// PrintAddresses controls whether to print the address of all pointers,
 	// slice elements, and maps.
 	PrintAddresses bool
+
+	// QualifiedNames controls whether FormatType uses the fully qualified name
+	// (including the full package path as opposed to just the package name).
+	QualifiedNames bool
+
+	// VerbosityLevel controls the amount of output to produce.
+	// A higher value produces more output. A value of zero or lower produces
+	// no output (represented using an ellipsis).
+	// If LimitVerbosity is false, then the level is treated as infinite.
+	VerbosityLevel int
+
+	// LimitVerbosity specifies that formatting should respect VerbosityLevel.
+	LimitVerbosity bool
 }
 
 // FormatType prints the type as if it were wrapping s.
@@ -44,12 +53,15 @@ func (opts formatOptions) FormatType(t reflect.Type, s textNode) textNode {
 		default:
 			return s
 		}
+		if opts.DiffMode == diffIdentical {
+			return s // elide type for identical nodes
+		}
 	case elideType:
 		return s
 	}
 
 	// Determine the type label, applying special handling for unnamed types.
-	typeName := t.String()
+	typeName := value.TypeString(t, opts.QualifiedNames)
 	if t.Name() == "" {
 		// According to Go grammar, certain type literals contain symbols that
 		// do not strongly bind to the next lexicographical token (e.g., *T).
@@ -57,39 +69,77 @@ func (opts formatOptions) FormatType(t reflect.Type, s textNode) textNode {
 		case reflect.Chan, reflect.Func, reflect.Ptr:
 			typeName = "(" + typeName + ")"
 		}
-		typeName = strings.Replace(typeName, "struct {", "struct{", -1)
-		typeName = strings.Replace(typeName, "interface {", "interface{", -1)
 	}
+	return &textWrap{Prefix: typeName, Value: wrapParens(s)}
+}
 
-	// Avoid wrap the value in parenthesis if unnecessary.
-	if s, ok := s.(textWrap); ok {
-		hasParens := strings.HasPrefix(s.Prefix, "(") && strings.HasSuffix(s.Suffix, ")")
-		hasBraces := strings.HasPrefix(s.Prefix, "{") && strings.HasSuffix(s.Suffix, "}")
+// wrapParens wraps s with a set of parenthesis, but avoids it if the
+// wrapped node itself is already surrounded by a pair of parenthesis or braces.
+// It handles unwrapping one level of pointer-reference nodes.
+func wrapParens(s textNode) textNode {
+	var refNode *textWrap
+	if s2, ok := s.(*textWrap); ok {
+		// Unwrap a single pointer reference node.
+		switch s2.Metadata.(type) {
+		case leafReference, trunkReference, trunkReferences:
+			refNode = s2
+			if s3, ok := refNode.Value.(*textWrap); ok {
+				s2 = s3
+			}
+		}
+
+		// Already has delimiters that make parenthesis unnecessary.
+		hasParens := strings.HasPrefix(s2.Prefix, "(") && strings.HasSuffix(s2.Suffix, ")")
+		hasBraces := strings.HasPrefix(s2.Prefix, "{") && strings.HasSuffix(s2.Suffix, "}")
 		if hasParens || hasBraces {
-			return textWrap{typeName, s, ""}
+			return s
 		}
 	}
-	return textWrap{typeName + "(", s, ")"}
+	if refNode != nil {
+		refNode.Value = &textWrap{Prefix: "(", Value: refNode.Value, Suffix: ")"}
+		return s
+	}
+	return &textWrap{Prefix: "(", Value: s, Suffix: ")"}
 }
 
 // FormatValue prints the reflect.Value, taking extra care to avoid descending
-// into pointers already in m. As pointers are visited, m is also updated.
-func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out textNode) {
+// into pointers already in ptrs. As pointers are visited, ptrs is also updated.
+func (opts formatOptions) FormatValue(v reflect.Value, parentKind reflect.Kind, ptrs *pointerReferences) (out textNode) {
 	if !v.IsValid() {
 		return nil
 	}
 	t := v.Type()
+
+	// Check slice element for cycles.
+	if parentKind == reflect.Slice {
+		ptrRef, visited := ptrs.Push(v.Addr())
+		if visited {
+			return makeLeafReference(ptrRef, false)
+		}
+		defer ptrs.Pop()
+		defer func() { out = wrapTrunkReference(ptrRef, false, out) }()
+	}
 
 	// Check whether there is an Error or String method to call.
 	if !opts.AvoidStringer && v.CanInterface() {
 		// Avoid calling Error or String methods on nil receivers since many
 		// implementations crash when doing so.
 		if (t.Kind() != reflect.Ptr && t.Kind() != reflect.Interface) || !v.IsNil() {
-			switch v := v.Interface().(type) {
-			case error:
-				return textLine("e" + formatString(v.Error()))
-			case fmt.Stringer:
-				return textLine("s" + formatString(v.String()))
+			var prefix, strVal string
+			func() {
+				// Swallow and ignore any panics from String or Error.
+				defer func() { recover() }()
+				switch v := v.Interface().(type) {
+				case error:
+					strVal = v.Error()
+					prefix = "e"
+				case fmt.Stringer:
+					strVal = v.String()
+					prefix = "s"
+				}
+			}()
+			if prefix != "" {
+				return opts.formatString(prefix, strVal)
 			}
 		}
 	}
@@ -102,94 +152,140 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 		}
 	}()
 
-	var ptr string
 	switch t.Kind() {
 	case reflect.Bool:
 		return textLine(fmt.Sprint(v.Bool()))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return textLine(fmt.Sprint(v.Int()))
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		// Unnamed uints are usually bytes or words, so use hexadecimal.
-		if t.PkgPath() == "" || t.Kind() == reflect.Uintptr {
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return textLine(fmt.Sprint(v.Uint()))
+	case reflect.Uint8:
+		if parentKind == reflect.Slice || parentKind == reflect.Array {
 			return textLine(formatHex(v.Uint()))
 		}
 		return textLine(fmt.Sprint(v.Uint()))
+	case reflect.Uintptr:
+		return textLine(formatHex(v.Uint()))
 	case reflect.Float32, reflect.Float64:
 		return textLine(fmt.Sprint(v.Float()))
 	case reflect.Complex64, reflect.Complex128:
 		return textLine(fmt.Sprint(v.Complex()))
 	case reflect.String:
-		return textLine(formatString(v.String()))
+		return opts.formatString("", v.String())
 	case reflect.UnsafePointer, reflect.Chan, reflect.Func:
-		return textLine(formatPointer(v))
+		return textLine(formatPointer(value.PointerOf(v), true))
 	case reflect.Struct:
 		var list textList
+		v := makeAddressable(v) // needed for retrieveUnexportedField
+		maxLen := v.NumField()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		for i := 0; i < v.NumField(); i++ {
 			vv := v.Field(i)
 			if value.IsZero(vv) {
 				continue // Elide fields with zero values
 			}
-			s := opts.WithTypeMode(autoType).FormatValue(vv, m)
-			list = append(list, textRecord{Key: t.Field(i).Name, Value: s})
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
+			}
+			sf := t.Field(i)
+			if supportExporters && !isExported(sf.Name) {
+				vv = retrieveUnexportedField(v, sf, true)
+			}
+			s := opts.WithTypeMode(autoType).FormatValue(vv, t.Kind(), ptrs)
+			list = append(list, textRecord{Key: sf.Name, Value: s})
 		}
-		return textWrap{"{", list, "}"}
+		return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 	case reflect.Slice:
 		if v.IsNil() {
 			return textNil
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
+
+		// Check whether this is a []byte of text data.
+		if t.Elem() == reflect.TypeOf(byte(0)) {
+			b := v.Bytes()
+			isPrintSpace := func(r rune) bool { return unicode.IsPrint(r) && unicode.IsSpace(r) }
+			if len(b) > 0 && utf8.Valid(b) && len(bytes.TrimFunc(b, isPrintSpace)) == 0 {
+				out = opts.formatString("", string(b))
+				return opts.WithTypeMode(emitType).FormatType(t, out)
+			}
 		}
+
 		fallthrough
 	case reflect.Array:
+		maxLen := v.Len()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		var list textList
 		for i := 0; i < v.Len(); i++ {
-			vi := v.Index(i)
-			if vi.CanAddr() { // Check for cyclic elements
-				p := vi.Addr()
-				if m.Visit(p) {
-					var out textNode
-					out = textLine(formatPointer(p))
-					out = opts.WithTypeMode(emitType).FormatType(p.Type(), out)
-					out = textWrap{"*", out, ""}
-					list = append(list, textRecord{Value: out})
-					continue
-				}
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
 			}
-			s := opts.WithTypeMode(elideType).FormatValue(vi, m)
+			s := opts.WithTypeMode(elideType).FormatValue(v.Index(i), t.Kind(), ptrs)
 			list = append(list, textRecord{Value: s})
 		}
-		return textWrap{ptr + "{", list, "}"}
+
+		out = &textWrap{Prefix: "{", Value: list, Suffix: "}"}
+		if t.Kind() == reflect.Slice && opts.PrintAddresses {
+			header := fmt.Sprintf("ptr:%v, len:%d, cap:%d", formatPointer(value.PointerOf(v), false), v.Len(), v.Cap())
+			out = &textWrap{Prefix: pointerDelimPrefix + header + pointerDelimSuffix, Value: out}
+		}
+		return out
 	case reflect.Map:
 		if v.IsNil() {
 			return textNil
 		}
-		if m.Visit(v) {
-			return textLine(formatPointer(v))
-		}
 
+		// Check pointer for cycles.
+		ptrRef, visited := ptrs.Push(v)
+		if visited {
+			return makeLeafReference(ptrRef, opts.PrintAddresses)
+		}
+		defer ptrs.Pop()
+
+		maxLen := v.Len()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		var list textList
 		for _, k := range value.SortKeys(v.MapKeys()) {
-			sk := formatMapKey(k)
-			sv := opts.WithTypeMode(elideType).FormatValue(v.MapIndex(k), m)
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
+			}
+			sk := formatMapKey(k, false, ptrs)
+			sv := opts.WithTypeMode(elideType).FormatValue(v.MapIndex(k), t.Kind(), ptrs)
 			list = append(list, textRecord{Key: sk, Value: sv})
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
-		}
-		return textWrap{ptr + "{", list, "}"}
+
+		out = &textWrap{Prefix: "{", Value: list, Suffix: "}"}
+		out = wrapTrunkReference(ptrRef, opts.PrintAddresses, out)
+		return out
 	case reflect.Ptr:
 		if v.IsNil() {
 			return textNil
 		}
-		if m.Visit(v) || opts.ShallowPointers {
-			return textLine(formatPointer(v))
+
+		// Check pointer for cycles.
+		ptrRef, visited := ptrs.Push(v)
+		if visited {
+			out = makeLeafReference(ptrRef, opts.PrintAddresses)
+			return &textWrap{Prefix: "&", Value: out}
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
-		}
+		defer ptrs.Pop()
+
 		skipType = true // Let the underlying value print the type instead
-		return textWrap{"&" + ptr, opts.FormatValue(v.Elem(), m), ""}
+		out = opts.FormatValue(v.Elem(), t.Kind(), ptrs)
+		out = wrapTrunkReference(ptrRef, opts.PrintAddresses, out)
+		out = &textWrap{Prefix: "&", Value: out}
+		return out
 	case reflect.Interface:
 		if v.IsNil() {
 			return textNil
@@ -197,19 +293,65 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 		// Interfaces accept different concrete types,
 		// so configure the underlying value to explicitly print the type.
 		skipType = true // Print the concrete type instead
-		return opts.WithTypeMode(emitType).FormatValue(v.Elem(), m)
+		return opts.WithTypeMode(emitType).FormatValue(v.Elem(), t.Kind(), ptrs)
 	default:
 		panic(fmt.Sprintf("%v kind not handled", v.Kind()))
 	}
 }
 
+func (opts formatOptions) formatString(prefix, s string) textNode {
+	maxLen := len(s)
+	maxLines := strings.Count(s, "\n") + 1
+	if opts.LimitVerbosity {
+		maxLen = (1 << opts.verbosity()) << 5   // 32, 64, 128, 256, etc...
+		maxLines = (1 << opts.verbosity()) << 2 //  4, 8, 16, 32, 64, etc...
+	}
+
+	// For multiline strings, use the triple-quote syntax,
+	// but only use it when printing removed or inserted nodes since
+	// we only want the extra verbosity for those cases.
+	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	isTripleQuoted := len(lines) >= 4 && (opts.DiffMode == '-' || opts.DiffMode == '+')
+	for i := 0; i < len(lines) && isTripleQuoted; i++ {
+		lines[i] = strings.TrimPrefix(strings.TrimSuffix(lines[i], "\r"), "\r") // trim leading/trailing carriage returns for legacy Windows endline support
+		isPrintable := func(r rune) bool {
+			return unicode.IsPrint(r) || r == '\t' // specially treat tab as printable
+		}
+		line := lines[i]
+		isTripleQuoted = !strings.HasPrefix(strings.TrimPrefix(line, prefix), `"""`) && !strings.HasPrefix(line, "...") && strings.TrimFunc(line, isPrintable) == "" && len(line) <= maxLen
+	}
+	if isTripleQuoted {
+		var list textList
+		list = append(list, textRecord{Diff: opts.DiffMode, Value: textLine(prefix + `"""`), ElideComma: true})
+		for i, line := range lines {
+			if numElided := len(lines) - i; i == maxLines-1 && numElided > 1 {
+				comment := commentString(fmt.Sprintf("%d elided lines", numElided))
+				list = append(list, textRecord{Diff: opts.DiffMode, Value: textEllipsis, ElideComma: true, Comment: comment})
+				break
+			}
+			list = append(list, textRecord{Diff: opts.DiffMode, Value: textLine(line), ElideComma: true})
+		}
+		list = append(list, textRecord{Diff: opts.DiffMode, Value: textLine(prefix + `"""`), ElideComma: true})
+		return &textWrap{Prefix: "(", Value: list, Suffix: ")"}
+	}
+
+	// Format the string as a single-line quoted string.
+	if len(s) > maxLen+len(textEllipsis) {
+		return textLine(prefix + formatString(s[:maxLen]) + string(textEllipsis))
+	}
+	return textLine(prefix + formatString(s))
+}
+
 // formatMapKey formats v as if it were a map key.
 // The result is guaranteed to be a single line.
-func formatMapKey(v reflect.Value) string {
+func formatMapKey(v reflect.Value, disambiguate bool, ptrs *pointerReferences) string {
 	var opts formatOptions
+	opts.DiffMode = diffIdentical
 	opts.TypeMode = elideType
-	opts.ShallowPointers = true
-	s := opts.FormatValue(v, visitedPointers{}).String()
+	opts.PrintAddresses = disambiguate
+	opts.AvoidStringer = disambiguate
+	opts.QualifiedNames = disambiguate
+	s := opts.FormatValue(v, reflect.Map, ptrs).String()
 	return strings.TrimSpace(s)
 }
 
@@ -227,7 +369,7 @@ func formatString(s string) string {
 	rawInvalid := func(r rune) bool {
 		return r == '`' || r == '\n' || !(unicode.IsPrint(r) || r == '\t')
 	}
-	if strings.IndexFunc(s, rawInvalid) < 0 {
+	if utf8.ValidString(s) && strings.IndexFunc(s, rawInvalid) < 0 {
 		return "`" + s + "`"
 	}
 	return qs
@@ -255,24 +397,4 @@ func formatHex(u uint64) string {
 		f = "0x%016x"
 	}
 	return fmt.Sprintf(f, u)
-}
-
-// formatPointer prints the address of the pointer.
-func formatPointer(v reflect.Value) string {
-	p := v.Pointer()
-	if flags.Deterministic {
-		p = 0xdeadf00f // Only used for stable testing purposes
-	}
-	return fmt.Sprintf("⟪0x%x⟫", p)
-}
-
-type visitedPointers map[value.Pointer]struct{}
-
-// Visit inserts pointer v into the visited map and reports whether it had
-// already been visited before.
-func (m visitedPointers) Visit(v reflect.Value) bool {
-	p := value.PointerOf(v)
-	_, visited := m[p]
-	m[p] = struct{}{}
-	return visited
 }

--- a/vendor/github.com/google/go-cmp/cmp/report_text.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_text.go
@@ -10,11 +10,14 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp/internal/flags"
 )
 
 var randBool = rand.New(rand.NewSource(time.Now().Unix())).Intn(2) == 0
+
+const maxColumnLength = 80
 
 type indentMode int
 
@@ -91,21 +94,22 @@ type textNode interface {
 // textWrap is a wrapper that concatenates a prefix and/or a suffix
 // to the underlying node.
 type textWrap struct {
-	Prefix string   // e.g., "bytes.Buffer{"
-	Value  textNode // textWrap | textList | textLine
-	Suffix string   // e.g., "}"
+	Prefix   string      // e.g., "bytes.Buffer{"
+	Value    textNode    // textWrap | textList | textLine
+	Suffix   string      // e.g., "}"
+	Metadata interface{} // arbitrary metadata; has no effect on formatting
 }
 
-func (s textWrap) Len() int {
+func (s *textWrap) Len() int {
 	return len(s.Prefix) + s.Value.Len() + len(s.Suffix)
 }
-func (s1 textWrap) Equal(s2 textNode) bool {
-	if s2, ok := s2.(textWrap); ok {
+func (s1 *textWrap) Equal(s2 textNode) bool {
+	if s2, ok := s2.(*textWrap); ok {
 		return s1.Prefix == s2.Prefix && s1.Value.Equal(s2.Value) && s1.Suffix == s2.Suffix
 	}
 	return false
 }
-func (s textWrap) String() string {
+func (s *textWrap) String() string {
 	var d diffMode
 	var n indentMode
 	_, s2 := s.formatCompactTo(nil, d)
@@ -114,7 +118,7 @@ func (s textWrap) String() string {
 	b = append(b, '\n')              // Trailing newline
 	return string(b)
 }
-func (s textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
+func (s *textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	n0 := len(b) // Original buffer length
 	b = append(b, s.Prefix...)
 	b, s.Value = s.Value.formatCompactTo(b, d)
@@ -124,7 +128,7 @@ func (s textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	}
 	return b, s
 }
-func (s textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
+func (s *textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 	b = append(b, s.Prefix...)
 	b = s.Value.formatExpandedTo(b, d, n)
 	b = append(b, s.Suffix...)
@@ -136,22 +140,23 @@ func (s textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 // of the textList.formatCompactTo method.
 type textList []textRecord
 type textRecord struct {
-	Diff    diffMode     // e.g., 0 or '-' or '+'
-	Key     string       // e.g., "MyField"
-	Value   textNode     // textWrap | textLine
-	Comment fmt.Stringer // e.g., "6 identical fields"
+	Diff       diffMode     // e.g., 0 or '-' or '+'
+	Key        string       // e.g., "MyField"
+	Value      textNode     // textWrap | textLine
+	ElideComma bool         // avoid trailing comma
+	Comment    fmt.Stringer // e.g., "6 identical fields"
 }
 
 // AppendEllipsis appends a new ellipsis node to the list if none already
 // exists at the end. If cs is non-zero it coalesces the statistics with the
 // previous diffStats.
 func (s *textList) AppendEllipsis(ds diffStats) {
-	hasStats := ds != diffStats{}
+	hasStats := !ds.IsZero()
 	if len(*s) == 0 || !(*s)[len(*s)-1].Value.Equal(textEllipsis) {
 		if hasStats {
-			*s = append(*s, textRecord{Value: textEllipsis, Comment: ds})
+			*s = append(*s, textRecord{Value: textEllipsis, ElideComma: true, Comment: ds})
 		} else {
-			*s = append(*s, textRecord{Value: textEllipsis})
+			*s = append(*s, textRecord{Value: textEllipsis, ElideComma: true})
 		}
 		return
 	}
@@ -191,7 +196,7 @@ func (s1 textList) Equal(s2 textNode) bool {
 }
 
 func (s textList) String() string {
-	return textWrap{"{", s, "}"}.String()
+	return (&textWrap{Prefix: "{", Value: s, Suffix: "}"}).String()
 }
 
 func (s textList) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
@@ -221,7 +226,7 @@ func (s textList) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	}
 	// Force multi-lined output when printing a removed/inserted node that
 	// is sufficiently long.
-	if (d == diffInserted || d == diffRemoved) && len(b[n0:]) > 80 {
+	if (d == diffInserted || d == diffRemoved) && len(b[n0:]) > maxColumnLength {
 		multiLine = true
 	}
 	if !multiLine {
@@ -236,15 +241,49 @@ func (s textList) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 			_, isLine := r.Value.(textLine)
 			return r.Key == "" || !isLine
 		},
-		func(r textRecord) int { return len(r.Key) },
+		func(r textRecord) int { return utf8.RuneCountInString(r.Key) },
 	)
 	alignValueLens := s.alignLens(
 		func(r textRecord) bool {
 			_, isLine := r.Value.(textLine)
 			return !isLine || r.Value.Equal(textEllipsis) || r.Comment == nil
 		},
-		func(r textRecord) int { return len(r.Value.(textLine)) },
+		func(r textRecord) int { return utf8.RuneCount(r.Value.(textLine)) },
 	)
+
+	// Format lists of simple lists in a batched form.
+	// If the list is sequence of only textLine values,
+	// then batch multiple values on a single line.
+	var isSimple bool
+	for _, r := range s {
+		_, isLine := r.Value.(textLine)
+		isSimple = r.Diff == 0 && r.Key == "" && isLine && r.Comment == nil
+		if !isSimple {
+			break
+		}
+	}
+	if isSimple {
+		n++
+		var batch []byte
+		emitBatch := func() {
+			if len(batch) > 0 {
+				b = n.appendIndent(append(b, '\n'), d)
+				b = append(b, bytes.TrimRight(batch, " ")...)
+				batch = batch[:0]
+			}
+		}
+		for _, r := range s {
+			line := r.Value.(textLine)
+			if len(batch)+len(line)+len(", ") > maxColumnLength {
+				emitBatch()
+			}
+			batch = append(batch, line...)
+			batch = append(batch, ", "...)
+		}
+		emitBatch()
+		n--
+		return n.appendIndent(append(b, '\n'), d)
+	}
 
 	// Format the list as a multi-lined output.
 	n++
@@ -256,7 +295,7 @@ func (s textList) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 		b = alignKeyLens[i].appendChar(b, ' ')
 
 		b = r.Value.formatExpandedTo(b, d|r.Diff, n)
-		if !r.Value.Equal(textEllipsis) {
+		if !r.ElideComma {
 			b = append(b, ',')
 		}
 		b = alignValueLens[i].appendChar(b, ' ')
@@ -330,6 +369,11 @@ type diffStats struct {
 	NumRemoved   int
 	NumInserted  int
 	NumModified  int
+}
+
+func (s diffStats) IsZero() bool {
+	s.Name = ""
+	return s == diffStats{}
 }
 
 func (s diffStats) NumDiff() int {

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -2525,6 +2525,7 @@ func strSliceContains(ss []string, s string) bool {
 
 type erringRoundTripper struct{ err error }
 
+func (rt erringRoundTripper) RoundTripErr() error                             { return rt.err }
 func (rt erringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, rt.err }
 
 // gzipReader wraps a response body so it can lazily

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -332,7 +332,7 @@ github.com/google/certificate-transparency-go/asn1
 github.com/google/certificate-transparency-go/client
 github.com/google/certificate-transparency-go/x509
 github.com/google/certificate-transparency-go/x509/pkix
-# github.com/google/go-cmp v0.3.1
+# github.com/google/go-cmp v0.5.1
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -486,7 +486,7 @@ github.com/hashicorp/go-msgpack/codec
 github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-sockaddr v1.0.2
 github.com/hashicorp/go-sockaddr
-# github.com/hashicorp/golang-lru v0.5.1 => github.com/hashicorp/golang-lru v0.5.0
+# github.com/hashicorp/golang-lru v0.5.4 => github.com/hashicorp/golang-lru v0.5.0
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/hashicorp/logutils v1.0.0
@@ -718,7 +718,7 @@ golang.org/x/crypto/scrypt
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/net v0.0.0-20200707034311-ab3426394381
+# golang.org/x/net v0.0.0-20200822124328-c89045814202
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -740,9 +740,9 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
-# golang.org/x/sync v0.0.0-20190423024810-112230192c58
+# golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 golang.org/x/sync/errgroup
-# golang.org/x/sys v0.0.0-20200803150936-fd5f0c170ac3 => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
+# golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae => golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2 => golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

I'm still going through some testing but decided that it wouldn't hurt to open PR to start gathering feedback as I don't expect the implementation to change significantly.

This is a pretty large changeset but what it does basically comes down to a couple of things:

* `tele build` (and `tele helm build`) accepts an `--upgrade-from` flag with the path to an installer tarball to build an incremental upgrade image from. The difference of the incremental image is that it only contains Docker images that are not present in the "base" tarball. It also doesn't include any of the system packages/apps, only user application.
* `tele build` also accepts a `--diff` flag which, combined with `--upgrade-from`, displays a diff table b/w images in the base tarball vs the one being built which looks kinda like this:

```
$ tele build robot-shop-app-2/resources/app.yaml --upgrade-from=robot-shop-1.1.0.tar -f --diff
                              robot-shop v1.1.0         robot-shop v1.2.0
                              -----------------         -----------------
gravitational/debian-tall     buster                    buster
rabbitmq                      3.7-management-alpine     3.7-management-alpine
redis                         4.0.6 (removed)           4.0.7 (added)
robotshop/rs-cart             latest                    latest
...
robotshop/rs-shipping         latest                    latest
robotshop/rs-user             latest                    latest
robotshop/rs-web              0.4.20 (removed)          0.4.30 (added)
```

In the example above, only the changed images (`redis:4.0.7` and `robotshop/rs-web:0.4.30`) will be vendored in the incremental image.

Installation using a partial image is prohibited. When it comes to upgrading, the process is exactly the same as using a "full" cluster/application image, it is basically the same as the scenario where runtime doesn't change and there's only application upgrade. This works out nicely because all Docker images missing from the tarball are supposed to be present in the cluster's registry. There is one gotcha described in the implementation section.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Refs https://github.com/gravitational/gravity/issues/1191.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [ ] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

One implementation detail worth mentioning is how an incremental upgrade image is handled when transferred to the cluster. Because it only contains a subset of all required Docker images, uploading it to the cluster as-is would be problematic because after GC the missing images would be gone from the registry.

For this reason, I "reconstruct" the incremental image's registry layers from the cluster's registry before uploading it to the cluster. This way it basically becomes a "full" image and as such no changes to garbage collection or anything else are required. It also lets validate the "integrity" of the application because the cluster registry is supposed to have all non-vendored images present and the upload will fail if any of them are missing (which would otherwise have resulted in a failed upgrade).

Another detail, is I introduced a "status" field in our manifest object, similar to K8s, to store some runtime kind of information. It is currently populated during tele build and stores information about Docker images the application depends on and vendors which is needed for some logic. I also tried another approach with storing it in a package envelope metadata but the manifest approach turned out to be cleaner and easier to work with.

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

Does not apply.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Lots of scenarios, gonna keep the list here for reference. I've tested most (if not all) of these before, but will be checking those off as I retest them:

### Build

- [x] Build an incremental upgrade cluster image
  - [x] Make sure --diff produces correct output
- [ ] Build an incremental upgrade app image
  - [ ] Make sure --diff produces correct output
- [ ] Building cluster image from cluster image with different base is prohibited

### Install/upgrade

- [x] Install cluster image, perform incremental upgrade
  - [x] Validate can join nodes and they pull the app properly
  - [x] Validate can run GC and everything’s preserved
  - [ ] Validate can export the app from cluster
- [ ] Install application image, perform incremental upgrade
- [x] Attempt to install incremental image should return an error
- [ ] Attempt to upgrade using incremental image from version other than the one if was built off of should show a warning
- [x] Attempt to upgrade the cluster with different base version should fail