### PR TITLE
(7.0) Fix audit event panic

### DIFF
--- a/lib/ops/opsservice/service.go
+++ b/lib/ops/opsservice/service.go
@@ -1441,9 +1441,11 @@ func (o *Operator) EmitAuditEvent(ctx context.Context, req ops.AuditEventRequest
 		return trace.Wrap(err)
 	}
 	o.Infof("%s.", req)
-	err = o.cfg.AuditLog.EmitAuditEvent(req.Event, req.Fields)
-	if err != nil {
-		return trace.Wrap(err)
+	if o.cfg.AuditLog != nil {
+		err = o.cfg.AuditLog.EmitAuditEvent(req.Event, req.Fields)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

The `AuditLog` interface is sometimes uninitialized for an operator, which can lead to a panic when trying to emit an audit event. For example, this happens when trying to `gravity plan complete` for a join operation.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Closes https://github.com/gravitational/gravity/issues/2230.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

None, a trivial change.