### PR TITLE
[7.0.x] save manifest file prior to vendoring

### DIFF
--- a/lib/builder/build.go
+++ b/lib/builder/build.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 
 	"github.com/gravitational/gravity/lib/docker"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/schema"
 
 	"github.com/gravitational/trace"
@@ -69,6 +70,7 @@ func (b *Builder) Build(ctx context.Context) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		b.Manifest.SetBase(loc.Runtime.WithVersion(*runtimeVersion))
 		err = b.SyncPackageCache(ctx, *runtimeVersion, b.UpgradeVia...)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -172,9 +172,14 @@ func (m *Manifest) WithBase(locator loc.Locator) Manifest {
 	if m.BaseImage != nil {
 		result.BaseImage = &BaseImage{Locator: locator}
 	}
-	result.SystemOptions = &SystemOptions{
-		Runtime: &Runtime{Locator: locator},
+	if m.SystemOptions != nil {
+		systemOptions := *m.SystemOptions
+		result.SystemOptions = &systemOptions
+	} else {
+		result.SystemOptions = &SystemOptions{}
 	}
+	// Reset the runtime with the specified locator
+	result.SystemOptions.Runtime = &Runtime{Locator: locator}
 	return result
 }
 

--- a/lib/schema/manifest.go
+++ b/lib/schema/manifest.go
@@ -169,7 +169,12 @@ func (m *Manifest) SetBase(locator loc.Locator) {
 // WithBase returns a copy of this manifest with the specified base application
 func (m *Manifest) WithBase(locator loc.Locator) Manifest {
 	result := *m
-	result.SetBase(locator)
+	if m.BaseImage != nil {
+		result.BaseImage = &BaseImage{Locator: locator}
+	}
+	result.SystemOptions = &SystemOptions{
+		Runtime: &Runtime{Locator: locator},
+	}
 	return result
 }
 


### PR DESCRIPTION
lib/builder: always write the manifest file in the vendor directory to persist the overridden runtime version. If the original manifest runtime version uses a template like `0.0.0+latest`, it might lead to the wrong (e.g. more recent) version of runtime to be actually used for building if the cache directory has a recent version of packages.

Updates https://github.com/gravitational/gravity/issues/2229.

## Description
<!--Required. Provide high-level overview of what the change is for.-->

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs #2229

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
So far I've tested manually on patched 7.0.12/7.0.20. Will see if I can add a manual test.

## Additional information
<!--Optional. Anything else that may be relevant.-->
