### PR TITLE
[6.1.x] reload service definition before creating a service

### DIFF
--- a/lib/install/client/install.go
+++ b/lib/install/client/install.go
@@ -80,8 +80,9 @@ func (r *InstallerStrategy) installSelfAsService() error {
 			WantedBy:         "multi-user.target",
 			WorkingDirectory: r.ApplicationDir,
 		},
-		NoBlock: true,
-		Name:    r.ServicePath,
+		NoBlock:             true,
+		ReloadConfiguration: true,
+		Name:                r.ServicePath,
 	}
 	req.ServiceSpec.Environment = utils.Getenv(constants.PreflightChecksOffEnvVar)
 	r.WithField("req", fmt.Sprintf("%+v", req)).Info("Install service.")

--- a/lib/system/service/oneshot.go
+++ b/lib/system/service/oneshot.go
@@ -71,5 +71,5 @@ func ReinstallOneshot(req systemservice.NewServiceRequest) error {
 
 func installOneshot(services systemservice.ServiceManager, req systemservice.NewServiceRequest) error {
 	req.ServiceSpec.Type = OneshotService
-	return trace.Wrap(install(services, req))
+	return trace.Wrap(reinstall(services, req))
 }

--- a/lib/system/service/service.go
+++ b/lib/system/service/service.go
@@ -82,6 +82,7 @@ func IsStatus(serviceName string, statuses ...string) error {
 }
 
 // Reinstall installs a systemd service specified with req.
+// It will attempt to remove the previous service with the name specified in request.
 // The operation is non-blocking and returns without waiting for service to start
 func Reinstall(req systemservice.NewServiceRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
@@ -91,7 +92,7 @@ func Reinstall(req systemservice.NewServiceRequest) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return trace.Wrap(install(services, req))
+	return trace.Wrap(reinstall(services, req))
 }
 
 // Name returns the unit name part of path
@@ -99,20 +100,16 @@ func Name(path string) string {
 	return filepath.Base(path)
 }
 
-func install(services systemservice.ServiceManager, req systemservice.NewServiceRequest) error {
+func reinstall(services systemservice.ServiceManager, req systemservice.NewServiceRequest) error {
 	if req.ServiceSpec.User == "" {
 		req.ServiceSpec.User = constants.RootUIDString
 	}
 	logger := log.WithField("service", req.Name)
-	err := services.DisableService(systemservice.DisableServiceRequest{
+	err := services.UninstallService(systemservice.UninstallServiceRequest{
 		Name: Name(req.Name),
 	})
 	if err != nil && !systemservice.IsUnknownServiceError(err) {
-		logger.WithError(err).Warn("Failed to disable.")
-	}
-	err = services.StopService(Name(req.Name))
-	if err != nil && !systemservice.IsUnknownServiceError(err) {
-		logger.WithError(err).Warn("Failed to stop.")
+		logger.WithError(err).Warn("Failed to uninstall.")
 	}
 	return trace.Wrap(services.InstallService(req))
 }

--- a/lib/system/service/service.go
+++ b/lib/system/service/service.go
@@ -114,10 +114,6 @@ func install(services systemservice.ServiceManager, req systemservice.NewService
 	if err != nil && !systemservice.IsUnknownServiceError(err) {
 		logger.WithError(err).Warn("Failed to stop.")
 	}
-	err = removeLingeringUnitFile(req.Name)
-	if err != nil && !systemservice.IsUnknownServiceError(err) {
-		logger.WithError(err).Warn("Failed to remove lingering unit files.")
-	}
 	return trace.Wrap(services.InstallService(req))
 }
 

--- a/lib/system/service/simple.go
+++ b/lib/system/service/simple.go
@@ -41,8 +41,9 @@ func ReinstallSimpleService(serviceName string, cmd []string) error {
 	}
 
 	err = services.InstallService(systemservice.NewServiceRequest{
-		Name:    serviceName,
-		NoBlock: true,
+		Name:                serviceName,
+		NoBlock:             true,
+		ReloadConfiguration: true,
 		ServiceSpec: systemservice.ServiceSpec{
 			User:         constants.RootUIDString,
 			Type:         SimpleService,

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -134,16 +134,9 @@ func (s *systemdManager) installService(service serviceTemplate, req NewServiceR
 	if _, ok := service.Environment[defaults.PathEnv]; !ok {
 		service.Environment[defaults.PathEnv] = defaults.PathEnvVal
 	}
-	f, err := os.Create(unitPath(req.Name))
-	if err != nil {
-		return trace.Wrap(err,
-			"error creating systemd unit file at %v", unitPath(req.Name))
-	}
-	defer f.Close()
 
-	err = serviceUnitTemplate.Execute(f, service)
-	if err != nil {
-		return trace.Wrap(err, "error rendering template")
+	if err := writeUnitFile(unitPath(req.Name), service); err != nil {
+		return trace.Wrap(err)
 	}
 
 	if req.ReloadConfiguration {
@@ -506,6 +499,21 @@ func invokeSystemctl(args ...string) (string, error) {
 	cmd := exec.Command("systemctl", append(args, "--no-pager")...)
 	err := utils.ExecL(cmd, &out, log)
 	return out.String(), trace.Wrap(err)
+}
+
+func writeUnitFile(path string, service serviceTemplate) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return trace.Wrap(err,
+			"error creating systemd unit file at %v", path)
+	}
+	defer f.Close()
+
+	err = serviceUnitTemplate.Execute(f, service)
+	if err != nil {
+		return trace.Wrap(err, "error rendering template")
+	}
+	return nil
 }
 
 // unitPath returns the default path for the systemd unit with the given name.

--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -76,8 +76,6 @@ WantedBy={{.WantedBy}}
 {{end}}
 `
 
-	systemdUnitFileSuffix = ".service"
-
 	systemdServiceDelimiter = "__"
 )
 
@@ -106,7 +104,7 @@ type systemdUnit struct {
 }
 
 func parseUnit(unit string) *loc.Locator {
-	unit = strings.TrimSuffix(unit, systemdUnitFileSuffix)
+	unit = strings.TrimSuffix(unit, ServiceSuffix)
 	parts := strings.Split(unit, systemdServiceDelimiter)
 	if len(parts) != 4 {
 		return nil
@@ -122,7 +120,7 @@ func parseUnit(unit string) *loc.Locator {
 func (u *systemdUnit) serviceName() string {
 	return strings.Join([]string{
 		servicePrefix, u.pkg.Repository, u.pkg.Name, u.pkg.Version},
-		systemdServiceDelimiter) + systemdUnitFileSuffix
+		systemdServiceDelimiter) + ServiceSuffix
 }
 
 func (u *systemdUnit) servicePath() string {
@@ -133,7 +131,9 @@ func (s *systemdManager) installService(service serviceTemplate, req NewServiceR
 	if service.Environment == nil {
 		service.Environment = make(map[string]string)
 	}
-	service.Environment[defaults.PathEnv] = defaults.PathEnvVal
+	if _, ok := service.Environment[defaults.PathEnv]; !ok {
+		service.Environment[defaults.PathEnv] = defaults.PathEnvVal
+	}
 	f, err := os.Create(unitPath(req.Name))
 	if err != nil {
 		return trace.Wrap(err,
@@ -144,6 +144,12 @@ func (s *systemdManager) installService(service serviceTemplate, req NewServiceR
 	err = serviceUnitTemplate.Execute(f, service)
 	if err != nil {
 		return trace.Wrap(err, "error rendering template")
+	}
+
+	if req.ReloadConfiguration {
+		if out, err := invokeSystemctl("daemon-reload"); err != nil {
+			return trace.Wrap(err, "failed to reload manager's configuration").AddField("output", out)
+		}
 	}
 
 	if err := s.EnableService(req.Name); err != nil {
@@ -262,7 +268,7 @@ func (s *systemdManager) ListPackageServices(opts ListServiceOptions) ([]Package
 	if opts.Pattern != "" {
 		args = append(args, opts.Pattern)
 	}
-	out, err := invokeSystemctl(args...)
+	out, err := invokeSystemctlQuiet(args...)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to list-units: %v", out)
 	}
@@ -361,23 +367,27 @@ func (s *systemdManager) UninstallService(req UninstallServiceRequest) error {
 
 	out, err := invokeSystemctl("stop", serviceName)
 	if err != nil && !IsUnknownServiceError(err) {
-		return trace.Wrap(err)
+		return trace.Wrap(err, out)
 	}
 
 	out, err = invokeSystemctl("disable", serviceName)
 	if err != nil && !IsUnknownServiceError(err) {
-		return trace.Wrap(err)
+		return trace.Wrap(err, out)
 	}
 
+	// Returns 0 if the unit is in failed state, non-zero otherwise
+	// See https://www.freedesktop.org/software/systemd/man/systemctl.html#is-failed%20PATTERN%E2%80%A6
 	out, err = invokeSystemctl("is-failed", serviceName)
 	status := strings.TrimSpace(out)
 
-	if err == nil {
+	if exitCode := utils.ExitStatusFromError(err); exitCode != nil && *exitCode != 0 {
 		unitPath := unitPath(req.Name)
 		logger = logger.WithField("path", unitPath)
 		if errDelete := os.Remove(unitPath); errDelete != nil {
 			if !os.IsNotExist(errDelete) {
 				logger.WithError(errDelete).Warn("Failed to remove service unit file.")
+			} else {
+				logger.Info("Service unit file does not exist.")
 			}
 		} else {
 			logger.Info("Removed service unit file.")
@@ -385,13 +395,13 @@ func (s *systemdManager) UninstallService(req UninstallServiceRequest) error {
 	}
 
 	switch status {
-	case ServiceStatusInactive:
-		// Ignore the inactive state
+	case ServiceStatusInactive, ServiceStatusUnknown:
+		// Ignore the inactive and unknown states
 		return nil
 	case ServiceStatusFailed:
 		return trace.CompareFailed("error stopping service %q: %s", serviceName, out)
 	default:
-		if err != nil && !IsUnknownServiceError(err) {
+		if err != nil {
 			// Results of `systemctl is-failed` are purely informational
 			// beyond the state values we already check above
 			logger.WithFields(logrus.Fields{
@@ -441,10 +451,16 @@ func (s *systemdManager) RestartService(name string) error {
 func (s *systemdManager) StatusService(name string) (string, error) {
 	out, err := invokeSystemctl("is-active", name)
 	out = strings.TrimSpace(out)
+	// TODO(dmitri): this is a dubious behavior at least w.r.t `unknown` state
+	// which one might consider actually unknown. In fact, the `is-active` predicate
+	// _always_ returns a state for a (arbitrary, even non-existent) service, and a
+	// non-zero exit code if the status is not 'active'
+	//
 	// do not report error in case if status is known
 	switch out {
-	case ServiceStatusActive, ServiceStatusFailed, ServiceStatusActivating,
-		ServiceStatusUnknown, ServiceStatusInactive:
+	case ServiceStatusActive, ServiceStatusInactive,
+		ServiceStatusFailed, ServiceStatusUnknown,
+		ServiceStatusActivating, ServiceStatusDeactivating:
 		return out, nil
 	}
 	return out, err
@@ -478,6 +494,11 @@ func (s *systemdManager) supportsTasksAccounting() bool {
 		return false
 	}
 	return version >= defaults.SystemdTasksMinVersion
+}
+
+func invokeSystemctlQuiet(args ...string) (string, error) {
+	out, err := exec.Command("systemctl", append(args, "--no-pager")...).CombinedOutput()
+	return string(out), trace.Wrap(err)
 }
 
 func invokeSystemctl(args ...string) (string, error) {

--- a/lib/utils/error.go
+++ b/lib/utils/error.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -344,6 +345,12 @@ func IsConnectionResetError(err error) bool {
 // 'connection refused' error.
 // err is expected to be non-nil
 func IsConnectionRefusedError(err error) bool {
+	if urlError, ok := trace.Unwrap(err).(*url.Error); ok {
+		if opError, ok := urlError.Err.(*net.OpError); ok {
+			errno, ok := opError.Err.(syscall.Errno)
+			return ok && errno == syscall.ECONNREFUSED
+		}
+	}
 	return strings.Contains(trace.Unwrap(err).Error(),
 		"connection refused")
 }

--- a/tool/gravity/cli/install.go
+++ b/tool/gravity/cli/install.go
@@ -475,8 +475,9 @@ func agent(env *localenv.LocalEnvironment, config agentConfig) error {
 			ServiceSpec: systemservice.ServiceSpec{
 				StartCommand: strings.Join(command, " "),
 			},
-			NoBlock: true,
-			Name:    config.serviceName,
+			NoBlock:             true,
+			ReloadConfiguration: true,
+			Name:                config.serviceName,
 		}
 		log.WithField("req", req).Info("Installing service with req.")
 		err := service.ReinstallOneshot(req)


### PR DESCRIPTION
lib/system*: introduce an attribute for explicitly reloading service state.

When creating a service unit, sometimes we re-purpose the existing unit files and the system manager (`systemd`) needs to be notified that the existing unit file have been changed so it refreshes in-memory state. Do this explicitly whenever a new service is created.

## Description
<!--Required. Provide high-level overview of what the change is for.-->

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
Updates https://github.com/gravitational/gravity/issues/2149.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
 * Install 3-node cluster.
 * Install 1-node cluster and join 2 nodes.
 * On a 3-node cluster (all masters), remove nodes from other nodes - e.g. avoid removing from the same node, always alternate to exercise the paths when there was previously a simple agent (i.e. like the one started during join on one of the master nodes) and the joining agent.

## Additional information
<!--Optional. Anything else that may be relevant.-->
