### PR TITLE
Remove 6.2 upgrade testing from nightly builds

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -13,11 +13,9 @@ UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical
 UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.0]="ubuntu:16"
 
-# 6.2 and 6.3 won't be supported upgrades to 7.1, but they're not *intentionally* broken yet
+# 6.3 won't be a supported upgrades to 7.1, it is not *intentionally* broken yet
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7" # compatible non-LTS version
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="centos:7" # compatible non-LTS version
-UPGRADE_MAP[6.2.0]="ubuntu:16"
 
 function build_upgrade_size_suite {
   local to_tarball=${INSTALLER_URL}


### PR DESCRIPTION
## Description
6.2.x fails to install the robotest app due to a busted hook init container,
described in #2243. Because 6.2.x won't eventually be supported to
7.1.x (when k8s 1.19 merges #2028), it doesn't hurt to remove
upgrade testing from it now.

Nightlies have been failing due to this bug since the cache fixes (#2233)
resulted in actually testing 6.2 upgrades.

## Type of change
* Internal change

## Linked tickets and other PRs
* Contributes to/avoids #2243
* Fixes nightly failures surfaced by #2233

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
Installed 6.2.5 manually, looked at the pods:

```
walt-70-upgrade-node-0:/$ kubectl get pods                                                                                                                                                    
NAME                              READY   STATUS                  RESTARTS   AGE                                                                                                              
echoserver-77f9c59fc5-j9r9z       1/1     Running                 0          3m16s                                                                                                            
echoserver-77f9c59fc5-k2tf2       1/1     Running                 0          3m16s                                                                                                            
echoserver-install-606670-q96lh   0/1     Completed               0          3m25s                                                                                                            
echoserver-status-23edee-c2g8p    0/1     Completed               0          3m15s                                                                                                            
echoserver-status-ece370-5h6j5    0/1     Init:CrashLoopBackOff   4          2m43s                                                                                                            
walt-70-upgrade-node-0:/$ kubectl logs -c init echoserver-status-ece370-5h6j5                                                                                                                 
                                                                                                                                                                                              
                                                                                                                                                                                              
connected to https://gravity-site.kube-system.svc.cluster.local:3009 adminagent@graciousbassi9271                                                                                             
[ERROR]: Get https://gravity-site.kube-system.svc.cluster.local:3009/pack/v1/repositories/gravitational.io/packages/robotest/6.2.5/envelope: stat /etc/kubernetes/kubectl.kubeconfig: no such 
file or directory, failed to create kubernetes client from /etc/kubernetes/kubectl.kubeconfig  
```

I also checked 6.3.18, it does not suffer from the same behavior:
```
walt-70-upgrade-node-0:/$ kubectl get pods                                                                                                                                                    
NAME                              READY   STATUS      RESTARTS   AGE                                                                                                                          
echoserver-77f9c59fc5-7hd25       1/1     Running     0          12m
echoserver-77f9c59fc5-rnctc       1/1     Running     0          12m
echoserver-install-efa6de-s6t8s   0/1     Completed   0          12m
echoserver-status-a93bb6-dhr8m    0/1     Completed   0          12m
```
