### PR TITLE
[7.0.x]    Certificate changes according to the latest MacOS specific requirements. (2209)

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1179,6 +1179,19 @@ const (
 	// during cluster installation (such as apiserver, etcd, kubelet, etc.)
 	CertificateExpiry = 10 * 365 * 24 * time.Hour // 10 years
 
+	// CertRenewBeforeExpiry is the time window to replace a certificate before expiration.
+	// Let's Encrypt recommends to renew certificates 30 days before expiration.
+	CertRenewBeforeExpiry = 30 * 24 * time.Hour
+
+	// CertBackdating is the time duration that will be used
+	// to shift back the start date of the certificate validity period.
+	// Following Let’s Encrypt example of intentionally backdating certificates by 1 hour.
+	// The backdating is needed in order to avoid issues with clock skew.
+	CertBackdating = -1 * time.Hour
+
+	// SelfSignedCertWebOrg is the Organization that is used to self-sign certificates.
+	SelfSignedCertWebOrg = "Gravitational Self-Signed Web Access"
+
 	// TransientErrorTimeout specifies the maximum amount of time to attempt
 	// an operation experiencing transient errors
 	TransientErrorTimeout = 15 * time.Minute

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -1492,6 +1492,7 @@ func (p *Process) initService(ctx context.Context) (err error) {
 		}
 
 		p.startService(p.runCertificateWatch(client))
+		p.startService(p.runCertExpirationWatch(client))
 		p.startService(p.runAuthGatewayWatch(client))
 		p.startService(p.runReloadEventsWatch(client))
 		p.startService(p.runRegistrySynchronizer)
@@ -1947,11 +1948,15 @@ func (p *Process) initClusterCertificate(ctx context.Context, client *kubernetes
 		return trace.Wrap(err)
 	}
 	if len(cert) != 0 && len(key) != 0 {
-		p.Info("Cluster certificate is already initialized.")
+		err = p.replaceCertIfAboutToExpire(ctx, p.client)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		p.Info("Cluster web UI certificate is already initialized.")
 		return nil
 	}
 
-	p.Info("Initializing cluster certificate.")
+	p.Infof("Initializing cluster web UI certificate from file: %v...", p.teleportConfig.Proxy.TLSCert)
 
 	certificateData, err := ioutil.ReadFile(p.teleportConfig.Proxy.TLSCert)
 	if err != nil {
@@ -1976,7 +1981,12 @@ func (p *Process) initClusterCertificate(ctx context.Context, client *kubernetes
 		return trace.Wrap(err)
 	}
 
-	p.Info("Cluster certificate has been initialized.")
+	err = p.replaceCertIfAboutToExpire(ctx, p.client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	p.Infof("Successfully initialized cluster web UI certificate from file: %v.", p.teleportConfig.Proxy.TLSCert)
 	return nil
 }
 
@@ -2337,7 +2347,7 @@ func initSelfSignedHTTPSCert(cfg *service.Config, hostname string) (err error) {
 	if hostname != "" {
 		hosts = append(hosts, hostname)
 	}
-	creds, err := teleutils.GenerateSelfSignedCert(hosts)
+	creds, err := utils.GenerateSelfSignedCert(hosts)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -18,9 +18,16 @@ package utils
 
 import (
 	"archive/tar"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/big"
+	"net"
 	"path/filepath"
 	"strings"
 	"time"
@@ -31,7 +38,9 @@ import (
 	cfsslhelpers "github.com/cloudflare/cfssl/helpers"
 	dockerarchive "github.com/docker/docker/pkg/archive"
 	"github.com/gravitational/license/authority"
+	teleutils "github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 )
 
 // CertificateOutput contains information about cluster certificate
@@ -52,6 +61,68 @@ type CertificateName struct {
 	Organization []string `json:"org"`
 	// OrganizationalUnit is the subject/issuer unit
 	OrganizationalUnit []string `json:"org_unit"`
+}
+
+// GenerateSelfSignedCert generates a self signed certificate that
+// is valid for given domain names and ips, returns PEM-encoded bytes with key and cert
+// Generates a certificate that is compatible with the MacOS requirements described at:
+// https://support.apple.com/en-us/HT210176
+func GenerateSelfSignedCert(hostNames []string) (*teleutils.TLSCredentials, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	notBefore := time.Now().Add(defaults.CertBackdating)
+	notAfter := notBefore.Add(time.Hour * 24 * 825) // 825 days or fewer is the required validity period for MacOS
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	entity := pkix.Name{
+		CommonName:   "localhost",
+		Country:      []string{"US"},
+		Organization: []string{"localhost"},
+		// OrganizationalUnit is needed in order to be able to identify the cert when doing
+		// automated cert rotation. If a user decides to use their own cert
+		// we should not rotate.
+		OrganizationalUnit: []string{defaults.SelfSignedCertWebOrg},
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Issuer:                entity,
+		Subject:               entity,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, // MacOS specific requirement
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// collect IP addresses localhost resolves to and add them to the cert. template:
+	template.DNSNames = append(hostNames, "localhost.local")
+	template.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(priv.Public())
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to marshal PKI public key.")
+		return nil, trace.Wrap(err)
+	}
+
+	return &teleutils.TLSCredentials{
+		PublicKey:  pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: publicKeyBytes}),
+		PrivateKey: pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}),
+		Cert:       pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}),
+	}, nil
 }
 
 // CertificateValidity contains information about certificate validity dates


### PR DESCRIPTION
Port of the MacOS cert changes to the 7.0.x branch [(2209)](https://github.com/gravitational/gravity/pull/2209)

(cherry picked from commit fdeebb9)