### PR TITLE
Add a shared cache to robotest image builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,12 @@ def robotest() {
   runRobotest = (env.RUN_ROBOTEST == 'run')
   stage('build robotest images') {
     if (runRobotest) {
-      sh 'make -C e/assets/robotest images'
+      // Use a shared cache outside the build directory, to avoid repeat downloads and improve
+      // build time. For more info see:
+      //   https://github.com/gravitational/gravity/blob/4c7ac3ada1e3fb50cf8afdd1d1a4ed4d34bb75d0/assets/robotest/README.md#local-caching
+      withEnv(["ROBOTEST_CACHE_ROOT=/var/lib/gravity/robotest-cache"]) {
+        sh 'make -C e/assets/robotest images'
+      }
     } else {
       echo 'skipping building robotest images'
     }


### PR DESCRIPTION
## Description
Re-using a cache outside of the build directory improves build times and saves on
cloud networking bills by avoiding re-downloading tele binaries and packages for
upgrade base image builds.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Requires #2233

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback

## Implementation
This cache lives on a dedicated 1TB volume:

```
[centos@jenkins gravity]$ df -h /var/lib/gravity
Filesystem      Size  Used Avail Use% Mounted on
/dev/sdc       1007G  345G  612G  37% /var/lib/gravity
```

This volume is (5.5, 6.1)/was (7.0, master) used for storing packages in `/var/lib/gravity/opscenter/read`:

https://github.com/gravitational/gravity/blob/e46900ed5948a7b2f76118345c7ada31c22966eb/Makefile#L153
https://github.com/gravitational/gravity/blob/e46900ed5948a7b2f76118345c7ada31c22966eb/Makefile#L157
https://github.com/gravitational/gravity/blob/e46900ed5948a7b2f76118345c7ada31c22966eb/Makefile#L160

```
[jenkins@jenkins gravity]$ du -sh /var/lib/gravity/opscenter/read
333G    /var/lib/gravity/opscenter/read
```

I need to backport [the changes that moved these packages to the build directory](https://github.com/gravitational/gravity/pull/1967/commits/3a06b8a7b219e9aabbfa32830a6ff826dd49b4c5) to 6.1 & 5.5, as then we could remove content inside `/var/lib/gravity/opscenter`. I'd keep the directory around (owned by jenkins:jenkins) for backwards compatibility.

## Performance/Scaling
Nightlies are already running with this shared cached set, which reduces the robotest build time by ~1m (20%).  More importantly than the time savings, this is saving a considerable amount of network & disk space:

```
[centos@jenkins Gravity-PR-5.2_PR-2279-GCQ7PBNT6VPPM3YGIIFTY3T56P4F2UC4PBYW2VI4IWIXTI65E7CA]$ du -sh e/build/cache/
15G     e/build/cache/
```

This load is:
1) moved from the 2TB `/var/lib/jenkins/workspace` to the 1TB `/var/lib/gravity`
2) mostly deduplicated (i.e. all builds that upgrade from 7.0.0 share a single state dir for 7.0.0, instead of each open PR keeping a copy of the data)

There is a risk that the `/var/lib/gravity`drive fills up over time.  In this case, these are just a cache, and older files may be found/removed (while no robotest build is running) with a command like:

```
find /var/lib/gravity/robotest-cache -atime +14 -type f -exec ls {} \;
```

I will be monitoring the growth of this cache closely for the next couple weeks, making sure we've got plenty of headroom & possibly implementing an automated pruning cron if our headroom is low.

## Testing done
I've been using a shared cache locally for several weeks, during my development of both master & 7.0s robotest build changes:

```
walt@gcp:~/git/gravity$ env | grep ROBOTEST_CACHE_ROOT
ROBOTEST_CACHE_ROOT=/home/walt/.cache/robotest
walt@gcp:~/git/gravity$ du -sh $ROBOTEST_CACHE_ROOT
33G     /home/walt/.cache/robotest
```

Nightlies are already using the shared cache:

```
[jenkins@jenkins gravity]$ du -sh /var/lib/gravity/robotest-cache
11G     /var/lib/gravity/robotest-cache
```

## Additional information
When I created this directory, I put the the following README.md in it:

```
[centos@jenkins ~]$ cat /var/lib/gravity/robotest-cache/README.md
This is a cache used by Enterprise & OSS robotest image builds.

It contains both per-version tele binaries and per-version package
caches suitable for use with the robotest Makefile.

If the directory is deleted, please make sure to either:

1) recreated it owned by jenkins:jenkins, so the build can re-cache data there
2) change the ROBOTEST_CACHE_ROOT parameter/environment variable on all gravity builds

For more information see:

https://github.com/gravitational/gravity/blob/4c7ac3ada1e3fb50cf8afdd1d1a4ed4d34bb75d0/assets/robotest/README.md#local-caching

As well as the related codepaths:

https://github.com/gravitational/gravity/blob/4c7ac3ada1e3fb50cf8afdd1d1a4ed4d34bb75d0/assets/robotest/Makefile#L46-L76
```
