### PR TITLE
[7.0] Add a shared cache to robotest image builds.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,12 @@ def robotest() {
   runRobotest = (env.RUN_ROBOTEST == 'run')
   stage('build robotest images') {
     if (runRobotest) {
-      sh 'make -C e/assets/robotest images'
+      // Use a shared cache outside the build directory, to avoid repeat downloads and improve
+      // build time. For more info see:
+      //   https://github.com/gravitational/gravity/blob/4c7ac3ada1e3fb50cf8afdd1d1a4ed4d34bb75d0/assets/robotest/README.md#local-caching
+      withEnv(["ROBOTEST_CACHE_ROOT=/var/lib/gravity/robotest-cache"]) {
+        sh 'make -C e/assets/robotest images'
+      }
     } else {
       echo 'skipping building robotest images'
     }


### PR DESCRIPTION
## Description
Backport of #2283.

This considerably improves subsequent build times by avoiding
re-downloading tele binaries and packages for upgrade base image builds.

(cherry picked from commit b0644df0df2dd78e69a7a809158d3a0915388c16)

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2283

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback

## Testing done
For testing done & infrastructure/performance concerns, see the original PR #2283, where there is a comprehensive breakdown.