### PR TITLE
[7.0.x] use executable's directory as application directory for install

### DIFF
--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -297,7 +298,7 @@ func (i *InstallConfig) CheckAndSetDefaults(validator resources.Validator) (err 
 		i.FieldLogger = log.WithField(trace.Component, "installer")
 	}
 	if i.StateDir == "" {
-		i.StateDir = utils.Exe.WorkingDir
+		i.StateDir = filepath.Dir(utils.Exe.Path)
 		i.WithField("dir", i.StateDir).Info("Set installer read state directory.")
 	}
 	i.writeStateDir = state.GravityInstallDir()


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Use the binary's directory as the default for the application directory for install. This reverts the accidental behavior change introduced in #2240 

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2292

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
