### PR TITLE
Release notes for 7.0.25

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -11,7 +11,7 @@ Find the latest Open Source Gravity releases at [Gravity Downloads](https://grav
 
 | Version             | Latest Patch | LTS | Release Date         | Latest Patch Date    | End of Support *        | Kubernetes Version   | Teleport Version |
 | ------------------- | ------------ | --- | -------------------- | -------------------- | ----------------------- | -------------------- | ---------------- |
-| [7.0](#70-releases) | 7.0.24       | Yes | April 3, 2020        | November 2, 2020   | July 9, 2022            | 1.17.9               | 3.2.14-gravity   |
+| [7.0](#70-releases) | 7.0.25       | Yes | April 3, 2020        | November 4, 2020   | July 9, 2022            | 1.17.9               | 3.2.14-gravity   |
 | [6.1](#61-releases) | 6.1.44       | Yes | August 2, 2019       | October 22, 2020   | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
 | [5.5](#55-releases) | 5.5.55       | Yes | March 8, 2019        | October 21, 2020   | March 8, 2021           | 1.13.11              | 3.0.7-gravity    |
 
@@ -50,6 +50,17 @@ extend updates past End of Support through customer agreements if required.
 # Release Notes
 
 ## 7.0 Releases
+
+### 7.0.25 LTS (November 4, 2020)
+
+#### Improvements
+
+* Allow configuration of the Pod subnet size through the Cluster Configuration resource ([#2302](https://github.com/gravitational/gravity/pull/2302), [planet#785](https://github.com/gravitational/planet/pull/785)).
+
+#### Bugfixes
+
+* Fix an issue where `gravity stop` fails when executed with a custom planet package ([#2191](https://github.com/gravitational/gravity/pull/2191)).
+
 
 ### 7.0.24 LTS (November 2, 2020)
 


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
7.0.25 Release notes

#### Improvements

 * Allow configuration of the Pod subnet size through the Cluster Configuration resource ([#2302](https://github.com/gravitational/gravity/pull/2302), [planet#785](https://github.com/gravitational/planet/pull/785)).

 #### Bugfixes

 * Fix an issue where `gravity stop` fails when executed with a custom planet package ([#2191](https://github.com/gravitational/gravity/pull/2191)).