### PR TITLE
Release notes for 6.1.45

### DIFF
--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -12,7 +12,7 @@ Find the latest Open Source Gravity releases at [Gravity Downloads](https://grav
 | Version             | Latest Patch | LTS | Release Date         | Latest Patch Date    | End of Support *        | Kubernetes Version   | Teleport Version |
 | ------------------- | ------------ | --- | -------------------- | -------------------- | ----------------------- | -------------------- | ---------------- |
 | [7.0](#70-releases) | 7.0.25       | Yes | April 3, 2020        | November 4, 2020   | July 9, 2022            | 1.17.9               | 3.2.14-gravity   |
-| [6.1](#61-releases) | 6.1.44       | Yes | August 2, 2019       | October 22, 2020   | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
+| [6.1](#61-releases) | 6.1.45       | Yes | August 2, 2019       | November 5, 2020   | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
 | [5.5](#55-releases) | 5.5.55       | Yes | March 8, 2019        | October 21, 2020   | March 8, 2021           | 1.13.11              | 3.0.7-gravity    |
 
 Gravity offers one Long Term Support (LTS) version for every 2nd Kubernetes
@@ -678,6 +678,13 @@ to learn how to gain insight into how the cluster status changes over time.
 * Upgrade Kubernetes to `v1.16.0`.
 
 ## 6.1 Releases
+
+### 6.1.45 LTS (November 5th, 2020)
+
+#### Improvements
+
+* Allow configuration of the Pod subnet size through the Cluster Configuration resource ([#2305](https://github.com/gravitational/gravity/pull/2305), [planet#788](https://github.com/gravitational/planet/pull/788)).
+
 
 ### 6.1.44 LTS (October 22nd, 2020)
 


### PR DESCRIPTION
### 6.1.45 Release notes

#### Improvements

 * Allow configuration of the Pod subnet size through the Cluster Configuration resource ([#2305](https://github.com/gravitational/gravity/pull/2305), [planet#788](https://github.com/gravitational/planet/pull/788)).