### PR TITLE
Increase robotest distro diversity

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -8,18 +8,18 @@ source $(dirname $0)/lib/utils.sh
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7 redhat:7 debian:9 ubuntu:18" # compatible LTS version
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.0]="ubuntu:16"
 
 # 6.3 won't be a supported upgrades to 7.1, it is not *intentionally* broken yet
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7" # compatible non-LTS version
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7.9" # compatible non-LTS version
 # UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
 
 function build_upgrade_size_suite {
   local to_tarball=${INSTALLER_URL}
-  local os="centos:7"
+  local os="centos:7.9"
   local cluster_sizes=( \
     '"flavor":"three","nodes":3,"role":"node"' \
     '"flavor":"six","nodes":6,"role":"node"' \
@@ -35,7 +35,6 @@ function build_upgrade_size_suite {
 
 function build_upgrade_to_release_under_test_suite {
   local to_tarball=${INSTALLER_URL}
-  local os="centos:7"
   local size='"flavor":"three","nodes":3,"role":"node"'
   local suite=''
   for release in ${!UPGRADE_MAP[@]}; do
@@ -59,9 +58,9 @@ EOF
 
 function build_resize_suite {
   local suite=$(cat <<EOF
- resize={"installer_url":"${INSTALLER_URL}","to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
- resize={"installer_url":"${INSTALLER_URL}","to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
- shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
+ resize={"installer_url":"${INSTALLER_URL}","to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
+ resize={"installer_url":"${INSTALLER_URL}","to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"redhat:7.9"}
+ shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
 EOF
 )
   echo -n $suite
@@ -84,14 +83,13 @@ EOF
 }
 function build_install_suite {
   local suite=''
-  local test_os="redhat:7 centos:7 debian:9 ubuntu:16 ubuntu:18"
+  local oses="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_sizes=( \
-    '"flavor":"three","nodes":3,"role":"node"' \
     '"flavor":"six","nodes":6,"role":"node"')
-  for os in $test_os; do
+  for os in $oses; do
     for size in ${cluster_sizes[@]}; do
       suite+=$(cat <<EOF
- install={"installer_url":"${INSTALLER_URL}",${size},"os":"${os}","storage_driver":"overlay2"}
+ install={"installer_url":"${INSTALLER_URL}",${size},"os":"${os}"}
 EOF
 )
       suite+=' '

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -7,8 +7,8 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7" # compatible LTS version
-UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2" # compatible LTS version
+UPGRADE_MAP[7.0.13]="centos:7.9" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
 # UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
@@ -37,7 +37,7 @@ function build_upgrade_suite {
 function build_resize_suite {
   local suite=$(cat <<EOF
  resize={"installer_url":"${INSTALLER_URL}","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
- shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
+ shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
 EOF
 )
     echo -n $suite

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -36,7 +36,7 @@ function build_upgrade_suite {
 
 function build_resize_suite {
   local suite=$(cat <<EOF
- resize={"installer_url":"${INSTALLER_URL}","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
+ resize={"installer_url":"${INSTALLER_URL}","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
  shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
 EOF
 )
@@ -65,7 +65,7 @@ function build_install_suite {
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF
- install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${os}","storage_driver":"overlay2"}
+ install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${os}"}
 EOF
 )
   done

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -61,12 +61,14 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local test_os="redhat:8.3"
-  local cluster_size='"flavor":"three","nodes":3,"role":"node"'
-  suite+=$(cat <<EOF
- install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${test_os}","storage_driver":"overlay2"}
+  local oses="redhat:8.3 redhat:7.9 centos:8.2 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local cluster_size='"flavor":"one","nodes":1,"role":"node"'
+  for os in $oses; do
+    suite+=$(cat <<EOF
+ install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${os}","storage_driver":"overlay2"}
 EOF
 )
+  done
   suite+=' '
   echo -n $suite
 }

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -13,12 +13,6 @@ UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
 # UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
 
-# 6.2 and 6.3 ignored in PR builds per https://github.com/gravitational/gravity/pull/1760#pullrequestreview-437838773
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="redhat:7" # compatible non-LTS version
-# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="redhat:7" # compatible non-LTS version
-# UPGRADE_MAP[6.2.0]="ubuntu:16"
-
 function build_upgrade_suite {
   local size='"flavor":"three","nodes":3,"role":"node"'
   local to_tarball=${INSTALLER_URL}

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -52,8 +52,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -90,8 +88,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -129,8 +125,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -55,9 +55,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: amz
           versions: ["2"]
       volumes:
@@ -91,9 +91,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"
@@ -128,9 +128,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -93,7 +93,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9", "10"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -132,7 +132,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9", "10"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -54,8 +54,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
         - name: amz
@@ -90,8 +88,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
       volumes:
@@ -127,8 +123,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
       volumes:

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -51,7 +51,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -87,7 +87,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -124,7 +124,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -55,7 +55,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["9"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -93,7 +93,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["8", "9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -132,7 +132,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["8", "9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/assets/robotest/run.sh
+++ b/assets/robotest/run.sh
@@ -25,7 +25,7 @@ GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
 GCE_VM=${GCE_VM:-custom-4-8192}
 GCE_PREEMPTIBLE=${GCE_PREEMPTIBLE:-'false'}
 # Parallelism & retry, tuned for GCE
-PARALLEL_TESTS=${PARALLEL_TESTS:-4}
+PARALLEL_TESTS=${PARALLEL_TESTS:-10}
 REPEAT_TESTS=${REPEAT_TESTS:-1}
 RETRIES=${RETRIES:-3}
 FAIL_FAST=${FAIL_FAST:-false}

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -52,8 +52,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -90,8 +88,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -129,8 +125,6 @@ nodeProfiles:
           versions: ["7", "8"]
         - name: ubuntu
           versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
         - name: debian
           versions: ["9", "10"]
         - name: suse

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -55,9 +55,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: amz
           versions: ["2"]
       volumes:
@@ -91,9 +91,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"
@@ -128,9 +128,9 @@ nodeProfiles:
         - name: debian
           versions: ["9", "10"]
         - name: suse
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -55,7 +55,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9", "10"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -93,7 +93,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9", "10"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -132,7 +132,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9", "10"]
+          versions: ["9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -54,8 +54,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
         - name: amz
@@ -90,8 +88,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
       volumes:
@@ -127,8 +123,6 @@ nodeProfiles:
           versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
-        - name: suse
-          versions: ["12", "15"]
         - name: sles  # Suse Linux Enterprise Server
           versions: ["12", "15"]
       volumes:

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -55,7 +55,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["8", "9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -93,7 +93,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["8", "9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server
@@ -132,7 +132,7 @@ nodeProfiles:
         - name: ubuntu-core
           versions: ["16"]
         - name: debian
-          versions: ["8", "9"]
+          versions: ["8", "9", "10"]
         - name: suse
           versions: ["12"]
         - name: sles  # Suse Linux Enterprise Server

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -51,7 +51,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -87,7 +87,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse
@@ -124,7 +124,7 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
           versions: ["9", "10"]
         - name: suse


### PR DESCRIPTION
## Description
This PR introduces a significant amount of install testing on other distros, facilitated by Robotest 2.2.0.  Most notably:

* SLES 12-sp5 and 15-sp2
* CentOS/RHEL 8.2 & 7.9
* Ubuntu 20.04

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Fixes https://github.com/gravitational/gravity/issues/1678
* Depends on https://github.com/gravitational/robotest/pull/273

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Performance/Scaling
I made two perf tweaks to ameliorate the large number of distro tests this PR introduces:
1) I reduced the install testing from 3 nodes to 1. Our 3 node upgrade tests sufficiently cover the 3 node install scenario on critical platforms.
2) I bumped parallelism from 4 to 10 concurrent tests.  I haven't seen any load related issues at this level, and doing so helps with all these short lived one node installs.  A goroutine can blaze through several of these during a single parallel multinode upgrade.

## Testing done
The PR build is sufficient to test all the changes in the PR config.  For nightly, see [this try build](https://jenkins.gravitational.io/view/Robotest/job/gravity-try-build/87/).

For complete configs see below:

<details><summary>pr</summary>

```
walt@gcp:~/git/gravity$ make -C assets/robotest get-config
make: Entering directory '/home/walt/git/gravity/assets/robotest'
install={"installer_url":"/images/telekube-7.1.0-alpha.1.276.tar","nodes":3,"flavor":"three","role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/opscenter-7.1.0-alpha.1.276.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"redhat:8.2"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"redhat:7.8"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"centos:8.2"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"centos:7.8"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"sles:12-sp5"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"sles:15-sp2"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:16"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:20"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"debian:9"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"debian:10"}
resize={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
shrink={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
upgrade={"from":"/images/robotest-7.0.7.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.2","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.13.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.12.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
```
</details>


<details><summary>nightly</summary>

```
walt@gcp:~/git/gravity$ make -C assets/robotest get-config ROBOTEST_CONFIG=nightly                                                                                                            
make: Entering directory '/home/walt/git/gravity/assets/robotest'
install={"installer_url":"/images/telekube-7.1.0-alpha.1.276.tar","nodes":3,"flavor":"three","role":"node","os":"ubuntu:18"}                                                                  
install={"installer_url":"/images/opscenter-7.1.0-alpha.1.276.tar","nodes":3,"flavor":"ha","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:8.2"}                                                                   
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:7.8"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"centos:8.2"}                                                                   
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.8"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"sles:12-sp5"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"sles:15-sp2"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:16"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:20"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"debian:9"}
install={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"debian:10"}
resize={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
resize={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"redhat:7.9"}
shrink={"installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.9","service_uid":997,"service_gid
":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"one","nodes":1,"role":"node","os":"centos:7.9","service_uid":997,"service_gid
":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.0.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gid
":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.2","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:7.8","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:8.2","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.8","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"sles:12-sp5","service_uid":997,"service_
gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"sles:15-sp2","service_uid":997,"service_
gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gi
d":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gi
d":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gi
d":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"debian:9","service_uid":997,"service_gid
":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"debian:10","service_uid":997,"service_gi
d":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-6.3.18.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_g
id":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.13.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7","service_uid":997,"service_gid
":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.12.tar","installer_url":"/images/robotest-7.1.0-alpha.1.276.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gi
d":994,"storage_driver":"overlay2"}
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
```
</details>