### PR TITLE
[7.0] set 100000 fds on systemd unit creation if unspecified (#2315)

### DIFF
--- a/lib/systemservice/systemd.go
+++ b/lib/systemservice/systemd.go
@@ -56,7 +56,7 @@ ExecStartPre={{.}}{{end}}
 {{if .StartPostCommand}}ExecStartPost={{.StartPostCommand}}{{end}}
 {{if .StopCommand}}ExecStop={{.StopCommand}}{{end}}
 {{if .StopPostCommand}}ExecStopPost={{.StopPostCommand}}{{end}}
-{{if .LimitNoFile}}LimitNOFILE={{.LimitNoFile}}{{end}}
+{{if .LimitNoFile}}LimitNOFILE={{.LimitNoFile}}{{else}}LimitNOFILE=100000{{end}}
 {{if .KillMode}}KillMode={{.KillMode}}{{end}}
 {{if .KillSignal}}KillSignal={{.KillSignal}}{{end}}
 {{if .Restart}}Restart={{.Restart}}{{end}}

--- a/lib/systemservice/systemd_test.go
+++ b/lib/systemservice/systemd_test.go
@@ -46,44 +46,49 @@ func (s *SystemdSuite) TestUnitParsing(c *C) {
 }
 
 func (s *SystemdSuite) TestServiceTemplate(c *C) {
-	buf := &bytes.Buffer{}
-	err := serviceUnitTemplate.Execute(buf, serviceTemplate{
-		Name:        "test.service",
-		Description: "test",
-		ServiceSpec: ServiceSpec{
-			Type:             "oneshot",
-			StartCommand:     "start",
-			StopCommand:      "stop",
-			StopPostCommand:  "stop post",
-			StartPreCommands: []string{"pre-command", "another pre-command"},
-			StartPostCommand: "start post",
-			WantedBy:         "test.target",
-			KillMode:         "cgroup",
-			KillSignal:       "SIGQUIT",
-			RestartSec:       3,
-			Timeout:          4,
-			Restart:          "always",
-			User:             "root",
-			LimitNoFile:      1000,
-			RemainAfterExit:  true,
-			Dependencies: Dependencies{
-				Requires: "foo.service",
-				After:    "foo.service",
-				Before:   "bar.service",
+	tt := []struct {
+		in          serviceTemplate
+		out         string
+		description string
+	}{
+		{
+			description: "Full service",
+			in: serviceTemplate{
+				Name:        "test.service",
+				Description: "test",
+				ServiceSpec: ServiceSpec{
+					Type:             "oneshot",
+					StartCommand:     "start",
+					StopCommand:      "stop",
+					StopPostCommand:  "stop post",
+					StartPreCommands: []string{"pre-command", "another pre-command"},
+					StartPostCommand: "start post",
+					WantedBy:         "test.target",
+					KillMode:         "cgroup",
+					KillSignal:       "SIGQUIT",
+					RestartSec:       3,
+					Timeout:          4,
+					Restart:          "always",
+					User:             "root",
+					LimitNoFile:      1000,
+					RemainAfterExit:  true,
+					Dependencies: Dependencies{
+						Requires: "foo.service",
+						After:    "foo.service",
+						Before:   "bar.service",
+					},
+					Environment: map[string]string{
+						"PATH": "/usr/bin",
+					},
+					TasksMax:                 "infinity",
+					TimeoutStopSec:           "5min",
+					ConditionPathExists:      "/path/to/foo",
+					RestartPreventExitStatus: "1 2 3",
+					SuccessExitStatus:        "254",
+					WorkingDirectory:         "/foo/bar",
+				},
 			},
-			Environment: map[string]string{
-				"PATH": "/usr/bin",
-			},
-			TasksMax:                 "infinity",
-			TimeoutStopSec:           "5min",
-			ConditionPathExists:      "/path/to/foo",
-			RestartPreventExitStatus: "1 2 3",
-			SuccessExitStatus:        "254",
-			WorkingDirectory:         "/foo/bar",
-		},
-	})
-	c.Assert(err, IsNil)
-	c.Assert(buf.String(), compare.DeepEquals, `[Unit]
+			out: `[Unit]
 Description=test
 
 Requires=foo.service
@@ -120,7 +125,91 @@ TasksMax=infinity
 [Install]
 WantedBy=test.target
 
-`)
+`,
+		},
+		{
+			description: "unspecified file limits",
+			in: serviceTemplate{
+				Name:        "test.service",
+				Description: "test",
+				ServiceSpec: ServiceSpec{
+					Type:             "oneshot",
+					StartCommand:     "start",
+					StopCommand:      "stop",
+					StopPostCommand:  "stop post",
+					StartPreCommands: []string{"pre-command", "another pre-command"},
+					StartPostCommand: "start post",
+					WantedBy:         "test.target",
+					KillMode:         "cgroup",
+					KillSignal:       "SIGQUIT",
+					RestartSec:       3,
+					Timeout:          4,
+					Restart:          "always",
+					User:             "root",
+					RemainAfterExit:  true,
+					Dependencies: Dependencies{
+						Requires: "foo.service",
+						After:    "foo.service",
+						Before:   "bar.service",
+					},
+					Environment: map[string]string{
+						"PATH": "/usr/bin",
+					},
+					TasksMax:                 "infinity",
+					TimeoutStopSec:           "5min",
+					ConditionPathExists:      "/path/to/foo",
+					RestartPreventExitStatus: "1 2 3",
+					SuccessExitStatus:        "254",
+					WorkingDirectory:         "/foo/bar",
+				},
+			},
+			out: `[Unit]
+Description=test
+
+Requires=foo.service
+After=foo.service
+Before=bar.service
+
+ConditionPathExists=/path/to/foo
+
+[Service]
+TimeoutStartSec=4
+Type=oneshot
+User=root
+ExecStart=start
+ExecStartPre=pre-command
+ExecStartPre=another pre-command
+ExecStartPost=start post
+ExecStop=stop
+ExecStopPost=stop post
+LimitNOFILE=100000
+KillMode=cgroup
+KillSignal=SIGQUIT
+Restart=always
+TimeoutStopSec=5min
+RestartSec=3
+RemainAfterExit=yes
+RestartPreventExitStatus=1 2 3
+SuccessExitStatus=254
+WorkingDirectory=/foo/bar
+Environment=PATH=/usr/bin
+
+TasksMax=infinity
+
+
+[Install]
+WantedBy=test.target
+
+`,
+		},
+	}
+
+	for _, test := range tt {
+		buf := &bytes.Buffer{}
+		err := serviceUnitTemplate.Execute(buf, test.in)
+		c.Assert(err, IsNil, Commentf(test.description))
+		c.Assert(buf.String(), compare.DeepEquals, test.out, Commentf(test.description))
+	}
 }
 
 func (s *SystemdSuite) TestMountServiceTemplate(c *C) {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Some distros / versions of systemd default to 1024 open fds. So by default if unspecified, create systemd units from gravity with 100000 fds as 1024 is far too low for gravity daemons by default.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)


## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates #2314
Ports #2315

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
I just set this to infinity if not specified, to avoid any defaults / limits. 

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->
I suppose in theory this could cause issues with lots of open connections that will present in a different way than being blocked due to max open fds.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Created an equivelant change and tested it on a test cluster. New Unit tests. Relying on robotest for this.

## Additional information
<!--Optional. Anything else that may be relevant.-->


(cherry picked from commit 4510a5d165e3b3bdebb8064a767adbbaf59e194b)