### PR TITLE
Increase dns-app update status checks

### DIFF
--- a/assets/dns-app/hooks/entrypoint.sh
+++ b/assets/dns-app/hooks/entrypoint.sh
@@ -10,7 +10,7 @@ if [ $1 = "update" ]; then
     rig delete ds/coredns-worker --resource-namespace=kube-system --force
 
     echo "Checking status"
-    rig status $RIG_CHANGESET --retry-attempts=120 --retry-period=1s --debug
+    rig status $RIG_CHANGESET --retry-attempts=600 --retry-period=1s --debug
     echo "Freezing"
     rig freeze
 elif [ $1 = "rollback" ]; then


### PR DESCRIPTION


## Description
<!--Required. Provide high-level overview of what the change is for.-->
The number of retry attempts when checking the status of rigging changes may be too short for clusters experiencing high scheduler load. We have a customer app that appears to crash during the app update, creating lots of kubernetes scheduler events and the dns pods can take more than 2 minutes to start.

Update the retry attempts to allow for ~10 minutes.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates #2282

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback

