### PR TITLE
Add TODO item for upstream pending PRs to template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,7 @@
 - [ ] Perform manual testing
 - [ ] Write documentation
 - [ ] Address review feedback
+- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)
 
 ## Implementation
 <!--Optional. Add any relevant implementation details that might help the reviewers.-->


### PR DESCRIPTION
I've seen a bit of confusion lately with the team practices that we tend to approve changes before the PR is totally complete, and will accept the changes expecting an update before merge. For the project I think this is a needed practice, but I think @wadells does a great job of communicating this intention as a checklist item as in #2335. 

So if the team is onboard, let's add a checklist item for it when required, to more clearly communicate when there are small changes to the upstream references needed ahead of merge. 

Thoughts?