### PR TITLE
[7.0.x] Increase robotest distro diversity

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -7,13 +7,13 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="centos:7" # this branch
-UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:7.9" # this branch
+UPGRADE_MAP[7.0.13]="centos:7.9" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
 # UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
 
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.1.x))]="redhat:7" # compatible LTS version
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.1.x))]="redhat:7.9" # compatible LTS version
 # UPGRADE_MAP[6.1.0]="debian:9" # 6.1.0 hook init containers are broken (#2243)
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="debian:9" # compatible non-LTS version
 
@@ -23,14 +23,8 @@ INTERMEDIATE_UPGRADE_VERSION=$(recommended_upgrade_tag $(branch 6.1.x))
 # latest + INTERMEDIATE_UPGRADE_VERSION image.  The chosen version will exercise a double etcd upgrade.
 # For example: v3.3.11 to v3.3.22 to v3.4.9
 declare -A INTERMEDIATE_UPGRADE_MAP
-INTERMEDIATE_UPGRADE_MAP[$(recommended_upgrade_tag $(branch 5.5.x))]="centos:7"
-INTERMEDIATE_UPGRADE_MAP[5.5.10]="centos:7"
-
-# 6.2 and 6.3 ignored in PR builds per https://github.com/gravitational/gravity/pull/1760#pullrequestreview-437838773
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="redhat:7" # compatible non-LTS version
-# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.2.x))]="redhat:7" # compatible non-LTS version
-# UPGRADE_MAP[6.2.0]="ubuntu:16"
+INTERMEDIATE_UPGRADE_MAP[$(recommended_upgrade_tag $(branch 5.5.x))]="centos:7.9"
+INTERMEDIATE_UPGRADE_MAP[5.5.10]="centos:7.9"
 
 function build_upgrade_suite {
   local size='"flavor":"three","nodes":3,"role":"node"'
@@ -63,8 +57,8 @@ function build_intermediate_upgrade_suite {
 
 function build_resize_suite {
   local suite=$(cat <<EOF
- resize={"installer_url":"${INSTALLER_URL}","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
- shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
+ resize={"installer_url":"${INSTALLER_URL}","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
+ shrink={"installer_url":"${INSTALLER_URL}","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
 EOF
 )
     echo -n $suite
@@ -88,12 +82,14 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local test_os="redhat:8.3"
-  local cluster_size='"flavor":"three","nodes":3,"role":"node"'
-  suite+=$(cat <<EOF
- install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${test_os}","storage_driver":"overlay2"}
+  local oses="redhat:8.3 redhat:7.9 centos:8.2 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local cluster_size='"flavor":"one","nodes":1,"role":"node"'
+  for os in $oses; do
+    suite+=$(cat <<EOF
+ install={"installer_url":"${INSTALLER_URL}",${cluster_size},"os":"${os}"}
 EOF
 )
+  done
   suite+=' '
   echo -n $suite
 }

--- a/assets/robotest/current/app.yaml
+++ b/assets/robotest/current/app.yaml
@@ -51,15 +51,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: amz
           versions: ["2"]
       volumes:
@@ -89,15 +85,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"
@@ -128,15 +120,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"

--- a/assets/robotest/run.sh
+++ b/assets/robotest/run.sh
@@ -25,7 +25,7 @@ GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
 GCE_VM=${GCE_VM:-custom-4-8192}
 GCE_PREEMPTIBLE=${GCE_PREEMPTIBLE:-'false'}
 # Parallelism & retry, tuned for GCE
-PARALLEL_TESTS=${PARALLEL_TESTS:-4}
+PARALLEL_TESTS=${PARALLEL_TESTS:-10}
 REPEAT_TESTS=${REPEAT_TESTS:-1}
 RETRIES=${RETRIES:-3}
 FAIL_FAST=${FAIL_FAST:-false}

--- a/assets/robotest/upgrade-base/app.yaml
+++ b/assets/robotest/upgrade-base/app.yaml
@@ -51,15 +51,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
         - name: amz
           versions: ["2"]
       volumes:
@@ -89,15 +85,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"
@@ -128,15 +120,11 @@ nodeProfiles:
         - name: rhel
           versions: ["7", "8"]
         - name: ubuntu
-          versions: ["16.04", "18.04"]
-        - name: ubuntu-core
-          versions: ["16"]
+          versions: ["16.04", "18.04", "20.04"]
         - name: debian
-          versions: ["8", "9"]
-        - name: suse
-          versions: ["12"]
+          versions: ["9", "10"]
         - name: sles  # Suse Linux Enterprise Server
-          versions: ["12"]
+          versions: ["12", "15"]
       volumes:
         - path: /var/lib/gravity
           capacity: "10GB"


### PR DESCRIPTION
## Description
This is a backport of #2318.

This PR introduces a significant amount of install testing on other distros, facilitated by Robotest 2.2.0.  Most notably:

* SLES 12-sp5 and 15-sp2
* CentOS/RHEL 8.2 & 7.9
* Ubuntu 20.04
* Debian 10

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Backports #2318
* Contributes to https://github.com/gravitational/gravity/issues/1678

## TODOs
- [x] Self-review the change
- [x] Make sure the PR build is green
- [ ] Address review feedback

## Testing done
The PR build is sufficient to test all the changes.

For complete configs see below:

<details><summary>pr config</summary>

```
walt@gcp:~/git/gravity$ make -C assets/robotest get-config
make: Entering directory '/home/walt/git/gravity/assets/robotest'
install={"installer_url":"/images/telekube-7.0.27-dev.6.tar","nodes":3,"flavor":"three","role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/opscenter-7.0.27-dev.6.tar","nodes":1,"flavor":"standalone","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"redhat:8.3"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"redhat:7.9"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"centos:8.2"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"centos:7.9"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"sles:12-sp5"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"sles:15-sp2"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:16"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"ubuntu:20"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"debian:9"}
install={"installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"one","nodes":1,"role":"node","os":"debian:10"}
resize={"installer_url":"/images/robotest-7.0.27-dev.6.tar","nodes":1,"to":3,"flavor":"one","role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
shrink={"installer_url":"/images/robotest-7.0.27-dev.6.tar","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
upgrade={"from":"/images/robotest-7.0.7.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.26.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-6.3.18.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"debian:9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.13.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.12.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-6.1.45.tar","installer_url":"/images/robotest-7.0.27-dev.6.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-5.5.10.tar","installer_url":"/images/robotest-7.0.27-dev.6-via-6.1.45.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-5.5.55.tar","installer_url":"/images/robotest-7.0.27-dev.6-via-6.1.45.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
```
</details>
