### PR TITLE
Update 7.0, 6.1, 5.5 supported distros

### DIFF
--- a/docs/5.x/requirements.md
+++ b/docs/5.x/requirements.md
@@ -15,9 +15,9 @@ Gravity supports the following distributions:
 | Linux Distribution       | Version          | Docker Storage Drivers                 |
 |--------------------------|------------------|----------------------------------------|
 | Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.2 | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7, 8.0-8.2 | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
+| Debian                   | 8, 9             | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu                   | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
 | openSuse                 | 12 SP2 - 12 SP3  | `overlay`, `overlay2`                  |
@@ -38,9 +38,9 @@ Following table lists all the supported distributions and how they can be specif
 
 | Distribution Name        | ID                         | Version          |
 |--------------------------|----------------------------|------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.2 |
-| CentOS                   | centos                     | 7.2-7.7, 8.0-8.2 |
-| Debian                   | debian                     | 8-9              |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3 |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3 |
+| Debian                   | debian                     | 8, 9             |
 | Ubuntu                   | ubuntu                     | 16.04            |
 | Ubuntu-Core              | ubuntu                     | 16.04            |
 | openSuse                 | suse, opensuse, opensuse-* | 12-SP2, 12-SP3   |
@@ -244,16 +244,16 @@ root$ modprobe iptable_nat
 Following table summarizes the required kernel modules per OS distribution.
 Gravity requires that these modules are loaded prior to installation.
 
-| Linux Distribution                   | Version        | Modules                                         |
-|--------------------------------------|----------------|-------------------------------------------------|
-| CentOS                               | 7.2            | bridge, ebtable_filter, iptables, overlay       |
-| RedHat Linux                         | 7.2            | bridge, ebtable_filter, iptables                |
-| CentOS                               | 7.3-7.6        | br_netfilter, ebtable_filter, iptables, overlay |
-| RedHat Linux                         | 7.3-7.6        | br_netfilter, ebtable_filter, iptables, overlay |
-| Debian                               | 8-9            | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu                               | 16.04          | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu-Core                          | 16.04          | br_netfilter, ebtable_filter, iptables, overlay |
-| Suse Linux (openSUSE and Enterprise) | 12 SP2, 12 SP3 | br_netfilter, ebtable_filter, iptables, overlay |
+| Linux Distribution                   | Version          | Modules                                         |
+|--------------------------------------|------------------|-------------------------------------------------|
+| CentOS                               | 7.2              | bridge, ebtable_filter, iptables, overlay       |
+| RedHat Linux                         | 7.2              | bridge, ebtable_filter, iptables                |
+| CentOS                               | 7.3-7.9, 8.0-8.3 | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.3 | br_netfilter, ebtable_filter, iptables, overlay |
+| Debian                               | 8, 9             | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu                               | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu-Core                          | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
+| Suse Linux (openSUSE and Enterprise) | 12 SP2, 12 SP3   | br_netfilter, ebtable_filter, iptables, overlay |
 
 ### Inotify watches
 

--- a/docs/6.x/requirements.md
+++ b/docs/6.x/requirements.md
@@ -7,17 +7,17 @@ Kubernetes and Gravity.
 
 Gravity supports the following Linux distributions:
 
-| Linux Distribution        | Version         | Docker Storage Drivers                |
-|--------------------------|------------------|---------------------------------------|
+| Linux Distribution        | Version         | Docker Storage Drivers                 |
+|--------------------------|------------------|----------------------------------------|
 | Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.2 | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.7, 8.0-8.1 | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8-9              | `devicemapper`*, `overlay`, `overlay2` |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
+| Debian                   | 8, 9             | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu                   | 16.04, 18.04     | `devicemapper`*, `overlay`, `overlay2` |
 | Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
 | openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
 | Suse Linux Enterprise    | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
-| Amazon Linux             | 2                | `overlay`, `overlay2`                 |
+| Amazon Linux             | 2                | `overlay`, `overlay2`                  |
 
 !!! note
     devicemapper has been deprecated by the docker project, and is not supported by gravity 5.3.4 or later
@@ -35,8 +35,8 @@ specified in the manifest:
 
 | Distribution Name        | ID                         | Version          |
 |--------------------------|----------------------------|------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.2 |
-| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3 |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3 |
 | Debian                   | debian                     | 8-9              |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04     |
 | Ubuntu-Core              | ubuntu                     | 16.04            |
@@ -254,16 +254,16 @@ root$ modprobe iptable_nat
 Following table summarizes the required kernel modules per OS distribution.
 Gravity requires that these modules are loaded prior to installation.
 
-| Linux Distribution                     | Version | Modules |
-|--------------------------|-----------|---------------------------|
-| CentOS                    | 7.2     | bridge, ebtable_filter, iptables, overlay  |
-| RedHat Linux | 7.2     | bridge, ebtable_filter, iptables  |
-| CentOS                  | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay  |
-| RedHat Linux | 7.3-7.6     | br_netfilter, ebtable_filter, iptables, overlay     |
-| Debian | 8-9 | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu-Core | 16.04 | br_netfilter, ebtable_filter, iptables, overlay |
-| Suse Linux (openSUSE and Enterprise) | 12 SP2, 12 SP3 | br_netfilter, ebtable_filter, iptables, overlay |
+| Linux Distribution                   | Version          | Modules                                         |
+|--------------------------------------|------------------|-------------------------------------------------|
+| CentOS                               | 7.2              | bridge, ebtable_filter, iptables, overlay       |
+| RedHat Linux                         | 7.2              | bridge, ebtable_filter, iptables                |
+| CentOS                               | 7.3-7.9, 8.0-8.3 | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.3 | br_netfilter, ebtable_filter, iptables, overlay |
+| Debian                               | 8, 9             | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu                               | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu-Core                          | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
+| Suse Linux (openSUSE and Enterprise) | 12-SP2, 12 SP3   | br_netfilter, ebtable_filter, iptables, overlay |
 
 ### Inotify watches
 

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -12,16 +12,16 @@ Kubernetes and Gravity.
 
 Gravity officially supports the following Linux distributions:
 
-| Linux Distribution       | Version          | Docker Storage Drivers                |
-|--------------------------|------------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.8, 8.0-8.2 | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.7, 8.0-8.1 | `overlay`, `overlay2`                 |
-| Debian                   | 9                | `overlay`, `overlay2`                 |
-| Ubuntu                   | 16.04, 18.04     | `overlay`, `overlay2`                 |
-| Ubuntu-Core              | 16.04            | `overlay`, `overlay2`                 |
-| openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                 |
-| Suse Linux Enterprise    | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                 |
-| Amazon Linux             | 2                | `overlay`, `overlay2`                 |
+| Linux Distribution       | Version             | Docker Storage Drivers                |
+|--------------------------|---------------------|---------------------------------------|
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3    | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.9, 8.0-8.3    | `overlay`, `overlay2`                 |
+| Debian                   | 9, 10               | `overlay`, `overlay2`                 |
+| Ubuntu                   | 16.04, 18.04, 20.04 | `overlay`, `overlay2`                 |
+| Ubuntu-Core              | 16.04               | `overlay`, `overlay2`                 |
+| openSuse                 | 12-SP2 to 12-SP5    | `overlay`, `overlay2`                 |
+| Suse Linux Enterprise    | 12-SP2 to 12-SP5    | `overlay`, `overlay2`                 |
+| Amazon Linux             | 2                   | `overlay`, `overlay2`                 |
 
 ### Identifying OS Distributions In Manifest
 
@@ -34,16 +34,16 @@ against `ID` attribute of the `/etc/os-release` file on a host.
 The following table lists all officially supported Linux distributions and how they can be
 specified in the manifest:
 
-| Distribution Name        | ID                         | Version          |
-|--------------------------|----------------------------|------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.8, 8.0-8.2 |
-| CentOS                   | centos                     | 7.2-7.7, 8.0-8.1 |
-| Debian                   | debian                     | 9                |
-| Ubuntu                   | ubuntu                     | 16.04, 18.04     |
-| Ubuntu-Core              | ubuntu                     | 16.04            |
-| openSuse                 | suse, opensuse, opensuse-* | 12-SP2 to 12-SP5 |
-| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2 to 12-SP5 |
-| Amazon Linux             | amz                        | 2                |
+| Distribution Name        | ID                         | Version             |
+|--------------------------|----------------------------|---------------------|
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3    |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3    |
+| Debian                   | debian                     | 9                   |
+| Ubuntu                   | ubuntu                     | 16.04, 18.04, 20.04 |
+| Ubuntu-Core              | ubuntu                     | 16.04               |
+| openSuse                 | suse, opensuse, opensuse-* | 12-SP2 to 12-SP5    |
+| Suse Linux Enterprise    | sles, sles_sap             | 12-SP2 to 12-SP5    |
+| Amazon Linux             | amz                        | 2                   |
 
 For example, to specify openSUSE as a dependency and support all services packs:
 
@@ -255,15 +255,15 @@ root$ modprobe iptable_nat
 Following table summarizes the required kernel modules per OS distribution.
 Gravity requires that these modules are loaded prior to installation.
 
-| Linux Distribution                   | Version          | Modules                                         |
-|--------------------------------------|------------------|-------------------------------------------------|
-| CentOS                               | 7.2              | bridge, ebtable_filter, iptables, overlay       |
-| CentOS                               | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
-| RedHat Linux                         | 7.3-7.6          | br_netfilter, ebtable_filter, iptables, overlay |
-| Debian                               | 9                | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu                               | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
-| Ubuntu-Core                          | 16.04            | br_netfilter, ebtable_filter, iptables, overlay |
-| Suse Linux (openSUSE and Enterprise) | 12-SP2 to 12-SP5 | br_netfilter, ebtable_filter, iptables, overlay |
+| Linux Distribution                   | Version             | Modules                                         |
+|--------------------------------------|---------------------|-------------------------------------------------|
+| CentOS                               | 7.2                 | bridge, ebtable_filter, iptables, overlay       |
+| CentOS                               | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
+| Debian                               | 9, 10               | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu                               | 16.04, 18.04, 20.04 | br_netfilter, ebtable_filter, iptables, overlay |
+| Ubuntu-Core                          | 16.04               | br_netfilter, ebtable_filter, iptables, overlay |
+| Suse Linux (openSUSE and Enterprise) | 12-SP2 to 12-SP5    | br_netfilter, ebtable_filter, iptables, overlay |
 
 ### Inotify watches
 


### PR DESCRIPTION
## Description
Add documentation on distributions supported by Gravity:
* master& 7.0 support Ubuntu 20.04, Debian 10 & RHEL 7.9, 8.3
* 6.1 and 5.5 support RHEL 7.9, 8.3 (and some cleanup of table formatting)

## Type of change
* Documentation
* This change has a user-facing impact

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/gravity/issues/2331
* Requires:
  * master Ubuntu, SLES, RHEL, Debian: https://github.com/gravitational/gravity/pull/2318
  * 7.0 Ubuntu, SLES: https://github.com/gravitational/gravity/pull/2342
  * 7.0 RHEL 7.9, 8.3: https://github.com/gravitational/gravity/pull/2335
  * 6.1 RHEL 7.9, 8.3: https://github.com/gravitational/gravity/pull/2337
  * 5.5 RHEL 7.9, 8.3: https://github.com/gravitational/gravity/pull/2338


## TODOs
- [x] Self-review the change
- [x] Write documentation
- [x] Address review feedback

## Testing done
Linted.  Also ran `make run RUN_CFG=6.x.yaml` and made sure all the formatting looked correct.

## Additional information
The only change that is not validated by CI is CentOS/RHEL 8.3 on 6.1.x, which is hitting https://github.com/gravitational/gravity/issues/2009.
