### PR TITLE
[6.1.x] Enable RHEL 8.3 install testing

### DIFF
--- a/build.assets/robotest/disableSELinux.sh
+++ b/build.assets/robotest/disableSELinux.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+setenforce Permissive
+sed -i s/^SELINUX=.*$/SELINUX=permissive/ /etc/selinux/config
+sestatus

--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -57,10 +57,10 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local test_os="redhat:7"
+  local test_os="redhat:8.3"
   local cluster_size='"flavor":"three","nodes":3,"role":"node"'
   suite+=$(cat <<EOF
- install={${cluster_size},"os":"${test_os}","storage_driver":"overlay2"}
+ install={${cluster_size},"os":"${test_os}","script":{"url":"/disableSELinux.sh"},"storage_driver":"overlay2"}
 EOF
 )
   suite+=' '

--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -10,17 +10,17 @@ declare -A UPGRADE_MAP
 
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.1.x))]="ubuntu:18" # this branch
 UPGRADE_MAP[6.1.0]="ubuntu:16"
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 5.5.x))]="redhat:7" # compatible LTS version
-UPGRADE_MAP[5.5.0]="centos:7"
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 5.5.x))]="redhat:7.9" # compatible LTS version
+UPGRADE_MAP[5.5.0]="centos:7.9"
 # 5.6.x upgrade testing disabled on PRs because it has been out of support for over a year
 # UPGRADE_MAP[$(recommended_upgrade_tag $(branch 5.6.x))]="debian:9" # compatible non-LTS version
 # UPGRADE_MAP[5.6.0]="debian:8"
 
 # customer specific scenarios, these versions have traction in the field
-UPGRADE_MAP[5.5.40]="centos:7"
-UPGRADE_MAP[5.5.38]="centos:7"
-UPGRADE_MAP[5.5.36]="centos:7"
-UPGRADE_MAP[5.5.28]="centos:7"
+UPGRADE_MAP[5.5.40]="centos:7.9"
+UPGRADE_MAP[5.5.38]="centos:7.9"
+UPGRADE_MAP[5.5.36]="centos:7.9"
+UPGRADE_MAP[5.5.28]="centos:7.9"
 
 UPGRADE_VERSIONS=${!UPGRADE_MAP[@]}
 
@@ -41,7 +41,7 @@ function build_upgrade_suite {
 function build_resize_suite {
   local suite=$(cat <<EOF
  resize={"to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18","storage_driver":"overlay2"}
- shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7"}
+ shrink={"nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
 EOF
 )
     echo -n $suite

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -49,7 +49,8 @@ function build_volume_mounts {
   done
 }
 
-export EXTRA_VOLUME_MOUNTS=$(build_volume_mounts)
+SCRIPT_MOUNT="-v $(readlink -f $(dirname $0))/disableSELinux.sh:/disableSELinux.sh"
+export EXTRA_VOLUME_MOUNTS="$(build_volume_mounts) $SCRIPT_MOUNT"
 
 tele=$GRAVITY_BUILDDIR/tele
 mkdir -p $UPGRADE_FROM_DIR

--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.1.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
Without the 6.1's backport of https://github.com/gravitational/gravity/issues/2009 we still want to test Gravity on RHEL/CentOS 8 without SELinux enabled.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Refs https://github.com/gravitational/gravity/issues/2009 
* Adds RHEL 8 testing that was removed from https://github.com/gravitational/gravity/pull/2337
* Gravity product support documented at https://github.com/gravitational/gravity/pull/2352

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback

## Testing done
I tested by hand, with a local robotest ([logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2251afeb41-e1bc-4fed-b84a-eee506c1f4d3%22%0Alabels.__suite__%3D%220d3db911-e251-4041-9fe1-498fe5f87dcf%22;timeRange=2020-12-02T23:27:59Z%2F2020-12-03T00:27:59Z?project=kubeadm-167321)), and as a [try build](https://jenkins.gravitational.io/job/gravity-try-build/90/console).  The CI build serves as validation too.
