### PR TITLE
Add note about 6.1.x and SELinux support.

### DIFF
--- a/docs/6.x/requirements.md
+++ b/docs/6.x/requirements.md
@@ -5,19 +5,24 @@ Kubernetes and Gravity.
 
 ## Linux Distributions
 
-Gravity supports the following Linux distributions:
+Gravity 6.1 supports the following Linux distributions:
 
-| Linux Distribution        | Version         | Docker Storage Drivers                 |
-|--------------------------|------------------|----------------------------------------|
-| Red Hat Enterprise Linux | 7.2-7.3          | `devicemapper`*                        |
-| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
-| CentOS                   | 7.2-7.9, 8.0-8.3 | `devicemapper`*, `overlay`, `overlay2` |
-| Debian                   | 8, 9             | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu                   | 16.04, 18.04     | `devicemapper`*, `overlay`, `overlay2` |
-| Ubuntu-Core              | 16.04            | `devicemapper`*, `overlay`, `overlay2` |
-| openSuse                 | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
-| Suse Linux Enterprise    | 12-SP2 to 12-SP5 | `overlay`, `overlay2`                  |
-| Amazon Linux             | 2                | `overlay`, `overlay2`                  |
+| Linux Distribution        | Version          | Docker Storage Drivers                 |
+|--------------------------|-------------------|----------------------------------------|
+| Red Hat Enterprise Linux | 7.2-7.3           | `devicemapper`*                        |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3* | `devicemapper`*, `overlay`, `overlay2` |
+| CentOS                   | 7.2-7.9, 8.0-8.3* | `devicemapper`*, `overlay`, `overlay2` |
+| Debian                   | 8, 9              | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu                   | 16.04, 18.04      | `devicemapper`*, `overlay`, `overlay2` |
+| Ubuntu-Core              | 16.04             | `devicemapper`*, `overlay`, `overlay2` |
+| openSuse                 | 12-SP2 to 12-SP5  | `overlay`, `overlay2`                  |
+| Suse Linux Enterprise    | 12-SP2 to 12-SP5  | `overlay`, `overlay2`                  |
+| Amazon Linux             | 2                 | `overlay`, `overlay2`                  |
+
+!!! note
+    * Gravity 6.1 does not install on CentOS & Red Hat Enterprise Linux 8+ with SELinux
+    enforcing due to [#2009](https://github.com/gravitational/gravity/issues/2009).
+    To install on CentOS & Red Hat Enterprise Linux 8+, please use Gravity 7.0+ or disable SELinux.
 
 !!! note
     devicemapper has been deprecated by the docker project, and is not supported by gravity 5.3.4 or later

--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -14,14 +14,19 @@ Gravity officially supports the following Linux distributions:
 
 | Linux Distribution       | Version             | Docker Storage Drivers                |
 |--------------------------|---------------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3    | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.9, 8.0-8.3    | `overlay`, `overlay2`                 |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
 | Debian                   | 9, 10               | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04, 20.04 | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04               | `overlay`, `overlay2`                 |
 | openSuse                 | 12-SP2 to 12-SP5    | `overlay`, `overlay2`                 |
 | Suse Linux Enterprise    | 12-SP2 to 12-SP5    | `overlay`, `overlay2`                 |
 | Amazon Linux             | 2                   | `overlay`, `overlay2`                 |
+
+!!! note
+    * Gravity 6.1 does not install on CentOS & Red Hat Enterprise Linux 8+ with SELinux
+    enforcing due to [#2009](https://github.com/gravitational/gravity/issues/2009).
+    To install on CentOS & Red Hat Enterprise Linux 8+, please use Gravity 7.0+ or disable SELinux.
 
 ### Identifying OS Distributions In Manifest
 


### PR DESCRIPTION
## Description
This adds documentation about the current state of RHEL SELinux support in 6.1.x. It formalizes (at least for now) our intention to leave Gravity 6.1.x +RHEL 8 + SELinux as a unsupported use case because the fix isn't high ROI compared to other work.

## Type of change
* Documentation
* This change has a user-facing impact

## Linked tickets and other PRs
* Refs #2009

## TODOs
- [x] Write documentation :wink: 
- [x] Address review feedback

## Testing done
None.
