### PR TITLE
HSTS header on web management endpoint

### DIFF
--- a/lib/httplib/http.go
+++ b/lib/httplib/http.go
@@ -184,6 +184,7 @@ func GRPCHandlerFunc(grpcHandler, httpHandler http.Handler) http.Handler {
 		if isGRPCRequest(r) {
 			grpcHandler.ServeHTTP(w, r)
 		} else {
+			w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 			httpHandler.ServeHTTP(w, r)
 		}
 	})


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

This PR adds a HSTS header to the web management endpoint.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/2347

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [X] Self-review the change
- [X] Perform manual testing
- [ ] Address review feedback


## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Loaded the cluster management url in Firefox and verified that the header shows up in the developer console.
