### PR TITLE
[5.5.x] Update 5.5 upgrade scenarios.

### DIFF
--- a/build.assets/robotest/pr_config.sh
+++ b/build.assets/robotest/pr_config.sh
@@ -20,9 +20,9 @@ UPGRADE_MAP[5.2.0]="centos:7.9"
 UPGRADE_MAP[5.0.36]="centos:7.9"
 
 # customer specific scenarios, these versions have traction in the field
-UPGRADE_MAP[5.5.41]="centos:7.9"
+UPGRADE_MAP[5.5.51]="centos:7.9"
+UPGRADE_MAP[5.5.49]="centos:7.9"
 UPGRADE_MAP[5.5.40]="centos:7.9"
-UPGRADE_MAP[5.5.38]="centos:7.9"
 UPGRADE_MAP[5.5.36]="centos:7.9"
 UPGRADE_MAP[5.5.28]="centos:7.9"
 


### PR DESCRIPTION
## Description
After discussion with an important customer, these versions are updated
to reflect their current usage in the field.

5.5.56 is excluded because it is presently covered by `(recommended_upgrade_tag $(branch 5.5.x))`

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Follow up to https://github.com/gravitational/gravity/pull/1195

## TODOs
- [x] Self-review the change
- [x] Make sure the PR build is green
- [x] Address review feedback

## Testing done
None.  The PR build should be sufficient testing for this change.
