### PR TITLE
Removing reference to dep and replacing with go modules.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,4 @@ If your patch depends on new packages, the dependencies must:
 
 - be licensed via Apache2 license
 - be approved by core Gravity contributors ahead of time
-- be vendored via [`dep`](https://github.com/golang/dep)
+- be vendored via go modules


### PR DESCRIPTION
## Description
Fixes Github issue #2377 to reflect our switch from dep to go modules.

## Type of change
Internal change.

## Linked tickets and other PRs
Fixes #2377 