### PR TITLE
Update docs with admission controllers section

### DIFF
--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -1120,16 +1120,18 @@ image instead of the default one.
 
 ### Kubenetes Admission Controllers
 
-Optional Kubernetes admission controllers can be enabled when using a custom `planet`
-image. Create an environment file and specify a list of admission controllers to
-be enabled in the `KUBE_ADMISSION_PLUGINS` variable. Then copy the environment file
-to `/etc/optional-environment` file path in the `planet` container.
+Gravity by default enables the `PodSecurityPolicy`, `NodeRestriction`, `AlwaysPullImages`,
+and `EventRateLimit` Kubernetes admission controllers. Optional admission controllers
+can be enabled alongside the defaults when using a [Custom System Container](#custom-system-container).
+Create an environment file and specify a list of admission controllers to be enabled
+in the `KUBE_ADMISSION_PLUGINS` variable. Then copy the environment file to `/etc/optional-environment`
+file path in the custom system container.
 
 Example:
 
 ```
 // /path/to/optional-environment
-KUBE_ADMISSION_PLUGINS=ImagePolicyWebhook,EventRateLimit,...
+KUBE_ADMISSION_PLUGINS=ImagePolicyWebhook,AlwaysAdmit,...
 
 // Dockerfile
 FROM <planet-image>:<version>

--- a/docs/7.x/pack.md
+++ b/docs/7.x/pack.md
@@ -1117,3 +1117,21 @@ When building a Cluster Image, `tele build` will discover `custom-planet:1.0.0`
 Docker image and vendor it along with other dependencies. During the Cluster
 installation all nodes with the role `worker` will use the custom "planet" Docker
 image instead of the default one.
+
+### Kubenetes Admission Controllers
+
+Optional Kubernetes admission controllers can be enabled when using a custom `planet`
+image. Create an environment file and specify a list of admission controllers to
+be enabled in the `KUBE_ADMISSION_PLUGINS` variable. Then copy the environment file
+to `/etc/optional-environment` file path in the `planet` container.
+
+Example:
+
+```
+// /path/to/optional-environment
+KUBE_ADMISSION_PLUGINS=ImagePolicyWebhook,EventRateLimit,...
+
+// Dockerfile
+FROM <planet-image>:<version>
+COPY /path/to/optional-environment /etc/optional-environment
+```


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Add documentation on how to enable optional Kubernetes admission controllers in a custom `planet` image. Related changes in `planet` can be found in https://github.com/gravitational/planet/pull/809.