### PR TITLE
Bump robotest to 2.2.1

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 2.2.0
+ROBOTEST_VERSION ?= 2.2.1
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build


### PR DESCRIPTION
## Description
This fixes a bootstrap failure on Ubuntu, Debian and Suse related
to installing awscli.  See:

  https://github.com/gravitational/robotest/issues/279

Without this, all robotest CI runs will fail.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Deploys https://github.com/gravitational/robotest/issues/279

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
Tested against different distros in https://github.com/gravitational/robotest/issues/280.  No gravity specific testing was performed, but the PR build for this will cover that.

## Additional information
This is the result of a change in external infrastructure. Pip dropped support for python 2, resulting in
```
curl https://bootstrap.pypa.io/get-pip.py | python -
```
failing on old distros where python 2 is the default python.  This is avoided by installing awscli v2, which no longer needs a system python.
