### PR TITLE
[7.0] Bump robotest to 2.2.1

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 2.2.0
+ROBOTEST_VERSION ?= 2.2.1
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build


### PR DESCRIPTION
## Description
7.0 backport of https://github.com/gravitational/gravity/pull/2399

The bump fixes a bootstrap failure on Ubuntu, Debian and Suse related
to installing awscli.  See:

  https://github.com/gravitational/robotest/issues/279

(cherry picked from commit 4054cefdcac02b74a4ea466ce4bfda0a9f74323b)

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Deploys https://github.com/gravitational/robotest/issues/279

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See https://github.com/gravitational/gravity/pull/2399.  No 7.0 specific testing was done. The PR build will cover this.