### PR TITLE
[6.1] Bump robotest to 2.2.1

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.1}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
6.1 backport of https://github.com/gravitational/gravity/pull/2399

The bump fixes a bootstrap failure on Ubuntu, Debian and Suse related
to installing awscli.  See:

  https://github.com/gravitational/robotest/issues/279

(cherry picked from commit 4054cefdcac02b74a4ea466ce4bfda0a9f74323b)

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Deploys https://github.com/gravitational/robotest/issues/279

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See https://github.com/gravitational/gravity/pull/2399.  No 6.1 specific testing was done. The PR build will cover this.