### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Security issues should be reported directly to security@gravitational.com.
 
 If you are unsure if you've found a bug, consider searching
 [current issues](https://github.com/gravitational/gravity/issues) or
-asking in the [community forum](https://community.gravitational.com/) first.
+asking in the [community forum](https://community.goteleport.com/) first.
 
 Once you know you have a issue, make sure to fill out all sections of the
 one of the templates at https://github.com/gravitational/gravity/issues/new/choose.


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity/issues/2379

## Description

Updated the link from [https://community.gravitational.com/](https://community.gravitational.com/) to [https://community.goteleport.com/](https://community.goteleport.com/). 

I saw that the issue was not addressed for the past 25 days and if someone has been working on this then I can close this PR.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
Closes #2379

## TODOs

None

## Implementation

None

## Performance/Scaling

None

## Testing done

None

## Additional information

None