### PR TITLE
[5.5] remove kapacitor from gravity status and intro hidden command

### DIFF
--- a/lib/status/status.go
+++ b/lib/status/status.go
@@ -117,7 +117,7 @@ func FromCluster(ctx context.Context, operator ops.Operator, cluster ops.Site, o
 		log.WithError(err).WithField("operation-id", operationID).Warn("Failed to query operation.")
 	}
 
-	status.KapacitorAlerts, err = fetchKapacitorAlerts(cluster)
+	status.KapacitorAlerts, err = FetchKapacitorAlerts(cluster)
 	if err != nil {
 		log.WithError(err).Warn("Failed to query Kapacitor alerts.")
 	}
@@ -429,7 +429,8 @@ func fetchOperationByID(clusterKey ops.SiteKey, operationID string, operator ops
 	return nil
 }
 
-func fetchKapacitorAlerts(cluster ops.Site) ([]opsmonitoring.StateResponse, error) {
+// FetchKapacitorAlerts returns active alerts from kapacitor
+func FetchKapacitorAlerts(cluster ops.Site) ([]opsmonitoring.StateResponse, error) {
 	// Very old clusters (5.0) do not have a DNS config defined so just skip
 	// them, it is only relevant when upgrading from 5.0 to 5.5.
 	if cluster.DNSConfig.IsEmpty() {

--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -102,6 +102,8 @@ type Application struct {
 	StatusClusterCmd StatusClusterCmd
 	// StatusHistoryCmd displays the cluster status history
 	StatusHistoryCmd StatusHistoryCmd
+	// StatusKapacitorCmd displays kapacitor alerts
+	StatusKapacitorCmd StatusKapacitorCmd
 	// StatusResetCmd resets the cluster to active state
 	StatusResetCmd StatusResetCmd
 	// BackupCmd launches app backup hook
@@ -684,6 +686,13 @@ type StatusClusterCmd struct {
 
 // StatusHistoryCmd displays cluster status history
 type StatusHistoryCmd struct {
+	*kingpin.CmdClause
+}
+
+// StatusKapacitorCmd displays alerts from Kapacitor
+// These alerts are being separated from `gravity status` due to confusion with stale alerts
+// https://github.com/gravitational/gravity/issues/2398
+type StatusKapacitorCmd struct {
 	*kingpin.CmdClause
 }
 

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -223,9 +223,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.StatusHistoryCmd.CmdClause = g.StatusCmd.Command("history", "Display cluster status history.")
 
 	// Display Kapacitor alerts
-	// Normally Kapacitor alerts would be displayed as part of gravity status. However, there are lots of false positives
-	// due to https://github.com/gravitational/gravity/issues/2398, so we're temporarily separating just kapacitor alerts into a
-	// separate subcommand until the underlying issues can be resolved.
+	// Hidden command as the information presented may be confusing. See https://github.com/gravitational/gravity/issues/2398
 	g.StatusKapacitorCmd.CmdClause = g.StatusCmd.Command("kapacitor", "Display kapacitor alerts.").Hidden()
 
 	// reset cluster state, for debugging/emergencies

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -222,6 +222,12 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	// Display cluster status history
 	g.StatusHistoryCmd.CmdClause = g.StatusCmd.Command("history", "Display cluster status history.")
 
+	// Display Kapacitor alerts
+	// Normally Kapacitor alerts would be displayed as part of gravity status. However, there are lots of false positives
+	// due to https://github.com/gravitational/gravity/issues/2398, so we're temporarily separating just kapacitor alerts into a
+	// separate subcommand until the underlying issues can be resolved.
+	g.StatusKapacitorCmd.CmdClause = g.StatusCmd.Command("kapacitor", "Display kapacitor alerts.").Hidden()
+
 	// reset cluster state, for debugging/emergencies
 	g.StatusResetCmd.CmdClause = g.Command("status-reset", "Force-reset the cluster state to active. USE WITH CAUTION, the cluster may end up in an inconsistent state.").Hidden()
 	g.StatusResetCmd.Confirmed = g.StatusResetCmd.Flag("confirm", "Bypass confirmation prompt.").Bool()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -486,6 +486,8 @@ func Execute(g *Application, cmd string, extraArgs []string) error {
 		}
 	case g.StatusHistoryCmd.FullCommand():
 		return statusHistory()
+	case g.StatusKapacitorCmd.FullCommand():
+		return statusKapacitor(localEnv)
 	case g.UpdateUploadCmd.FullCommand():
 		return uploadUpdate(context.Background(), localEnv,
 			*g.UpdateUploadCmd.OpsCenterURL,

--- a/tool/gravity/cli/status.go
+++ b/tool/gravity/cli/status.go
@@ -321,8 +321,13 @@ func statusKapacitor(env *localenv.LocalEnvironment) error {
 		printClusterAlerts(alerts, os.Stdout)
 	}
 
+	// TODO(knisbet): Remove warning after https://github.com/gravitational/gravity/issues/2398 is fixed
 	fmt.Fprintf(os.Stdout, "\nWarning:\n  Cluster alerts may experience false positives.\n"+
 		"  See https://github.com/gravitational/gravity/issues/2398 for more information.\n")
+
+	if len(alerts) != 0 {
+		os.Exit(1)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Request from Customer M

Removes kapacitor alerts from gravity status, as they're currently confusing customers. Introduces a hiddden subcommand to access the information so Customer M support is still able to access this information.


## Type of change
<!--Required. Keep only those that apply.-->
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

Updates https://github.com/gravitational/gravity/issues/2398

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->

Sample Kapacitor Output:
```
root@kevin-test1:~/build# ./gravity status kapacitor
Cluster alerts:
	* [CRITICAL] CRITICAL / etcd: cluster is unhealthy
	* [CRITICAL] CRITICAL / Kubernetes node is not ready: kevin-test2

Warning:
  Cluster alerts may experience false positives.
  See https://github.com/gravitational/gravity/issues/2398 for more information.
```

Sample Status Output:
```
root@kevin-test1:~/build# ./gravity status
Cluster name:		goofymclean7651
Cluster status:		active
Application:		telekube, version 5.5.58-dev.1
Gravity version:	5.5.58-dev.1 (client) / 5.5.58-dev.1 (server)
Join token:		ac65d79a5974
Last completed operation:
    * operation_expand (575d7ab9-e397-4e13-b1c5-acdee2ccf3ae)
      started:		Wed Feb  3 20:37 UTC (2 minutes ago)
      completed:	Wed Feb  3 20:39 UTC (33 seconds ago)
Cluster endpoints:
    * Authentication gateway:
        - 10.162.0.7:32009
        - 10.162.0.6:32009
    * Cluster management URL:
        - https://10.162.0.7:32009
        - https://10.162.0.6:32009
Cluster nodes:
    Masters:
        * kevin-test1 (10.162.0.7, node)
            Status:		healthy
            Remote access:	online
        * kevin-test2 (10.162.0.6, master)
            Status:		healthy
            Remote access:	online
```
