### PR TITLE
Return the first found operation

### DIFF
--- a/tool/gravity/cli/operation.go
+++ b/tool/gravity/cli/operation.go
@@ -301,6 +301,7 @@ func getLastOperation(localEnv *localenv.LocalEnvironment, environ LocalEnvironm
 		if op == nil {
 			return nil, newOperationNotFound("no operation with ID %v found", operationID)
 		}
+		return op, nil
 	}
 
 	op := b.GetLastOperation(localEnv, environ)


### PR DESCRIPTION
I've had this change pending for a long time without a good reason to not submit a PR.


## Description
tool/cli/gravity: return the operation if found instead of falling through.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

<!--This PR addresses the following issues.-->
* Ports https://github.com/gravitational/gravity/pull/2412
* Fixes https://github.com/gravitational/gravity/issues/2309.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [ ] Perform manual testing
