### PR TITLE
Add Drone CI build for Pull Requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,107 @@
 ---
 kind: pipeline
 type: kubernetes
-name: docs-pr
+name: pr build
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+  # If a change is entirely documentation, skip the expensive build & test steps.
+  - name: short circuit docs changes
+    image: docker:git
+    commands:
+    -  ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      GITHUB_RO_KEY_PR:
+        from_secret: GITHUB_RO_KEY_PR
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli
+      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - make -C e production telekube opscenter
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: unit test
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - make -C e test
+      - make test
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build robotest images
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - make -C e/assets/robotest images
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: run robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - make -C e robotest-run
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: pr docs
 
 trigger:
   event:
@@ -54,6 +154,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: ecf6ccc933d41d1db58d885ae7f9cae6ef3d3139444333586f6c0ba63002f9de
+hmac: f810426f93774968d92285ce5ee304608848c26dd88f7165dcbfb9965c2045bb
 
 ...

--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -78,13 +78,6 @@ ROBOTEST_CACHES = $(ROBOTEST_GRAVITY_PKG_CACHE) $(ROBOTEST_TELE_CACHE)
 
 # Image configuration.
 
-TELE_BUILD_DOCKER_BASE_IMAGE = quay.io/gravitational/debian-grande:buster-20201001
-# TELE_BUILD_DOCKER_IMAGE is the base image with `tele build` prerequisites (such as the docker cli) added to it.
-TELE_BUILD_DOCKER_IMAGE = $(notdir $(TELE_BUILD_DOCKER_BASE_IMAGE))-tele-build
-# TELE_BUILD_DOCKER_IDDFILE is used to prevent make from constantly rebuilding the image.
-# subst because ':' in filenames breaks using them in make targets.
-TELE_BUILD_DOCKER_IIDFILE = $(ROBOTEST_BUILDDIR)/$(subst :,-,$(TELE_BUILD_DOCKER_IMAGE)).iid
-
 # ROBOTEST_IMAGEDIR is a store of robotest images used only for the current
 # robotest run. Expected to be populated on demand from the caches and mounted
 # as a volume into the robotest container. This exists to prevent any
@@ -177,14 +170,6 @@ $(ROBOTEST_BUILD_TMP):
 $(ROBOTEST_CACHE_TMP):
 	mkdir -p $(ROBOTEST_CACHE_TMP)
 
-.PHONY: docker-image-tele-build
-docker-image-tele-build: ## Build a docker image suitable to run `tele build`.
-docker-image-tele-build: $(TELE_BUILD_DOCKER_IIDFILE)
-
-$(TELE_BUILD_DOCKER_IIDFILE): $(TOP)/Dockerfile $(ROBOTEST_BUILDDIR)
-	docker build --tag $(TELE_BUILD_DOCKER_IMAGE) --build-arg BASE=$(TELE_BUILD_DOCKER_BASE_IMAGE) $(TOP)
-	touch $(TELE_BUILD_DOCKER_IIDFILE)
-
 .PHONY: images
 images: ## Build all images necessary to run robotest CI tests.
 images: image-telekube image-opscenter image-robotest image-robotest-upgrade
@@ -208,14 +193,12 @@ image-robotest: ## Build robotest cluster image using the current tele.
 image-robotest: $(ROBOTEST_IMAGE)
 
 $(ROBOTEST_IMAGE): export TARGET = $(ROBOTEST_IMAGE)
-$(ROBOTEST_IMAGE): export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGE): export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGE): export APP_MANIFEST = $(ROBOTEST_IMAGE_MANIFEST)
-$(ROBOTEST_IMAGE): export APP_SRCDIR = $(ROBOTEST_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGE): export VERSION = $(GRAVITY_VERSION)
 $(ROBOTEST_IMAGE): export TELE = $(TELE_OUT)
 $(ROBOTEST_IMAGE): export STATE_DIR = $(PACKAGES_DIR)
-$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh $(TELE_BUILD_DOCKER_IIDFILE) | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
+$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
 	$(TOP)/tele_build.sh
 
 # When using a shared state dir 7.0.x package syncing is prone to races
@@ -266,10 +249,8 @@ endif
 # .PRECIOUS because these need to be present through the run target.
 .PRECIOUS: $(ROBOTEST_IMAGEDIR)/robotest-%.tar
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TARGET = $@
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_MANIFEST = $(ROBOTEST_UPGRADE_BASE_IMAGE_MANIFEST)
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_SRCDIR = $(ROBOTEST_UPGRADE_BASE_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export VERSION = $*
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TELE = $<
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export STATE_DIR = $(ROBOTEST_GRAVITY_PKG_CACHE)/$*

--- a/assets/robotest/tele_build.sh
+++ b/assets/robotest/tele_build.sh
@@ -11,11 +11,9 @@
 #
 # The following environment variables must be specified by the caller:
 #
-# IMAGE - A docker container that the build will run in
 # BUILD_TMP - Partially constructed images are built here. Must be on the same filesystem as TARGET for atomic move operations.
 # TARGET - Where the cluster image should end up
 # TELE  - The tele to build the image, should typically be equal to VERSION
-# APP_SRCDIR - The directory that contains all files necessary to build the application.
 # APP_YAML - The image manifest to be built.
 # VERSION - The application version to use in the cluster image. Must be within SRCDIR.
 # STATE_DIR - The gravity state dir where packages are cached/drawn from. May be shared across subsequent builds.
@@ -29,24 +27,11 @@ trap "rm -rf $TMP" exit
 
 TGT=$TMP/$(basename "$TARGET")
 
-
-NOROOT="--user=$(id -u):$(id -g) --group-add=$(getent group docker | cut -d: -f3)"
-VOLUMES="-v $TELE:$TELE:ro -v $APP_SRCDIR:$APP_SRCDIR:ro -v $STATE_DIR:$STATE_DIR -v $TMP:$TMP"
-VOLUMES="$VOLUMES -v /var/run/docker.sock:/var/run/docker.sock"
-VOLUMES="$VOLUMES --tmpfs /tmp"
-
-(
 set -o xtrace
-docker run --rm=true --net=host $NOROOT \
-    $VOLUMES \
-    -w "$TMP" \
-    $IMAGE \
-    dumb-init \
-    "$TELE" build \
-    "$APP_MANIFEST" \
-    --state-dir="$STATE_DIR" \
-    --version="$VERSION" \
-    --output="$TGT"
+"$TELE" build \
+"$APP_MANIFEST" \
+--state-dir="$STATE_DIR" \
+--version="$VERSION" \
+--output="$TGT"
 
 mv "$TGT" "$TARGET"
-)

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -13,19 +13,21 @@ ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
 ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 
-RUN (groupadd jenkins --gid=$GID -o && \
-     useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
-     # install development libraries used when compiling fio
-     apt-get -q -y update --fix-missing && apt-get -q -y install libaio-dev zlib1g-dev)
+# install development libraries used when compiling fio
+RUN apt-get -q -y update --fix-missing && apt-get -q -y install libaio-dev zlib1g-dev
+
+RUN getent group  $GID || groupadd builder --gid=$GID -o; \
+    getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 
 RUN (mkdir -p /opt/protoc && \
      mkdir -p /.cache && \
-     chown -R jenkins:jenkins /gopath && \
-     chown -R jenkins:jenkins /opt/protoc && \
+     chown -R $UID:$GID /gopath && \
+     chown -R $UID:$GID /opt/protoc && \
      chmod 777 /.cache && \
      chmod 777 /tmp)
 
-USER jenkins
+USER $UID:$GID
+
 ENV LANGUAGE="en_US.UTF-8" \
      LANG="en_US.UTF-8" \
      LC_ALL="en_US.UTF-8" \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -409,7 +409,7 @@ tiller-app:
 
 .PHONY: site-app
 site-app:
-	$(eval TMPDIR := $(shell mktemp -d --tmpdir=$(GRAVITY_BUILDDIR)))
+	$(eval TMPDIR := $(shell mktemp -d -p $(GRAVITY_BUILDDIR)))
 	cp -r $(ASSETSDIR)/site-app/* $(TMPDIR)
 	cp $(GRAVITY_BUILDDIR)/gravity $(TMPDIR)/images/site
 	cd $(TMPDIR) && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -188,7 +188,7 @@ build: build-on-host
 else
 .PHONY: build
 build: selinux grpc build-in-container
-	ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+	ln -sfT $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
 endif
 
 #

--- a/build.assets/drone/diff-is-all-docs.sh
+++ b/build.assets/drone/diff-is-all-docs.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# examine the output of git diff --raw to determine whether any files
+# which don't match the pattern '^docs/' or '.md$' were changed. if there are no
+# changes to non-docs code
+
+REVLIST=$1
+if [ -z "$REVLIST" ]; then
+    echo "$0: please supply a git rev-list"
+    echo "For more info see: git help rev-list"
+    exit 2
+fi
+
+echo "---> git diff --raw ${REVLIST}"
+git diff --raw ${REVLIST}
+if [ $? -ne 0 ]; then
+    echo "---> Unable to determine diff"
+    exit 2
+fi
+git diff --raw ${REVLIST} | awk '{print $6}' | grep -Ev '^docs/' | grep -Ev '.md$' | grep -v ^$ | wc -l > /tmp/.change_count.txt
+export CHANGE_COUNT=$(cat /tmp/.change_count.txt | tr -d '\n')
+rm /tmp/.change_count.txt
+echo "---> Non-docs changes detected: $CHANGE_COUNT"
+if [ "$CHANGE_COUNT" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/build.assets/etcd.mk
+++ b/build.assets/etcd.mk
@@ -12,7 +12,7 @@ endif
 
 .PHONY: base-etcd
 base-etcd:
-	if docker ps | grep $(TEST_ETCD_INSTANCE) --quiet; then \
+	if docker ps | grep $(TEST_ETCD_INSTANCE) -q; then \
 	  echo "ETCD is already running"; \
 	else \
 	  echo "starting test ETCD instance"; \


### PR DESCRIPTION
## Description
This PR adds a Drone CI pipeline that will replace https://jenkins.gravitational.io/job/Gravity-PR-5.2/

This includes:
 - Building the tooling
 - Building a variety of cluster images

Furthermore, there is one extra quality of life feature: The full build & robotest will no longer run when a change consists entirely of  `.md` or items in `docs/` edits.

## Type of change
* New feature (non-breaking change which adds functionality)

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/ops/issues/139

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Write documentation
- [x] Address review feedback

## Implementation
Moving robotest tele builds out of a container decreases the reliability of the jenkins job (removing `~jenkins/.gravity` isolation) but I expect that won't matter shortly when the jenkins job is turned off.

It was needed for Drone because we already run docker-in-docker (dind) inside of kubernetes.  Nesting docker a further layer was a recipe for madness.

## Performance/Scaling
We take a slight performance hit because there is no longer parallelism between the unit test and robotest stages.  This is more than made up for by beefy nodes in the Drone kubernetes cluster and autoscaling to help with many builds at the same time.

## Testing done
Most importantly, see the PR build for this PR.

For short-circuiting docs changes, see: https://github.com/gravitational/gravity/pull/2414.  The push build can be ignored -- I cancelled that one to save a build because push builds:
1) aren't part of the final changeset
2) don't always have a reasonable diff (in the case of a rebase)

All of the `walt/drone-build jobs` here: https://drone.gravitational.io/gravitational/gravity/ are further intermediate testing ... though they're probably not of much interest.

## Secrets

There are several secrets available to this PR job:

* `GITHUB_RO_KEY_PR` is a ssh key set up as a deploy key for https://github.com/gravitational/selinux/settings/keys.  It does not have access to anything else
* `AWS_S3_RO...` is a token associated with an Read Only S3 IAM user provisioned here: https://github.com/gravitational/cloud-terraform/pull/132
* `GCP_ROBOTEST_CREDENTIALS` is a json token associated with a GCP service user. This was hand provisioned and uses the standard Robotest policy.

All of the above are also saved in 1Password.

## Notes
I've not included any of the publishing work in this changeset -- though that is coming soon.  I'm trying to keep the PRs smaller and relatively digestable -- and also to give some soak time to catch issues.

This work loses some functionality that was present in Jenkins.  Particularly, robotest saves log tarballs to the local filesystem.  Since the local FS is now in a kubernetes pod this data is immediately lost.  The right answer here is likely to update robotest to save those logs to an appropriate data dump (s3) and set up a housekeeping process to remove old logs.  However, I'm not aware of anyone who uses these logs other than Dima and I -- so I've posponed on this task as lower priority work.  See https://github.com/gravitational/robotest/issues/281.

