### PR TITLE
Drone CI: Automatically deploy docs upon merge to master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,12 +8,12 @@ trigger:
   - pull_request
 
 steps:
-  # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
-  # If a change is entirely documentation, skip the expensive build & test steps.
   - name: short circuit docs changes
     image: docker:git
     commands:
-    -  ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+      # If a change is entirely documentation, skip the expensive build & test steps.
+      # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+      -  ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
   - name: fetch tags
     image: docker:git
     commands:
@@ -154,6 +154,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: f810426f93774968d92285ce5ee304608848c26dd88f7165dcbfb9965c2045bb
+hmac: 5b23b8408806e4123df0c5d524e9d705b498fda7dba596f8b985302d31f3e780
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -153,7 +153,112 @@ volumes:
   - name: dockersock
     temp: {}
 ---
+kind: pipeline
+type: kubernetes
+name: deploy docs
+
+trigger:
+  event:
+  - push
+  branch:
+  - master
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git checkout $DRONE_COMMIT
+  - name: short circuit non-docs changes
+    image: docker:git
+    # Skip the rest of this pipeline if no docs were changed.
+    # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+    commands:
+      - cd gravity
+      -  ./build.assets/drone/diff-has-no-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs bbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: lint
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs lint
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs docs
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: clone web
+    image: docker:git
+    environment:
+      WEB_REPO:
+        from_secret: WEB_REPO
+      GITHUB_WEB_DEPLOY_KEY:
+        from_secret: GITHUB_WEB_DEPLOY_KEY
+      WEB_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_WEB_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $WEB_REPO web
+    - cd web
+    - git checkout $WEB_REF
+  - name: deploy
+    image: docker:git
+    environment:
+      ANSIBLE_HOST_KEY_CHECKING: False
+      WEB_ANSIBLE_SSH_KEY:
+        from_secret: WEB_ANSIBLE_SSH_KEY
+      CLOUDFLARE_API_TOKEN_STAGING:
+        from_secret: CLOUDFLARE_API_TOKEN_STAGING
+      CLOUDFLARE_API_TOKEN_PRODUCTION:
+        from_secret: CLOUDFLARE_API_TOKEN_PRODUCTION
+    commands:
+      - apk add --no-cache make curl rsync ansible
+      - mkdir -m 0700 /root/.ssh && echo "$WEB_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - cd web
+      - export ENV=${ENV:-production}
+      - make deploy-docs
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
 kind: signature
-hmac: 5b23b8408806e4123df0c5d524e9d705b498fda7dba596f8b985302d31f3e780
+hmac: c937acc90f6f6cdd42588aa74401c5d10a8b2e35d1b837c49fc6fd526f9fb19a
 
 ...

--- a/build.assets/drone/diff-has-no-docs.sh
+++ b/build.assets/drone/diff-has-no-docs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Examine the output of git diff --raw to determine whether any files
+# which match the pattern '^docs/' were changed.
+
+REVLIST=$1
+if [ -z "$REVLIST" ]; then
+    echo "$0: please supply a git rev-list"
+    echo "For more info see: git help rev-list"
+    exit 2
+fi
+
+echo "---> git diff --raw ${REVLIST}"
+git diff --raw ${REVLIST}
+if [ $? -ne 0 ]; then
+    echo "---> Unable to determine diff"
+    exit 2
+fi
+git diff --raw ${REVLIST} | awk '{print $6}' | grep -E '^docs/' | wc -l > /tmp/.change_count.txt
+export CHANGE_COUNT=$(cat /tmp/.change_count.txt | tr -d '\n')
+rm /tmp/.change_count.txt
+echo "---> Docs changes detected: $CHANGE_COUNT"
+if [ "$CHANGE_COUNT" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/build.assets/drone/diff-is-all-docs.sh
+++ b/build.assets/drone/diff-is-all-docs.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-# examine the output of git diff --raw to determine whether any files
-# which don't match the pattern '^docs/' or '.md$' were changed. if there are no
-# changes to non-docs code
+# Examine the output of git diff --raw to determine whether any files
+# which don't match the pattern '^docs/' or '.md$' were changed.
 
 REVLIST=$1
 if [ -z "$REVLIST" ]; then


### PR DESCRIPTION
## Description
This PR adds Gravity's first official Continuous Deployment.  If docs changes are merged to master, they are automatically deployed to https://goteleport.com/gravity/docs/ by Drone CI.

## Type of change
* Internal change

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/ops/issues/139
* Requires https://github.com/gravitational/web/pull/1574, https://github.com/gravitational/web/pull/1559

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Merhr related web PRs

## Implementation
I chose to implement full CD (auto deploy on change to master) as opposed to a job that needed to be invoked by hand.

This has the following downsides:
 - Rollback is not possible via Drone, at least without reverting the change and committing to master
 - Deploying before merge is not possible via Drone

Both of these can be done via hand from a workstation with the appropriate access.

However it has the following upsides:
 - Nothing extra to remember or teach.  Docs deploy is as simple as merging.

I have an alternative implementation available at https://github.com/gravitational/gravity/tree/walt/drone-docs-promote, which does not auto deploy, and must be invoked via `drone build promote`.  For example:

```
drone build promote gravitational/gravity 114 docs -p ENV=staging
```

```
drone build promote gravitational/gravity 114 docs
```

This allows rollback and pre-deploy, but it also requires:
* installing the drone tooling on developer workstations
* finding the correct build number to promote from (not particularly intuitive)
* remembering the extra step

## Performance/Scaling
N/A. This is a lightweight job.

## Testing done
See https://drone.gravitational.io/gravitational/gravity/115 for a successful deploy to staging.

I haven't yet tested deploy to production, as I'm waiting on approval of https://github.com/gravitational/web/pull/1574 before granting drone access to prod.  I will update this section once that is available.


## Additional information
Credentials required:
* Github deploy key to clone the web repo
* Ansible SSH key (see https://github.com/gravitational/web/pull/1559)
* Cloudflare Api Token (with perms limited to cache flush)
  * for staging
  * for production

These are all:
 * new credentials, not shared with Jenkins or any other automation
 * unavailable to pull requests
 * saved in 1Password

The ansible ssh key is particularly sensitive as it is equivalent to root on our web properties.