### PR TITLE
Drone CI: Add post-merge builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -101,6 +101,101 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
+name: post-merge build
+
+trigger:
+  event:
+  - push
+  branch:
+  - master
+
+steps:
+  - name: short circuit docs changes
+    image: docker:git
+    commands:
+      # If a change is entirely documentation, skip the expensive build & test steps.
+      # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+      - ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      GITHUB_RO_KEY_PR:
+        from_secret: GITHUB_RO_KEY_PR
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli
+      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - make -C e production telekube opscenter
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build robotest images
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - export ROBOTEST_CONFIG=nightly
+      - make -C e/assets/robotest images
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: run robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - export ROBOTEST_CONFIG=nightly
+      - make -C e robotest-run
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
 name: pr docs
 
 trigger:
@@ -259,6 +354,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: c937acc90f6f6cdd42588aa74401c5d10a8b2e35d1b837c49fc6fd526f9fb19a
+hmac: c56d5b1982015f5fa034e19f788c6cd51c5fe59b233716936c40c15ce1ff4ef1
 
 ...


### PR DESCRIPTION
## Description
These are a heavier version of our test suite, formerly "nightlies".

Now they run upon push to master (because we're typically seeing less
than one change to master a day so running nightly would waste more
than it saves).

This replaces the Gravity-Nightly Jenkins job.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to gravitational/ops#139
* Builds off https://github.com/gravitational/gravity/pull/2415

## TODOs
- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Implementation
This is essentially a duplication of the PR build, with the following changes:

* Triggered upon merge/push to master
* Unit tests are skipped
* ROBOTEST_CONFIG=nightly

I skipped unit testing, as that is always checked at the PR phase -- no need to repeat the effort.  Everything else is needed to produce the artifacts for nightly testing.

Unfortunately, there isn't a great way do dedupe the shared code without going to something like Starlark or https://github.com/gravitational/teleport/pull/5644. See https://github.com/gravitational/teleport/issues/5533 for further discussion.  I don't want to invent this wheel in parallel, so I'm sticking to vanilla drone yaml for the moment.

I didn't take the time to refactor out the "nightly" terminology in favor of something more trigger agnostic.   I may revisit this later, but there isn't much ROI.

## Performance/Scaling
"Nightly"  runs are pretty consistent between 2-3 hours.  I currently have the job timeout set at 4 hours.  Although the runtime is long, the load on Drone is minimal, as this skips the  CPU expensive unit tests.

## Testing done
See https://drone.gravitational.io/gravitational/gravity/119 for a build I triggered by including this branch.

The real test will occur after this merges, and we see the master trigger kick off.
