### PR TITLE
Adjust documentation to reflect Teleport focus.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,3 @@ contact_links:
   - name: Gravity Documentation
     url: https://gravitational.com/gravity/docs/
     about: Check out the Gravity documentation for answers to common questions
-  - name: Gravitational Gravity community
-    url: https://community.gravitational.com/c/gravity
-    about: Ask Gravity related questions, answered by the Team and community. 
-  - name: Request a Demo
-    url: https://gravitational.com/gravity/demo/
-    about: Want to see the full power of Gravity? Our team is happy to give a demo. 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at info@gravitational.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at info@goteleport.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,15 @@ We follow a [code of conduct](./CODE_OF_CONDUCT.md).
 
 ## Filing an Issue
 
-Security issues should be reported directly to security@gravitational.com.
+Security issues should be reported directly to security@goteleport.com.
 
 If you are unsure if you've found a bug, consider searching
-[current issues](https://github.com/gravitational/gravity/issues) or
-asking in the [community forum](https://community.goteleport.com/) first.
+[current issues](https://github.com/gravitational/gravity/issues).
 
 Once you know you have a issue, make sure to fill out all sections of the
 one of the templates at https://github.com/gravitational/gravity/issues/new/choose.
 
-Gravity contributors will triage the issue shortly.
+Gravity contributors will triage the issue.
 
 
 ## Contributing A Patch

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
     <img src='https://gravitational.com/gravitational/images/logos/logo-gravity-x-large.png' alt='Gravity'>
 </a>
 
-Gravity is an [upstream Kubernetes](https://kubernetes.io/) packaging solution
+Gravity is a [Kubernetes](https://kubernetes.io/) packaging solution
 that takes the drama out of deploying and running applications in someone
 else's cloud accounts, on-premise data centers, edge locations and other
 "uncharted territory" environments.
 
-With Gravity, your Kubernetes apps can run and be regularly updated anywhere in
+With Gravity, Kubernetes apps can run and be regularly updated anywhere in
 the world without a massive DevOps team.
 
 |Project Links| Description
@@ -16,8 +16,7 @@ the world without a massive DevOps team.
 | [Gravity Documentation](https://gravitational.com/gravity/docs/)  | Gravity Documentation |
 | [Gravity Examples](examples/) | Examples of applications packaged with Gravity |
 | [Blog](http://blog.gravitational.com) | Our blog, where we publish Gravity news |
-| [Security and Release Updates](https://community.gravitational.com/c/gravity-news) | Gravity Community Security and Release Updates |
-| [Community Forum](https://community.gravitational.com) | Gravity Community Forum|
+| [Security and Release Updates](https://goteleport.com/gravity/docs/changelog/) | Gravity Security and Release Updates |
 
 ## Introduction
 
@@ -141,17 +140,14 @@ organizations](https://gravitational.com/teleport).
 
 ## Is Gravity Production Ready?
 
-Yes! Even though Gravity was open sourced in September 2018, it started life
-much earlier, as a component of a larger, proprietary system called Telekube.
+Yes!
 
 Fully autonomous Gravity clusters are running inside of large banks, government
-institutions, enterprises, etc. Some of the commercial users of Gravity are
-listed on the [Gravitational web site](https://gravitational.com)
+institutions, enterprises, etc. We use Gravity to run our own infrastructure.
 
 ## Why did We Build Gravity?
 
-Gravity was built by [Gravitational Inc](https://gravitational.com), a company
-based in Oakland, California.
+Gravity is built by [Teleport](https://goteleport.com).
 
 The original use case for Gravity was to allow Kubernetes applications to be
 deployed into 3rd party environments, like on-premises datacenters. That's why
@@ -190,22 +186,8 @@ $ make install
 $ make clean
 ```
 
-## Known Issues
-
-While the code is open source, we're still working on updating the
-documentation to reflect the differences between the proprietary and
-community/OSS editions of the software. We are also working on providing open
-source users with pre-built binaries on a regular basis.
-
 ## Contributing
 
 To contribute, please read the [contribution guidelines](./CONTRIBUTING.md).
 
-## Talk to us
-
-* Want to join our team? [We are always hiring!](https://jobs.lever.co/gravitational)
-* Want to stop managing Kubernetes and have autonomous appliance-like clusters?
-* Want to take your complex SaaS application and convert it into a downloadable
-  appliance so your customers can run it on their own AWS account or in a colo?
-
-Reach out to `info@gravitational.com`
+Want to join our team? [We are always hiring!](https://jobs.lever.co/gravitational)

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -11,7 +11,6 @@ Gravity Website:  https://gravitational.com/gravity/
 Quick Start    :  https://gravitational.com/gravity/docs/quickstart/
 Gravity Source :  https://github.com/gravitational/gravity
 Blog           :  https://blog.gravitational.com
-Community Forum:  https://community.gravitational.com
 
 Introduction
 ============
@@ -49,9 +48,4 @@ https://gravitational.com/gravity/docs/quickstart/
 Talk to us
 ==========
 
-* Want to join our team to hack on Gravity? https://gravitational.com/careers/
-* Want to stop managing Kubernetes and have autonomous appliance-like clusters?
-* Want to take your complex SaaS application and convert it into a downloadable
-  appliance so your customers can run it on their own AWS account or in a colo?
-
-Reach out to info@gravitational.com
+* Want to join our team? https://jobs.lever.co/gravitational

--- a/docs/7.x/changelog.md
+++ b/docs/7.x/changelog.md
@@ -397,8 +397,7 @@ extend updates past End of Support through customer agreements if required.
 ### 7.0.2 (April 23rd, 2020)
 
 !!! warning
-    This release has a known issue that can lead to new Teleport nodes failing to join the cluster.
-    See our community [article](https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649) for more details and workaround.
+    This release has a known issue that can lead to new Teleport nodes failing to join the cluster. Please use a more current release.
 
 #### Improvements
 
@@ -505,8 +504,7 @@ to learn how to gain insight into how the cluster status changes over time.
 ### 6.3.12 (April 15th, 2020)
 
 !!! warning
-    This release has a known issue that can lead to new Teleport nodes failing to join the cluster.
-    See our community [article](https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649) for more details and workaround.
+    This release has a known issue that can lead to new Teleport nodes failing to join the cluster. Please use a more current release.
 
 #### Improvements
 
@@ -1772,8 +1770,7 @@ to learn how to gain insight into how the cluster status changes over time.
 ### 5.5.40 LTS (April 3rd, 2020)
 
 !!! warning
-    This release has a known issue that can lead to new Teleport nodes failing to join the cluster.
-    See our community [article](https://community.gravitational.com/t/recover-teleport-nodes-failing-to-join-due-to-bad-token/649) for more details and workaround.
+    This release has a known issue that can lead to new Teleport nodes failing to join the cluster. Please use a more current release.
 
 #### Improvements
 

--- a/docs/theme/footer.html
+++ b/docs/theme/footer.html
@@ -54,13 +54,6 @@
         <h3>CONNECT</h3>
         <ul>
           <li class="has-icon clearfix">
-            <a class="l-space-right-1" href="https://community.gravitational.com/">
-              <img alt="Community Forum" src="https://gravitational.com/gravitational/images/icons/discourse.svg">
-              Community Forum
-            </a>
-          </li>
-
-          <li class="has-icon clearfix">
             <a class="l-space-right-1" href="https://github.com/gravitational">
               <img alt="Github" src="https://gravitational.com/gravitational/images/icons/github.svg">
               Github


### PR DESCRIPTION
## Description
* Remove the links to the community forums.
* Remove sales call to action.
* Adjust hiring call to action.

There are many more related to the domain change that I didn't update yet.  I only tried to get the most egregious instances.

Why?  We don't want to direct folks towards the forums (which may be retired soon) or towards sales (since our sales team isn't focusing on selling Gravity).

## Type of change
* This change has a user-facing impact

## Linked tickets and other PRs
N/A

## TODOs
- [x] Address review feedback

## Testing done
Clicked around the relevant pages here: https://github.com/gravitational/gravity/tree/bb151608235c64ce74d6363aa5fc440694a89e72
