### PR TITLE
bump coredns request/limits up a bit

### DIFF
--- a/assets/dns-app/resources/dns.yaml
+++ b/assets/dns-app/resources/dns.yaml
@@ -110,11 +110,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: 200m
-            memory: 170Mi
+            cpu: 250m
+            memory: 400Mi
           requests:
-            cpu: 100m
-            memory: 70Mi
+            cpu: 200m
+            memory: 275Mi
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume
@@ -210,10 +210,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 170Mi
+            memory: 400Mi
           requests:
-            cpu: 100m
-            memory: 70Mi
+            cpu: 200m
+            memory: 275Mi
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
## Description

We were seeing scaling problems on coredns, usually represented as OOMs 
or huge CPU (gc) spikes during cluster rolling ops or new deploys.

These numbers were tuned based on our current biggest cluster, with the
requests being based around the 1.1 * max(the 95% of each individual
pod) and the limits being 1.5*max(mem) and 1.1*max(cpu)

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

(might possibly be a breaking change for small demo clusters, but probably not for any real installs)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [X] Self-review the change
- [n/a?] Write tests
- [X] Perform manual testing
- [n/a?] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

Should scale better, and avoid the OOMs that were common on startup.

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Soak-tested in our biggest cluster over a period of weeks, and adjusted via the metrics in the description.

## Additional information
Here's a soak-tested cat.
![soak-tested cat](https://live.staticflickr.com/4034/4546211344_38cc0e8ed7_b.jpg)
