### PR TITLE
Fix `tsh` builds in 7.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,6 +40,7 @@ steps:
       - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production telekube opscenter
+      - make build-tsh
     volumes:
       - name: dockersock
         path: /var/run
@@ -142,6 +143,7 @@ steps:
       - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production telekube opscenter
+      - make build-tsh
     volumes:
       - name: dockersock
         path: /var/run
@@ -354,6 +356,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 15f38b42dfd5d3a2d95ca3134862668d327d9810a85e98d58e6d79fc16eb362f
+hmac: 32edcc34ff4ecd21271808a2a8bb6c0a2c4490ada512b9e12892b29ad1f338d1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -139,7 +139,7 @@ steps:
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
     commands:
-      - apk add --no-cache make bash libc6-compat aws-cli
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
       - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production telekube opscenter
@@ -356,6 +356,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 32edcc34ff4ecd21271808a2a8bb6c0a2c4490ada512b9e12892b29ad1f338d1
+hmac: 9346aad6bf4ff7ff4f2668655a5976c409e01e6174af9e54da0ccc3a23d26d56
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -490,7 +490,7 @@ build-tsh-on-host:
 .PHONY: build-tsh-inside-container
 build-tsh-inside-container:
 	@echo "\n----> Building Tsh binary inside container...\n"
-	go build -ldflags "$(GOLFLAGS)" -o $(LOCAL_GRAVITY_BUILDDIR)/tsh $(TELEPORT_PKG_PATH)/tool/tsh
+	GO111MODULE=off go build -ldflags "$(GOLFLAGS)" -o $(LOCAL_GRAVITY_BUILDDIR)/tsh $(TELEPORT_PKG_PATH)/tool/tsh
 	@echo "Done --> $(LOCAL_GRAVITY_BUILDDIR)/tsh"
 
 .PHONY: clone-teleport


### PR DESCRIPTION
## Description
This patch fixes a `tsh` build failure blocking the alpha release of 7.1.

In #1454 we switched from go1.12 to go.1.13, which included the following change:

> The GO111MODULE environment variable continues to default to auto, but the auto setting now activates the module-aware mode of the go command whenever the current working directory contains, or is below a directory containing, a go.mod file — even if the current directory is within GOPATH/src.

Per https://golang.org/doc/go1.13#modules.

This caused the `build-tsh` target to break, as it depended on old GOPATH building but lived under `gravity/build/teleport` and gravity has a go mod.  Ultimately, this caused the build to download too current dependencies, and hit the following error:

```
# github.com/gravitational/teleport/tool/tsh
/gopath/pkg/mod/github.com/gravitational/teleport@v3.2.17+incompatible/tool/tsh/tsh.go:316:35: cannot use &"github.com/google/gops/agent".Options literal (type *"github.com/google/gops/agent".Options) as type "github.com/google/gops/agent".Options in argument to "github.com/google/gops/agent".Listen
```

And subsequently fail the release. We didn't see this earlier because this is the first time we've released off this branch in almost a year.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Fixes an bug introduced in #1454


## TODOs

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
Alternatives I considered:

1) Use [teleport's build process](https://github.com/gravitational/teleport/blob/4dd89e36d2f0f4992a3220e55e09f82be3d2f45b/Makefile#L244-L247).  This means we'd always have a correct build for the teleport branch we use, but also that we'll need to make more changes to the `branch/3.2-g` branch of teleport. (e.g. a go security release would need a commit there as well as in the gravity repo)
2) Revert to an earlier version of the buildbox.  This is more work and has the same effect as the current implementation.
3) Update teleport `version/3.2-g` to use go modules. ROI isn't there -- more current teleport versions have already made the cutover and it would be better to migrate to one of those that continue working with the stable old version we're on currently.

## Performance/Scaling
This adds <1 minute of build time to PR and post-merge builds.

## Testing done
Most importantly importantly, this is now part of the drone build, which should be green, and prevent future regressions like this. Also, tested on my workstation:

<details><summary>local testing</summary>

Before:
```
walt@work:~/git/gravity$ make build-tsh
make -C build.assets build-tsh
make[1]: Entering directory '/home/walt/git/gravity/build.assets'
if [ "linux" = "darwin" ]; then make build-tsh-on-host; else make build-tsh-in-container; fi
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
if [ ! -d "/home/walt/git/gravity/build/teleport/src/teleport" ]; then cd /home/walt/git/gravity/build/teleport/src && git clone git@github.com:gravitational/teleport.git; fi
cd /home/walt/git/gravity/build/teleport/src/teleport && git fetch --all --tags && git checkout v3.2.17
Fetching origin
From github.com:gravitational/teleport
   fe5bcfc12..91c903718  jane/tshPlayFileArg -> origin/jane/tshPlayFileArg
   0cad81b11..d769fec37  joerger/api-proxy-dialer -> origin/joerger/api-proxy-dialer
HEAD is now at f1f03fe76 Increment version in version.go
docker run --rm=true -u $(id -u):$(id -g) \
           -v /home/walt/git/gravity:/gopath/src/github.com/gravitational/gravity \
	   -v /home/walt/git/gravity/build/teleport/src/teleport:/gopath/src/github.com/gravitational/teleport \
	   -e "GRAVITY_PKG_PATH=github.com/gravitational/gravity" \
	   -e "GRAVITY_VERSION=7.1.0-alpha.3" \
	   -e "GRAVITY_TAG=7.1.0-alpha.3" \
	   -e "LOCAL_GRAVITY_BUILDDIR=/gopath/src/github.com/gravitational/gravity/build/7.1.0-alpha.3" \
	   gravity-buildbox:latest \
	   dumb-init make -C /gopath/src/github.com/gravitational/gravity/build.assets build-tsh-inside-container
make: Entering directory '/gopath/src/github.com/gravitational/gravity/build.assets'

----> Building Tsh binary inside container...

go build -ldflags "-w -s" -o /gopath/src/github.com/gravitational/gravity/build/7.1.0-alpha.3/tsh github.com/gravitational/teleport/tool/tsh
go: downloading github.com/gravitational/teleport v3.2.17+incompatible
go: extracting github.com/gravitational/teleport v3.2.17+incompatible
go: downloading golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
go: downloading github.com/jonboulle/clockwork v0.2.0
go: downloading github.com/gravitational/logrus v1.4.3
go: downloading github.com/google/gops v0.3.8
go: downloading github.com/gravitational/go-oidc v0.0.1
go: downloading github.com/gravitational/moby v1.4.2-0.20191008111026-2adf434ca696
go: downloading github.com/json-iterator/go v1.1.5
go: downloading github.com/tstranex/u2f v0.0.0-20160508205855-eb799ce68da4
go: downloading github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b
go: extracting github.com/jonboulle/clockwork v0.2.0
go: extracting github.com/google/gops v0.3.8
go: downloading github.com/coreos/go-semver v0.2.0
go: extracting github.com/tstranex/u2f v0.0.0-20160508205855-eb799ce68da4
go: extracting github.com/gravitational/logrus v1.4.3
go: downloading gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/vulcand/predicate v1.1.0
go: extracting github.com/gravitational/go-oidc v0.0.1
go: downloading github.com/gravitational/roundtrip v1.0.0
go: extracting github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b
go: downloading k8s.io/apimachinery v0.16.15
go: extracting github.com/json-iterator/go v1.1.5
go: downloading github.com/prometheus/client_golang v0.9.2
go: extracting github.com/coreos/go-semver v0.2.0
go: downloading golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f
go: extracting github.com/vulcand/predicate v1.1.0
go: extracting github.com/gravitational/roundtrip v1.0.0
go: downloading github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
go: downloading github.com/mdp/rsc v0.0.0-20160131164516-90f07065088d
go: extracting gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
go: downloading github.com/julienschmidt/httprouter v1.1.0
go: extracting golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
go: extracting gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/beevik/etree v1.1.0
go: downloading github.com/russellhaering/goxmldsig v1.1.0
go: extracting github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
go: extracting github.com/mdp/rsc v0.0.0-20160131164516-90f07065088d
go: extracting github.com/prometheus/client_golang v0.9.2
go: downloading k8s.io/client-go v0.16.15
go: downloading github.com/gravitational/kingpin v2.1.11-0.20160205192003-785686550a08+incompatible
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: extracting github.com/julienschmidt/httprouter v1.1.0
go: extracting github.com/beevik/etree v1.1.0
go: downloading github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
go: downloading github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f
go: extracting github.com/russellhaering/goxmldsig v1.1.0
go: downloading github.com/cyphar/filepath-securejoin v0.2.2
go: extracting github.com/gravitational/moby v1.4.2-0.20191008111026-2adf434ca696
go: extracting github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: extracting github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
go: downloading github.com/pquerna/otp v0.0.0-20160912161815-54653902c20e
go: extracting github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f
go: downloading github.com/gravitational/configure v0.0.0-20191213111049-fce91dea0d0d
go: downloading github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
go: extracting k8s.io/apimachinery v0.16.15
go: extracting github.com/gravitational/kingpin v2.1.11-0.20160205192003-785686550a08+incompatible
go: downloading github.com/golang/protobuf v1.3.2
go: extracting github.com/cyphar/filepath-securejoin v0.2.2
go: downloading github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
go: downloading github.com/davecgh/go-spew v1.1.0
go: extracting github.com/pquerna/otp v0.0.0-20160912161815-54653902c20e
go: extracting github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
go: extracting github.com/gravitational/configure v0.0.0-20191213111049-fce91dea0d0d
go: downloading github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: downloading github.com/russellhaering/gosaml2 v0.0.0-20170515204909-8908227c114a
go: downloading github.com/gravitational/oxy v0.0.0-20180629203109-e4a7e35311e6
go: extracting github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
go: extracting github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: downloading github.com/mailgun/ttlmap v0.0.0-20150816203249-16b258d86efc
go: extracting github.com/davecgh/go-spew v1.1.0
go: downloading github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb
go: extracting github.com/golang/protobuf v1.3.2
go: extracting github.com/gravitational/oxy v0.0.0-20180629203109-e4a7e35311e6
go: extracting github.com/russellhaering/gosaml2 v0.0.0-20170515204909-8908227c114a
go: downloading github.com/mailgun/timetools v0.0.0-20150505213551-fd192d755b00
go: extracting github.com/mailgun/ttlmap v0.0.0-20150816203249-16b258d86efc
go: downloading github.com/boombuler/barcode v0.0.0-20161226211916-fe0f26ff6d26
go: extracting github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb
go: downloading github.com/kr/pretty v0.2.0
go: downloading github.com/alecthomas/template v0.0.0-20150530000104-b867cc6ab45c
go: extracting k8s.io/client-go v0.16.15
go: extracting github.com/mailgun/timetools v0.0.0-20150505213551-fd192d755b00
go: downloading github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082
go: downloading k8s.io/klog v0.1.0
go: extracting github.com/kr/pretty v0.2.0
go: downloading github.com/pkg/errors v0.9.1
go: extracting github.com/boombuler/barcode v0.0.0-20161226211916-fe0f26ff6d26
go: extracting github.com/alecthomas/template v0.0.0-20150530000104-b867cc6ab45c
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: extracting k8s.io/klog v0.1.0
go: extracting github.com/pkg/errors v0.9.1
go: downloading github.com/fatih/color v1.7.0
go: downloading golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
go: extracting github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082
go: downloading github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
go: extracting golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f
go: downloading github.com/mailgun/lemma v0.0.0-20160211003854-e8b0cd607f58
go: downloading github.com/kr/text v0.1.0
go: downloading github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
go: downloading k8s.io/api v0.16.15
go: extracting github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
go: extracting github.com/fatih/color v1.7.0
go: downloading github.com/prometheus/procfs v0.0.5
go: extracting golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: downloading github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
go: downloading github.com/gogo/protobuf v1.3.0
go: extracting github.com/mailgun/lemma v0.0.0-20160211003854-e8b0cd607f58
go: extracting github.com/kr/text v0.1.0
go: downloading github.com/mattn/go-isatty v0.0.3
go: downloading gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
go: extracting github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
go: downloading github.com/spf13/pflag v1.0.5
go: extracting golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
go: extracting github.com/prometheus/procfs v0.0.5
go: extracting github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
go: downloading github.com/google/gofuzz v0.0.0-20150304233714-bbcb9da2d746
go: extracting github.com/mattn/go-isatty v0.0.3
go: downloading github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70
go: extracting github.com/spf13/pflag v1.0.5
go: extracting gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
go: extracting github.com/google/gofuzz v0.0.0-20150304233714-bbcb9da2d746
go: downloading github.com/mailgun/minheap v0.0.0-20131208021033-7c28d80e2ada
go: extracting github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70
go: downloading github.com/mattn/go-colorable v0.0.9
go: extracting github.com/mailgun/minheap v0.0.0-20131208021033-7c28d80e2ada
go: extracting github.com/mattn/go-colorable v0.0.9
go: extracting github.com/gogo/protobuf v1.3.0
go: extracting k8s.io/api v0.16.15
go: downloading github.com/gravitational/trace v1.1.14
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading github.com/xeipuuv/gojsonschema v0.0.0-20151204154511-3988ac14d6f6
go: downloading github.com/gravitational/bolt v1.3.2-gravitational
go: downloading golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
go: downloading github.com/imdario/mergo v0.0.0-20160517064435-50d4dbd4eb0e
go: downloading gopkg.in/inf.v0 v0.9.0
go: downloading k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
go: downloading github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
go: downloading github.com/mailgun/metrics v0.0.0-20150124003306-2b3c4565aafd
go: extracting github.com/gravitational/trace v1.1.14
go: extracting sigs.k8s.io/yaml v1.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v0.0.0-20151011102529-d0c3fe89de86
go: downloading golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
go: extracting gopkg.in/inf.v0 v0.9.0
go: extracting github.com/imdario/mergo v0.0.0-20160517064435-50d4dbd4eb0e
go: extracting github.com/xeipuuv/gojsonschema v0.0.0-20151204154511-3988ac14d6f6
go: extracting golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
go: extracting github.com/mailgun/metrics v0.0.0-20150124003306-2b3c4565aafd
go: downloading github.com/satori/go.uuid v1.1.1-0.20170321230731-5bf94b69c6b6
go: extracting github.com/gravitational/bolt v1.3.2-gravitational
go: downloading github.com/googleapis/gnostic v0.2.0
go: downloading google.golang.org/grpc v1.26.0
go: extracting github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
go: extracting github.com/matttproud/golang_protobuf_extensions v0.0.0-20151011102529-d0c3fe89de86
go: extracting github.com/satori/go.uuid v1.1.1-0.20170321230731-5bf94b69c6b6
go: extracting k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
go: extracting golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
go: downloading github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c
go: extracting github.com/googleapis/gnostic v0.2.0
go: extracting github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076
go: extracting github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076
go: extracting google.golang.org/grpc v1.26.0
go: downloading google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0
go: extracting google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0
go: finding github.com/gravitational/teleport v3.2.17+incompatible
go: finding github.com/google/gops v0.3.8
go: finding github.com/gravitational/trace v1.1.14
go: finding github.com/gravitational/moby v1.4.2-0.20191008111026-2adf434ca696
go: finding github.com/gravitational/oxy v0.0.0-20180629203109-e4a7e35311e6
go: finding github.com/jonboulle/clockwork v0.2.0
go: finding github.com/gravitational/logrus v1.4.3
go: finding k8s.io/client-go v0.16.15
go: finding github.com/mailgun/timetools v0.0.0-20150505213551-fd192d755b00
go: finding golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
go: finding github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
go: finding github.com/mailgun/ttlmap v0.0.0-20150816203249-16b258d86efc
go: finding github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
go: finding github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
go: finding golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5
go: finding github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b
go: finding gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
go: finding golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: finding github.com/gravitational/roundtrip v1.0.0
go: finding github.com/imdario/mergo v0.0.0-20160517064435-50d4dbd4eb0e
go: finding k8s.io/api v0.16.15
go: finding github.com/mailgun/minheap v0.0.0-20131208021033-7c28d80e2ada
go: finding github.com/spf13/pflag v1.0.5
go: finding github.com/beevik/etree v1.1.0
go: finding k8s.io/apimachinery v0.16.15
go: finding github.com/golang/protobuf v1.3.2
go: finding github.com/gravitational/go-oidc v0.0.1
go: finding github.com/googleapis/gnostic v0.2.0
go: finding github.com/gravitational/configure v0.0.0-20191213111049-fce91dea0d0d
go: finding github.com/gogo/protobuf v1.3.0
go: finding github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
go: finding github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70
go: finding github.com/cyphar/filepath-securejoin v0.2.2
go: finding github.com/fatih/color v1.7.0
go: finding github.com/google/gofuzz v0.0.0-20150304233714-bbcb9da2d746
go: finding k8s.io/klog v0.1.0
go: finding github.com/mdp/rsc v0.0.0-20160131164516-90f07065088d
go: finding github.com/coreos/go-semver v0.2.0
go: finding github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
go: finding github.com/mattn/go-colorable v0.0.9
go: finding gopkg.in/yaml.v2 v2.2.2
go: finding github.com/pkg/errors v0.9.1
go: finding github.com/russellhaering/gosaml2 v0.0.0-20170515204909-8908227c114a
go: finding gopkg.in/inf.v0 v0.9.0
go: finding github.com/json-iterator/go v1.1.5
go: finding github.com/julienschmidt/httprouter v1.1.0
go: finding github.com/gravitational/kingpin v2.1.11-0.20160205192003-785686550a08+incompatible
go: finding github.com/mattn/go-isatty v0.0.3
go: finding github.com/xeipuuv/gojsonschema v0.0.0-20151204154511-3988ac14d6f6
go: finding github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
go: finding github.com/russellhaering/goxmldsig v1.1.0
go: finding golang.org/x/text v0.0.0-20161230201740-fd889fe3a20f
go: finding github.com/gravitational/bolt v1.3.2-gravitational
go: finding github.com/davecgh/go-spew v1.1.0
go: finding github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c
go: finding github.com/tstranex/u2f v0.0.0-20160508205855-eb799ce68da4
go: finding github.com/vulcand/predicate v1.1.0
go: finding github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: finding github.com/kylelemons/godebug v0.0.0-20160406211939-eadb3ce320cb
go: finding gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
go: finding sigs.k8s.io/yaml v1.2.0
go: finding github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076
go: finding github.com/pquerna/otp v0.0.0-20160912161815-54653902c20e
go: finding github.com/mailgun/lemma v0.0.0-20160211003854-e8b0cd607f58
go: finding github.com/alecthomas/template v0.0.0-20150530000104-b867cc6ab45c
go: finding github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: finding github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
go: finding golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2
go: finding golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced
go: finding github.com/satori/go.uuid v1.1.1-0.20170321230731-5bf94b69c6b6
go: finding github.com/prometheus/client_golang v0.9.2
go: finding k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
go: finding github.com/kr/pretty v0.2.0
go: finding google.golang.org/grpc v1.26.0
go: finding github.com/mailgun/metrics v0.0.0-20150124003306-2b3c4565aafd
go: finding github.com/boombuler/barcode v0.0.0-20161226211916-fe0f26ff6d26
go: finding github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f
go: finding github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
go: finding github.com/kr/text v0.1.0
go: finding github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082
go: finding github.com/prometheus/procfs v0.0.5
go: finding google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0
go: finding github.com/matttproud/golang_protobuf_extensions v0.0.0-20151011102529-d0c3fe89de86
# github.com/gravitational/teleport/tool/tsh
/gopath/pkg/mod/github.com/gravitational/teleport@v3.2.17+incompatible/tool/tsh/tsh.go:316:35: cannot use &"github.com/google/gops/agent".Options literal (type *"github.com/google/gops/agent".Options) as type "github.com/google/gops/agent".Options in argument to "github.com/google/gops/agent".Listen
make: *** [build-tsh-inside-container] Error 2
Makefile:492: recipe for target 'build-tsh-inside-container' failed
make: Leaving directory '/gopath/src/github.com/gravitational/gravity/build.assets'
make[2]: *** [Makefile:467: build-tsh-in-container] Error 2
make[2]: Leaving directory '/home/walt/git/gravity/build.assets'
make[1]: *** [Makefile:460: build-tsh] Error 2
make[1]: Leaving directory '/home/walt/git/gravity/build.assets'
make: *** [Makefile:254: build-tsh] Error 2
```

After:
```
walt@work:~/git/gravity$ make build-tsh
make -C build.assets build-tsh
make[1]: Entering directory '/home/walt/git/gravity/build.assets'
if [ "linux" = "darwin" ]; then make build-tsh-on-host; else make build-tsh-in-container; fi
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
if [ ! -d "/home/walt/git/gravity/build/teleport/src/teleport" ]; then cd /home/walt/git/gravity/build/teleport/src && git clone git@github.com:gravitational/teleport.git; fi
cd /home/walt/git/gravity/build/teleport/src/teleport && git fetch --all --tags && git checkout v3.2.17
Fetching origin
HEAD is now at f1f03fe76 Increment version in version.go
docker run --rm=true -u $(id -u):$(id -g) \
           -v /home/walt/git/gravity:/gopath/src/github.com/gravitational/gravity \
           -v /home/walt/git/gravity/build/teleport/src/teleport:/gopath/src/github.com/gravitational/teleport \
           -e "GRAVITY_PKG_PATH=github.com/gravitational/gravity" \
           -e "GRAVITY_VERSION=7.1.0-alpha.3.3" \
           -e "GRAVITY_TAG=7.1.0-alpha.3.3" \
           -e "LOCAL_GRAVITY_BUILDDIR=/gopath/src/github.com/gravitational/gravity/build/7.1.0-alpha.3.3" \
           gravity-buildbox:latest \
           dumb-init make -C /gopath/src/github.com/gravitational/gravity/build.assets build-tsh-inside-container
make: Entering directory '/gopath/src/github.com/gravitational/gravity/build.assets'

----> Building Tsh binary inside container...

GO111MODULE=off go build -ldflags "-w -s" -o /gopath/src/github.com/gravitational/gravity/build/7.1.0-alpha.3.3/tsh github.com/gravitational/teleport/tool/tsh
Done --> /gopath/src/github.com/gravitational/gravity/build/7.1.0-alpha.3.3/tsh
make: Leaving directory '/gopath/src/github.com/gravitational/gravity/build.assets'
make[2]: Leaving directory '/home/walt/git/gravity/build.assets'
make[1]: Leaving directory '/home/walt/git/gravity/build.assets'
```

</details>


