### PR TITLE
Fix tsh builds on Mac

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -480,11 +480,11 @@ build-tsh-in-container: clone-teleport
 .PHONY: build-tsh-on-host
 build-tsh-on-host:
 	@echo "\n----> Building Tsh binary on host...\n"
-	GOPATH=$(BUILDDIR) go get -v $(TELEPORT_PKG_PATH) && \
+	GO111MODULE=off GOPATH=$(BUILDDIR) go get -v $(TELEPORT_PKG_PATH) && \
 		cd $(BUILDDIR)/src/$(TELEPORT_PKG_PATH) && \
 		git fetch --all --tags && \
 		git checkout $(TELEPORT_REPOTAG) && \
-		GOPATH=$(BUILDDIR) go build -ldflags "$(GOLFLAGS)" -o $(TSH_OUT) ./tool/tsh
+		GO111MODULE=off GOPATH=$(BUILDDIR) go build -ldflags "$(GOLFLAGS)" -o $(TSH_OUT) ./tool/tsh
 	@echo "Done --> $(TSH_OUT)"
 
 .PHONY: build-tsh-inside-container


### PR DESCRIPTION

## Description
This is a fast follow to d13b064ee038e996568f37b8eb95e7b8efd3591c / #2434, but applied to our
Mac builds.  This addresses release failures, as seen at:

https://jenkins.gravitational.io/job/Telekube-Publish-5.2/354/console

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Fixes an bug introduced in #1454
* Adds to #2434

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Performance/Scaling
No impact.

## Testing done
Tested on the xcloud build box:

<details><summary><code>make build-tsh</code></summary>

```
xcloud843:gravity Xcloud$ make build-tsh
/Library/Developer/CommandLineTools/usr/bin/make -C build.assets build-tsh
if [ "darwin" = "darwin" ]; then /Library/Developer/CommandLineTools/usr/bin/make build-tsh-on-host; else /Library/Developer/CommandLineTools/usr/bin/make build-tsh-in-container; fi

----> Building Tsh binary on host...

GO111MODULE=off GOPATH=/Users/Xcloud/walt/gravity/build go get -v github.com/gravitational/teleport && \
                cd /Users/Xcloud/walt/gravity/build/src/github.com/gravitational/teleport && \
                git fetch --all --tags && \
                git checkout v3.2.17 && \
                GO111MODULE=off GOPATH=/Users/Xcloud/walt/gravity/build go build -ldflags "-w -s" -o /Users/Xcloud/walt/gravity/build/7.1.0-alpha.4/tsh ./tool/tsh
github.com/gravitational/teleport (download)
github.com/gravitational/teleport/vendor/github.com/gravitational/teleport/api/constants
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/flags
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/set
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/sortkeys
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/detrand
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/errors
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/encoding/protowire
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/pragma
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/reflect/protoreflect
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/descfmt
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/descopts
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/strs
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/encoding/text
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/encoding/defval
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/genid
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/reflect/protoregistry
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/encoding/messageset
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/fieldsort
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/mapsort
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/runtime/protoiface
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/proto
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/filedesc
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/encoding/prototext
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/encoding/tag
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/impl
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/gogoproto
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/types
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/filetype
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/internal/version
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/runtime/protoimpl
github.com/gravitational/teleport/vendor/google.golang.org/protobuf/types/known/timestamppb
github.com/gravitational/teleport/vendor/github.com/golang/protobuf/ptypes/timestamp
github.com/gravitational/teleport/vendor/github.com/gravitational/teleport/api/defaults
github.com/gravitational/teleport/vendor/github.com/jonboulle/clockwork
github.com/gravitational/teleport/vendor/golang.org/x/sys/internal/unsafeheader
github.com/gravitational/teleport/vendor/golang.org/x/sys/unix
github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/jsonpb
github.com/gravitational/teleport/vendor/github.com/sirupsen/logrus
github.com/gravitational/teleport/vendor/golang.org/x/term
github.com/gravitational/teleport/vendor/golang.org/x/net/context
github.com/gravitational/teleport/vendor/golang.org/x/crypto/ssh/terminal
github.com/gravitational/teleport/vendor/github.com/gravitational/trace
github.com/gravitational/teleport/vendor/github.com/gravitational/teleport/api/types/wrappers
github.com/gravitational/teleport/vendor/github.com/gravitational/teleport/api/utils
github.com/gravitational/teleport/vendor/github.com/gravitational/teleport/api/types
github.com/gravitational/teleport
Fetching origin
warning: unable to rmdir webassets: Directory not empty
M       e
Note: checking out 'v3.2.17'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at f1f03fe76... Increment version in version.go
Done --> /Users/Xcloud/walt/gravity/build/7.1.0-alpha.4/tsh
```

</details>
