### PR TITLE
Do not require a kubernetes config to sync apps

### DIFF
--- a/tool/gravity/cli/sync.go
+++ b/tool/gravity/cli/sync.go
@@ -141,10 +141,8 @@ func appSyncEnv(env *localenv.LocalEnvironment, imageEnv *localenv.ImageEnvironm
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	} else if httplib.InKubernetes() {
-		// If we're running inside generic Kubernetes cluster, sync images
-		// to the registry specified on the command line.
-		log.Info("Detected generic Kubernetes cluster.")
+	} else {
+		// sync images to the registry specified on the command line.
 		env.PrintStep("Pushing application images to Docker registry %v", conf.Registry)
 		imageService, err := conf.imageService()
 		if err != nil {
@@ -161,8 +159,6 @@ func appSyncEnv(env *localenv.LocalEnvironment, imageEnv *localenv.ImageEnvironm
 		if err != nil {
 			return trace.Wrap(err)
 		}
-	} else {
-		return trace.BadParameter("not inside a Kubernetes cluster")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
This fixes a `gravity app sync` bug I discovered while working on porting
our release pipeline from Jenkins to Drone CI.  See the following logs:

https://drone.gravitational.io/gravitational/gravity/184/1/6

## Context
In 6b5c5552096ecf027b07e3bcdde450a4ab7fa252, container image scanning was added to the gravity release process, reusing logic from `gravity app sync`.  However that logic was initially developed (a4a1a224b8ca4978c978d0da8729e53c229a710e) under the assumption of syncing apps for helm in a Kubernetes cluster.

For the upload & scan workflow, we don't expect to be in a kubernetes
cluster, but instead a build environment. Thus this patch removes some
logic requiring that we have a Kubernetes config available.



## Type of change
* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

There is some risk here of breaking the gravity app sync workflow inside
a kubernetes cluster that doesn't use gravity, but that is not a use
case we're particularly concerned with at the moment.

## Linked tickets and other PRs
* Addresses an issue stemming from the intersection of #134 and #1550

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
I considered the more substantial change to more cleanly factor the scan upload
logic from the sync logic, but it doesn't have good risk/reward ration in my opinion.


## Testing Done
Before:
```
walt@work:~/git/gravity$ gravity --state-dir=/home/walt/git/gravity/build/7.1.0-alpha.2/state  app sync \
        --registry=quay.io/gravitational \
        --registry-username=*** \
        --registry-password=*** \
        --scan-repository=gravitational/gravity-scan \
        --scan-prefix=7.1.0-alpha.2 \
        /home/walt/git/gravity/build/7.1.0-alpha.2/telekube.tar
[ERROR]: not inside a Kubernetes cluster
```

After:
```
walt@work:~/git/gravity$ gravity --state-dir=/home/walt/git/gravity/build/7.1.0-alpha.2/state  app sync \        
        --registry=quay.io/gravitational \
        --registry-username=*** \
        --registry-password=*** \
        --scan-repository=gravitational/gravity-scan \
        --scan-prefix=7.1.0-alpha.2 \
        /home/walt/git/gravity/build/7.1.0-alpha.2/telekube.tar
Fri Mar 19 00:57:32 UTC Pushing application images to Docker registry quay.io/gravitational
Pushing image gravitational/debian-tall:buster -> gravitational/gravity-scan:7.1.0-alpha.2_gravitational_debian-tall_buster
Pushing image coredns/coredns:1.7.0 -> gravitational/gravity-scan:7.1.0-alpha.2_coredns_coredns_1.7.0
Pushing image cpa/cluster-proportional-autoscaler-amd64:1.8.3 -> gravitational/gravity-scan:7.1.0-alpha.2_cpa_cluster-proportional-autoscaler-amd64_1.8.3
...
```
