### PR TITLE
Add 7.1 -> 7.1 upgrade tests to robotest

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-
+UPGRADE_MAP[7.1.0-alpha.5]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -7,6 +7,7 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
+UPGRADE_MAP[7.1.0-alpha.5]="ubuntu:20" # this version
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2" # compatible LTS version
 UPGRADE_MAP[7.0.13]="centos:7.9" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release


### PR DESCRIPTION
## Description
We have our first alpha of 7.1 out, we want to start making sure it can
upgrade to future versions.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)


## Linked tickets and other PRs
N/A

I was inspired to write this to help validate the substantial changes at https://github.com/gravitational/gravity/pull/2433

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Implementation

`recommended_upgrade_tag` ignores pre-release versions:

https://github.com/gravitational/gravity/blob/db43b62ce7cb64772ad361ea7000aac3f79f0cba/assets/robotest/config/lib/utils.sh#L20-L28

So I needed to hardcode the alpha version for now. Once we have a official release, we can use `$(recommended_upgrade_tag master)`

## Performance/Scaling
This does add 11 upgrade test (~33 node hours) to our post-merge build which is rather expensive.  I imagine we'll deduplicate some 7.0/7.1 scenarios once 7.1 is out officially.  For the interim, there is extra upgrade scrutiny though.

## Testing done
See the PR build.  No testing for nightly, yet but I'll eyeball the build after this merges.

```
walt@gcp:~/git/gravity$ make -C assets/robotest ROBOTEST_CONFIG=pr get-upgrade-versions     
make: Entering directory '/home/walt/git/gravity/assets/robotest'
7.0.7 7.0.30 7.1.0-alpha.5 7.0.13 7.0.12
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
walt@gcp:~/git/gravity$ make -C assets/robotest ROBOTEST_CONFIG=nightly get-upgrade-versions
make: Entering directory '/home/walt/git/gravity/assets/robotest'
7.0.0 7.0.30 7.1.0-alpha.5 6.3.18 7.0.13 7.0.12
make: Leaving directory '/home/walt/git/gravity/assets/robotest'
```

