### PR TITLE
[7.0.x] Chown logrange directory to service-uid/gid

### DIFF
--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -249,6 +249,7 @@ func (p *bootstrapExecutor) configureSystemDirectories(ctx context.Context) erro
 		filepath.Join(stateDir, "secrets"),
 		filepath.Join(stateDir, "backup"),
 		filepath.Join(stateDir, "monitoring"),
+		filepath.Join(stateDir, "logrange"),
 	}
 	for _, dir := range chownList {
 		p.Infof("Setting ownership on system directory %v to %v:%v.",

--- a/lib/ops/opsservice/deploy.go
+++ b/lib/ops/opsservice/deploy.go
@@ -120,6 +120,7 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("secrets"),
 		server.InGravity("backup"),
 		server.InGravity("monitoring"),
+		server.InGravity("logrange"),
 	}
 
 	chmodList := []string{


### PR DESCRIPTION
-------

## Description
<!--Required. Provide high-level overview of what the change is for.-->
This change makes it possible to run some of the logrange K8s resources with `service-uid: -1` and fixes permission errors for those containers.

PR for the logging-app will be provided when all manual tests pass.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->