### PR TITLE
Forward-port chown of monitoring/logrange directories

### DIFF
--- a/lib/ops/opsservice/deploy.go
+++ b/lib/ops/opsservice/deploy.go
@@ -102,6 +102,10 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("secrets"),
 		server.InGravity("backup"),
 		server.InGravity("logrange"),
+		// names prometheus-db/alertmanager-db are hardcoded subPath values
+		// in prometheus-operator
+		server.InGravity("monitoring", "prometheus-db"),
+		server.InGravity("monitoring", "alertmanager-db"),
 	}
 
 	chownList := []string{
@@ -115,6 +119,8 @@ func remoteDirectories(operation ops.SiteOperation, server *ProvisionedServer, m
 		server.InGravity("site"),
 		server.InGravity("secrets"),
 		server.InGravity("backup"),
+		server.InGravity("monitoring"),
+		server.InGravity("logrange"),
 	}
 
 	chmodList := []string{


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
* Create directories for monitoring data
* Chown logrange and monitoring data directories to service-user/gid

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2447, #1950

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->