### PR TITLE
Release via Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -354,8 +354,298 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: tag
+
+# This pipeline generates placeholder builds that Drone CI promotions can reference.
+# See https://docs.drone.io/promote/
+#
+# This is useful, because it allows re-running release steps without re-pushing
+# tags to the repo, in case of faulty infrastructure. We don't ever want to overwrite
+# released tags.  It'd be good to verify that the tags are signed and not already
+# present in this build. -- walt 2021-03
+
+trigger:
+  event:
+  - tag
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: check version
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash
+      - make get-version
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-dependencies
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-dependencies
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - make -C e production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish dependencies
+    image: docker:git
+    environment:
+      TELE_COPY_TO_USER:
+        from_secret: QUAY_IO_SCAN_UPLOAD_USER
+      TELE_COPY_TO_PASS:
+        from_secret: QUAY_IO_SCAN_UPLOAD_TOKEN
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RW_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli
+      - make -C e publish
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-oss
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-oss
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git fetch --tags
+    - git checkout $DRONE_COMMIT
+  - name: clone ops
+    image: docker:git
+    environment:
+      OPS_REPO:
+        from_secret: OPS_REPO
+      GITHUB_OPS_DEPLOY_KEY:
+        from_secret: GITHUB_OPS_DEPLOY_KEY
+      OPS_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $OPS_REPO ops
+    - cd ops
+    - git checkout $OPS_REF
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      GITHUB_RO_KEY_PR:
+        from_secret: GITHUB_RO_KEY_PR
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - cd gravity
+      - make production telekube build-tsh release hub-vars
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RW_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+      MAC_ANSIBLE_BUILD_HOST:
+        from_secret: MAC_ANSIBLE_BUILD_HOST
+      MAC_ANSIBLE_SSH_KEY:
+        from_secret: MAC_ANSIBLE_SSH_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli ansible
+      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
+      - export WORKSPACE=/drone/src
+      - export GRAVITY_TAG=$DRONE_COMMIT_REF
+      - cd ops/hub
+      - make bucket sync
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-enterprise
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-enterprise
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git fetch --tags
+    - git checkout $DRONE_COMMIT
+  - name: clone ops
+    image: docker:git
+    environment:
+      OPS_REPO:
+        from_secret: OPS_REPO
+      GITHUB_OPS_DEPLOY_KEY:
+        from_secret: GITHUB_OPS_DEPLOY_KEY
+      OPS_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $OPS_REPO ops
+    - cd ops
+    - git checkout $OPS_REF
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish on linux
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      TELE_KEY:
+        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - cd gravity
+      - make -C e production
+      - e/build/current/tele login --hub get.gravitational.io --token $TELE_KEY
+      - make -C e telekube opscenter publish-telekube publish-artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish on mac
+    image: docker:git
+    environment:
+      TELE_KEY:
+        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
+      MAC_ANSIBLE_BUILD_HOST:
+        from_secret: MAC_ANSIBLE_BUILD_HOST
+      MAC_ANSIBLE_SSH_KEY:
+        from_secret: MAC_ANSIBLE_SSH_KEY
+    commands:
+      - apk add --no-cache make ansible
+      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
+      - export TELEKUBE_TAG=$DRONE_COMMIT_REF
+      - cd ops/xcloud
+      - make release-telekube-mac
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 ---
 kind: signature
-hmac: 9346aad6bf4ff7ff4f2668655a5976c409e01e6174af9e54da0ccc3a23d26d56
+hmac: 66fb20c94f617c28f44f3e0a13d95a98c37b29404d408eea0402f26ca300c5b2
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -635,20 +635,6 @@ $(GRAVITY_BUILDDIR):
 $(BINARIES): selinux grpc
 	GO111MODULE=on go install -mod=vendor -ldflags $(GRAVITY_LINKFLAGS) -tags "$(GRAVITY_BUILDTAGS)" $(GRAVITY_PKG_PATH)/tool/$@
 
-.PHONY: wizard-publish
-wizard-publish: BUILD_BUCKET_URL = s3://get.gravitational.io
-wizard-publish: S3_OPTS = --region us-west-1
-wizard-publish: K8S_OUT := kubernetes-$(GRAVITY_VERSION).tar.gz
-wizard-publish:
-	gravity ops create-wizard --ops-url=$(LOCAL_OPS_URL) gravitational.io/kubernetes:0.0.0+latest /tmp/k8s
-	tar -C /tmp -czf $(K8S_OUT) k8s
-	aws s3 cp $(S3_OPTS) $(K8S_OUT) $(BUILD_BUCKET_URL)/telekube/$(K8S_OUT)
-
-.PHONY: wizard-gen
-wizard-gen: K8S_OUT := kubernetes-$(GRAVITY_VERSION).tar.gz
-wizard-gen:
-	gravity ops create-wizard --ops-url=$(LOCAL_OPS_URL) gravitational.io/telekube:0.0.0+latest /tmp/telekube
-
 .PHONY: dev
 dev: goinstall
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -69,7 +69,6 @@ ARCH := $(shell uname -m)
 
 # Address of OpsCenter to publish telekube binaries to
 DISTRIBUTION_OPSCENTER ?= https://get.gravitational.io
-S3_DISTRIBUTION_BUCKET ?= s3://get.gravitational.io/releases/$(GRAVITY_VERSION)
 
 # Telekube package names
 TELEKUBE_GRAVITY_PKG := gravitational.io/gravity_$(OS)_$(ARCH):$(GRAVITY_TAG)
@@ -272,21 +271,6 @@ publish-telekube: build
 	@echo -e "\n----> Publishing Tsh to $(DISTRIBUTION_OPSCENTER)...\n"
 	$(GRAVITY_OUT) package delete --ops-url=$(DISTRIBUTION_OPSCENTER) $(TELEKUBE_PUBLISH_FLAGS) --force $(TELEKUBE_TSH_PKG) && \
 	$(GRAVITY_OUT) package import --ops-url=$(DISTRIBUTION_OPSCENTER) $(TELEKUBE_PUBLISH_FLAGS) $(TSH_OUT) $(TELEKUBE_TSH_PKG)
-
-
-#
-# publish telekube/opscenter application packages to S3
-#
-.PHONY: publish-telekube-s3
-publish-telekube-s3:
-	@echo -e "\n----> Publishing Telekube application to $(S3_DISTRIBUTION_BUCKET)...\n"
-	$(AWS) s3 cp $(S3_OPTS) "$(GRAVITY_BUILDDIR)/telekube.tar" $(S3_DISTRIBUTION_BUCKET)/
-	@echo -e "\n----> Publishing Ops Center application to $(S3_DISTRIBUTION_BUCKET)...\n"
-	$(AWS) s3 cp $(S3_OPTS) "$(GRAVITY_BUILDDIR)/opscenter.tar" $(S3_DISTRIBUTION_BUCKET)/
-	@echo -e "\n----> Publishing Gravity to $(S3_DISTRIBUTION_BUCKET)...\n"
-	$(AWS) s3 cp $(S3_OPTS) "$(GRAVITY_OUT)" $(S3_DISTRIBUTION_BUCKET)/
-	@echo -e "\n----> Publishing Tele to $(S3_DISTRIBUTION_BUCKET)...\n"
-	$(AWS) s3 cp $(S3_OPTS) "$(TELE_OUT)" $(S3_DISTRIBUTION_BUCKET)/
 
 
 #


### PR DESCRIPTION
## Description
This patch adds Drone CI as a parallel release system for Jenkins.  This is the last set of piplines needed to move gravity off Jenkins.

This (and earlier Drone PRs) need porting to all active branches

## Type of change
* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* This is the last big milestone for https://github.com/gravitational/ops/issues/139
* Requires https://github.com/gravitational/ops/pull/212, https://github.com/gravitational/ops/pull/207, and just about all of these: https://github.com/gravitational/cloud-terraform/pulls?q=is%3Apr+is%3Aclosed+author%3Awadells

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback
- [ ] Clean up `7.1.0-alpha.2` test build in s3://hub.gravitational.io and get.gravitational.io opscenter

## Implementation
### UX
After pushing a tag, Drone will generate a placeholder build that doesn't do anything meaningful (at the moment).  Using that placeholder `<BUILD_NUMBER>`, run the following command:

```
drone build promote gravitational/gravity <BUILD_NUMBER> release
```

This will kick off all release pipelines.  To trigger individual ones, `release` may be replaced with `publish-dependencies`, `publish-oss`, or `publish-enterprise`.  This can also be done via the drone WebUI by navigating to the build and selecting the cloud icon:

![image](https://user-images.githubusercontent.com/187314/113223961-3255a280-923f-11eb-9748-2e4aac654c9a.png)

### Alternatives
Promotions are kinda a odd fit for the release workflow, as Drone thinks about it as "promoting an environment (e.g. stage) to a ref" instead of "publish artifacts for a ref" -- leading to some UI impedance mismatch, e.g. https://drone.gravitational.io/gravitational/gravity/deployments assumes `publish-oss` is "at" build x, wheras there are many published builds -- it isn't just the most recent one that is relevant.

As such, I considered some alternatives:

* I could have triggered the build off tags (what I've done for smaller projects) -- but this would have required re-pushing tags to re-run parts of the build, which I didn't like.  Also, it wouldn't have allowed re-running just part (e.g. `publish-oss`) of the pipeline easily.

* I would like to produce all artifacts in every tag/post-merge build, and have the publish step be copying from an internal staging bucket to the final home.  However this is significant refactoring that would have broken Jenkins -- and as such I'd rather do it in a later phase.

* Mac binaries inherited the legacy ansible + xcloud infrastructure.  Again, once there is no longer a need for parity with Jenkins, we can refactor this to be separate ssh pipelines within Drone CI.  This will require fewer moving parts, and allow mac specific build/publish steps to be run independently.

## Testing done
Lots -- this was developed and tested over ~2 months with the `7.1.0-alpha.2.  Most notably:

* https://drone.gravitational.io/gravitational/gravity/253 for a full run that failed because publishing enterprise isn't idempotent
* https://drone.gravitational.io/gravitational/gravity/262 for the followup `publish-enterprise` after clearing out the previous telekube

<details><summary>smoke test released artifacts</summary>

OSS
```
walt@work:~/Downloads$ wget https://get.gravitational.com/gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz                        
--2021-03-31 16:30:48--  https://get.gravitational.com/gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz
Resolving get.gravitational.com (get.gravitational.com)... 35.192.55.246
Connecting to get.gravitational.com (get.gravitational.com)|35.192.55.246|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 61044837 (58M) [application/x-tar]
Saving to: ‘gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz’

gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz   100%[=====================================================================================================>]  58.22M  7.79MB/s    in 6.4s    

2021-03-31 16:30:55 (9.03 MB/s) - ‘gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz’ saved [61044837/61044837]
walt@work:~/Downloads$ tar -xzf gravity-7.1.0-alpha.2-linux-x86_64-bin.tar.gz 
walt@work:~/Downloads$ ./tele version
Edition:        open-source
Version:        7.1.0-alpha.2
Git Commit:     5bca4d2d246b10b7e6c6b20cb8c47e9bf8edf37a
Helm Version:   v2.16
walt@work:~/Downloads$ ./gravity version
Edition:        open-source
Version:        7.1.0-alpha.2
Git Commit:     5bca4d2d246b10b7e6c6b20cb8c47e9bf8edf37a
Helm Version:   v2.16
walt@work:~/Downloads$ ./tsh version
Teleport v3.2.18-gravity git: go1.13.8
```
Enterprise:
```
walt@work:~/Downloads$ wget https://get.gravitational.io/telekube/bin/7.1.0-alpha.2/linux/x86_64/tele
--2021-03-31 16:45:44--  https://get.gravitational.io/telekube/bin/7.1.0-alpha.2/linux/x86_64/tele
Resolving get.gravitational.io (get.gravitational.io)... 54.82.183.63, 52.87.138.232, 54.83.3.107
Connecting to get.gravitational.io (get.gravitational.io)|54.82.183.63|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 75542160 (72M) [application/octet-stream]
Saving to: ‘tele’

tele                                            100%[=====================================================================================================>]  72.04M  7.10MB/s    in 9.4s    

2021-03-31 16:45:54 (7.66 MB/s) - ‘tele’ saved [75542160/75542160]

walt@work:~/Downloads$ chmod u+x tele
walt@work:~/Downloads$ ./tele version
Edition:        enterprise
Version:        7.1.0-alpha.2
Git Commit:     ba5676b7a0b24e6753177201038f83275bdb1b68
Helm Version:   v2.16
```
</details>

I'll clean up all these artifacts once this PR merges.
