### PR TITLE
Default to skipping Robotest on Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def setRobotestParameters() {
       parameters([
         // WARNING: changing parameters will not affect the next build, only the following one
         // see issue #1315 or https://stackoverflow.com/questions/46680573/ -- 2020-04 walt
-        choice(choices: ["run", "skip"].join("\n"),
+        choice(choices: ["skip", "run"].join("\n"),
           // defaultValue is not applicable to choices. The first choice will be the default.
           description: 'Run or skip robotest system wide tests.',
           name: 'RUN_ROBOTEST'),


### PR DESCRIPTION
## Description
This saves us expensive cloud resources.  Robotest has been duplicated
between Jenkins/Drone -- looking for parity.  However they've been
consistent for long enough, and now it is time to stop investing a
second set of clusters to re-validate each PR.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)


## Linked tickets and other PRs
Builds off https://github.com/gravitational/gravity/pull/2415

## TODOs
- [ ] Address review feedback

## Testing done
None. But we should see it reflected in a quick Jenkins run on this PR.
