### PR TITLE
Bump Robotest to 2.2.2

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 2.2.1
+ROBOTEST_VERSION ?= 2.2.2
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build


### PR DESCRIPTION
## Description
This mitigates an issue with 3rd party rpm distribution infrastructure
that has disrupted many runs in the past day. See:
  https://github.com/gravitational/robotest/issues/282

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
* Requires https://github.com/gravitational/robotest/pull/283 (or rather the 2.2x backport thereof)

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
Tested by hand on RHEL 7, 8 and CentOS 7 & 8 in https://github.com/gravitational/robotest/pull/283.  If the PR build passes here, that is sufficient testing for this branch.
