### PR TITLE
[5.5] Bump Robotest to 2.2.2

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.1}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-2.2.2}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
This mitigates an issue with 3rd party rpm distribution infrastructure
that has disrupted many runs in the past day. See:
  https://github.com/gravitational/robotest/issues/282

(cherry picked from commit fbf2d72d44859218183a6d92cb1dc1d1baab7ee0)

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
* Requires https://github.com/gravitational/robotest/pull/283 (or rather the 2.2x backport thereof)
* Ports https://github.com/gravitational/gravity/pull/2454

## TODOs
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
Tested by hand on RHEL 7, 8 and CentOS 7 & 8 in https://github.com/gravitational/robotest/pull/283.  If the PR build passes here, that is sufficient testing for this branch.