### PR TITLE
Fetch SSM service url and token in a single API call

### DIFF
--- a/lib/autoscale/aws/services.go
+++ b/lib/autoscale/aws/services.go
@@ -31,7 +31,7 @@ import (
 
 // SSM is an interface representing AWS Systems Manager
 type SSM interface {
-	GetParameterWithContext(aws.Context, *ssm.GetParameterInput, ...request.Option) (*ssm.GetParameterOutput, error)
+	GetParametersWithContext(aws.Context, *ssm.GetParametersInput, ...request.Option) (*ssm.GetParametersOutput, error)
 	PutParameterWithContext(aws.Context, *ssm.PutParameterInput, ...request.Option) (*ssm.PutParameterOutput, error)
 }
 

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -1209,12 +1209,7 @@ func updateJoinConfigFromCloudMetadata(ctx context.Context, config *autojoinConf
 		return trace.Wrap(err)
 	}
 
-	config.serviceURL, err = autoscaler.GetServiceURL(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	config.token, err = autoscaler.GetJoinToken(ctx)
+	config.serviceURL, config.token, err = autoscaler.GetServiceURLAndJoinToken(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
Logic was to do 2x SSM API calls every 15 seconds until service URL is reachable. Booting up a new cluster or joining a lot of nodes they will all hit the SSM API without any jitter which in turn will throttle the clients (https://aws.amazon.com/premiumsupport/knowledge-center/ssm-parameter-store-rate-exceeded). This halfs the requests.

Adding jitter could help and doing progressively longer backoffs (without being exponential)

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Write tests
- [ ] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->