### PR TITLE
Use https to clone public repos instead of ssh

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,16 +29,12 @@ steps:
   - name: build
     image: docker:git
     environment:
-      GITHUB_RO_KEY_PR:
-        from_secret: GITHUB_RO_KEY_PR
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production telekube opscenter
       - make build-tsh
     volumes:
@@ -132,16 +128,12 @@ steps:
   - name: build
     image: docker:git
     environment:
-      GITHUB_RO_KEY_PR:
-        from_secret: GITHUB_RO_KEY_PR
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production telekube opscenter
       - make build-tsh
     volumes:
@@ -417,7 +409,6 @@ steps:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - make -C e production
     volumes:
       - name: dockersock
@@ -500,16 +491,12 @@ steps:
   - name: build
     image: docker:git
     environment:
-      GITHUB_RO_KEY_PR:
-        from_secret: GITHUB_RO_KEY_PR
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_RO_KEY_PR" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - cd gravity
       - make production telekube build-tsh release hub-vars
     volumes:
@@ -607,7 +594,6 @@ steps:
         from_secret: DISTRIBUTION_OPSCENTER_TOKEN
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - cd gravity
       - make -C e production
       - e/build/current/tele login --hub get.gravitational.io --token $TELE_KEY
@@ -646,6 +632,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 66fb20c94f617c28f44f3e0a13d95a98c37b29404d408eea0402f26ca300c5b2
+hmac: caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -39,15 +39,15 @@ SELINUX_BRANCH ?= distro/centos_rhel/7
 GOLFLAGS ?= -w -s
 
 # Git repositories
-TELEPORT_REPO = git@github.com:gravitational/teleport.git
-PLANET_REPO = git@github.com:gravitational/planet.git
-LOGGING_APP_REPO = git@github.com:gravitational/logging-app.git
-MONITORING_APP_REPO = git@github.com:gravitational/monitoring-app.git
-INGRESS_APP_REPO = git@github.com:gravitational/ingress-app.git
-STORAGE_APP_REPO = git@github.com:gravitational/storage-app.git
-BANDWAGON_REPO = git@github.com:gravitational/bandwagon.git
-FIO_REPO = git@github.com:axboe/fio.git
-SELINUX_REPO = git@github.com:gravitational/selinux.git
+TELEPORT_REPO = https://github.com/gravitational/teleport.git
+PLANET_REPO = https://github.com/gravitational/planet.git
+LOGGING_APP_REPO = https://github.com/gravitational/logging-app.git
+MONITORING_APP_REPO = https://github.com/gravitational/monitoring-app.git
+INGRESS_APP_REPO = https://github.com/gravitational/ingress-app.git
+STORAGE_APP_REPO = https://github.com/gravitational/storage-app.git
+BANDWAGON_REPO = https://github.com/gravitational/bandwagon.git
+FIO_REPO = https://github.com/axboe/fio.git
+SELINUX_REPO = https://github.com/gravitational/selinux.git
 
 # Amazon S3
 BUILD_BUCKET_URL = s3://clientbuilds.gravitational.io


### PR DESCRIPTION
## Description
SSH requires a unique deploy key per repo (or a dedicated service user),
wheras https will happily clone unauthenticated. This simplifies CI as well
as the new user build experience, as a github ssh key no longer needs to
be set up to build.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
Unblocks https://github.com/gravitational/gravity/pull/2465

## TODOs

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
Tested in my 7.0 drone backport where I initially discovered this issue: https://drone.gravitational.io/gravitational/gravity/299/1/5.  Before it looked like this: https://drone.gravitational.io/gravitational/gravity/295/1/5

## Additional information
The clone code paths are typically short-circuited because published artifacts are cached in clientbuilds s3 bucket and the build prefers to download those over building from source code.  We could also consider adding a tag build to the various `*-app` projects that pushes to clientbulilds to preempt failures like this.
