### PR TITLE
[7.0] Backport Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,637 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr build
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  - name: short circuit docs changes
+    image: docker:git
+    commands:
+      # If a change is entirely documentation, skip the expensive build & test steps.
+      # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+      -  ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - make -C e production telekube opscenter
+      - make build-tsh
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: unit test
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - make -C e test
+      - make test
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build robotest images
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - make -C e/assets/robotest images
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: run robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - make -C e robotest-run
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: post-merge build
+
+trigger:
+  event:
+  - push
+  branch:
+  - master
+
+steps:
+  - name: short circuit docs changes
+    image: docker:git
+    commands:
+      # If a change is entirely documentation, skip the expensive build & test steps.
+      # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+      - ./build.assets/drone/diff-is-all-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - make -C e production telekube opscenter
+      - make build-tsh
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build robotest images
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - export ROBOTEST_CONFIG=nightly
+      - make -C e/assets/robotest images
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: run robotest
+    image: docker:git
+    environment:
+      GCP_ROBOTEST_CREDENTIALS:
+        from_secret: GCP_ROBOTEST_CREDENTIALS
+      # These files need to be in a volume that the docker service has access to
+      # We choose /tmp to accommodate https://github.com/gravitational/robotest/blob/3774f8641439b19c4e0e598db8f87c52ea0e4817/docker/suite/run_suite.sh#L106
+      SSH_KEY: /tmp/secrets/robotest
+      SSH_PUB: /tmp/secrets/robotest.pub
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/secrets/gcp.json
+    commands:
+      - apk add --no-cache make bash
+      - mkdir -p $(dirname $SSH_KEY)
+      - ssh-keygen -t ed25519 -N '' -f $SSH_KEY
+      - echo "$GCP_ROBOTEST_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+      - export ROBOTEST_CONFIG=nightly
+      - make -C e robotest-run
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: dockertmp
+        path: /tmp
+
+volumes:
+  - name: dockersock
+    temp: {}
+  - name: dockertmp
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: pr docs
+
+trigger:
+  event:
+  - pull_request
+
+steps:
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make -C docs bbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make -C docs docs
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: lint
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make -C docs lint
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
+kind: pipeline
+type: kubernetes
+name: deploy docs
+
+trigger:
+  event:
+  - push
+  branch:
+  - master
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git checkout $DRONE_COMMIT
+  - name: short circuit non-docs changes
+    image: docker:git
+    # Skip the rest of this pipeline if no docs were changed.
+    # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+    commands:
+      - cd gravity
+      -  ./build.assets/drone/diff-has-no-docs.sh $DRONE_COMMIT_BEFORE..$DRONE_COMMIT_AFTER && exit 78 || exit 0
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build buildbox
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs bbox
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: lint
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs lint
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - cd gravity
+      - make -C docs docs
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: clone web
+    image: docker:git
+    environment:
+      WEB_REPO:
+        from_secret: WEB_REPO
+      GITHUB_WEB_DEPLOY_KEY:
+        from_secret: GITHUB_WEB_DEPLOY_KEY
+      WEB_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_WEB_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $WEB_REPO web
+    - cd web
+    - git checkout $WEB_REF
+  - name: deploy
+    image: docker:git
+    environment:
+      ANSIBLE_HOST_KEY_CHECKING: False
+      WEB_ANSIBLE_SSH_KEY:
+        from_secret: WEB_ANSIBLE_SSH_KEY
+      CLOUDFLARE_API_TOKEN_STAGING:
+        from_secret: CLOUDFLARE_API_TOKEN_STAGING
+      CLOUDFLARE_API_TOKEN_PRODUCTION:
+        from_secret: CLOUDFLARE_API_TOKEN_PRODUCTION
+    commands:
+      - apk add --no-cache make curl rsync ansible
+      - mkdir -m 0700 /root/.ssh && echo "$WEB_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - cd web
+      - export ENV=${ENV:-production}
+      - make deploy-docs
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: tag
+
+# This pipeline generates placeholder builds that Drone CI promotions can reference.
+# See https://docs.drone.io/promote/
+#
+# This is useful, because it allows re-running release steps without re-pushing
+# tags to the repo, in case of faulty infrastructure. We don't ever want to overwrite
+# released tags.  It'd be good to verify that the tags are signed and not already
+# present in this build. -- walt 2021-03
+
+trigger:
+  event:
+  - tag
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: check version
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash
+      - make get-version
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-dependencies
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-dependencies
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - make -C e production
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish dependencies
+    image: docker:git
+    environment:
+      TELE_COPY_TO_USER:
+        from_secret: QUAY_IO_SCAN_UPLOAD_USER
+      TELE_COPY_TO_PASS:
+        from_secret: QUAY_IO_SCAN_UPLOAD_TOKEN
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RW_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli
+      - make -C e publish
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-oss
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-oss
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git fetch --tags
+    - git checkout $DRONE_COMMIT
+  - name: clone ops
+    image: docker:git
+    environment:
+      OPS_REPO:
+        from_secret: OPS_REPO
+      GITHUB_OPS_DEPLOY_KEY:
+        from_secret: GITHUB_OPS_DEPLOY_KEY
+      OPS_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $OPS_REPO ops
+    - cd ops
+    - git checkout $OPS_REF
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - cd gravity
+      - make production telekube build-tsh release hub-vars
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RW_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+      MAC_ANSIBLE_BUILD_HOST:
+        from_secret: MAC_ANSIBLE_BUILD_HOST
+      MAC_ANSIBLE_SSH_KEY:
+        from_secret: MAC_ANSIBLE_SSH_KEY
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli ansible
+      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
+      - export WORKSPACE=/drone/src
+      - export GRAVITY_TAG=$DRONE_COMMIT_REF
+      - cd ops/hub
+      - make bucket sync
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-enterprise
+
+trigger:
+  event:
+  - promote
+  target:
+  - release
+  - publish-enterprise
+
+clone:
+  disable: true
+
+steps:
+  - name: clone gravity
+    image: docker:git
+    commands:
+    - git clone $DRONE_REPO_LINK gravity
+    - cd gravity
+    - git fetch --tags
+    - git checkout $DRONE_COMMIT
+  - name: clone ops
+    image: docker:git
+    environment:
+      OPS_REPO:
+        from_secret: OPS_REPO
+      GITHUB_OPS_DEPLOY_KEY:
+        from_secret: GITHUB_OPS_DEPLOY_KEY
+      OPS_REF: master
+    commands:
+    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+    - git clone $OPS_REPO ops
+    - cd ops
+    - git checkout $OPS_REF
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish on linux
+    image: docker:git
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RO_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      TELE_KEY:
+        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
+    commands:
+      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
+      - cd gravity
+      - make -C e production
+      - e/build/current/tele login --hub get.gravitational.io --token $TELE_KEY
+      - make -C e telekube opscenter publish-telekube publish-artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish on mac
+    image: docker:git
+    environment:
+      TELE_KEY:
+        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
+      MAC_ANSIBLE_BUILD_HOST:
+        from_secret: MAC_ANSIBLE_BUILD_HOST
+      MAC_ANSIBLE_SSH_KEY:
+        from_secret: MAC_ANSIBLE_SSH_KEY
+    commands:
+      - apk add --no-cache make ansible
+      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
+      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
+      - export TELEKUBE_TAG=$DRONE_COMMIT_REF
+      - cd ops/xcloud
+      - make release-telekube-mac
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+---
+kind: signature
+hmac: caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761
+
+...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def setRobotestParameters() {
       parameters([
         // WARNING: changing parameters will not affect the next build, only the following one
         // see issue #1315 or https://stackoverflow.com/questions/46680573/ -- 2020-04 walt
-        choice(choices: ["run", "skip"].join("\n"),
+        choice(choices: ["skip", "run"].join("\n"),
           // defaultValue is not applicable to choices. The first choice will be the default.
           description: 'Run or skip robotest system wide tests.',
           name: 'RUN_ROBOTEST'),

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ RBAC_APP_OUT := $(GRAVITY_BUILDDIR)/rbac-app.tar.gz
 TELEKUBE_APP_OUT := $(GRAVITY_BUILDDIR)/telekube-app.tar.gz
 TILLER_APP_OUT := $(GRAVITY_BUILDDIR)/tiller-app.tar.gz
 TELEKUBE_OUT := $(GRAVITY_BUILDDIR)/telekube.tar
+OPSCENTER_OUT := $(GRAVITY_BUILDDIR)/opscenter.tar
 TF_PROVIDER_GRAVITY_OUT := $(GRAVITY_BUILDDIR)/terraform-provider-gravity
 TF_PROVIDER_GRAVITYENTERPRISE_OUT := $(GRAVITY_BUILDDIR)/terraform-provider-gravityenterprise
 SELINUX_ASSETSDIR := $(TOP)/lib/system/selinux/internal/policy/assets/centos
@@ -473,35 +474,35 @@ web-assets:
 # publish-artifacts uploads build artifacts to the distribution Ops Center
 #
 .PHONY: publish-artifacts
-publish-artifacts: opscenter telekube
+publish-artifacts: $(OPSCENTER_OUT) $(TELEKUBE_OUT)
 	if [ -z "$(TELE_KEY)" ] || [ -z "$(DISTRIBUTION_OPSCENTER)" ]; then \
 	   echo "TELE_KEY or DISTRIBUTION_OPSCENTER are not set"; exit 1; \
 	fi;
 	$(GRAVITY_BUILDDIR)/tele logout
 	$(GRAVITY_BUILDDIR)/tele login -o $(DISTRIBUTION_OPSCENTER) --token=$(TELE_KEY)
-	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/telekube.tar
-	$(GRAVITY_BUILDDIR)/tele push $(GRAVITY_BUILDDIR)/opscenter.tar
+	$(GRAVITY_BUILDDIR)/tele push $(TELEKUBE_OUT)
+	$(GRAVITY_BUILDDIR)/tele push $(OPSCENTER_OUT)
 
 #
 # scan-artifacts uploads a copy of all vendored containers to a docker registry for scanning and vulnerability reporting
 #
 .PHONY: scan-artifacts
-scan-artifacts: telekube
+scan-artifacts: $(TELEKUBE_OUT)
 	$(GRAVITY) app sync \
 		--registry=$(TELE_COPY_TO_REGISTRY) \
 		--registry-username=$(TELE_COPY_TO_USER) \
 		--registry-password=$(TELE_COPY_TO_PASS) \
 		--scan-repository=$(TELE_COPY_TO_REPOSITORY) \
 		--scan-prefix=$(TELE_COPY_TO_PREFIX) \
-		$(GRAVITY_BUILDDIR)/telekube.tar
+		$(TELEKUBE_OUT)
 
 #
 # builds telekube installer
 #
 .PHONY: telekube
-telekube: GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
 telekube: $(TELEKUBE_OUT)
 
+$(TELEKUBE_OUT): GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
 $(TELEKUBE_OUT): packages
 	GRAVITY_K8S_VERSION=$(K8S_VER) $(GRAVITY_BUILDDIR)/tele build \
 		$(ASSETSDIR)/telekube/resources/app.yaml -f \
@@ -535,8 +536,8 @@ $(GRAVITY_BUILDDIR)/wormhole.tar: packages
 # Uploads opscenter to S3 is used to test custom releases of the ops center
 #
 .PHONY: upload-opscenter
-upload-opscenter:
-	aws s3 cp $(GRAVITY_BUILDDIR)/opscenter.tar s3://testreleases.gravitational.io/$(GRAVITY_TAG)/opscenter.tar
+upload-opscenter: $(OPSCENTER_OUT)
+	aws s3 cp $(OPSCENTER_OUT) s3://testreleases.gravitational.io/$(GRAVITY_TAG)/opscenter.tar
 
 #
 # Uploads gravity to test builds
@@ -550,10 +551,10 @@ upload-binaries:
 # builds opscenter installer
 #
 .PHONY: opscenter
-opscenter: GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
-opscenter: $(GRAVITY_BUILDDIR)/opscenter.tar
+opscenter: $(OPSCENTER_OUT)
 
-$(GRAVITY_BUILDDIR)/opscenter.tar: packages
+$(OPSCENTER_OUT): GRAVITY=$(GRAVITY_OUT) --state-dir=$(PACKAGES_DIR)
+$(OPSCENTER_OUT): packages
 	mkdir -p $(BUILDDIR)
 # this is for Jenkins pipeline integration
 	@echo env.GRAVITY_BUILDDIR=\"$(GRAVITY_BUILDDIR)\" > $(BUILDDIR)/properties.groovy
@@ -576,7 +577,7 @@ $(GRAVITY_BUILDDIR)/opscenter.tar: packages
 	cat $(TEMPDIR)/resources/app.yaml
 	$(GRAVITY_BUILDDIR)/tele build $(TEMPDIR)/resources/app.yaml -f \
 		--state-dir=$(PACKAGES_DIR) \
-		-o $(GRAVITY_BUILDDIR)/opscenter.tar
+		-o $(OPSCENTER_OUT)
 	rm -rf $(TEMPDIR)
 
 #

--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -78,13 +78,6 @@ ROBOTEST_CACHES = $(ROBOTEST_GRAVITY_PKG_CACHE) $(ROBOTEST_TELE_CACHE)
 
 # Image configuration.
 
-TELE_BUILD_DOCKER_BASE_IMAGE = quay.io/gravitational/debian-grande:buster-20201001
-# TELE_BUILD_DOCKER_IMAGE is the base image with `tele build` prerequisites (such as the docker cli) added to it.
-TELE_BUILD_DOCKER_IMAGE = $(notdir $(TELE_BUILD_DOCKER_BASE_IMAGE))-tele-build
-# TELE_BUILD_DOCKER_IDDFILE is used to prevent make from constantly rebuilding the image.
-# subst because ':' in filenames breaks using them in make targets.
-TELE_BUILD_DOCKER_IIDFILE = $(ROBOTEST_BUILDDIR)/$(subst :,-,$(TELE_BUILD_DOCKER_IMAGE)).iid
-
 # ROBOTEST_IMAGEDIR is a store of robotest images used only for the current
 # robotest run. Expected to be populated on demand from the caches and mounted
 # as a volume into the robotest container. This exists to prevent any
@@ -182,14 +175,6 @@ $(ROBOTEST_BUILD_TMP):
 $(ROBOTEST_CACHE_TMP):
 	mkdir -p $(ROBOTEST_CACHE_TMP)
 
-.PHONY: docker-image-tele-build
-docker-image-tele-build: ## Build a docker image suitable to run `tele build`.
-docker-image-tele-build: $(TELE_BUILD_DOCKER_IIDFILE)
-
-$(TELE_BUILD_DOCKER_IIDFILE): $(TOP)/Dockerfile $(ROBOTEST_BUILDDIR)
-	docker build --tag $(TELE_BUILD_DOCKER_IMAGE) --build-arg BASE=$(TELE_BUILD_DOCKER_BASE_IMAGE) $(TOP)
-	touch $(TELE_BUILD_DOCKER_IIDFILE)
-
 .PHONY: images
 images: ## Build all images necessary to run robotest CI tests.
 images: image-telekube image-opscenter image-robotest image-robotest-intermediate image-robotest-upgrade
@@ -213,14 +198,12 @@ image-robotest: ## Build robotest cluster image using the current tele.
 image-robotest: $(ROBOTEST_IMAGE)
 
 $(ROBOTEST_IMAGE): export TARGET = $(ROBOTEST_IMAGE)
-$(ROBOTEST_IMAGE): export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGE): export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGE): export APP_MANIFEST = $(ROBOTEST_IMAGE_MANIFEST)
-$(ROBOTEST_IMAGE): export APP_SRCDIR = $(ROBOTEST_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGE): export VERSION = $(GRAVITY_VERSION)
 $(ROBOTEST_IMAGE): export TELE = $(TELE_OUT)
 $(ROBOTEST_IMAGE): export STATE_DIR = $(PACKAGES_DIR)
-$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh $(TELE_BUILD_DOCKER_IIDFILE) | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
+$(ROBOTEST_IMAGE): $(TELE_OUT) $(ROBOTEST_IMAGE_SRC) $(TOP)/tele_build.sh | $(ROBOTEST_IMAGEDIR) $(ROBOTEST_BUILD_TMP)
 	$(TOP)/tele_build.sh
 
 .PHONY: image-robotest-intermediate
@@ -287,10 +270,8 @@ endif
 # .PRECIOUS because these need to be present through the run target.
 .PRECIOUS: $(ROBOTEST_IMAGEDIR)/robotest-%.tar
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TARGET = $@
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export IMAGE = $(TELE_BUILD_DOCKER_IMAGE)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export BUILD_TMP = $(ROBOTEST_BUILD_TMP)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_MANIFEST = $(ROBOTEST_UPGRADE_BASE_IMAGE_MANIFEST)
-$(ROBOTEST_IMAGEDIR)/robotest-%.tar: export APP_SRCDIR = $(ROBOTEST_UPGRADE_BASE_IMAGE_SRCDIR)
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export VERSION = $*
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export TELE = $<
 $(ROBOTEST_IMAGEDIR)/robotest-%.tar: export STATE_DIR = $(ROBOTEST_GRAVITY_PKG_CACHE)/$*

--- a/assets/robotest/tele_build.sh
+++ b/assets/robotest/tele_build.sh
@@ -11,11 +11,9 @@
 #
 # The following environment variables must be specified by the caller:
 #
-# IMAGE - A docker container that the build will run in
 # BUILD_TMP - Partially constructed images are built here. Must be on the same filesystem as TARGET for atomic move operations.
 # TARGET - Where the cluster image should end up
 # TELE  - The tele to build the image, should typically be equal to VERSION
-# APP_SRCDIR - The directory that contains all files necessary to build the application.
 # APP_YAML - The image manifest to be built.
 # VERSION - The application version to use in the cluster image. Must be within SRCDIR.
 # STATE_DIR - The gravity state dir where packages are cached/drawn from. May be shared across subsequent builds.
@@ -30,25 +28,12 @@ trap "rm -rf $TMP" exit
 
 TGT=$TMP/$(basename "$TARGET")
 
-
-NOROOT="--user=$(id -u):$(id -g) --group-add=$(getent group docker | cut -d: -f3)"
-VOLUMES="-v $TELE:$TELE:ro -v $APP_SRCDIR:$APP_SRCDIR:ro -v $STATE_DIR:$STATE_DIR -v $TMP:$TMP"
-VOLUMES="$VOLUMES -v /var/run/docker.sock:/var/run/docker.sock"
-VOLUMES="$VOLUMES --tmpfs /tmp"
-
-(
 set -o xtrace
-docker run --rm=true --net=host $NOROOT \
-    $VOLUMES \
-    -w "$TMP" \
-    $IMAGE \
-    dumb-init \
-    "$TELE" build \
-    $EXTRA_TELE_BUILD_OPTIONS \
-    "$APP_MANIFEST" \
-    --state-dir="$STATE_DIR" \
-    --version="$VERSION" \
-    --output="$TGT"
+"$TELE" build \
+$EXTRA_TELE_BUILD_OPTIONS \
+"$APP_MANIFEST" \
+--state-dir="$STATE_DIR" \
+--version="$VERSION" \
+--output="$TGT"
 
 mv "$TGT" "$TARGET"
-)

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -6,18 +6,24 @@ ARG GOGO_PROTO_TAG
 ARG GRPC_GATEWAY_TAG
 ARG GODEP_TAG
 ARG VERSION_TAG
+ARG UID
+ARG GID
 
 ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ENV GRPC_GATEWAY_ROOT /src/github.com/grpc-ecosystem/grpc-gateway
 ENV GOGOPROTO_ROOT /src/github.com/gogo/protobuf
 ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 
-RUN set -ex && adduser jenkins --uid=995 --disabled-password --system
+RUN getent group  $GID || groupadd builder --gid=$GID -o; \
+    getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
+
 RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity && \
-     chown -R jenkins /gopath && \
+     chown -R $UID:$GID /gopath && \
      mkdir -p /.cache && \
      chmod 777 /.cache && \
      chmod 777 /tmp)
+
+USER $UID:$GID
 
 ENV LANGUAGE="en_US.UTF-8" \
      LANG="en_US.UTF-8" \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -37,14 +37,14 @@ SELINUX_BRANCH ?= distro/centos_rhel/7
 GOLFLAGS ?= -w -s
 
 # Git repositories
-TELEPORT_REPO = git@github.com:gravitational/teleport.git
-PLANET_REPO = git@github.com:gravitational/planet.git
-LOGGING_APP_REPO = git@github.com:gravitational/logging-app.git
-MONITORING_APP_REPO = git@github.com:gravitational/monitoring-app.git
-STORAGE_APP_REPO = git@github.com:gravitational/storage-app.git
-BANDWAGON_REPO = git@github.com:gravitational/bandwagon.git
-FIO_REPO = git@github.com:axboe/fio.git
-SELINUX_REPO = git@github.com:gravitational/selinux.git
+TELEPORT_REPO = https://github.com/gravitational/teleport.git
+PLANET_REPO = https://github.com/gravitational/planet.git
+LOGGING_APP_REPO = https://github.com/gravitational/logging-app.git
+MONITORING_APP_REPO = https://github.com/gravitational/monitoring-app.git
+STORAGE_APP_REPO = https://github.com/gravitational/storage-app.git
+BANDWAGON_REPO = https://github.com/gravitational/bandwagon.git
+FIO_REPO = https://github.com/axboe/fio.git
+SELINUX_REPO = https://github.com/gravitational/selinux.git
 
 # Amazon S3
 BUILD_BUCKET_URL = s3://clientbuilds.gravitational.io
@@ -187,7 +187,7 @@ build: build-on-host
 else
 .PHONY: build
 build: selinux grpc build-in-container
-	ln --symbolic --force --no-target-directory $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
+	ln -sfT $(GRAVITY_BUILDDIR) $(GRAVITY_CURRENT_BUILDDIR)
 endif
 
 #
@@ -413,7 +413,7 @@ tiller-app:
 
 .PHONY: site-app
 site-app:
-	$(eval TMPDIR := $(shell mktemp -d --tmpdir=$(GRAVITY_BUILDDIR)))
+	$(eval TMPDIR := $(shell mktemp -d -p $(GRAVITY_BUILDDIR)))
 	cp -r $(ASSETSDIR)/site-app/* $(TMPDIR)
 	cp $(GRAVITY_BUILDDIR)/gravity $(TMPDIR)/images/site
 	cd $(TMPDIR) && \
@@ -484,17 +484,17 @@ build-tsh-in-container: clone-teleport
 .PHONY: build-tsh-on-host
 build-tsh-on-host:
 	@echo "\n----> Building Tsh binary on host...\n"
-	GOPATH=$(BUILDDIR) go get -v $(TELEPORT_PKG_PATH) && \
+	GO111MODULE=off GOPATH=$(BUILDDIR) go get -v $(TELEPORT_PKG_PATH) && \
 		cd $(BUILDDIR)/src/$(TELEPORT_PKG_PATH) && \
 		git fetch --all --tags && \
 		git checkout $(TELEPORT_REPOTAG) && \
-		GOPATH=$(BUILDDIR) go build -ldflags "$(GOLFLAGS)" -o $(TSH_OUT) ./tool/tsh
+		GO111MODULE=off GOPATH=$(BUILDDIR) go build -ldflags "$(GOLFLAGS)" -o $(TSH_OUT) ./tool/tsh
 	@echo "Done --> $(TSH_OUT)"
 
 .PHONY: build-tsh-inside-container
 build-tsh-inside-container:
 	@echo "\n----> Building Tsh binary inside container...\n"
-	go build -ldflags "$(GOLFLAGS)" -o $(LOCAL_GRAVITY_BUILDDIR)/tsh $(TELEPORT_PKG_PATH)/tool/tsh
+	GO111MODULE=off go build -ldflags "$(GOLFLAGS)" -o $(LOCAL_GRAVITY_BUILDDIR)/tsh $(TELEPORT_PKG_PATH)/tool/tsh
 	@echo "Done --> $(LOCAL_GRAVITY_BUILDDIR)/tsh"
 
 .PHONY: clone-teleport

--- a/build.assets/drone/diff-has-no-docs.sh
+++ b/build.assets/drone/diff-has-no-docs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Examine the output of git diff --raw to determine whether any files
+# which match the pattern '^docs/' were changed.
+
+REVLIST=$1
+if [ -z "$REVLIST" ]; then
+    echo "$0: please supply a git rev-list"
+    echo "For more info see: git help rev-list"
+    exit 2
+fi
+
+echo "---> git diff --raw ${REVLIST}"
+git diff --raw ${REVLIST}
+if [ $? -ne 0 ]; then
+    echo "---> Unable to determine diff"
+    exit 2
+fi
+git diff --raw ${REVLIST} | awk '{print $6}' | grep -E '^docs/' | wc -l > /tmp/.change_count.txt
+export CHANGE_COUNT=$(cat /tmp/.change_count.txt | tr -d '\n')
+rm /tmp/.change_count.txt
+echo "---> Docs changes detected: $CHANGE_COUNT"
+if [ "$CHANGE_COUNT" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/build.assets/drone/diff-is-all-docs.sh
+++ b/build.assets/drone/diff-is-all-docs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Examine the output of git diff --raw to determine whether any files
+# which don't match the pattern '^docs/' or '.md$' were changed.
+
+REVLIST=$1
+if [ -z "$REVLIST" ]; then
+    echo "$0: please supply a git rev-list"
+    echo "For more info see: git help rev-list"
+    exit 2
+fi
+
+echo "---> git diff --raw ${REVLIST}"
+git diff --raw ${REVLIST}
+if [ $? -ne 0 ]; then
+    echo "---> Unable to determine diff"
+    exit 2
+fi
+git diff --raw ${REVLIST} | awk '{print $6}' | grep -Ev '^docs/' | grep -Ev '.md$' | grep -v ^$ | wc -l > /tmp/.change_count.txt
+export CHANGE_COUNT=$(cat /tmp/.change_count.txt | tr -d '\n')
+rm /tmp/.change_count.txt
+echo "---> Non-docs changes detected: $CHANGE_COUNT"
+if [ "$CHANGE_COUNT" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/build.assets/etcd.mk
+++ b/build.assets/etcd.mk
@@ -12,7 +12,7 @@ endif
 
 .PHONY: base-etcd
 base-etcd:
-	if docker ps | grep $(TEST_ETCD_INSTANCE) --quiet; then \
+	if docker ps | grep $(TEST_ETCD_INSTANCE) -q; then \
 	  echo "ETCD is already running"; \
 	else \
 	  echo "starting test ETCD instance"; \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -14,7 +14,9 @@ ARG GID
 ARG WORKDIR
 ARG PORT
 
-RUN groupadd builder --gid=$GID -o && useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash
+RUN getent group  $GID || groupadd builder --gid=$GID -o; \
+    getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash;
+
 COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 
 VOLUME [$WORKDIR]

--- a/tool/gravity/cli/sync.go
+++ b/tool/gravity/cli/sync.go
@@ -138,10 +138,8 @@ func appSyncEnv(env *localenv.LocalEnvironment, imageEnv *localenv.ImageEnvironm
 			Upsert:  true,
 		}
 		return puller.PullApp(context.TODO(), imageEnv.Manifest.Locator())
-	} else if httplib.InKubernetes() {
-		// If we're running inside generic Kubernetes cluster, sync images
-		// to the registry specified on the command line.
-		log.Info("Detected generic Kubernetes cluster.")
+	} else {
+		// sync images to the registry specified on the command line.
 		env.PrintStep("Pushing application images to Docker registry %v", conf.Registry)
 		imageService, err := conf.imageService()
 		if err != nil {


### PR DESCRIPTION
## Description
This PR backports everything needed for PR builds and releasing via Drone to 7.0.

Certain pipelines are present, but not used due to having `branch: master` trigger conditions.  These are:
- post merge build
- deploy docs

The docs pr build is still run, though it is irrelevant.  I'll add a master tag to this in some future update.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/ops/issues/139
* Requires https://github.com/gravitational/ops/pull/213
* Ports: https://github.com/gravitational/gravity/pull/2368, https://github.com/gravitational/gravity/pull/2415, https://github.com/gravitational/gravity/pull/2419, https://github.com/gravitational/gravity/pull/2420, https://github.com/gravitational/gravity/pull/2422, https://github.com/gravitational/gravity/pull/2434, https://github.com/gravitational/gravity/pull/2436, https://github.com/gravitational/gravity/pull/2438, https://github.com/gravitational/gravity/pull/2451, https://github.com/gravitational/gravity/pull/2453, https://github.com/gravitational/gravity/pull/2466

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Squash everything but https://github.com/gravitational/gravity/pull/2438

## Implementation
No major differences were needed for 7.0.  I uncovered a couple issues (particularly https://github.com/gravitational/gravity/pull/2466) but they've already been added to master.  It is easy to tell because the signature is identical in both drone files:

caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761

## Testing done
The PR build is sufficient for demonstrating the PR part of the pipeline.  For release, see 7.0.32-alpha.1: https://drone.gravitational.io/gravitational/gravity/332
