### PR TITLE
[6.1] Add selinux gitignore

### DIFF
--- a/lib/system/selinux/internal/policy/.gitignore
+++ b/lib/system/selinux/internal/policy/.gitignore
@@ -1,0 +1,3 @@
+assets/**/*.bz2
+assets/**/*.template
+policy_embed.go


### PR DESCRIPTION
These artifacts are only present in 7.0+, however because we
switch branches often, it is useful to gitignore these so that they
don't show up as potential changes.

## Testing Done
```
walt@work:~/git/gravity$ git status
On branch version/6.1.x
Your branch is up to date with 'grav/version/6.1.x'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        lib/system/selinux/

nothing added to commit but untracked files present (use "git add" to track)
walt@work:~/git/gravity$ git checkout walt/6.1-gitignore      
Switched to branch 'walt/6.1-gitignore'
walt@work:~/git/gravity$ git status
On branch walt/6.1-gitignore
nothing to commit, working tree clean
```
