### PR TITLE
[5.5] Add selinux and web/shared gitignore

### DIFF
--- a/e/web/.gitignore
+++ b/e/web/.gitignore
@@ -1,4 +1,5 @@
 oss-src
+shared
 node_modules
 *.log
 dist/**/*

--- a/lib/system/selinux/internal/policy/.gitignore
+++ b/lib/system/selinux/internal/policy/.gitignore
@@ -1,0 +1,3 @@
+assets/**/*.bz2
+assets/**/*.template
+policy_embed.go


### PR DESCRIPTION
Backport some .gitignore directives from more recent gravity versions.
This makes interacting with 5.5. minorly easier as build artifacts from the
future no longer clutter up git status.

## Testing Done
```
walt@work:~/git/gravity$ git checkout version/5.5.x 
Switched to branch 'version/5.5.x'
Your branch is up to date with 'grav/version/5.5.x'.
walt@work:~/git/gravity$ git status
On branch version/5.5.x
Your branch is up to date with 'grav/version/5.5.x'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        e/web/shared/
        lib/system/selinux/

nothing added to commit but untracked files present (use "git add" to track)
walt@work:~/git/gravity$ git checkout walt/5.5-gitignore 
Switched to branch 'walt/5.5-gitignore'
walt@work:~/git/gravity$ git status
On branch walt/5.5-gitignore
nothing to commit, working tree clean
```