### PR TITLE
Do not run docs validation non-master branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,6 +195,8 @@ name: pr docs
 trigger:
   event:
   - pull_request
+  branch:
+  - master
 
 steps:
   - name: wait for docker
@@ -632,6 +634,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761
+hmac: 6ee463482d9943a4b9974c97cad601bf274c544f6cd55b5c2b7939c036fa510d
 
 ...


### PR DESCRIPTION
## Description
Only run the docs PR validation on PRs to master.
We don't deploy docs off any other branches, and this was adding complexity
to backports as seen in https://drone.gravitational.io/gravitational/gravity/341/2/5

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
None yet.  This will get picked up in my 5.5 and 6.0 backport tomorrow though, and I'll report back if it works.
