### PR TITLE
[7.0] Do not run docs validation non-master branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,6 +195,8 @@ name: pr docs
 trigger:
   event:
   - pull_request
+  branch:
+  - master
 
 steps:
   - name: wait for docker
@@ -632,6 +634,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761
+hmac: 6ee463482d9943a4b9974c97cad601bf274c544f6cd55b5c2b7939c036fa510d
 
 ...


### PR DESCRIPTION


## Description
We only deploy docs of master.  No point in validating docs on anything
else.

(cherry picked from commit f12f19137c00956449e9207d6fa6ec5ae88c61dd)

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2478

## TODOs
- [x] Self-review the change
- [ ] Address review feedback

## Testing done
The PR build is sufficient

## Additional information
Backported to save us a bit of cpu and avoid merge conflicts for future drone backports.  Running docs validation on 7.0 wasn't really hurting anything,
but it wasn't helping either.
