### PR TITLE
[7.0] Add UID and GID args to the buildbox

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -699,6 +699,8 @@ buildbox:
 		--build-arg GRPC_GATEWAY_TAG=$(GRPC_GATEWAY_TAG) \
 		--build-arg GODEP_TAG=$(GODEP_TAG) \
 		--build-arg VERSION_TAG=$(VERSION_TAG) \
+		--build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
 		$(DOCKER_ARGS) --tag $(BUILDBOX) .
 #
 # testbox container: container used for tests


### PR DESCRIPTION
## Description
This was missed in 5e2b4c2e2bb1e1136a521e2c912060745f6b609a, resulting
in a buildbox without a UID corresponding to the UID of a developer
running the build as non-root.  This is mostly harmless, but will
cause anything that tries to pull user info in the buildbox to get
weird results.

I caught this oversight while doing the 6.1 (https://github.com/gravitational/gravity/pull/2476) and 5.5 (https://github.com/gravitational/gravity/pull/2482) backports.  They already have
the fix in them -- as does master/8.0. Only 7.0 was missing this logic.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Adds some logic missed in the https://github.com/gravitational/gravity/pull/2473 backport

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
The PR build is sufficient.  Particularly, notice that during the buildbox target there is no longer output like the following:

<details><summary>old incorrect output</summary>

```
Step 14/24 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Running in 70eee806cddb
root:x:0:
daemon:x:1:
bin:x:2:
sys:x:3:
adm:x:4:
tty:x:5:
disk:x:6:
lp:x:7:
mail:x:8:
news:x:9:
uucp:x:10:
man:x:12:
proxy:x:13:
kmem:x:15:
dialout:x:20:
fax:x:21:
voice:x:22:
cdrom:x:24:
floppy:x:25:
tape:x:26:
sudo:x:27:
audio:x:29:
dip:x:30:
www-data:x:33:
backup:x:34:
operator:x:37:
list:x:38:
irc:x:39:
src:x:40:
gnats:x:41:
shadow:x:42:
utmp:x:43:
video:x:44:
sasl:x:45:
plugdev:x:46:
staff:x:50:
games:x:60:
users:x:100:
nogroup:x:65534:
ssh:x:101:
docker:x:999:
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
_apt:x:100:65534::/nonexistent:/bin/false
Removing intermediate container 70eee806cddb
 ---> b82507cc3796
Step 15/24 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity &&      chown -R $UID:$GID /gopath &&      mkdir -p /.cache &&      chmod 777 /.cache &&      chmod 777 /tmp)
 ---> Running in 31019a35e222
+ mkdir -p /gopath/src/github.com/gravitational/gravity
+ chown -R : /gopath
+ mkdir -p /.cache
+ chmod 777 /.cache
+ chmod 777 /tmp
Removing intermediate container 31019a35e222
```

</details>

It now looks like:
```
Step 14/24 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Running in 18ace4bd3d56
root:x:0:
root:x:0:0:root:/root:/bin/bash
Removing intermediate container 18ace4bd3d56
 ---> b8baf62cb5d0
Step 15/24 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity &&      chown -R $UID:$GID /gopath &&      mkdir -p /.cache &&      chmod 777 /.cache &&      chmod 777 /tmp)
 ---> Running in abe46646ab3a
+ mkdir -p /gopath/src/github.com/gravitational/gravity
+ chown -R 0:0 /gopath
+ mkdir -p /.cache
+ chmod 777 /.cache
+ chmod 777 /tmp
Removing intermediate container abe46646ab3a
```

