### PR TITLE
[7.0.x] Fix terraform deprecation warnings and ansible module for 2.8+

### DIFF
--- a/terraform-dev/install.yaml
+++ b/terraform-dev/install.yaml
@@ -41,7 +41,6 @@
     when: inventory_hostname == groups['all'][0]
     become: yes
     unarchive:
-      force: yes
       src: "{{tarball_path}}"
       dest: "{{ ansible_env.HOME }}/installer"
 
@@ -49,7 +48,6 @@
     when: inventory_hostname != groups['all'][0]
     become: yes
     copy:
-      force: yes
       src: "{{gravity_bin_path}}"
       dest: "{{ ansible_env.HOME }}/gravity"
       mode: 0755


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->

Fixed some deprecation warnings for terraform > 0.12.x. Ansible unarchive module in the latest versions does not have `force` parameter and that parameter didn't make sense in the first place(usually it is safer to recreated nodes from scratch to avoid any already running gravity binaries on nodes).

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Backport to 5.5.x and forward-port to master
-
## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
