### PR TITLE
[7.0] Bump robotest so it can run outside kubeadm

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 2.2.2
+ROBOTEST_VERSION ?= 3.0.0
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build

--- a/assets/robotest/run.sh
+++ b/assets/robotest/run.sh
@@ -18,7 +18,7 @@ TAG=$(git rev-parse --short HEAD)
 # cloud provider that test clusters will be provisioned on
 # see https://github.com/gravitational/robotest/blob/v2.0.0/infra/gravity/config.go#L72
 DEPLOY_TO=${DEPLOY_TO:-gce}
-GCL_PROJECT_ID=${GCL_PROJECT_ID:-"kubeadm-167321"}
+GCL_PROJECT_ID=${GCL_PROJECT_ID:-"robotest-production"}
 GCE_REGION="northamerica-northeast1,us-west1,us-east1,us-east4,us-central1"
 # GCE_VM tuned down from the Robotest's 7 cpu default in 09cec0e49e9d51c3603950209cec3c26dfe0e66b
 # We should consider changing Robotest's default so that we can drop the override here. -- 2019-04 walt
@@ -71,6 +71,7 @@ EOF
 EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$CUSTOM_VAR_FILE:/robotest/config/vars.json
 
 GCE_CONFIG="gce:
+  project: ${GCL_PROJECT_ID}
   credentials: /robotest/config/creds.json
   vm_type: ${GCE_VM}
   region: ${GCE_REGION}


### PR DESCRIPTION
## Description
7.0 backport of https://github.com/gravitational/gravity/pull/2490

This patch switches robotest execution from the `kubeadm` GCP project to the `robotest-production` GCP project.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
* Backports https://github.com/gravitational/gravity/pull/2490
* Depends on https://github.com/gravitational/robotest/pull/285/

## TODOs

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
See https://github.com/gravitational/robotest/pull/285/ for manual testing of this robotest.  The PR build for this suffices for all further testing.