### PR TITLE
Linter configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,14 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
+  - name: lint
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash libc6-compat
+      - make -C build.assets golint
+    volumes:
+      - name: dockersock
+        path: /var/run
   - name: build
     image: docker:git
     environment:
@@ -634,6 +642,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 6ee463482d9943a4b9974c97cad601bf274c544f6cd55b5c2b7939c036fa510d
+hmac: a5a4d3e7ce9069e99d8fc7a23b44838aca0f0dd3ca9565ef21a3aef6fa142bea
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - revive
     - goimports
     - bodyclose
     - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,64 @@
+issues:
+  exclude-rules:
+    - linters: gosimple
+      text: "S1002: should omit comparison to bool constant"
+    - linters:
+        - gosec
+      text: "G204: Subprocess launched with variable"
+    - linters:
+        - gosec
+      text: "G204: Subprocess launched with function call as argument or cmd arguments"
+  exclude-use-default: true
+  max-same-issues: 0
+  max-issues-per-linter: 0
+
+linters-settings:
+  gosec:
+    excludes:
+      - G204
+  gofmt:
+    simplify: false
+  exhaustive:
+    default-signifies-exhaustive: true
+
+linters:
+  disable-all: true
+  enable:
+    - goimports
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+
+output:
+  uniq-by-line: false
+
+run:
+  skip-dirs:
+    - vendor
+    - mage
+  skip-dirs-use-default: false
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -27,20 +27,11 @@ K8S_VER := 1.21.0
 K8S_VER_SUFFIX := $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
 GOLFLAGS ?= -w -s
 GOLINT ?= golangci-lint
-# TODO(dima): this is a WIP configuration which will be finalized
-# once all lint warnings have been fixed
-GOLINT_PACKAGES ?= \
-	./lib/app/... \
-	./lib/cloudprovider/... \
-	./lib/constants/... \
-	./lib/docker/... \
-	./lib/httplib/... \
-	./lib/localenv/... \
-	./lib/ops/opsservice/... \
-	./lib/system/... \
-	./lib/utils/... \
-	./lib/webapi/... \
-	./tool/gravity/...
+# TODO(dima): target package configuration (check everything).
+# Package configuration will vary as new PRs are merged.
+GOLINT_PACKAGES ?= ./lib/... \
+	./tool/.. \
+	./e/..
 
 GOPATH ?= $(shell go env GOPATH)
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -5,6 +5,7 @@ ARG PROTOC_PLATFORM
 ARG GOGO_PROTO_TAG
 ARG GRPC_GATEWAY_TAG
 ARG VERSION_TAG
+ARG GOLANGCI_LINT_VER
 ARG UID
 ARG GID
 
@@ -19,7 +20,7 @@ RUN apt-get -q -y update --fix-missing && apt-get -q -y install libaio-dev zlib1
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 
-RUN (mkdir -p /opt/protoc && \
+RUN set -ex && (mkdir -p /opt/protoc && \
      mkdir -p /.cache && \
      chown -R $UID:$GID /gopath && \
      chown -R $UID:$GID /opt/protoc && \
@@ -35,18 +36,23 @@ ENV LANGUAGE="en_US.UTF-8" \
      GOPATH="/gopath" \
      PATH="$PATH:/opt/protoc/bin:/opt/go/bin:/gopath/bin"
 
-RUN (mkdir -p /gopath/src/github.com/gravitational && \
+RUN set -ex && (mkdir -p /gopath/src/github.com/gravitational && \
      cd /gopath/src/github.com/gravitational && \
      git clone https://github.com/gravitational/version.git && \
      cd /gopath/src/github.com/gravitational/version && \
      git checkout ${VERSION_TAG} && \
      go install github.com/gravitational/version/cmd/linkflags)
 
-RUN (wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} && \
+RUN set -ex && (wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} && \
      unzip -d /opt/protoc /tmp/${TARBALL} && \
      mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem && \
      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /gopath/src/github.com/gogo/protobuf && cd /gopath/src/github.com/gogo/protobuf && make install && \
      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /gopath/src/github.com/grpc-ecosystem/grpc-gateway && cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
+
+ENV GOLANGCI_RELEASE_TARBALL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VER}/golangci-lint-${GOLANGCI_LINT_VER}-linux-amd64.tar.gz
+
+RUN set -ex && \
+	curl -sSfL ${GOLANGCI_RELEASE_TARBALL} | tar xz --strip-components=1 -C $(go env GOPATH)/bin golangci-lint-${GOLANGCI_LINT_VER}-linux-amd64/golangci-lint
 
 ENV PROTO_INCLUDE "/usr/local/include":"/gopath/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -7,7 +7,9 @@
 #
 
 OPS_URL ?=
-LOCALDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+LOCALDIR := $(realpath $(patsubst %/,%,$(dir $(MKFILE_PATH))))
+TOP := $(abspath $(LOCALDIR)/..)
 LOCAL_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build
 # Path to the local gravity build assets directory used inside the container
 LOCAL_GRAVITY_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build/$(GRAVITY_VERSION)
@@ -100,12 +102,15 @@ BASH ?= /bin/bash
 # packages to test
 TEST_PACKAGES ?= $(GRAVITY_PKG_PATH)/lib/... $(GRAVITY_PKG_PATH)/tool/...
 
-GRPC_PROTOS = \
-	$(TOP)/lib/install/proto/installer.proto \
-	$(TOP)/lib/rpc/proto/agent.proto \
-	$(TOP)/lib/rpc/proto/discovery.proto \
-	$(TOP)/lib/network/validation/proto/validation.proto
-GRPC_PROTO_OUTPUTS = $(GRPC_PROTOS:.proto=.pb.go)
+# Version of the version tool
+VERSION_TAG := 0.0.2
+GOLANGCI_LINT_VER := 1.40.1
+
+# grpc
+PROTOC_VER ?= 3.10.0
+PROTOC_PLATFORM := linux-x86_64
+GOGO_PROTO_TAG ?= v1.3.0
+GRPC_GATEWAY_TAG ?= v1.11.3
 
 # Export variables for recursive make invocations
 export GRAVITY_PKG_PATH
@@ -194,13 +199,11 @@ endif
 # generate gRPC code
 #
 .PHONY: grpc
-grpc: buildbox $(GRPC_PROTO_OUTPUTS)
-
-$(GRPC_PROTO_OUTPUTS): $(GRPC_PROTOS)
+grpc:
 	docker run --rm=true $(NOROOT) \
-		   -v $(TOP):$(SRCDIR) \
-		   $(BBOX) \
-		   dumb-init make -C $(subst $(TOP),$(SRCDIR),$(@D))
+	   -v $(TOP):$(SRCDIR) \
+	   $(BBOX) \
+	   dumb-init make -C $(SRCDIR) grpc
 
 #
 # this is a temporary target until we upgrade docker packages
@@ -236,6 +239,26 @@ build-in-container: buildbox
 		   $(GOCACHE_DOCKER_OPTIONS) \
 		   $(BBOX) \
 		   dumb-init make -C $(SRCDIR)/build.assets -j $(TARGETS)
+
+#
+# golint gravity binaries in a buildbox container
+#
+.PHONY: golint
+golint: buildbox
+	docker run --rm=true $(NOROOT) \
+		   -v $(TOP):$(SRCDIR) \
+		   -w /gopath/src/github.com/gravitational/gravity \
+		   -e "LOCAL_BUILDDIR=$(LOCAL_BUILDDIR)" \
+		   -e "LOCAL_GRAVITY_BUILDDIR=$(LOCAL_GRAVITY_BUILDDIR)" \
+		   -e "GRAVITY_PKG_PATH=$(GRAVITY_PKG_PATH)" \
+		   -e "GRAVITY_VERSION=$(GRAVITY_VERSION)" \
+		   -e "GRAVITY_TAG=$(GRAVITY_TAG)" \
+		   -e 'GRAVITY_LINKFLAGS=$(GRAVITY_LINKFLAGS)' \
+		   -e "GRAVITY_BUILDFLAGS=$(GRAVITY_BUILDFLAGS)" \
+		   -e "GRAVITY_BUILDTAGS=$(GRAVITY_BUILDTAGS)" \
+		   $(GOCACHE_DOCKER_OPTIONS) \
+		   $(BBOX) \
+		   dumb-init make -C $(SRCDIR) golint
 
 #
 # build gravity binaries on host
@@ -698,6 +721,7 @@ buildbox:
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg GRPC_GATEWAY_TAG=$(GRPC_GATEWAY_TAG) \
 		--build-arg VERSION_TAG=$(VERSION_TAG) \
+		--build-arg GOLANGCI_LINT_VER=$(GOLANGCI_LINT_VER) \
 		--build-arg UID=$(shell id -u) \
 		--build-arg GID=$(shell id -g) \
 		$(DOCKER_ARGS) --tag $(BBOX) .


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR implements just the configuration required to set up linting as requested in https://github.com/gravitational/gravity/pull/2488#pullrequestreview-663470519

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
I flipped the `golint` target (and correspondingly `grpc` as the version definitions moved to build.assets/Makefile) so that the root Makefile builds on host and docker-based targets are available in build.assets/Makefile - this is the way teleport's makefiles are structured and I find it more meaningful.

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
