### PR TITLE
[7.0] Fix ownership issues in buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -10,17 +10,26 @@ ARG UID
 ARG GID
 
 ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
-ENV GRPC_GATEWAY_ROOT /src/github.com/grpc-ecosystem/grpc-gateway
-ENV GOGOPROTO_ROOT /src/github.com/gogo/protobuf
+ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
+ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 
-RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity && \
+# install some development libraries used when compiling fio
+RUN set -ex && apt -q -y update --fix-missing && apt -q -y install libaio-dev zlib1g-dev
+
+# install DEP tool
+RUN wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
+
+RUN (set -ex && \
+     mkdir -p /gopath && \
      chown -R $UID:$GID /gopath && \
+     mkdir -p /opt/protoc && \
+     chown -R $UID:$GID /opt/protoc && \
      mkdir -p /.cache && \
-     chmod 777 /.cache && \
+     chown -R $UID:$GID /.cache && \
      chmod 777 /tmp)
 
 USER $UID:$GID
@@ -42,17 +51,12 @@ RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational && \
 RUN (set -ex && mkdir -p /opt/protoc && \
      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} && \
      unzip -d /opt/protoc /tmp/${TARBALL} && \
-     mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem && \
-     git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install && \
-     git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
+     mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem && \
+     git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /gopath/src/github.com/gogo/protobuf && \
+     cd /gopath/src/github.com/gogo/protobuf && make install && \
+     git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /gopath/src/github.com/grpc-ecosystem/grpc-gateway && \
+     cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway && GO111MODULE=on go install ./protoc-gen-grpc-gateway)
 
-ENV PROTO_INCLUDE "/usr/local/include":"/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
-
-# install DEP tool
-RUN set -ex && wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
-RUN set -ex && chmod -R a+rw /gopath
-
-# install some development libraries used when compiling fio
-RUN set -ex && apt -q -y update --fix-missing && apt -q -y install libaio-dev zlib1g-dev
+ENV PROTO_INCLUDE "/usr/local/include":"/gopath/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
 
 VOLUME ["/gopath/src/github.com/gravitational/gravity"]


### PR DESCRIPTION
## Description

The 5e2b4c2e2bb1e1136a521e2c912060745f6b609a backport introduced ownership issues in 7.0, resulting in errors like the following when building the buildbox locally:

```
$ make -C e production
...
Step 19/24 : RUN (set -ex && mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
 ---> Running in 0108b77cdcfe
+ mkdir -p /opt/protoc
mkdir: cannot create directory ‘/opt/protoc’: Permission denied

```

This changeset fixes the issue  by also backporting structural parity with the post-gomodules Dockerfile introduced in 294286adbac7bf36b63456809b7fc0938b7d95e4.

The buildbox build is split into two phases:

The first phase is performed as root -- and can write anywhere on the fs.
This is used to set up packages, as well as bootstrap directories for use in the second phase.

The second phase operates as the local user, and sets up the remainder of the gravity tool chain.

## Type of change
* Regression fix (non-breaking change which fixes a regression)


## Linked tickets and other PRs
* Fixes an issue introduced in https://github.com/gravitational/gravity/pull/2483 / https://github.com/gravitational/gravity/pull/2473

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<details><summary>Before</summary>

```console
$ make -C e production
make: Entering directory '/home/walt/git/gravity/e'
make -C .. production
make[1]: Entering directory '/home/walt/git/gravity'
GRAVITY="/home/walt/git/gravity/e/build/7.0.32-dev.5/gravity --state-dir=/tmp/tmp.NdwYN7yXiX" make -C build.assets production
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
docker build \
        --build-arg PROTOC_VER=3.10.0 \
        --build-arg PROTOC_PLATFORM=linux-x86_64 \
        --build-arg GOGO_PROTO_TAG=v1.3.0 \
        --build-arg GRPC_GATEWAY_TAG=v1.11.3 \
        --build-arg GODEP_TAG=v0.5.4 \
        --build-arg VERSION_TAG=0.0.2 \
        --build-arg UID=1000 \
        --build-arg GID=1000 \
        --pull --tag gravity-buildbox:7.0.x .
Sending build context to Docker daemon  49.66kB
Step 1/24 : FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
go1.12.9-stretch: Pulling from gravitational/debian-venti
Digest: sha256:c9c99de75f1777f71d17c17afa63c09ee74b35360f0b33657c1d3dafcf0f5f58
Status: Image is up to date for quay.io/gravitational/debian-venti:go1.12.9-stretch
 ---> e3961cb1e828
Step 2/24 : ARG PROTOC_VER
 ---> Using cache
 ---> b483a96a26b7
Step 3/24 : ARG PROTOC_PLATFORM
 ---> Using cache
 ---> 92ebd811c98d
Step 4/24 : ARG GOGO_PROTO_TAG
 ---> Using cache
 ---> 6c0a97f268f9
Step 5/24 : ARG GRPC_GATEWAY_TAG
 ---> Using cache
 ---> f1b9c203fec6
Step 6/24 : ARG GODEP_TAG
 ---> Using cache
 ---> ae16249cfb48
Step 7/24 : ARG VERSION_TAG
 ---> Using cache
 ---> 764f842faf5f
Step 8/24 : ARG UID
 ---> Using cache
 ---> 05e112e85ac1
Step 9/24 : ARG GID
 ---> Using cache
 ---> 971c39b2e0ee
Step 10/24 : ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> c5eabda9556d
Step 11/24 : ENV GRPC_GATEWAY_ROOT /src/github.com/grpc-ecosystem/grpc-gateway
 ---> Using cache
 ---> 02a8060d2594
Step 12/24 : ENV GOGOPROTO_ROOT /src/github.com/gogo/protobuf
 ---> Using cache
 ---> 71bd38ed0680
Step 13/24 : ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> dc989303a374
Step 14/24 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Using cache
 ---> d46c0fadd895
Step 15/24 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity &&      chown -R $UID:$GID /gopath &&      mkdir -p /.cache &&      chmod 777 /.cache &&      chmod 777 /tmp)
 ---> Using cache
 ---> d46a0d1ecabe
Step 16/24 : USER $UID:$GID
 ---> Using cache
 ---> 0c42cbaee4e6
Step 17/24 : ENV LANGUAGE="en_US.UTF-8"      LANG="en_US.UTF-8"      LC_ALL="en_US.UTF-8"      LC_CTYPE="en_US.UTF-8"      GOPATH="/gopath"      PATH="$PATH:/opt/protoc/bin:/opt/go/bin:/gopath/bin"
 ---> Using cache
 ---> 644dfb49075e
Step 18/24 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational &&      cd /gopath/src/github.com/gravitational &&      git clone https://github.com/gravitational/version.git &&      cd /gopath/src/github.com/gravitational/version &&      git checkout ${VERSION_TAG} &&      go install github.com/gravitational/version/cmd/linkflags)
 ---> Using cache
 ---> e0178ea70394
Step 19/24 : RUN (set -ex && mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
 ---> Running in 417ad72506dd
+ mkdir -p /opt/protoc
mkdir: cannot create directory ‘/opt/protoc’: Permission denied
The command '/bin/sh -c (set -ex && mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)' returned a non-zero code: 1
make[2]: *** [Makefile:695: buildbox] Error 1
make[2]: Leaving directory '/home/walt/git/gravity/build.assets'
make[1]: *** [Makefile:242: production] Error 2
make[1]: Leaving directory '/home/walt/git/gravity'
make: *** [Makefile:74: production] Error 2
make: Leaving directory '/home/walt/git/gravity/e'
```

</details>

<details><summary>After</summary>

```console
$ make -C e production
make: Entering directory '/home/walt/git/gravity/e'
make -C .. production
make[1]: Entering directory '/home/walt/git/gravity'
GRAVITY="/home/walt/git/gravity/e/build/7.0.32-dev.6/gravity --state-dir=/tmp/tmp.H68C2I3SN1" make -C build.assets production
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
docker build \
        --build-arg PROTOC_VER=3.10.0 \
        --build-arg PROTOC_PLATFORM=linux-x86_64 \
        --build-arg GOGO_PROTO_TAG=v1.3.0 \
        --build-arg GRPC_GATEWAY_TAG=v1.11.3 \
        --build-arg GODEP_TAG=v0.5.4 \
        --build-arg VERSION_TAG=0.0.2 \
        --build-arg UID=1000 \
        --build-arg GID=1000 \
        --pull --tag gravity-buildbox:7.0.x .
Sending build context to Docker daemon  50.18kB
Step 1/23 : FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
go1.12.9-stretch: Pulling from gravitational/debian-venti
Digest: sha256:c9c99de75f1777f71d17c17afa63c09ee74b35360f0b33657c1d3dafcf0f5f58
Status: Image is up to date for quay.io/gravitational/debian-venti:go1.12.9-stretch
 ---> e3961cb1e828
Step 2/23 : ARG PROTOC_VER
 ---> Using cache
 ---> b483a96a26b7
Step 3/23 : ARG PROTOC_PLATFORM
 ---> Using cache
 ---> 92ebd811c98d
Step 4/23 : ARG GOGO_PROTO_TAG
 ---> Using cache
 ---> 6c0a97f268f9
Step 5/23 : ARG GRPC_GATEWAY_TAG
 ---> Using cache
 ---> f1b9c203fec6
Step 6/23 : ARG GODEP_TAG
 ---> Using cache
 ---> ae16249cfb48
Step 7/23 : ARG VERSION_TAG
 ---> Using cache
 ---> 764f842faf5f
Step 8/23 : ARG UID
 ---> Using cache
 ---> 05e112e85ac1
Step 9/23 : ARG GID
 ---> Using cache
 ---> 971c39b2e0ee
Step 10/23 : ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> c5eabda9556d
Step 11/23 : ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
 ---> Using cache
 ---> f4db191e9b56
Step 12/23 : ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ---> Using cache
 ---> b3797b83563f
Step 13/23 : ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> e3b655e88299
Step 14/23 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Using cache
 ---> a26ddb1a4e52
Step 15/23 : RUN set -ex && apt -q -y update --fix-missing && apt -q -y install libaio-dev zlib1g-dev
 ---> Running in ad9ebb62b7f8
+ apt -q -y update --fix-missing

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Ign:1 http://httpredir.debian.org/debian stretch InRelease
Get:2 http://security.debian.org stretch/updates InRelease [53.0 kB]
Get:3 http://httpredir.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://httpredir.debian.org/debian stretch Release [118 kB]
Get:5 https://download.docker.com/linux/debian stretch InRelease [44.8 kB]
Get:6 http://security.debian.org stretch/updates/main amd64 Packages [688 kB]
Get:7 http://httpredir.debian.org/debian stretch Release.gpg [2410 B]
Get:8 http://security.debian.org stretch/updates/main Translation-en [315 kB]
Get:9 http://security.debian.org stretch/updates/contrib amd64 Packages [1760 B]
Get:10 http://security.debian.org stretch/updates/contrib Translation-en [1759 B]
Get:11 http://security.debian.org stretch/updates/non-free amd64 Packages [5604 B]
Get:12 http://security.debian.org stretch/updates/non-free Translation-en [15.6 kB]
Get:13 https://download.docker.com/linux/debian stretch/stable amd64 Packages [15.9 kB]
Get:14 http://httpredir.debian.org/debian stretch/main amd64 Packages [7080 kB]
Get:15 http://httpredir.debian.org/debian stretch/main Translation-en [5377 kB]
Get:16 http://httpredir.debian.org/debian stretch/contrib amd64 Packages [50.7 kB]
Get:17 http://httpredir.debian.org/debian stretch/contrib Translation-en [45.8 kB]
Get:18 http://httpredir.debian.org/debian stretch/non-free amd64 Packages [78.3 kB]
Get:19 http://httpredir.debian.org/debian stretch/non-free Translation-en [80.2 kB]
Fetched 14.1 MB in 5s (2698 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
All packages are up to date.
+ apt -q -y install libaio-dev zlib1g-dev

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libaio1
The following NEW packages will be installed:
  libaio-dev libaio1 zlib1g-dev
0 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.
Need to get 233 kB of archives.
After this operation, 512 kB of additional disk space will be used.
Get:1 http://httpredir.debian.org/debian stretch/main amd64 libaio1 amd64 0.3.110-3 [9412 B]
Get:2 http://httpredir.debian.org/debian stretch/main amd64 libaio-dev amd64 0.3.110-3 [18.3 kB]
Get:3 http://httpredir.debian.org/debian stretch/main amd64 zlib1g-dev amd64 1:1.2.8.dfsg-5 [205 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 233 kB in 0s (501 kB/s)
Selecting previously unselected package libaio1:amd64.
(Reading database ... 12817 files and directories currently installed.)
Preparing to unpack .../libaio1_0.3.110-3_amd64.deb ...
Unpacking libaio1:amd64 (0.3.110-3) ...
Selecting previously unselected package libaio-dev.
Preparing to unpack .../libaio-dev_0.3.110-3_amd64.deb ...
Unpacking libaio-dev (0.3.110-3) ...
Selecting previously unselected package zlib1g-dev:amd64.
Preparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-5_amd64.deb ...
Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-5) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Setting up libaio1:amd64 (0.3.110-3) ...
Setting up libaio-dev (0.3.110-3) ...
Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-5) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Removing intermediate container ad9ebb62b7f8
 ---> 65e19c7f4ddf
Step 16/23 : RUN wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
 ---> Running in a1d97eae9709
Removing intermediate container a1d97eae9709
 ---> 5fafd10d71db
Step 17/23 : RUN (set -ex &&      mkdir -p /gopath &&      chown -R $UID:$GID /gopath &&      mkdir -p /opt/protoc &&      chown -R $UID:$GID /opt/protoc &&      mkdir -p /.cache &&      chown -R $UID:$GID /.cache &&      chmod 777 /tmp)
 ---> Running in bf91c20d126d
+ mkdir -p /gopath
+ chown -R 1000:1000 /gopath
+ mkdir -p /opt/protoc
+ chown -R 1000:1000 /opt/protoc
+ mkdir -p /.cache
+ chown -R 1000:1000 /.cache
+ chmod 777 /tmp
Removing intermediate container bf91c20d126d
 ---> cbf2482acb5e
Step 18/23 : USER $UID:$GID
 ---> Running in c241729963f0
Removing intermediate container c241729963f0
 ---> 0ba574e33730
Step 19/23 : ENV LANGUAGE="en_US.UTF-8"      LANG="en_US.UTF-8"      LC_ALL="en_US.UTF-8"      LC_CTYPE="en_US.UTF-8"      GOPATH="/gopath"      PATH="$PATH:/opt/protoc/bin:/opt/go/bin:/gopath/bin"
 ---> Running in 6d6ab54a0c41
Removing intermediate container 6d6ab54a0c41
 ---> ee989dd6a8b5
Step 20/23 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational &&      cd /gopath/src/github.com/gravitational &&      git clone https://github.com/gravitational/version.git &&      cd /gopath/src/github.com/gravitational/version &&      git checkout ${VERSION_TAG} &&      go install github.com/gravitational/version/cmd/linkflags)
 ---> Running in 65c304b801d4
+ mkdir -p /gopath/src/github.com/gravitational
+ cd /gopath/src/github.com/gravitational
+ git clone https://github.com/gravitational/version.git
Cloning into 'version'...
+ cd /gopath/src/github.com/gravitational/version
+ git checkout 0.0.2
Note: checking out '0.0.2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 95d33ec... Merge pull request #5 from gravitational/roman/semver
+ go install github.com/gravitational/version/cmd/linkflags
Removing intermediate container 65c304b801d4
 ---> 9038ec0a21df
Step 21/23 : RUN (set -ex && mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /gopath/src/github.com/gogo/protobuf &&      cd /gopath/src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /gopath/src/github.com/grpc-ecosystem/grpc-gateway &&      cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway && GO111MODULE=on go install ./protoc-gen-grpc-gateway)
 ---> Running in 9b852a7c51c3
+ mkdir -p /opt/protoc
+ wget --quiet -O /tmp/protoc-3.10.0-linux-x86_64.zip https://github.com/google/protobuf/releases/download/v3.10.0/protoc-3.10.0-linux-x86_64.zip
+ unzip -d /opt/protoc /tmp/protoc-3.10.0-linux-x86_64.zip
Archive:  /tmp/protoc-3.10.0-linux-x86_64.zip
   creating: /opt/protoc/include/
   creating: /opt/protoc/include/google/
   creating: /opt/protoc/include/google/protobuf/
  inflating: /opt/protoc/include/google/protobuf/type.proto
  inflating: /opt/protoc/include/google/protobuf/duration.proto
  inflating: /opt/protoc/include/google/protobuf/empty.proto
  inflating: /opt/protoc/include/google/protobuf/wrappers.proto
  inflating: /opt/protoc/include/google/protobuf/field_mask.proto
   creating: /opt/protoc/include/google/protobuf/compiler/
  inflating: /opt/protoc/include/google/protobuf/compiler/plugin.proto
  inflating: /opt/protoc/include/google/protobuf/struct.proto
  inflating: /opt/protoc/include/google/protobuf/any.proto
  inflating: /opt/protoc/include/google/protobuf/descriptor.proto
  inflating: /opt/protoc/include/google/protobuf/source_context.proto
  inflating: /opt/protoc/include/google/protobuf/timestamp.proto
  inflating: /opt/protoc/include/google/protobuf/api.proto
   creating: /opt/protoc/bin/
  inflating: /opt/protoc/bin/protoc
  inflating: /opt/protoc/readme.txt
+ mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem
+ git clone https://github.com/gogo/protobuf --branch v1.3.0 /gopath/src/github.com/gogo/protobuf
Cloning into '/gopath/src/github.com/gogo/protobuf'...
Note: checking out '0ca988a254f991240804bf9821f3450d87ccbb1b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

+ cd /gopath/src/github.com/gogo/protobuf
+ make install
go install ./proto
go install ./gogoproto
go install ./jsonpb
go install ./protoc-gen-gogo
go install ./protoc-gen-gofast
go install ./protoc-gen-gogofast
go install ./protoc-gen-gogofaster
go install ./protoc-gen-gogoslick
go install ./protoc-gen-gostring
go install ./protoc-min-version
go install ./protoc-gen-combo
go install ./gogoreplace
+ git clone https://github.com/grpc-ecosystem/grpc-gateway --branch v1.11.3 /gopath/src/github.com/grpc-ecosystem/grpc-gateway
Cloning into '/gopath/src/github.com/grpc-ecosystem/grpc-gateway'...
Note: checking out 'ece8fdf051b731392b407fdb9a9b1b9ffb6f9793'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

+ cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway
+ GO111MODULE=on go install ./protoc-gen-grpc-gateway
go: finding github.com/kr/pretty v0.1.0
go: finding github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
go: finding github.com/golang/protobuf v1.2.0
go: finding github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: finding github.com/ghodss/yaml v1.0.0
go: finding golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
go: finding golang.org/x/net v0.0.0-20181220203305-927f97764cc3
go: finding gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
go: finding gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: finding gopkg.in/resty.v1 v1.12.0
go: finding github.com/kr/text v0.1.0
go: finding google.golang.org/grpc v1.19.0
go: finding google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: finding github.com/kr/pty v1.1.1
go: finding golang.org/x/sys v0.0.0-20180830151530-49385e6e1522
go: finding github.com/client9/misspell v0.3.4
go: finding golang.org/x/text v0.3.0
go: finding golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
go: finding golang.org/x/tools v0.0.0-20190114222345-bf090417da8b
go: finding google.golang.org/appengine v1.1.0
go: finding golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
go: finding github.com/golang/mock v1.1.1
go: finding cloud.google.com/go v0.26.0
go: finding golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3
go: finding honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099
go: finding github.com/BurntSushi/toml v0.3.1
go: finding golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading github.com/golang/protobuf v1.2.0
go: downloading github.com/ghodss/yaml v1.0.0
go: downloading google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: extracting github.com/ghodss/yaml v1.0.0
go: extracting github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: extracting gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: extracting github.com/golang/protobuf v1.2.0
go: extracting google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
Removing intermediate container 9b852a7c51c3
 ---> 240069334982
Step 22/23 : ENV PROTO_INCLUDE "/usr/local/include":"/gopath/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
 ---> Running in 63fd0efc20b6
Removing intermediate container 63fd0efc20b6
 ---> 0b9460b3e747
Step 23/23 : VOLUME ["/gopath/src/github.com/gravitational/gravity"]
 ---> Running in cfd632a6cec1
Removing intermediate container cfd632a6cec1
 ---> 18ad0dea8d3d
Successfully built 18ad0dea8d3d
Successfully tagged gravity-buildbox:7.0.x
```

</details>

## Additional Info
Discovered during 5.5. backport testing.  Needs ports to 6.1 and 5.5. 7.0+ has the go modules refactoring and is fine.