### PR TITLE
[6.1] Fix ownership issues in buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -10,17 +10,23 @@ ARG UID
 ARG GID
 
 ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
-ENV GRPC_GATEWAY_ROOT /src/github.com/grpc-ecosystem/grpc-gateway
-ENV GOGOPROTO_ROOT /src/github.com/gogo/protobuf
+ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
+ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 
-RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity && \
+# install DEP tool
+RUN wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
+
+RUN (set -ex && \
+     mkdir -p /gopath && \
      chown -R $UID:$GID /gopath && \
+     mkdir -p /opt/protoc && \
+     chown -R $UID:$GID /opt/protoc && \
      mkdir -p /.cache && \
-     chmod 777 /.cache && \
+     chown -R $UID:$GID /.cache && \
      chmod 777 /tmp)
 
 USER $UID:$GID
@@ -42,14 +48,12 @@ RUN (mkdir -p /gopath/src/github.com/gravitational && \
 RUN (mkdir -p /opt/protoc && \
      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} && \
      unzip -d /opt/protoc /tmp/${TARBALL} && \
-     mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem && \
-     git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install && \
-     git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
+     mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem && \
+     git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /gopath/src/github.com/gogo/protobuf && \
+     cd /gopath/src/github.com/gogo/protobuf && make install && \
+     git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /gopath/src/github.com/grpc-ecosystem/grpc-gateway && \
+     cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway && GO111MODULE=on go install ./protoc-gen-grpc-gateway)
 
-ENV PROTO_INCLUDE "/usr/local/include":"/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
-
-# install DEP tool
-RUN wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
-RUN chmod -R a+rw /gopath
+ENV PROTO_INCLUDE "/usr/local/include":"/gopath/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
 
 VOLUME ["/gopath/src/github.com/gravitational/gravity"]


### PR DESCRIPTION
## Description
Backport of https://github.com/gravitational/gravity/pull/2502, see #2502 for more context.

The 6567fe26e2845aec19e1b17be08ba1e762b7eb47 backport introduced ownership issues in 6.1 when building the buildbox locally.

This changeset fixes 6.1's issue by also backporting structural parity with the post-gomodules Dockerfile introduced in 294286adbac7bf36b63456809b7fc0938b7d95e4.

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
* Fixes an issue introduced in https://github.com/gravitational/gravity/pull/2476

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<details><summary>Before</summary>

```console
$ make -C e production
make: Entering directory '/home/walt/git/gravity/e'
make -C .. production
make[1]: Entering directory '/home/walt/git/gravity'
GRAVITY="/home/walt/git/gravity/e/build/6.1.49-dev.6/gravity --state-dir=/tmp/tmp.MrlkNb1Go5" make -C build.assets production
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
docker build \
        --build-arg PROTOC_VER=3.10.0 \
        --build-arg PROTOC_PLATFORM=linux-x86_64 \
        --build-arg GOGO_PROTO_TAG=v1.3.0 \
        --build-arg GRPC_GATEWAY_TAG=v1.11.3 \
        --build-arg GODEP_TAG=v0.5.4 \
        --build-arg VERSION_TAG=0.0.2 \
        --build-arg UID=1000 \
        --build-arg GID=1000 \
        --pull --tag gravity-buildbox:latest .
Sending build context to Docker daemon  61.95kB
Step 1/23 : FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
go1.12.9-stretch: Pulling from gravitational/debian-venti
Digest: sha256:c9c99de75f1777f71d17c17afa63c09ee74b35360f0b33657c1d3dafcf0f5f58
Status: Image is up to date for quay.io/gravitational/debian-venti:go1.12.9-stretch
 ---> e3961cb1e828
Step 2/23 : ARG PROTOC_VER
 ---> Using cache
 ---> b483a96a26b7
Step 3/23 : ARG PROTOC_PLATFORM
 ---> Using cache
 ---> 92ebd811c98d
Step 4/23 : ARG GOGO_PROTO_TAG
 ---> Using cache
 ---> 6c0a97f268f9
Step 5/23 : ARG GRPC_GATEWAY_TAG
 ---> Using cache
 ---> f1b9c203fec6
Step 6/23 : ARG GODEP_TAG
 ---> Using cache
 ---> ae16249cfb48
Step 7/23 : ARG VERSION_TAG
 ---> Using cache
 ---> 764f842faf5f
Step 8/23 : ARG UID
 ---> Using cache
 ---> 05e112e85ac1
Step 9/23 : ARG GID
 ---> Using cache
 ---> 971c39b2e0ee
Step 10/23 : ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> c5eabda9556d
Step 11/23 : ENV GRPC_GATEWAY_ROOT /src/github.com/grpc-ecosystem/grpc-gateway
 ---> Using cache
 ---> 02a8060d2594
Step 12/23 : ENV GOGOPROTO_ROOT /src/github.com/gogo/protobuf
 ---> Using cache
 ---> 71bd38ed0680
Step 13/23 : ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> dc989303a374
Step 14/23 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Using cache
 ---> d46c0fadd895
Step 15/23 : RUN (set -ex && mkdir -p /gopath/src/github.com/gravitational/gravity &&      chown -R $UID:$GID /gopath &&      mkdir -p /.cache &&      chmod 777 /.cache &&      chmod 777 /tmp)
 ---> Using cache
 ---> d46a0d1ecabe
Step 16/23 : USER $UID:$GID
 ---> Using cache
 ---> 0c42cbaee4e6
Step 17/23 : ENV LANGUAGE="en_US.UTF-8"      LANG="en_US.UTF-8"      LC_ALL="en_US.UTF-8"      LC_CTYPE="en_US.UTF-8"      GOPATH="/gopath"      PATH="$PATH:/opt/protoc/bin:/opt/go/bin:/gopath/bin"
 ---> Using cache
 ---> 644dfb49075e
Step 18/23 : RUN (mkdir -p /gopath/src/github.com/gravitational &&      cd /gopath/src/github.com/gravitational &&      git clone https://github.com/gravitational/version.git &&      cd /gopath/src/github.com/gravitational/version &&      git checkout ${VERSION_TAG} &&      go install github.com/gravitational/version/cmd/linkflags)
 ---> Using cache
 ---> 16ee0ff112d8
Step 19/23 : RUN (mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)
 ---> Running in c5da49d30564
mkdir: cannot create directory ‘/opt/protoc’: Permission denied
The command '/bin/sh -c (mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /src/github.com/gogo/ /src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /src/github.com/gogo/protobuf && cd /src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /src/github.com/grpc-ecosystem/grpc-gateway && cd /src/github.com/grpc-ecosystem/grpc-gateway && pwd && go install ./protoc-gen-grpc-gateway)' returned a non-zero code: 1
make[2]: *** [Makefile:570: buildbox] Error 1
make[2]: Leaving directory '/home/walt/git/gravity/build.assets'
make[1]: *** [Makefile:223: production] Error 2
make[1]: Leaving directory '/home/walt/git/gravity'
make: *** [Makefile:64: production] Error 2
make: Leaving directory '/home/walt/git/gravity/e'
```

</details>

<details><summary>After</summary>

```console
$ make -C e production
make: Entering directory '/home/walt/git/gravity/e'
make -C .. production
make[1]: Entering directory '/home/walt/git/gravity'
GRAVITY="/home/walt/git/gravity/e/build/6.1.49-dev.6/gravity --state-dir=/tmp/tmp.d1qmAvhfr9" make -C build.assets production
make[2]: Entering directory '/home/walt/git/gravity/build.assets'
docker build \
        --build-arg PROTOC_VER=3.10.0 \
        --build-arg PROTOC_PLATFORM=linux-x86_64 \
        --build-arg GOGO_PROTO_TAG=v1.3.0 \
        --build-arg GRPC_GATEWAY_TAG=v1.11.3 \
        --build-arg GODEP_TAG=v0.5.4 \
        --build-arg VERSION_TAG=0.0.2 \
        --build-arg UID=1000 \
        --build-arg GID=1000 \
        --pull --tag gravity-buildbox:latest .
Sending build context to Docker daemon  61.95kB
Step 1/22 : FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
go1.12.9-stretch: Pulling from gravitational/debian-venti
Digest: sha256:c9c99de75f1777f71d17c17afa63c09ee74b35360f0b33657c1d3dafcf0f5f58
Status: Image is up to date for quay.io/gravitational/debian-venti:go1.12.9-stretch
 ---> e3961cb1e828
Step 2/22 : ARG PROTOC_VER
 ---> Using cache
 ---> b483a96a26b7
Step 3/22 : ARG PROTOC_PLATFORM
 ---> Using cache
 ---> 92ebd811c98d
Step 4/22 : ARG GOGO_PROTO_TAG
 ---> Using cache
 ---> 6c0a97f268f9
Step 5/22 : ARG GRPC_GATEWAY_TAG
 ---> Using cache
 ---> f1b9c203fec6
Step 6/22 : ARG GODEP_TAG
 ---> Using cache
 ---> ae16249cfb48
Step 7/22 : ARG VERSION_TAG
 ---> Using cache
 ---> 764f842faf5f
Step 8/22 : ARG UID
 ---> Using cache
 ---> 05e112e85ac1
Step 9/22 : ARG GID
 ---> Using cache
 ---> 971c39b2e0ee
Step 10/22 : ENV TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> c5eabda9556d
Step 11/22 : ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
 ---> Using cache
 ---> f4db191e9b56
Step 12/22 : ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ---> Using cache
 ---> b3797b83563f
Step 13/22 : ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ---> Using cache
 ---> e3b655e88299
Step 14/22 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
 ---> Using cache
 ---> a26ddb1a4e52
Step 15/22 : RUN wget --quiet -O /usr/bin/dep https://github.com/golang/dep/releases/download/${GODEP_TAG}/dep-linux-amd64 && chmod +x /usr/bin/dep
 ---> Running in 5fa0437c6751
Removing intermediate container 5fa0437c6751
 ---> 20bdc7fdd887
Step 16/22 : RUN (set -ex &&      mkdir -p /gopath &&      chown -R $UID:$GID /gopath &&      mkdir -p /opt/protoc &&      chown -R $UID:$GID /opt/protoc &&      mkdir -p /.cache &&      chown -R $UID:$GID /.cache &&      chmod 777 /tmp)
 ---> Running in 490f55647e0a
+ mkdir -p /gopath
+ chown -R 1000:1000 /gopath
+ mkdir -p /opt/protoc
+ chown -R 1000:1000 /opt/protoc
+ mkdir -p /.cache
+ chown -R 1000:1000 /.cache
+ chmod 777 /tmp
Removing intermediate container 490f55647e0a
 ---> 1f486d09f2c7
Step 17/22 : USER $UID:$GID
 ---> Running in 8df6afca56a2
Removing intermediate container 8df6afca56a2
 ---> e2c2677664aa
Step 18/22 : ENV LANGUAGE="en_US.UTF-8"      LANG="en_US.UTF-8"      LC_ALL="en_US.UTF-8"      LC_CTYPE="en_US.UTF-8"      GOPATH="/gopath"      PATH="$PATH:/opt/protoc/bin:/opt/go/bin:/gopath/bin"
 ---> Running in 28ff011a75c5
Removing intermediate container 28ff011a75c5
 ---> 9ec4af9a6b58
Step 19/22 : RUN (mkdir -p /gopath/src/github.com/gravitational &&      cd /gopath/src/github.com/gravitational &&      git clone https://github.com/gravitational/version.git &&      cd /gopath/src/github.com/gravitational/version &&      git checkout ${VERSION_TAG} &&      go install github.com/gravitational/version/cmd/linkflags)
 ---> Running in d76a3e6f806b
Cloning into 'version'...
Note: checking out '0.0.2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 95d33ec... Merge pull request #5 from gravitational/roman/semver
Removing intermediate container d76a3e6f806b
 ---> 99c0b90a8de1
Step 20/22 : RUN (mkdir -p /opt/protoc &&      wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} &&      unzip -d /opt/protoc /tmp/${TARBALL} &&      mkdir -p /gopath/src/github.com/gogo/ /gopath/src/github.com/grpc-ecosystem &&      git clone https://github.com/gogo/protobuf --branch ${GOGO_PROTO_TAG} /gopath/src/github.com/gogo/protobuf &&      cd /gopath/src/github.com/gogo/protobuf && make install &&      git clone https://github.com/grpc-ecosystem/grpc-gateway --branch ${GRPC_GATEWAY_TAG} /gopath/src/github.com/grpc-ecosystem/grpc-gateway &&      cd /gopath/src/github.com/grpc-ecosystem/grpc-gateway && GO111MODULE=on go install ./protoc-gen-grpc-gateway)
 ---> Running in 7c7ce671461a
Archive:  /tmp/protoc-3.10.0-linux-x86_64.zip
   creating: /opt/protoc/include/
   creating: /opt/protoc/include/google/
   creating: /opt/protoc/include/google/protobuf/
  inflating: /opt/protoc/include/google/protobuf/type.proto
  inflating: /opt/protoc/include/google/protobuf/duration.proto
  inflating: /opt/protoc/include/google/protobuf/empty.proto
  inflating: /opt/protoc/include/google/protobuf/wrappers.proto
  inflating: /opt/protoc/include/google/protobuf/field_mask.proto
   creating: /opt/protoc/include/google/protobuf/compiler/
  inflating: /opt/protoc/include/google/protobuf/compiler/plugin.proto
  inflating: /opt/protoc/include/google/protobuf/struct.proto
  inflating: /opt/protoc/include/google/protobuf/any.proto
  inflating: /opt/protoc/include/google/protobuf/descriptor.proto
  inflating: /opt/protoc/include/google/protobuf/source_context.proto
  inflating: /opt/protoc/include/google/protobuf/timestamp.proto
  inflating: /opt/protoc/include/google/protobuf/api.proto
   creating: /opt/protoc/bin/
  inflating: /opt/protoc/bin/protoc
  inflating: /opt/protoc/readme.txt
Cloning into '/gopath/src/github.com/gogo/protobuf'...
Note: checking out '0ca988a254f991240804bf9821f3450d87ccbb1b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

go install ./proto
go install ./gogoproto
go install ./jsonpb
go install ./protoc-gen-gogo
go install ./protoc-gen-gofast
go install ./protoc-gen-gogofast
go install ./protoc-gen-gogofaster
go install ./protoc-gen-gogoslick
go install ./protoc-gen-gostring
go install ./protoc-min-version
go install ./protoc-gen-combo
go install ./gogoreplace
Cloning into '/gopath/src/github.com/grpc-ecosystem/grpc-gateway'...
Note: checking out 'ece8fdf051b731392b407fdb9a9b1b9ffb6f9793'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

go: finding github.com/golang/protobuf v1.2.0
go: finding github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: finding github.com/kr/pretty v0.1.0
go: finding github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
go: finding golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
go: finding google.golang.org/grpc v1.19.0
go: finding google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: finding gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
go: finding gopkg.in/resty.v1 v1.12.0
go: finding gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: finding github.com/kr/text v0.1.0
go: finding golang.org/x/net v0.0.0-20181220203305-927f97764cc3
go: finding github.com/ghodss/yaml v1.0.0
go: finding github.com/kr/pty v1.1.1
go: finding golang.org/x/sys v0.0.0-20180830151530-49385e6e1522
go: finding github.com/client9/misspell v0.3.4
go: finding golang.org/x/tools v0.0.0-20190114222345-bf090417da8b
go: finding golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
go: finding golang.org/x/text v0.3.0
go: finding google.golang.org/appengine v1.1.0
go: finding github.com/golang/mock v1.1.1
go: finding golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
go: finding golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3
go: finding cloud.google.com/go v0.26.0
go: finding golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
go: finding github.com/BurntSushi/toml v0.3.1
go: finding honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading github.com/golang/protobuf v1.2.0
go: downloading github.com/ghodss/yaml v1.0.0
go: downloading google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: extracting github.com/ghodss/yaml v1.0.0
go: extracting github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: extracting gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: extracting github.com/golang/protobuf v1.2.0
go: extracting google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
Removing intermediate container 7c7ce671461a
 ---> ceb7c3f12bc7
Step 21/22 : ENV PROTO_INCLUDE "/usr/local/include":"/gopath/src":"${GRPC_GATEWAY_ROOT}/third_party/googleapis":"${GOGOPROTO_ROOT}/gogoproto"
 ---> Running in 8ea4099fa010
Removing intermediate container 8ea4099fa010
 ---> df2e02f4ad96
Step 22/22 : VOLUME ["/gopath/src/github.com/gravitational/gravity"]
 ---> Running in 42b129d2b013
Removing intermediate container 42b129d2b013
 ---> b91e6f830ea2
Successfully built b91e6f830ea2
Successfully tagged gravity-buildbox:latest
```

</details>