### PR TITLE
[8.0.x] Add possibility to disable label reconciliation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/go-restful v2.11.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fatih/color v1.9.0
 	github.com/fsouza/go-dockerclient v1.7.2
 	github.com/garyburd/redigo v0.0.0-20151029235527-6ece6e0a09f2 // indirect

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -25,10 +25,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/gravitational/gravity/lib/constants"
-
 	"github.com/coreos/go-semver/semver"
+
+	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/teleport/lib/utils"
+
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -723,15 +724,6 @@ const (
 
 	// MaxRouterIdleConnsPerHost defines tha maximum number of idle connections for "opsroute" transport
 	MaxRouterIdleConnsPerHost = 5
-
-	// KubernetesRoleLabel is the Kubernetes node label with system role
-	KubernetesRoleLabel = "gravitational.io/k8s-role"
-
-	// KubernetesAdvertiseIPLabel is the kubernetes node label of the advertise IP address
-	KubernetesAdvertiseIPLabel = "gravitational.io/advertise-ip"
-
-	// RunLevelLabel is the Kubernetes node taint label representing a run-level
-	RunLevelLabel = "gravitational.io/runlevel"
 
 	// RunLevelSystem is the Kubernetes run-level for system applications
 	RunLevelSystem = "system"

--- a/lib/defaults/labels.go
+++ b/lib/defaults/labels.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// KubernetesRoleLabel is the Kubernetes node label with system role
+	KubernetesRoleLabel = "gravitational.io/k8s-role"
+
+	// KubernetesAdvertiseIPLabel is the kubernetes node label of the advertise IP address
+	KubernetesAdvertiseIPLabel = "gravitational.io/advertise-ip"
+
+	// RunLevelLabel is the Kubernetes node taint label representing a run-level
+	RunLevelLabel = "gravitational.io/runlevel"
+
+	// KubernetesReconcileLabel is the kubernetes node label to define the reconcile mode,
+	// which controls the reconciliation process for the node labels.
+	KubernetesReconcileLabel = "label-reconciler.gravitational.io/mode"
+)
+
+// ReconcileMode is the type for reconcile mode values
+type ReconcileMode string
+
+const (
+	// ReconcileModeEnsureExists describes a label reconciliation mode when the labels will only be checked for existence. Users can edit the labels as they want.
+	// This is default value for ReconcileMode.
+	// Valid values: "EnsureExists"
+	ReconcileModeEnsureExists = "EnsureExists"
+
+	// ReconcileModeEnabled enables full reconciliation.
+	// If the value of the label on the node is not equal to the value from the NodeProfile, the value will be restored from the profile.
+	// Valid values: "Enabled", "enabled", "true", "True"
+	ReconcileModeEnabled = "Enabled"
+
+	// ReconcileModeDisabled disables reconciliation.
+	// Valid values: "Disabled", "disabled", "false", "False"
+	ReconcileModeDisabled = "Disabled"
+)
+
+// ParseReconcileMode parses the value to determine the reconciliation mode
+func ParseReconcileMode(v string) (ReconcileMode, error) {
+	if len(strings.TrimSpace(v)) == 0 {
+		return "", trace.BadParameter("empty ReconcileMode value")
+	}
+	switch strings.ToLower(v) {
+	case strings.ToLower(ReconcileModeEnsureExists):
+		return ReconcileModeEnsureExists, nil
+	case strings.ToLower(ReconcileModeEnabled), "true":
+		return ReconcileModeEnabled, nil
+	case strings.ToLower(ReconcileModeDisabled), "false":
+		return ReconcileModeDisabled, nil
+	}
+	return "", trace.BadParameter("unable to parse ReconcileMode value: %q", v)
+}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -19,6 +19,7 @@ package process
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -30,6 +31,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	jsonpatch "github.com/evanphx/json-patch"
 
 	"github.com/gravitational/gravity/lib/app"
 	apphandler "github.com/gravitational/gravity/lib/app/handler"
@@ -718,7 +723,7 @@ func (p *Process) reconcileNodeLabels(ctx context.Context, client *kubernetes.Cl
 		return trace.Wrap(err)
 	}
 	for ip, node := range nodes {
-		if err := p.reconcileNode(client, *cluster, ip, node); err != nil {
+		if err := p.reconcileNode(ctx, client, *cluster, ip, node); err != nil {
 			p.WithError(err).Errorf("Failed to reconcile labels for node %v/%v.",
 				node.Name, ip)
 		}
@@ -726,41 +731,66 @@ func (p *Process) reconcileNodeLabels(ctx context.Context, client *kubernetes.Cl
 	return nil
 }
 
-func (p *Process) reconcileNode(client *kubernetes.Clientset, cluster ops.Site, ip string, node v1.Node) error {
+func (p *Process) reconcileNode(ctx context.Context, client *kubernetes.Clientset, cluster ops.Site, ip string, node v1.Node) error {
 	server, err := cluster.ClusterState.FindServerByIP(ip)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	missingLabels, err := getMissingLabels(cluster, *server, node)
+	profile, err := cluster.App.Manifest.NodeProfiles.ByName(server.Role)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(missingLabels) == 0 {
+
+	oldData, err := json.Marshal(node)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	requiredLabels := server.GetNodeLabels(profile.Labels)
+	needUpdate := false
+	node.Labels, needUpdate = reconcileLabels(p, node.Labels, requiredLabels)
+	if needUpdate {
 		return nil
 	}
-	p.Infof("Adding missing labels to node %v/%v: %v.", node.Name, ip, missingLabels)
-	for key, val := range missingLabels {
-		node.Labels[key] = val
+	newData, err := json.Marshal(node)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	if _, err := client.CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{}); err != nil {
+	patchData, err := jsonpatch.CreateMergePatch(oldData, newData)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Patching node %v/%v: %s", node.Name, ip, string(patchData))
+	if _, err := client.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchData, metav1.PatchOptions{}); err != nil {
 		return rigging.ConvertError(err)
 	}
 	return nil
 }
 
-func getMissingLabels(cluster ops.Site, server storage.Server, node v1.Node) (map[string]string, error) {
-	profile, err := cluster.App.Manifest.NodeProfiles.ByName(server.Role)
-	if err != nil {
-		return nil, trace.Wrap(err)
+func reconcileLabels(logger logrus.FieldLogger, currentLabels, requiredLabels map[string]string) (map[string]string, bool) {
+	labels := make(map[string]string)
+	for key, value := range currentLabels {
+		labels[key] = value
 	}
-	missingLabels := make(map[string]string)
-	requiredLabels := server.GetNodeLabels(profile.Labels)
+	needUpdate := false
+	reconcileMode, err := defaults.ParseReconcileMode(labels[defaults.KubernetesReconcileLabel])
+	if err != nil {
+		logger.WithError(err).Error("Unable to get reconcile mode, will reset to EnsureExists.")
+		needUpdate = true
+		reconcileMode = defaults.ReconcileModeEnsureExists
+		labels[defaults.KubernetesReconcileLabel] = defaults.ReconcileModeEnsureExists
+	}
+	if reconcileMode == defaults.ReconcileModeDisabled {
+		return labels, false
+	}
 	for key, val := range requiredLabels {
-		if _, ok := node.Labels[key]; !ok {
-			missingLabels[key] = val
+		currentVal, ok := labels[key]
+		if !ok || reconcileMode == defaults.ReconcileModeEnabled && currentVal != val {
+			labels[key] = val
+			needUpdate = true
 		}
 	}
-	return missingLabels, nil
+	return labels, needUpdate
 }
 
 func (p *Process) runNodeLabelsReconciler(client *kubernetes.Clientset) clusterService {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
User can change node label `label-reconciler.gravitational.io/mode` to change behavior for label reconciliation.
Available values:

`EnsureExists` - checking for existence only. Users can edit the labels as they want. (default value)
`Enabled` - enables full reconciliation. If the value of the label on the node is not equal to the value from the NodeProfile, the value will be restored from the profile.
`Disabled` - reconciliation is disabled for current node

## Type of change
Bug fix (non-breaking change which fixes an issue)
<!--Required. Keep only those that apply.-->

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #2459
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2486
* Docs #2508

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
