### PR TITLE
[7.0.x] Add possibility to disable label reconciliation

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -734,15 +734,6 @@ const (
 	// MaxRouterIdleConnsPerHost defines tha maximum number of idle connections for "opsroute" transport
 	MaxRouterIdleConnsPerHost = 5
 
-	// KubernetesRoleLabel is the Kubernetes node label with system role
-	KubernetesRoleLabel = "gravitational.io/k8s-role"
-
-	// KubernetesAdvertiseIPLabel is the kubernetes node label of the advertise IP address
-	KubernetesAdvertiseIPLabel = "gravitational.io/advertise-ip"
-
-	// RunLevelLabel is the Kubernetes node taint label representing a run-level
-	RunLevelLabel = "gravitational.io/runlevel"
-
 	// RunLevelSystem is the Kubernetes run-level for system applications
 	RunLevelSystem = "system"
 

--- a/lib/defaults/labels.go
+++ b/lib/defaults/labels.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaults
+
+import (
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// KubernetesRoleLabel is the Kubernetes node label with system role
+	KubernetesRoleLabel = "gravitational.io/k8s-role"
+
+	// KubernetesAdvertiseIPLabel is the kubernetes node label of the advertise IP address
+	KubernetesAdvertiseIPLabel = "gravitational.io/advertise-ip"
+
+	// RunLevelLabel is the Kubernetes node taint label representing a run-level
+	RunLevelLabel = "gravitational.io/runlevel"
+
+	// KubernetesReconcileLabel is the kubernetes node label to define the reconcile mode,
+	// which controls the reconciliation process for the node labels.
+	KubernetesReconcileLabel = "label-reconciler.gravitational.io/mode"
+)
+
+// ReconcileMode is the type for reconcile mode values
+type ReconcileMode string
+
+const (
+	// ReconcileModeEnsureExists describes a label reconciliation mode when the labels will only be checked for existence. Users can edit the labels as they want.
+	// This is default value for ReconcileMode.
+	// Valid values: "EnsureExists"
+	ReconcileModeEnsureExists = "EnsureExists"
+
+	// ReconcileModeEnabled enables full reconciliation.
+	// If the value of the label on the node is not equal to the value from the NodeProfile, the value will be restored from the profile.
+	// Valid values: "Enabled", "enabled", "true", "True"
+	ReconcileModeEnabled = "Enabled"
+
+	// ReconcileModeDisabled disables reconciliation.
+	// Valid values: "Disabled", "disabled", "false", "False"
+	ReconcileModeDisabled = "Disabled"
+)
+
+// ParseReconcileMode parses the value to determine the reconciliation mode
+func ParseReconcileMode(v string) (ReconcileMode, error) {
+	if len(strings.TrimSpace(v)) == 0 {
+		return "", trace.BadParameter("empty ReconcileMode value")
+	}
+	switch strings.ToLower(v) {
+	case strings.ToLower(ReconcileModeEnsureExists):
+		return ReconcileModeEnsureExists, nil
+	case strings.ToLower(ReconcileModeEnabled), "true":
+		return ReconcileModeEnabled, nil
+	case strings.ToLower(ReconcileModeDisabled), "false":
+		return ReconcileModeDisabled, nil
+	}
+	return "", trace.BadParameter("unable to parse ReconcileMode value: %q", v)
+}


### PR DESCRIPTION
## Description
User can change node label `label-reconciler.gravitational.io/mode` to change behavior for label reconciliation.
Available values:

`EnsureExists` - checking for existence only. Users can edit the labels as they want. (default value)
`Enabled` - enables full reconciliation. If the value of the label on the node is not equal to the value from the NodeProfile, the value will be restored from the profile.
`Disabled` - reconciliation is disabled for current node

## Type of change
Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #2459
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2486

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
