### PR TITLE
Update .drone.yml for drone.teleport.dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -642,6 +642,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: a5a4d3e7ce9069e99d8fc7a23b44838aca0f0dd3ca9565ef21a3aef6fa142bea
+hmac: 2afce3d2515ccd174a22c90caad4c91293a82021d1f319eb4d7d56bcd73b344a
 
 ...

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -19,5 +19,4 @@ RUN getent group  $GID || groupadd builder --gid=$GID -o; \
 
 COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 
-VOLUME [$WORKDIR]
 EXPOSE $PORT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,6 @@ $(DOCBOX_ID_FILE): Dockerfile
 	docker build \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		--build-arg WORKDIR=$(WORKDIR) \
 		--build-arg PORT=$(PORT) \
 		--tag $(DOCBOX) .
 	# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141


### PR DESCRIPTION
## Description
We're migrating CI and release from drone.gravitational.io to drone.teleport.dev.

This requires re-signing to automatically run jobs.  For folks who sign, they'll need to update their ENV per https://drone.teleport.dev/account.

Additionally I found one runtime related error with the docs job.  Declaring a volume in the image build caused
an incorrect mapping later when that image was used, as seen at:

https://drone.teleport.dev/gravitational/gravity/15

I put a couple hours into researching this as well as GKE runtime differences -- in the end I never found a satisfying infrastructural fix, and decided to yank the volume declaration as that fixed the symptom.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* N/A

## TODOs
- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
See the PR build.

## Additional information
Backports to all active releases required.
