### PR TITLE
Pin docker:dind to a known good version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -89,7 +89,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -181,7 +181,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -242,7 +242,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -347,7 +347,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -443,7 +443,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -538,7 +538,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -631,7 +631,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -642,6 +642,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: a5a4d3e7ce9069e99d8fc7a23b44838aca0f0dd3ca9565ef21a3aef6fa142bea
+hmac: 7d0e8e2f5d66fa12085e459fe2531573704eae346b688c070e5342bd0d82e8cd
 
 ...


### PR DESCRIPTION
## Description
A recent push to https://hub.docker.com/_/docker updated `docker:dind` from `20.10.6` -> `20.10.7` causing invalid (but previously working) volumes to start failing, as seen at:

https://drone.teleport.dev/gravitational/gravity/15

```
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-compile-docs
docker: Error response from daemon: OCI runtime create failed: invalid mount 
{Destination:[/home] Type:bind Source:/var/lib/docker/volumes/681067d5a2e8bb1287a6c63a13a1b67da85592a773dd45c44754a62777064431/_data Options:[rbind]}:
mount destination [/home] not absolute: unknown.
```

This addresses the issue by pinning the dind image to stable and known good tag.

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
* Failures like this serve as motivation for looking into something like https://github.com/gravitational/teleport/issues/6895

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the [PR build](https://drone.teleport.dev/gravitational/gravity/29)