### PR TITLE
Remove volume declaration from docs buildbox

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,7 +11,6 @@ FROM quay.io/gravitational/mkdocs-base:1.0.3-1
 
 ARG UID
 ARG GID
-ARG WORKDIR
 ARG PORT
 
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
@@ -19,5 +18,4 @@ RUN getent group  $GID || groupadd builder --gid=$GID -o; \
 
 COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 
-VOLUME [$WORKDIR]
 EXPOSE $PORT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,6 @@ $(DOCBOX_ID_FILE): Dockerfile
 	docker build \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		--build-arg WORKDIR=$(WORKDIR) \
 		--build-arg PORT=$(PORT) \
 		--tag $(DOCBOX) .
 	# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141


### PR DESCRIPTION
## Description
When this volume is present docker 10.20.7+ will fail to run the docs buildbox
with the following error:
```
docker: Error response from daemon: OCI runtime create failed: invalid mount
{Destination:[/home] Type:bind Source:/var/lib/docker/volumes/0c25dcb63ea9d7b794f7a397ec3504576cee6ae85300add40b5e5222a2f01937/_data Options:[rbind]}:
mount destination [/home] not absolute: unknown.
```

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
This is an alternative approach to fixing https://github.com/gravitational/gravity/pull/2522.  We should take it anyhow, as this `VOLUME` declaration was not being properly used, and doing so will allow forward compatibility with `docker:20.10.7-dind`+

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the PR build.
