### PR TITLE
[8.0] Drone CI backports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -632,6 +632,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: caab2cfccea5948cc372cd269e409daf721baf73000a0f50ea26e6165db53761
+hmac: 002fc319d27d03db777ef31fad26c99170f51813845547a24186aa21e5493126
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -173,7 +173,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -232,7 +232,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -337,7 +337,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -433,7 +433,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -528,7 +528,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -621,7 +621,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -632,6 +632,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 002fc319d27d03db777ef31fad26c99170f51813845547a24186aa21e5493126
+hmac: 8e41bffa827781154d349257a548d2c3300a8ddd58fc475e60fef09be2bac4c5
 
 ...

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,7 +11,6 @@ FROM quay.io/gravitational/mkdocs-base:1.0.3-1
 
 ARG UID
 ARG GID
-ARG WORKDIR
 ARG PORT
 
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
@@ -19,5 +18,4 @@ RUN getent group  $GID || groupadd builder --gid=$GID -o; \
 
 COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 
-VOLUME [$WORKDIR]
 EXPOSE $PORT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,6 @@ $(DOCBOX_ID_FILE): Dockerfile
 	docker build \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		--build-arg WORKDIR=$(WORKDIR) \
 		--build-arg PORT=$(PORT) \
 		--tag $(DOCBOX) .
 	# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141


### PR DESCRIPTION
## Description
This PR backports 3 changes related to CI stability and security to 8.0:
 - Switch CI to drone.teleport.dev
 - Remove an unneeded volume from the docs buildbox
 - Pin docker:dind image

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2524, https://github.com/gravitational/gravity/pull/2523, https://github.com/gravitational/gravity/pull/2522

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the [PR build](https://drone.teleport.dev/gravitational/gravity/35) at drone.teleport.dev.
