### PR TITLE
[7.0] Drone CI backports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -173,7 +173,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -234,7 +234,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -339,7 +339,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -435,7 +435,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -530,7 +530,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -623,7 +623,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -634,6 +634,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 88ad0a30ab64b2854df9f716a81dcb9d65fac683043465f7b1b12554e03cb186
+hmac: fc7bcba6e3cb847ee5f298704dee2c99237afee127ef9eacbb55076bd3ef06fa
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -634,6 +634,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 6ee463482d9943a4b9974c97cad601bf274c544f6cd55b5c2b7939c036fa510d
+hmac: 88ad0a30ab64b2854df9f716a81dcb9d65fac683043465f7b1b12554e03cb186
 
 ...

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -11,7 +11,6 @@ FROM quay.io/gravitational/mkdocs-base:1.0.3-1
 
 ARG UID
 ARG GID
-ARG WORKDIR
 ARG PORT
 
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
@@ -19,5 +18,4 @@ RUN getent group  $GID || groupadd builder --gid=$GID -o; \
 
 COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
 
-VOLUME [$WORKDIR]
 EXPOSE $PORT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,6 @@ $(DOCBOX_ID_FILE): Dockerfile
 	docker build \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		--build-arg WORKDIR=$(WORKDIR) \
 		--build-arg PORT=$(PORT) \
 		--tag $(DOCBOX) .
 	# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141


### PR DESCRIPTION
## Description
This PR backports 3 changes related to CI stability and security to 7.0:
 - Switch CI to drone.teleport.dev
 - Remove an unneeded volume from the docs buildbox
 - Pin docker:dind image

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2524, https://github.com/gravitational/gravity/pull/2523, https://github.com/gravitational/gravity/pull/2522

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the [PR build](https://drone.teleport.dev/gravitational/gravity/) at drone.teleport.dev.
