### PR TITLE
[6.1] Drone CI backports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -617,6 +617,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 5bbe5c0eb531b4a2398cf5ca139700909b883c5fcf9f01f221d64b4512758571
+hmac: b6a3c0685b1e20545513d037d5fe8edb4b8bb000037d20cc767ebf0a22b365a6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,7 +73,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -156,7 +156,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -217,7 +217,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -322,7 +322,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -418,7 +418,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -513,7 +513,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -606,7 +606,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -617,6 +617,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: b6a3c0685b1e20545513d037d5fe8edb4b8bb000037d20cc767ebf0a22b365a6
+hmac: 2efc1766aa10485a37ebe0b23b94c8349d900167423eccf5ce30bb5e6c6c29ec
 
 ...


### PR DESCRIPTION
## Description
This PR backports 2 changes related to CI stability and security to  6.1:
 - Switch CI to drone.teleport.dev
 - Pin docker:dind image

https://github.com/gravitational/gravity/pull/2523 is not backported, as 6.1 used a different docs build system.  Although it
is vulnerable to the same failure, I don't think anyone will ever use it, so I didn't want to wast time adjusting the port.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2524, https://github.com/gravitational/gravity/pull/2522

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the [PR build](https://drone.teleport.dev/gravitational/gravity/39) at drone.teleport.dev.