### PR TITLE
[5.5] Drone CI backports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,7 +73,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -156,7 +156,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -217,7 +217,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -322,7 +322,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -418,7 +418,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -513,7 +513,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -606,7 +606,7 @@ steps:
 
 services:
   - name: run docker daemon
-    image: docker:dind
+    image: docker:20.10.6-dind
     privileged: true
     volumes:
       - name: dockersock
@@ -617,6 +617,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: fc8c591f6b6163ff3aa86522a9e35539134f5f0b6c517835c4eb74caeb13f590
+hmac: 271c2b3c145b76e37f87e70c5eee222ae9b61fe6f2692b52fe1bafbd9b781944
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -617,6 +617,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 2f81ad1a14cadc85f211f1c18c199e086544270741e281ea81cf9e90610f6b5d
+hmac: fc8c591f6b6163ff3aa86522a9e35539134f5f0b6c517835c4eb74caeb13f590
 
 ...


### PR DESCRIPTION
## Description
This PR backports 2 changes related to CI stability and security to 5.5:
 - Switch CI to drone.teleport.dev
 - Pin docker:dind image

https://github.com/gravitational/gravity/pull/2523 is not backported, as 5.5 used a different docs build system.  Although it
is vulnerable to the same failure, I don't think anyone will ever use it, so I didn't want to wast time adjusting the port.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports https://github.com/gravitational/gravity/pull/2524, https://github.com/gravitational/gravity/pull/2522

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
See the [PR build](https://drone.teleport.dev/gravitational/gravity/38) at drone.teleport.dev.