### PR TITLE
Update robotest upgrade maps and direct upgrade versions

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -7,12 +7,8 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[7.1.0-alpha.5]="ubuntu:20" # this version
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2" # compatible LTS version
-UPGRADE_MAP[7.0.13]="centos:7.9" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
-UPGRADE_MAP[7.0.12]="ubuntu:18" # 7.0.12 is the first LTS 7.0 release
-UPGRADE_MAP[7.0.7]="ubuntu:16" # 7.0.7 is the first 7.0 with https://github.com/gravitational/planet/pull/671 included
-# UPGRADE_MAP[7.0.0]="ubuntu:16" # 7.0.0 is prone to upgrade failure without https://github.com/gravitational/planet/pull/671
+UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
+UPGRADE_MAP[8.0.0-beta.0]="redhat:8.2,centos:7.9,ubuntu:16,ubuntu:18"
 
 function build_upgrade_suite {
   local size='"flavor":"three","nodes":3,"role":"node"'

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 source $(dirname $0)/lib/utils.sh
 
-# UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
+# UPGRADE_MAP maps gravity version -> space separated list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
-UPGRADE_MAP[8.0.0-beta.0]="redhat:8.2,centos:7.9,ubuntu:16,ubuntu:18"
+UPGRADE_MAP[8.0.0-beta.0]="redhat:8.2 centos:7.9 ubuntu:16 ubuntu:18"
 
 function build_upgrade_suite {
   local size='"flavor":"three","nodes":3,"role":"node"'

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -59,6 +59,8 @@ var (
 	// For instance, if the version is 5.2.10, the current version can upgrade
 	// directly from 5.2.10, 5.2.11 and so on.
 	DirectUpgradeVersions = Versions{
+		// Gravity version 7.1.x adopted Kubernetes 1.19.x, but development
+		// has stopped on 7.1.x and is being continued on 8.0.x.
 		semver.New("7.1.0"),
 		semver.New("8.0.0"),
 	}

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -59,11 +59,8 @@ var (
 	// For instance, if the version is 5.2.10, the current version can upgrade
 	// directly from 5.2.10, 5.2.11 and so on.
 	DirectUpgradeVersions = Versions{
-		semver.New("6.1.0"),
-		semver.New("6.2.0"),
-		semver.New("6.3.0"),
-		semver.New("7.0.0"),
 		semver.New("7.1.0"),
+		semver.New("8.0.0"),
 	}
 
 	// UpgradeViaVersions maps older gravity versions to versions that can be


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR updates the robotest upgrade maps and direct upgrade versions for gravity 9.0.x. Gravity 9.0.x should only allow upgrades from 7.1.x and 8.0.x.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback