### PR TITLE
Remove call to ComponentStatus API

### DIFF
--- a/lib/install/phases/postsystem.go
+++ b/lib/install/phases/postsystem.go
@@ -90,11 +90,6 @@ func (p *waitExecutor) waitForAPI(ctx context.Context, done chan bool) {
 	for {
 		select {
 		case <-timer.C:
-			if err := p.tryQueryAPI(); err != nil {
-				p.Infof("Waiting for Kubernetes API to start: %v", err)
-				continue
-			}
-			p.Debug("Kubernetes API is available.")
 			if err := p.tryQueryNamespace(); err != nil {
 				p.Infof("Waiting for kube-system namespace: %v", err)
 				continue
@@ -106,12 +101,6 @@ func (p *waitExecutor) waitForAPI(ctx context.Context, done chan bool) {
 			return
 		}
 	}
-}
-
-func (p *waitExecutor) tryQueryAPI() error {
-	_, err := p.Client.CoreV1().ComponentStatuses().
-		Get(context.TODO(), "scheduler", metav1.GetOptions{})
-	return trace.Wrap(err)
 }
 
 func (p *waitExecutor) tryQueryNamespace() error {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
ComponentStatus API has been deprecated in Kubernetes 1.19+. We might want to re-implement this check using a different method, but the API check will be removed for now.  See [CHANGELOG](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#deprecation-5)
## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback