### PR TITLE
Add current version (v9) to support upgrades within

### DIFF
--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -63,6 +63,8 @@ var (
 		// has stopped on 7.1.x and is being continued on 8.0.x.
 		semver.New("7.1.0"),
 		semver.New("8.0.0"),
+		// Keep the latest version to allow upgrade within the current major
+		semver.New("9.0.0"),
 	}
 
 	// UpgradeViaVersions maps older gravity versions to versions that can be


### PR DESCRIPTION
## Description
Add current version (v9) to support upgrades within

The bug here was that you could upgrade from 8 to 9 but not 9 alpha to 9 beta or 9.0.0 to 9.0.1 and so on.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
