### PR TITLE
Add current version (v8) to support upgrades within 

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 source $(dirname $0)/lib/utils.sh
 
-# UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
+# UPGRADE_MAP maps gravity version -> space separated list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 UPGRADE_MAP[7.1.0-alpha.5]="ubuntu:20" # this version
 UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2" # compatible LTS version

--- a/lib/ops/opsservice/versions.go
+++ b/lib/ops/opsservice/versions.go
@@ -59,11 +59,10 @@ var (
 	// For instance, if the version is 5.2.10, the current version can upgrade
 	// directly from 5.2.10, 5.2.11 and so on.
 	DirectUpgradeVersions = Versions{
-		semver.New("6.1.0"),
-		semver.New("6.2.0"),
-		semver.New("6.3.0"),
 		semver.New("7.0.0"),
 		semver.New("7.1.0"),
+		// Keep the latest version to allow upgrade within the current major
+		semver.New("8.0.0"),
 	}
 
 	// UpgradeViaVersions maps older gravity versions to versions that can be


### PR DESCRIPTION
Description
Add current version (v8) to support upgrades within

Removes support upgrading from 6 to 8

Somewhat backports #2541

Type of change
Regression fix (non-breaking change which fixes a regression)