### PR TITLE
[7.0.x] Add ability to cache docker images

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -124,7 +124,7 @@ endif
 #
 .PHONY: test
 test: testbox test-etcd
-	docker run --net=host --rm=true $(NOROOT) \
+	docker run --net=host --rm=true -u root  \
 		-v $(TOP):$(SRCDIR) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		--tmpfs /tmp:rw,nosuid,nodev,exec,relatime \

--- a/e/tool/tele/cli/run.go
+++ b/e/tool/tele/cli/run.go
@@ -84,6 +84,7 @@ func Run(tele Application) error {
 			PackageVersion:         *tele.BuildCmd.Version,
 			ResourcePatterns:       *tele.BuildCmd.VendorPatterns,
 			IgnoreResourcePatterns: *tele.BuildCmd.VendorIgnorePatterns,
+			ImageCacheDir:          *tele.BuildCmd.ImageCacheDir,
 			SetImages:              *tele.BuildCmd.SetImages,
 			SetDeps:                *tele.BuildCmd.SetDeps,
 			Parallel:               *tele.BuildCmd.Parallel,

--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -69,6 +69,22 @@ func exportLayers(
 	return nil
 }
 
+// excludeImagesStartingWith excludes the items witch start with prefix
+// It works with zero memory allocation and changes the input slice
+func excludeImagesStartingWith(images []string, prefix string) []string {
+	if prefix == "" {
+		return images
+	}
+	x := 0
+	for _, image := range images {
+		if !strings.HasPrefix(image, prefix) {
+			images[x] = image
+			x++
+		}
+	}
+	return images[:x]
+}
+
 // parseImageNameTag parses the specified image reference into name/tag tuple.
 // The returned name will include domain/path parts merged in a way to conform
 // to telekube package name syntax.

--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -19,13 +19,10 @@ package service
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/docker"
 	"github.com/gravitational/gravity/lib/loc"
-	"github.com/gravitational/gravity/lib/run"
 	"github.com/gravitational/gravity/lib/utils"
 
 	dockerapi "github.com/fsouza/go-dockerclient"
@@ -37,126 +34,39 @@ import (
 // the specified local directory
 func exportLayers(
 	ctx context.Context,
-	dir string,
+	registryDir string,
 	images []string,
 	dockerClient docker.DockerInterface,
 	log log.FieldLogger,
-	parallel int, progress utils.Progress) error {
-	layerExporter, err := newLayerExporter(dir, dockerClient, log, progress)
-	if err != nil {
-		return trace.Wrap(err, "failed to create layer export")
-	}
-	defer func() {
-		if errStop := layerExporter.stop(); errStop != nil {
-			log.Warnf("Failed to stop exporter: %v.", errStop)
-		}
-	}()
+	parallel int,
+	forcePull bool,
+	progress utils.Progress) error {
 
-	if err = layerExporter.push(ctx, images, parallel); err != nil {
-		return trace.Wrap(err, "failed to push images to local registry")
-	}
-
-	return nil
-}
-
-// newLayerExporter creates an instance of layer exporter
-func newLayerExporter(exportDir string, client docker.DockerInterface, log log.FieldLogger, progress utils.Progress) (*layerExporter, error) {
-	outputDir := filepath.Join(exportDir, defaults.RegistryDir)
-	config := docker.BasicConfiguration("127.0.0.1:0", outputDir)
+	config := docker.BasicConfiguration("127.0.0.1:0", registryDir)
 	registry, err := docker.NewRegistry(config)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err = registry.Start(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &layerExporter{
-		FieldLogger:      log,
-		dockerClient:     client,
-		registry:         registry,
-		progressReporter: progress,
-	}, nil
-}
-
-// layerExporter implements the logic of exporting layers of specified docker
-// images to the given output directory using an instance of a temporary
-// docker registry
-type layerExporter struct {
-	log.FieldLogger
-	dockerClient     docker.DockerInterface
-	registry         *docker.Registry
-	progressReporter utils.Progress
-}
-
-// push pushes the list of specified images into the temporary local registry
-func (r *layerExporter) push(ctx context.Context, images []string, parallel int) error {
-	group, ctx := run.WithContext(ctx, run.WithParallel(parallel))
-	for _, image := range images {
-		group.Go(ctx, r.pushImage(image))
-	}
-	if err := group.Wait(); err != nil {
 		return trace.Wrap(err)
 	}
+	if err = registry.Start(); err != nil {
+		return trace.Wrap(err)
+	}
+	defer func() {
+		if errStop := registry.Close(); errStop != nil {
+			log.Warnf("Failed to stop registry: %v.", errStop)
+		}
+	}()
+	s := docker.NewSynchronizer(log, dockerClient, progress)
+	regInfo := docker.RegistryInfo{
+		Address:  registry.Addr(),
+		Protocol: "http",
+	}
+
+	err = s.PullAndExportImages(ctx, images, regInfo, forcePull, parallel)
+	if err != nil {
+		return trace.Wrap(err, "failed to export image layers")
+	}
+
 	return nil
-}
-
-// stop stops the instance of the local registry
-func (r *layerExporter) stop() error {
-	return r.registry.Close()
-}
-
-func (r *layerExporter) pushImage(image string) func() error {
-	return func() error {
-		parsed, err := loc.ParseDockerImage(image)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if err = r.tagCmd(image, parsed.Repository, parsed.Tag); err != nil {
-			return trace.Wrap(err)
-		}
-		if err = r.pushCmd(parsed.Repository, parsed.Tag); err != nil {
-			r.Warnf("Failed to push %v: %v.", image, err)
-			return trace.Wrap(err)
-		}
-		r.progressReporter.PrintSubStep("Vendored image %v", image)
-		if err = r.removeTagCmd(parsed.Repository, parsed.Tag); err != nil {
-			r.Warnf("Failed to remove %v.", image)
-		}
-		return nil
-	}
-}
-
-func (r *layerExporter) tagCmd(image, repository, tag string) error {
-	opts := dockerapi.TagImageOptions{
-		Repo:  fmt.Sprintf("%v/%v", r.registry.Addr(), repository),
-		Tag:   tag,
-		Force: true,
-	}
-	r.Infof("Tagging %v with opts=%v.", image, opts)
-	return r.dockerClient.TagImage(image, opts)
-}
-
-func (r *layerExporter) pushCmd(name, tag string) error {
-	opts := dockerapi.PushImageOptions{
-		Name: fmt.Sprintf("%v/%v", r.registry.Addr(), name),
-		Tag:  tag,
-	}
-	r.Infof("Pushing %v.", opts)
-	// Workaround a registry issue after updating go-dockerclient, set the password field to an invalid value so the
-	// auth headers are set.
-	// https://github.com/moby/moby/issues/10983
-	return r.dockerClient.PushImage(opts, dockerapi.AuthConfiguration{
-		Password: "not-a-real-password",
-	})
-}
-
-func (r *layerExporter) removeTagCmd(name, tag string) error {
-	if tag == "" {
-		tag = "latest"
-	}
-	localImage := fmt.Sprintf("%v/%v:%v", r.registry.Addr(), name, tag)
-	r.Infof("Removing %v.", localImage)
-	return r.dockerClient.RemoveImage(localImage)
 }
 
 // parseImageNameTag parses the specified image reference into name/tag tuple.

--- a/lib/app/service/docker_test.go
+++ b/lib/app/service/docker_test.go
@@ -18,6 +18,8 @@ package service
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
 
 	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/loc"
@@ -81,5 +83,81 @@ func (s *VendorSuite) TestGeneratesProperPackageName(c *C) {
 		runtimePackage, err := generate(testCase.image)
 		c.Assert(err, IsNil, comment)
 		c.Assert(*runtimePackage, compare.DeepEquals, testCase.result, comment)
+	}
+}
+
+func Test_excludeImagesStartingWith(t *testing.T) {
+	type args struct {
+		images []string
+		prefix string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty input - no changes",
+			args: args{
+				images: []string{},
+				prefix: "123",
+			},
+			want: []string{},
+		},
+		{
+			name: "empty pattern - nothing is excluded",
+			args: args{
+				images: []string{"name1", "name2"},
+				prefix: "",
+			},
+			want: []string{"name1", "name2"},
+		},
+		{
+			name: "exclude all images. result is empty slice",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2"},
+				prefix: "registry1",
+			},
+			want: []string{},
+		},
+		{
+			name: "doesn't exclude images since the pattern does not match",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2", "registry2/name2"},
+				prefix: "registry3",
+			},
+			want: []string{"registry1/name1", "registry1/name2", "registry2/name2"},
+		},
+		{
+			name: "search pattern at the start of slice",
+			args: args{
+				images: []string{"registry1/image1", "registry1/image2", "registry2/image3", "registry2/image4"},
+				prefix: "registry1",
+			},
+			want: []string{"registry2/image3", "registry2/image4"},
+		},
+		{
+			name: "search pattern in the middle of slice",
+			args: args{
+				images: []string{"registry1/image1", "registry2/image2", "registry2/image3", "registry3/image4"},
+				prefix: "registry2",
+			},
+			want: []string{"registry1/image1", "registry3/image4"},
+		},
+		{
+			name: "search pattern at the end of slice",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2", "registry2/name2", "registry2/name3"},
+				prefix: "registry2",
+			},
+			want: []string{"registry1/name1", "registry1/name2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludeImagesStartingWith(tt.args.images, tt.args.prefix); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("excludeImagesStartingWith() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/gravitational/gravity/lib/app/hooks"
 	"github.com/gravitational/gravity/lib/app/resources"
 	"github.com/gravitational/gravity/lib/archive"
 	"github.com/gravitational/gravity/lib/constants"
@@ -101,6 +100,8 @@ type VendorRequest struct {
 	ResourcePatterns []string
 	// IgnoreResourcePatterns is a list of file path patterns to ignore when searching for images
 	IgnoreResourcePatterns []string
+	// ImageCacheDir is the directory were the pulled docker images are cached between builds
+	ImageCacheDir string
 	// SetImages is a list of images to rewrite to new versions
 	SetImages []loc.DockerImage
 	// SetDeps is a list of app dependencies to rewrite to new versions
@@ -208,6 +209,10 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 	log.Infof("Chart images: %v.", chartImages)
 
 	images = append(images, chartImages...)
+	// pull the default container image along with the rest of images
+	images = append(images, defaults.ContainerImage)
+
+	log.Infof("All images to push to the registry: %v.", images)
 
 	// Now that we have all referenced images in our local registry, and can find them without
 	// a registry prefix, rewrite our resource files to vendor the images.
@@ -230,25 +235,16 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 		return trace.Wrap(err)
 	}
 
-	// pull the default container image along with the rest of images
-	imagesToPull := append(images, defaults.ContainerImage)
-	imagesToPull = append(imagesToPull, runtimeImages...)
-
 	group, groupCtx := run.WithContext(ctx, run.WithParallel(req.Parallel))
-	for _, image := range imagesToPull {
+	for i := range runtimeImages {
+		image := runtimeImages[i] // create new variable for goroutine below
 		log := log.WithField("image", image)
-		if strings.HasPrefix(image, v.registryURL) {
-			// image has already been vendored
-			continue
-		}
-		image := image // create new variable for go routine below
 		group.Go(groupCtx, func() error {
 			// pull all missing images (this will correctly fail for images without a remote
 			// registry that do not exist i.e. due to failed image build)
 			if err := pullMissingRemoteImage(image, v.dockerPuller, log, req); err != nil {
 				return trace.Wrap(err)
 			}
-
 			// tag all images without their registry, so that we can find them later after
 			// stripping remote registries
 			if err := tagImageWithoutRegistry(image, v.dockerClient, log); err != nil {
@@ -272,29 +268,8 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 		return trace.Wrap(err)
 	}
 
-	if ok, _ := utils.IsDirectory(filepath.Join(unpackedDir, defaults.RegistryDir)); ok {
-		log.Debug("Registry layers are present.")
-		return nil
-	}
-
-	// if the application package does not contain the dump of docker images of the referenced
-	// containers, pull all the necessary images, then export those images to disk
-	images, err = resourceFiles.Images()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	images = append(images, hooks.InitContainerImage)
-	for i, image := range images {
-		images[i] = v.imageService.Unwrap(image)
-	}
-
-	log.Infof("No registry layers found, will pull and export images %q.", images)
-	if err = v.pullAndExportImages(ctx, teleutils.Deduplicate(images), unpackedDir, req.Parallel, req.ProgressReporter); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if err = v.pullAndExportImages(ctx, teleutils.Deduplicate(chartImages), unpackedDir, req.Parallel, req.ProgressReporter); err != nil {
+	if err = v.pullAndExportImages(ctx, teleutils.Deduplicate(images), unpackedDir, req.ImageCacheDir, req.Parallel,
+		req.Pull, req.ProgressReporter); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -379,7 +354,14 @@ func printResourceStatus(resourceFile resources.ResourceFile, req VendorRequest)
 // pullAndExportImages pulls the docker images of all referenced container images (if not yet
 // present locally), pushes them into an instance of a private docker registry and then
 // dumps the contents of this private registry into the specified directory
-func (v *vendorer) pullAndExportImages(ctx context.Context, images []string, exportDir string, parallel int, progress utils.Progress) error {
+func (v *vendorer) pullAndExportImages(ctx context.Context, images []string, exportDir, dockerCacheDir string,
+	parallel int, forcePull bool, progress utils.Progress) error {
+	if dockerCacheDir != "" {
+		_, err := utils.StatDir(dockerCacheDir)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	resourcesDir := filepath.Join(exportDir, "resources")
 	if err := os.MkdirAll(resourcesDir, defaults.PrivateDirMask); err != nil {
 		return trace.Wrap(trace.ConvertSystemError(err),
@@ -397,9 +379,22 @@ func (v *vendorer) pullAndExportImages(ctx context.Context, images []string, exp
 			"failed to create %q", layersDir)
 	}
 
-	if err := exportLayers(ctx, exportDir, images, v.dockerClient,
-		log.WithField("export-directory", exportDir), parallel, progress); err != nil {
+	registryDir := layersDir
+	if dockerCacheDir != "" {
+		registryDir = dockerCacheDir
+	}
+
+	if err := exportLayers(ctx, registryDir, images, v.dockerClient,
+		log.WithField("export-directory", registryDir), parallel, forcePull, progress); err != nil {
 		return trace.Wrap(err)
+	}
+	if dockerCacheDir != "" {
+		if err := utils.CopyDirContents(dockerCacheDir, layersDir); err != nil {
+			return trace.Wrap(err, "failed to copy directory from %q to %q", dockerCacheDir, layersDir)
+		}
+		if err := docker.CleanRegistry(ctx, layersDir, images); err != nil {
+			return trace.Wrap(err, "failed to clean registry %s", registryDir)
+		}
 	}
 	return nil
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -268,7 +268,8 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 		return trace.Wrap(err)
 	}
 
-	if err = v.pullAndExportImages(ctx, teleutils.Deduplicate(images), unpackedDir, req.ImageCacheDir, req.Parallel,
+	exportImages := excludeImagesStartingWith(teleutils.Deduplicate(images), v.registryURL)
+	if err = v.pullAndExportImages(ctx, exportImages, unpackedDir, req.ImageCacheDir, req.Parallel,
 		req.Pull, req.ProgressReporter); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/docker/cleaner.go
+++ b/lib/docker/cleaner.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+
+	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/loc"
+
+	"github.com/docker/distribution"
+	dockerref "github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/storage"
+	"github.com/docker/distribution/registry/storage/driver/filesystem"
+	"github.com/gravitational/trace"
+)
+
+// CleanRegistry removes images not present in requiredImages from registry rooted at registryDir
+func CleanRegistry(ctx context.Context, registryDir string, requiredImages []string) error {
+	c, err := newCleaner(ctx, registryDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	unusedIndex, err := c.indexUnused(ctx, requiredImages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err = c.untag(ctx, unusedIndex); err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(c.deleteUnusedBlobs(ctx))
+}
+
+func newCleaner(ctx context.Context, registryDir string) (*cleaner, error) {
+	driver := filesystem.New(filesystem.DriverParameters{
+		RootDirectory: registryDir,
+		MaxThreads:    defaults.ImageServiceMaxThreads,
+	})
+	registry, err := storage.NewRegistry(ctx, driver, storage.EnableDelete)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	repositoryEnumerator, ok := registry.(distribution.RepositoryEnumerator)
+	if !ok {
+		return nil, trace.Errorf("unable to convert Registry to RepositoryEnumerator")
+	}
+	return &cleaner{
+		registry: registry,
+		driver:   driver,
+		enum:     repositoryEnumerator,
+	}, nil
+}
+
+func (c *cleaner) indexUnused(ctx context.Context, images []string) (*repoIndex, error) {
+	repoIndex, err := imagesToRepoIndex(images)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	deletedIndex := newRepoIndex()
+	err = c.enum.Enumerate(ctx, func(repoName string) error {
+		requiredRepoTagIndex := repoIndex.getTagIndex(repoName)
+
+		repository, err := c.getRepository(ctx, repoName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		tags, err := repository.Tags(ctx).All(ctx)
+		if err != nil {
+			return trace.Wrap(err, "failed to get all tags for repo name %s", repoName)
+		}
+		for _, tag := range tags {
+			// need to delete entire repository
+			if requiredRepoTagIndex == nil {
+				deletedIndex.ensureTagIndex(repoName).add(tag)
+				continue
+			}
+
+			if !requiredRepoTagIndex.tags[tag] {
+				deletedIndex.ensureTagIndex(repoName).add(tag)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return deletedIndex, nil
+}
+
+func (c *cleaner) getRepository(ctx context.Context, name string) (distribution.Repository, error) {
+	named, err := dockerref.WithName(name)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse repo name %s", name)
+	}
+	repository, err := c.registry.Repository(ctx, named)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to construct repository")
+	}
+	return repository, nil
+}
+
+// untag untags the images given with index from the registry
+func (c *cleaner) untag(ctx context.Context, index *repoIndex) error {
+	for _, repoTagIndex := range index.repos {
+		repository, err := c.getRepository(ctx, repoTagIndex.name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		tagService := repository.Tags(ctx)
+		for tag := range repoTagIndex.tags {
+			err := tagService.Untag(ctx, tag)
+			if err != nil {
+				return trace.Wrap(err, "unable to untag %s:%s", repoTagIndex.name, tag)
+			}
+		}
+	}
+	return nil
+}
+
+type cleaner struct {
+	enum     distribution.RepositoryEnumerator
+	registry distribution.Namespace
+	driver   *filesystem.Driver
+}
+
+func (c *cleaner) deleteUnusedBlobs(ctx context.Context) error {
+	opts := storage.GCOpts{
+		RemoveUntagged: true,
+	}
+	return trace.Wrap(storage.MarkAndSweep(ctx, c.driver, c.registry, opts))
+}
+
+type repoIndex struct {
+	repos map[string]*repoTagIndex
+}
+
+func newRepoIndex() *repoIndex {
+	return &repoIndex{
+		repos: map[string]*repoTagIndex{},
+	}
+}
+
+func (r *repoIndex) getTagIndex(repoName string) *repoTagIndex {
+	return r.repos[repoName]
+}
+
+func (r *repoIndex) ensureTagIndex(repoName string) *repoTagIndex {
+	repoTagIndex := r.repos[repoName]
+	if repoTagIndex == nil {
+		repoTagIndex = newRepoTagIndex(repoName)
+		r.repos[repoName] = repoTagIndex
+	}
+	return repoTagIndex
+}
+
+type repoTagIndex struct {
+	name string
+	tags map[string]bool
+}
+
+func (t *repoTagIndex) add(tag string) {
+	t.tags[tag] = true
+}
+
+func newRepoTagIndex(name string) *repoTagIndex {
+	return &repoTagIndex{
+		name: name,
+		tags: map[string]bool{},
+	}
+}
+
+func imagesToRepoIndex(images []string) (*repoIndex, error) {
+	index := newRepoIndex()
+	for _, image := range images {
+		parsedImage, err := loc.ParseDockerImage(image)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		index.ensureTagIndex(parsedImage.Repository).add(parsedImage.Tag)
+	}
+	return index, nil
+}

--- a/lib/docker/cleaner_test.go
+++ b/lib/docker/cleaner_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"sort"
+
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/utils"
+
+	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&CleanerSuite{})
+
+type CleanerSuite struct {
+	client      *dockerapi.Client
+	sync        *Synchronizer
+	registry    *registryHelper
+	registryDir string
+}
+
+func (s *CleanerSuite) SetUpTest(c *check.C) {
+	var err error
+	s.client, err = NewClientFromEnv()
+	c.Assert(err, check.IsNil)
+	s.sync = NewSynchronizer(logrus.New(), s.client, utils.DiscardProgress)
+	s.registryDir = c.MkDir()
+	s.registry = newRegistry(s.registryDir, s.sync, c)
+}
+
+func (s *CleanerSuite) TearDownTest(*check.C) {
+	_ = s.registry.r.Close()
+}
+
+func (s *CleanerSuite) removeImages(images []loc.DockerImage) {
+	for _, image := range images {
+		// Error is ignored since this is a best-effort cleanup
+		_ = s.client.RemoveImage(image.String())
+	}
+}
+
+func (s *CleanerSuite) generateImages(c *check.C) ([]loc.DockerImage, []loc.DockerImage, []loc.DockerImage) {
+	cleanImages := generateDockerImages(s.client, "test/clean", 5, c)
+	validImages := generateDockerImages(s.client, "test/valid", 5, c)
+	invalidImages := generateDockerImages(s.client, "test/invalid", 6, c)
+
+	allImages := make([]loc.DockerImage, 0)
+	allImages = append(allImages, cleanImages...)
+	allImages = append(allImages, validImages...)
+	allImages = append(allImages, invalidImages...)
+
+	requiredImages := make([]loc.DockerImage, 0)
+	requiredImages = append(requiredImages, validImages...)
+	requiredImages = append(requiredImages, invalidImages[3:]...)
+
+	expectedDeletedImages := make([]loc.DockerImage, 0)
+	expectedDeletedImages = append(expectedDeletedImages, cleanImages...)
+	expectedDeletedImages = append(expectedDeletedImages, invalidImages[:3]...)
+
+	return allImages, requiredImages, expectedDeletedImages
+}
+
+func getTags(images []loc.DockerImage, repoName string) []string {
+	tags := make([]string, 0)
+	for _, image := range images {
+		if image.Repository == repoName {
+			tags = append(tags, image.Tag)
+		}
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+func (s *CleanerSuite) TestCleanRegistry(c *check.C) {
+	allImages, requiredImages, expectedDeletedImages := s.generateImages(c)
+
+	defer s.removeImages(allImages)
+
+	s.registry.pushImages(allImages, c)
+	// registry http server must be stopped since CleanRegistry requires direct access to the registry's root directory
+	_ = s.registry.r.Close()
+
+	requiredImageReferences := make([]string, 0)
+	for _, i := range requiredImages {
+		requiredImageReferences = append(requiredImageReferences, i.String())
+	}
+	ctx := context.Background()
+
+	// delete unnecessary images
+	err := CleanRegistry(ctx, s.registryDir, requiredImageReferences)
+	c.Assert(err, check.IsNil)
+
+	// restart the registry http server to make sure all the required images are there
+	s.registry = newRegistry(s.registryDir, s.sync, c)
+
+	for _, image := range requiredImages {
+		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image.Repository, image.Tag)
+		c.Assert(err, check.IsNil)
+		c.Assert(exists, check.Equals, true)
+	}
+	for _, image := range expectedDeletedImages {
+		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image.Repository, image.Tag)
+		c.Assert(err, check.IsNil)
+		c.Assert(exists, check.Equals, false)
+	}
+	validTags, err := s.sync.ImageTags(ctx, s.registry.info.GetURL(), "test/valid")
+	c.Assert(err, check.IsNil)
+	sort.Strings(validTags)
+	c.Assert(validTags, check.DeepEquals, getTags(requiredImages, "test/valid"))
+
+	invalidTags, err := s.sync.ImageTags(ctx, s.registry.info.GetURL(), "test/invalid")
+	c.Assert(err, check.IsNil)
+	sort.Strings(invalidTags)
+	c.Assert(invalidTags, check.DeepEquals, getTags(requiredImages, "test/invalid"))
+
+	cleanedTags, err := s.sync.ImageTags(ctx, s.registry.info.GetURL(), "test/clean")
+	c.Assert(err, check.IsNil)
+	sort.Strings(cleanedTags)
+	c.Assert(cleanedTags, check.DeepEquals, getTags(requiredImages, "test/clean"))
+}

--- a/lib/docker/synchronizer.go
+++ b/lib/docker/synchronizer.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/run"
+	"github.com/gravitational/gravity/lib/utils"
+
+	"github.com/docker/distribution"
+	dockerref "github.com/docker/distribution/reference"
+	regclient "github.com/docker/distribution/registry/client"
+	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+// RegistryInfo contains information about connecting to a registry.
+type RegistryInfo struct {
+	// Address stores the address of the registry as host:port
+	Address string
+	// Protocol stores the Protocol (https or http)
+	Protocol string
+}
+
+// GetURL returns the url for current registry
+func (i *RegistryInfo) GetURL() string {
+	return fmt.Sprintf("%s://%s", i.Protocol, i.Address)
+}
+
+// NewSynchronizer creates a new docker image synchronizer responsible for exporting docker images to a filesystem during build.
+func NewSynchronizer(log log.FieldLogger, dockerClient DockerInterface, progressReporter utils.Progress) *Synchronizer {
+	return &Synchronizer{
+		log:              log,
+		dockerPuller:     NewDockerPuller(dockerClient),
+		dockerClient:     dockerClient,
+		progressReporter: progressReporter,
+	}
+}
+
+// Synchronizer contains the logic for pulling and exporting image layers
+type Synchronizer struct {
+	log              log.FieldLogger
+	dockerPuller     DockerPuller
+	dockerClient     DockerInterface
+	progressReporter utils.Progress
+}
+
+// Push pushes the specified image into the registry
+func (h *Synchronizer) Push(image, registryAddr string) error {
+	parsedImage, err := loc.ParseDockerImage(image)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	dstDockerImage := loc.DockerImage{
+		Registry:   registryAddr,
+		Repository: parsedImage.Repository,
+		Tag:        parsedImage.Tag,
+	}
+	if err = h.tagCmd(image, dstDockerImage); err != nil {
+		return trace.Wrap(err)
+	}
+	if err = h.pushCmd(dstDockerImage); err != nil {
+		h.log.Warnf("Failed to push %v: %v.", image, err)
+		return trace.Wrap(err).AddField("image", image)
+	}
+	h.progressReporter.PrintSubStep("Vendored image %v", image)
+	if err = h.removeTagCmd(dstDockerImage); err != nil {
+		h.log.WithError(err).Debugf("Failed to remove %v.", image)
+	}
+	return nil
+}
+
+func (h *Synchronizer) tagCmd(image string, tag loc.DockerImage) error {
+	opts := dockerapi.TagImageOptions{
+		Repo:  fmt.Sprintf("%v/%v", tag.Registry, tag.Repository),
+		Tag:   tag.Tag,
+		Force: true,
+	}
+	h.log.Infof("Tagging %v with opts=%v.", image, opts)
+	return trace.Wrap(h.dockerClient.TagImage(image, opts))
+}
+
+func (h *Synchronizer) pushCmd(image loc.DockerImage) error {
+	opts := dockerapi.PushImageOptions{
+		Name: fmt.Sprintf("%v/%v", image.Registry, image.Repository),
+		Tag:  image.Tag,
+	}
+	h.log.Infof("Pushing %v.", opts)
+	// Workaround a registry issue after updating go-dockerclient, set the password field to an invalid value so the
+	// auth headers are set.
+	// https://github.com/moby/moby/issues/10983
+	return trace.Wrap(h.dockerClient.PushImage(opts, dockerapi.AuthConfiguration{
+		Password: "not-a-real-password",
+	}))
+}
+
+// ImageExists checks if the image exists in the registry
+func (h *Synchronizer) ImageExists(ctx context.Context, registryURL, repository, tag string) (bool, error) {
+	refName, err := dockerref.WithName(repository)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	rep, err := regclient.NewRepository(refName, registryURL, nil)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	manifestService, err := rep.Manifests(ctx)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	_, err = manifestService.Get(ctx, "", distribution.WithTag(tag))
+	if err != nil {
+		if strings.Contains(err.Error(), "manifest unknown") {
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+	return true, nil
+}
+
+// PullAndExportImages pulls and pushes the list of specified images into the registry
+func (h *Synchronizer) PullAndExportImages(ctx context.Context, images []string, reg RegistryInfo, forcePull bool, parallel int) error {
+	group, ctx := run.WithContext(ctx, run.WithParallel(parallel))
+	for i := range images {
+		image := images[i]
+		group.Go(ctx, func() error {
+			return h.pullAndExportImageIfNeeded(ctx, image, reg, forcePull)
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (h *Synchronizer) pullAndExportImageIfNeeded(ctx context.Context, image string, reg RegistryInfo, forcePull bool) error {
+	if forcePull {
+		return h.pullAndPush(image, reg, true)
+	}
+	exists, err := h.checkImageInRegistry(ctx, image, reg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if exists {
+		h.log.Infof("Skip pushing image %q. The image is already in the registry.", image)
+		return nil
+	}
+	present, err := h.dockerPuller.IsImagePresent(image)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(h.pullAndPush(image, reg, !present))
+}
+
+func (h *Synchronizer) checkImageInRegistry(ctx context.Context, image string, reg RegistryInfo) (bool, error) {
+	parsedImage, err := loc.ParseDockerImage(image)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	exists, err := h.ImageExists(ctx, reg.GetURL(), parsedImage.Repository, parsedImage.Tag)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return exists, nil
+}
+
+func (h *Synchronizer) pullAndPush(image string, reg RegistryInfo, needPull bool) error {
+	if needPull {
+		err := h.dockerPuller.Pull(image)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return trace.Wrap(h.Push(image, reg.Address))
+}
+
+// ImageTags returns the list of tags for specified image from the registry
+func (h *Synchronizer) ImageTags(ctx context.Context, registryURL, repository string) ([]string, error) {
+	refName, err := dockerref.WithName(repository)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rep, err := regclient.NewRepository(refName, registryURL, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	list, err := rep.Tags(ctx).All(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return list, nil
+}
+
+func (h *Synchronizer) removeTagCmd(tag loc.DockerImage) error {
+	localImage := tag.String()
+	h.log.Infof("Removing %v.", localImage)
+	return h.dockerClient.RemoveImage(localImage)
+}

--- a/lib/docker/synchronizer_test.go
+++ b/lib/docker/synchronizer_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/gravitational/gravity/lib/archive"
+	"github.com/gravitational/gravity/lib/loc"
+	"github.com/gravitational/gravity/lib/utils"
+
+	. "gopkg.in/check.v1"
+
+	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
+)
+
+// Set up a separate Suite for this test so we can use SetUp/TearDown phases
+type DockerSuite struct {
+	client   *dockerapi.Client
+	helper   *Synchronizer
+	src, dst *registryHelper
+}
+
+func (s *DockerSuite) SetUpTest(c *C) {
+	var err error
+	s.client, err = NewClientFromEnv()
+	c.Assert(err, IsNil)
+	s.helper = NewSynchronizer(logrus.New(), s.client, utils.DiscardProgress)
+	// Set up source and destination registries
+	s.src = newRegistry(c.MkDir(), s.helper, c)
+	s.dst = newRegistry(c.MkDir(), s.helper, c)
+}
+
+func (s *DockerSuite) TearDownTest(*C) {
+	s.src.r.Close()
+	s.dst.r.Close()
+}
+
+func (s *DockerSuite) listTags(repository string, c *C) (tags map[string]bool) {
+	opts := dockerapi.ListImagesOptions{Filters: map[string][]string{
+		"reference": {repository},
+	}}
+	images, err := s.client.ListImages(opts)
+	c.Assert(err, IsNil)
+	tags = make(map[string]bool)
+	for _, image := range images {
+		for _, imageName := range image.RepoTags {
+			dockerImage, err := loc.ParseDockerImage(imageName)
+			c.Assert(err, IsNil)
+			tags[dockerImage.Tag] = true
+		}
+	}
+	return tags
+}
+
+// newRegistry returns a new started docker registry
+func newRegistry(dir string, s *Synchronizer, c *C) *registryHelper {
+	config := BasicConfiguration("127.0.0.1:0", dir)
+	r, err := NewRegistry(config)
+	c.Assert(err, IsNil)
+	c.Assert(r.Start(), IsNil)
+	return &registryHelper{
+		r:   r,
+		dir: dir,
+		info: RegistryInfo{
+			Address:  r.Addr(),
+			Protocol: "http",
+		},
+		helper: s,
+	}
+}
+
+func generateDockerImage(client *dockerapi.Client, repoName, tag string, c *C) loc.DockerImage {
+	image := loc.DockerImage{
+		Repository: repoName,
+		Tag:        tag,
+	}
+	imageName := image.String()
+	files := make([]*archive.Item, 0)
+	files = append(files, archive.ItemFromStringMode("version.txt", tag, 0666))
+	dockerFile := "FROM scratch\nCOPY version.txt .\n"
+	files = append(files, archive.ItemFromStringMode("Dockerfile", dockerFile, 0666))
+	r := archive.MustCreateMemArchive(files)
+	c.Assert(client.BuildImage(dockerapi.BuildImageOptions{
+		Name:         imageName,
+		InputStream:  r,
+		OutputStream: os.Stdout,
+	}), IsNil)
+	return image
+}
+
+func generateDockerImages(client *dockerapi.Client, repoName string, size int, c *C) []loc.DockerImage {
+	// Use a predictable tagging scheme
+	imageTag := func(i int) string {
+		return fmt.Sprintf("v0.0.%d", i)
+	}
+	images := make([]loc.DockerImage, 0, size)
+	for i := 0; i < size; i++ {
+		image := generateDockerImage(client, repoName, imageTag(i), c)
+		images = append(images, image)
+	}
+	return images
+}
+
+func (s *DockerSuite) removeImages(images []loc.DockerImage) {
+	for _, image := range images {
+		// Error is ignored since this is a best-effort cleanup
+		_ = s.client.RemoveImage(image.String())
+	}
+}
+
+func (s *DockerSuite) removeTaggedImages(registryAddr string, images []loc.DockerImage) {
+	for _, image := range images {
+		// Error is ignored since this is a best-effort cleanup
+		image.Registry = registryAddr
+		_ = s.client.RemoveImage(image.String())
+	}
+}
+
+func (r *registryHelper) push(image loc.DockerImage, c *C) {
+	c.Assert(r.helper.Push(image.String(), r.r.Addr()), IsNil)
+}
+
+func (r *registryHelper) pushImages(images []loc.DockerImage, c *C) {
+	for _, image := range images {
+		r.push(image, c)
+	}
+}
+
+type registryHelper struct {
+	dir    string
+	r      *Registry
+	info   RegistryInfo
+	helper *Synchronizer
+}
+
+func splitAsTagsAndImages(images []loc.DockerImage, regAddr string) (tags, exportedImages []string) {
+	for _, image := range images {
+		tags = append(tags, image.Tag)
+
+		exportedImage := image
+		exportedImage.Registry = regAddr
+		exportedImages = append(exportedImages, exportedImage.String())
+	}
+	sort.Strings(tags)
+	return tags, exportedImages
+}
+
+const imageRepository = "test/image"
+
+var _ = Suite(&DockerSuite{})
+
+func (s *DockerSuite) TestPullAndPushImages(c *C) {
+	// Setup
+	const dockerImageSize = 6
+
+	dockerImages := generateDockerImages(s.client, imageRepository, dockerImageSize, c)
+	defer s.removeImages(dockerImages)
+	defer s.removeTaggedImages(s.src.info.Address, dockerImages)
+
+	// the first 3 docker images are pushed to both registries
+	var pushedDockerTags []string
+	for _, image := range dockerImages[:3] {
+		s.src.push(image, c)
+		s.dst.push(image, c)
+		pushedDockerTags = append(pushedDockerTags, image.Tag)
+	}
+	sort.Strings(pushedDockerTags)
+
+	// the last docker images are pushed only to the source registry
+	var unpushedDockerTags []string
+	for _, image := range dockerImages[3:] {
+		s.src.push(image, c)
+		unpushedDockerTags = append(unpushedDockerTags, image.Tag)
+	}
+
+	allDockerTags, exportedImages := splitAsTagsAndImages(dockerImages, s.src.r.Addr())
+	srcImageRepository := fmt.Sprintf("%s/%s", s.src.r.Addr(), imageRepository)
+	localImageTags := s.listTags(srcImageRepository, c)
+
+	// generated docker images should not be in the local docker registry
+	for _, tag := range allDockerTags {
+		if localImageTags[tag] {
+			c.Errorf("image %s:%s should not be in the local docker registry", imageRepository, tag)
+		}
+	}
+
+	// all docker images should be in the source docker registry
+	srcTags, err := s.helper.ImageTags(context.Background(), s.src.info.GetURL(), imageRepository)
+	c.Assert(err, IsNil)
+	sort.Strings(srcTags)
+	c.Assert(srcTags, DeepEquals, allDockerTags)
+
+	// only pushed docker images should be in the target docker registry
+	dstTags, err := s.helper.ImageTags(context.Background(), s.dst.info.GetURL(), imageRepository)
+	c.Assert(err, IsNil)
+	sort.Strings(dstTags)
+	c.Assert(dstTags, DeepEquals, pushedDockerTags)
+
+	// export images
+	err = s.helper.PullAndExportImages(context.Background(), exportedImages, s.dst.info, false, dockerImageSize)
+	c.Assert(err, IsNil)
+
+	// Validate: this is where actual validation starts
+	// relist tags
+	localImageTags = s.listTags(srcImageRepository, c)
+
+	// only unpushed docker images should not be in the local docker registry
+	for _, tag := range unpushedDockerTags {
+		if !localImageTags[tag] {
+			c.Errorf("image %s:%s should be in the local docker registry", srcImageRepository, tag)
+		}
+	}
+	for _, tag := range pushedDockerTags {
+		if localImageTags[tag] {
+			c.Errorf("image %s:%s should not be in the local docker registry", srcImageRepository, tag)
+		}
+	}
+
+	// all docker images should be in the target docker registry
+	dstTags, err = s.helper.ImageTags(context.Background(), s.dst.info.GetURL(), imageRepository)
+	c.Assert(err, IsNil)
+	sort.Strings(dstTags)
+	c.Assert(dstTags, DeepEquals, allDockerTags)
+}

--- a/tool/tele/cli/commands.go
+++ b/tool/tele/cli/commands.go
@@ -59,6 +59,8 @@ type BuildCmd struct {
 	OutFile *string
 	// Overwrite overwrites existing tarball
 	Overwrite *bool
+	// ImageCacheDir is the docker image cache directory to speed up subsequent builds
+	ImageCacheDir *string
 	// Name allows to override app name
 	Name *string
 	// Version allows to override app version

--- a/tool/tele/cli/register.go
+++ b/tool/tele/cli/register.go
@@ -44,6 +44,7 @@ func RegisterCommands(app *kingpin.Application) Application {
 	tele.BuildCmd.ManifestPath = tele.BuildCmd.Arg("path", fmt.Sprintf("Path to the cluster image manifest file (must be named %q), or unpacked Helm chart to build an application image out of.", defaults.ManifestFileName)).Default(defaults.ManifestFileName).String()
 	tele.BuildCmd.OutFile = tele.BuildCmd.Flag("output", "Cluster or application image file name. Defaults to <name>-<version>.tar.").Short('o').String()
 	tele.BuildCmd.Overwrite = tele.BuildCmd.Flag("overwrite", "Overwrite the existing image file.").Short('f').Bool()
+	tele.BuildCmd.ImageCacheDir = tele.BuildCmd.Flag("image-cache-dir", "The docker image cache directory to speed up subsequent builds.").String()
 	tele.BuildCmd.Name = tele.BuildCmd.Flag("name", "Optional cluster image name, overrides the one specified in the manifest file.").Hidden().String()
 	tele.BuildCmd.Version = tele.BuildCmd.Flag("version", "Optional cluster image version, overrides the one specified in the manifest file.").Hidden().String()
 	tele.BuildCmd.VendorPatterns = tele.BuildCmd.Flag("glob", "File pattern to search for container image references.").Default(defaults.VendorPattern).Hidden().Strings()

--- a/tool/tele/cli/run.go
+++ b/tool/tele/cli/run.go
@@ -66,6 +66,7 @@ func Run(tele Application) error {
 			PackageVersion:         *tele.BuildCmd.Version,
 			ResourcePatterns:       *tele.BuildCmd.VendorPatterns,
 			IgnoreResourcePatterns: *tele.BuildCmd.VendorIgnorePatterns,
+			ImageCacheDir:          *tele.BuildCmd.ImageCacheDir,
 			SetImages:              *tele.BuildCmd.SetImages,
 			SetDeps:                *tele.BuildCmd.SetDeps,
 			Parallel:               *tele.BuildCmd.Parallel,


### PR DESCRIPTION
## Description
This PR adds a new `--image-cache-dir` flag. This path will correspond to the file store for the docker registry. When `tele build` creates a new tarball, each docker image will be put into this registry. And this folder is copied to `vendor/registry` when building target app.
This cache registry will contain all tagged images from the previous build. But after this directory is copied to `vendor/ registry`, the cleanup procedure will remove all unnecessary images.

These are not breaking changes. If you do not use this flag, then everything works as before.


## Type of change
* New feature (non-breaking change which adds functionality)act

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2540

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
