### PR TITLE
allow gravity workers to install into separate regions

### DIFF
--- a/tool/gravity/cli/commands.go
+++ b/tool/gravity/cli/commands.go
@@ -483,6 +483,9 @@ type AutoJoinCmd struct {
 	// the client will simply connect to the service and stream its output and errors
 	// and control whether it should stop
 	FromService *bool
+	// Region specifies the region the cluster controllers is running in, so the worker can discover the cluster
+	// in the correct region
+	Region *string
 }
 
 // LeaveCmd removes the current node from the cluster

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -1095,6 +1095,7 @@ type autojoinConfig struct {
 	advertiseAddr string
 	token         string
 	seLinux       bool
+	region        string
 }
 
 func (r *agentConfig) newServiceArgs(gravityPath string) (args []string) {
@@ -1206,6 +1207,7 @@ func updateJoinConfigFromCloudMetadata(ctx context.Context, config *autojoinConf
 
 	autoscaler, err := autoscaleaws.New(autoscaleaws.Config{
 		ClusterName: config.clusterName,
+		Region:      config.region,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/gravity/cli/register.go
+++ b/tool/gravity/cli/register.go
@@ -130,6 +130,7 @@ func RegisterCommands(app *kingpin.Application) *Application {
 	g.AutoJoinCmd.Token = g.AutoJoinCmd.Flag("token", "Unique token to authorize this node to join the cluster.").Hidden().String()
 	g.AutoJoinCmd.SELinux = g.AutoJoinCmd.Flag("selinux", "Run with SELinux support. Default 'false'.").Default("false").Envar(defaults.GravitySELinuxEnv).Bool()
 	g.AutoJoinCmd.FromService = g.AutoJoinCmd.Flag("from-service", "Run in service mode.").Hidden().Bool()
+	g.AutoJoinCmd.Region = g.AutoJoinCmd.Flag("region", "The region to discover the controller nodes").String()
 
 	g.LeaveCmd.CmdClause = g.Command("leave", "Decommission this node from the cluster.")
 	g.LeaveCmd.Force = g.LeaveCmd.Flag("force", "Force local state cleanup.").Bool()

--- a/tool/gravity/cli/run.go
+++ b/tool/gravity/cli/run.go
@@ -388,6 +388,7 @@ func Execute(g *Application, cmd string, extraArgs []string) (err error) {
 			serviceURL:    *g.AutoJoinCmd.ServiceAddr,
 			token:         *g.AutoJoinCmd.Token,
 			advertiseAddr: *g.AutoJoinCmd.AdvertiseAddr,
+			region:        *g.AutoJoinCmd.Region,
 		})
 	case g.UpdateCheckCmd.FullCommand():
 		return updateCheck(localEnv, *g.UpdateCheckCmd.App)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Quick and dirty gravity patch that allows worker nodes to join from a separate region in AWS. 