### PR TITLE
Move component version to a dedicated sub-makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,8 @@ GRAVITY_PKG_PATH ?= github.com/gravitational/gravity
 ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
-# Current Kubernetes version
-K8S_VER := 1.21.2
-# Kubernetes version suffix for the planet package, constructed by concatenating
-# major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
-# 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
-K8S_VER_SUFFIX := $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
+include versions.mk
+
 GOLFLAGS ?= -w -s
 GOLINT ?= golangci-lint
 GOLINT_PACKAGES ?= \
@@ -36,41 +32,22 @@ GOPATH ?= $(shell go env GOPATH)
 
 TODO_PKGS ?= lib/ mage/ tool/ e/
 
-ETCD_VER := v2.3.7
-
-FIO_VER ?= 3.15
 FIO_TAG := fio-$(FIO_VER)
 FIO_PKG_TAG := $(FIO_VER).0
 
 # Current versions of the dependencies
-CURRENT_TAG ?= $(shell ./version.sh)
-GRAVITY_TAG := $(CURRENT_TAG)
-# Abbreviated gravity version to use as a build ID
-GRAVITY_VERSION := $(CURRENT_TAG)
+GRAVITY_TAG ?= $(GRAVITY_VERSION)
 
 RELEASE_TARBALL_NAME ?=
 RELEASE_OUT ?=
 
-TELEPORT_TAG = 3.2.17
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 9.0.3-$(K8S_VER_SUFFIX)
-PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)
 WORMHOLE_APP_TAG := $(GRAVITY_TAG)
-INGRESS_APP_TAG ?= 0.0.1
-STORAGE_APP_TAG ?= 0.0.4
-LOGGING_APP_TAG ?= 7.1.2
-MONITORING_APP_TAG ?= 7.1.4
-DNS_APP_TAG = 7.1.2
-BANDWAGON_TAG ?= 7.1.0
 RBAC_APP_TAG := $(GRAVITY_TAG)
-TILLER_VERSION = 2.16.12
-TILLER_APP_TAG = 7.1.0
-SELINUX_VERSION ?= 6.0.0
-# URI of Wormhole container for default install
-WORMHOLE_IMG ?= quay.io/gravitational/wormhole:0.3.3
+
 # set this to true if you want to use locally built planet packages
 DEV_PLANET ?=
 OS := $(shell uname | tr '[:upper:]' '[:lower:]')

--- a/Makefile.buildx
+++ b/Makefile.buildx
@@ -3,43 +3,11 @@ CURRENT_DIR := $(realpath $(patsubst %/,%,$(dir $(MKFILE_PATH))))
 
 BUILDDIR ?= $(CURRENT_DIR)/_build
 
+include versions.mk
 GOLANG_VER := 1.13.8-stretch
-FIO_VER := 3.15
-TELEPORT_TAG = 3.2.17
-K8S_VER := 1.21.0
-# Kubernetes version suffix for the planet package, constructed by concatenating
-# major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
-# 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
-K8S_VER_SUFFIX := $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG := 9.0.0-$(K8S_VER_SUFFIX)
-PLANET_BRANCH := master
-# system applications
-INGRESS_APP_TAG := 0.0.1
-STORAGE_APP_TAG := 0.0.4
-LOGGING_APP_TAG := 7.1.2
-MONITORING_APP_TAG := 7.1.4
-DNS_APP_TAG := 7.1.2
-BANDWAGON_TAG := 7.1.0
-TILLER_VERSION := 2.16.12
-TILLER_APP_TAG := 7.1.0
-# abbreviated gravity version to use as a build ID
-GRAVITY_VERSION := $(shell ./version.sh)
-# grpc
-PROTOC_VER := 3.10.0
-PROTOC_PLATFORM := linux-x86_64
-GOGO_PROTO_TAG := v1.3.0
-GRPC_GATEWAY_TAG := v1.11.3
-# current Kubernetes version
-K8S_VER := 1.21.0
-# wormhole container URI for default install
-WORMHOLE_IMG ?= quay.io/gravitational/wormhole:0.3.3
-# selinux
-SELINUX_VERSION := 6.0.0
-SELINUX_REPO := git@github.com:a-palchikov/selinux.git
-SELINUX_BRANCH := dmitri/buildx
-#TODO(dima): update once the https://github.com/gravitational/selinux/pull/16 has been merged
-#SELINUX_REPO := git@github.com:gravitational/selinux.git
-#SELINUX_BRANCH := distro/centos_rhel/7
+
+SELINUX_REPO := git@github.com:gravitational/selinux.git
+SELINUX_BRANCH := distro/centos_rhel/7
 
 # Set to non-empty value to trigger streaming builder progress
 CI ?=
@@ -113,6 +81,7 @@ magnet-vars: | $(BUILDDIR)
 	@echo MAGNET_SELINUX_BRANCH=$(SELINUX_BRANCH)
 	@echo MAGNET_WORMHOLE_IMG=$(WORMHOLE_IMG)
 	@echo MAGNET_BUILD_VERSION=$(GRAVITY_VERSION)
+	@echo MAGNET_GOLANGCI_LINT_VER=$(GOLANGCI_LINT_VER)
 	@echo MAGNET_CI=$(CI)
 	@echo MAGNET_BUILDDIR=$(BUILDDIR)
 

--- a/Makefile.buildx
+++ b/Makefile.buildx
@@ -6,9 +6,6 @@ BUILDDIR ?= $(CURRENT_DIR)/_build
 include versions.mk
 GOLANG_VER := 1.13.8-stretch
 
-SELINUX_REPO := git@github.com:gravitational/selinux.git
-SELINUX_BRANCH := distro/centos_rhel/7
-
 # Set to non-empty value to trigger streaming builder progress
 CI ?=
 

--- a/build.assets/Dockerfile.buildx
+++ b/build.assets/Dockerfile.buildx
@@ -17,7 +17,7 @@ ENV GRPC_GATEWAY_ROOT /gopath/src/github.com/grpc-ecosystem/grpc-gateway
 ENV GOGOPROTO_ROOT /gopath/src/github.com/gogo/protobuf
 ENV PROTOC_URL https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GOPATH/bin ${GOLANGCI_VER}
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GOPATH/bin v${GOLANGCI_VER}
 
 # install development libraries used when compiling fio
 RUN --mount=type=cache,sharing=locked,id=gravity-aptlib,target=/var/lib/apt \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -14,6 +14,8 @@ LOCAL_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build
 # Path to the local gravity build assets directory used inside the container
 LOCAL_GRAVITY_BUILDDIR ?= /gopath/src/github.com/gravitational/gravity/build/$(GRAVITY_VERSION)
 
+include ../versions.mk
+
 DOCKER_ARGS ?= --pull
 NOROOT=-u $$(id -u):$$(id -g)
 BBOX = gravity-buildbox:latest
@@ -21,22 +23,11 @@ BBOX = gravity-buildbox:latest
 GRAVITY_WEB_APP_DIR ?= $(abspath $(LOCALDIR)/../web)/
 
 # Git versions (refspecs) for build targets
-TELEPORT_TAG ?= master
-PLANET_TAG ?= master
-PLANET_BRANCH ?= $(PLANET_TAG)
-BANDWAGON_TAG ?= 1.0.0
 BANDWAGON_BRANCH ?= $(BANDWAGON_TAG)
-LOGGING_APP_TAG ?= 0.0.1
 LOGGING_APP_BRANCH ?= $(LOGGING_APP_TAG)
-MONITORING_APP_TAG ?= 0.0.1
 MONITORING_APP_BRANCH ?= $(MONITORING_APP_TAG)
-INGRESS_APP_TAG ?= 0.0.1
 INGRESS_APP_BRANCH ?= $(INGRESS_APP_TAG)
-STORAGE_APP_TAG ?= 0.0.1
 STORAGE_APP_BRANCH ?= $(STORAGE_APP_TAG)
-K8S_APP_TAG ?= 0.0.1
-TILLER_APP_TAG ?= 0.0.1
-SELINUX_BRANCH ?= distro/centos_rhel/7
 
 GOLFLAGS ?= -w -s
 
@@ -49,7 +40,6 @@ INGRESS_APP_REPO = https://github.com/gravitational/ingress-app.git
 STORAGE_APP_REPO = https://github.com/gravitational/storage-app.git
 BANDWAGON_REPO = https://github.com/gravitational/bandwagon.git
 FIO_REPO = https://github.com/axboe/fio.git
-SELINUX_REPO = https://github.com/gravitational/selinux.git
 
 # Amazon S3
 BUILD_BUCKET_URL = s3://clientbuilds.gravitational.io
@@ -104,13 +94,6 @@ TEST_PACKAGES ?= $(GRAVITY_PKG_PATH)/lib/... $(GRAVITY_PKG_PATH)/tool/...
 
 # Version of the version tool
 VERSION_TAG := 0.0.2
-GOLANGCI_LINT_VER := 1.40.1
-
-# grpc
-PROTOC_VER ?= 3.10.0
-PROTOC_PLATFORM := linux-x86_64
-GOGO_PROTO_TAG ?= v1.3.0
-GRPC_GATEWAY_TAG ?= v1.11.3
 
 # Export variables for recursive make invocations
 export GRAVITY_PKG_PATH

--- a/build.assets/etcd.mk
+++ b/build.assets/etcd.mk
@@ -1,7 +1,7 @@
 where-am-i = $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 TEST_ETCD_CERTS := $(realpath $(dir $(call where-am-i))../assets/certs)
 TEST_ETCD_CONFIG := '{"nodes": ["https://localhost:4001"], "key":"/gravity/test", "tls_key_file": "$(TEST_ETCD_CERTS)/proxy1-key.pem", "tls_cert_file": "$(TEST_ETCD_CERTS)/proxy1.pem", "tls_ca_file": "$(TEST_ETCD_CERTS)/ca.pem"}'
-TEST_ETCD_IMAGE := quay.io/coreos/etcd:v2.3.7
+TEST_ETCD_IMAGE := quay.io/coreos/etcd:v$(ETCD_VER)
 TEST_ETCD_INSTANCE := testetcd0
 
 ifeq ($(TEST_ETCD_STATEFUL),yes)

--- a/mage/vars.go
+++ b/mage/vars.go
@@ -55,7 +55,10 @@ var (
 
 	// golangciVersion is the version of golangci-lint to use for linting
 	// https://github.com/golangci/golangci-lint/releases
-	golangciVersion = "v1.39.0"
+	golangciVersion = env.E(magnet.EnvVar{
+		Key:   "GOLANGCI_LINT_VER",
+		Short: "The version of Go linter",
+	})
 
 	// FIO vars
 	fioVersion = env.E(magnet.EnvVar{

--- a/versions.mk
+++ b/versions.mk
@@ -1,7 +1,7 @@
 
 FIO_VER ?= 3.15
 TELEPORT_TAG ?= 3.2.17
-ETCD_VER ?= v2.3.7
+ETCD_VER ?= 2.3.7
 # abbreviated gravity version to use as a build ID
 GRAVITY_VERSION ?= $(shell ./version.sh)
 # current Kubernetes version

--- a/versions.mk
+++ b/versions.mk
@@ -1,0 +1,35 @@
+
+FIO_VER ?= 3.15
+TELEPORT_TAG ?= 3.2.17
+ETCD_VER ?= v2.3.7
+# abbreviated gravity version to use as a build ID
+GRAVITY_VERSION ?= $(shell ./version.sh)
+# current Kubernetes version
+K8S_VER ?= 1.21.2
+# Kubernetes version suffix for the planet package, constructed by concatenating
+# major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
+# 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
+K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
+PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)
+PLANET_BRANCH ?= $(PLANET_TAG)
+# system applications
+INGRESS_APP_TAG ?= 0.0.1
+STORAGE_APP_TAG ?= 0.0.4
+LOGGING_APP_TAG ?= 7.1.2
+MONITORING_APP_TAG ?= 7.1.4
+DNS_APP_TAG ?= 7.1.2
+BANDWAGON_TAG ?= 7.1.0
+TILLER_VERSION ?= 2.16.12
+TILLER_APP_TAG ?= 7.1.0
+# grpc
+PROTOC_VER ?= 3.10.0
+PROTOC_PLATFORM ?= linux-x86_64
+GOGO_PROTO_TAG ?= v1.3.0
+GRPC_GATEWAY_TAG ?= v1.11.3
+GOLANGCI_LINT_VER ?= 1.40.1
+# wormhole container URI for default install
+WORMHOLE_IMG ?= quay.io/gravitational/wormhole:0.3.3
+SELINUX_VERSION ?= 6.0.0
+SELINUX_BRANCH ?= distro/centos_rhel/7
+SELINUX_REPO ?= https://github.com/gravitational/selinux.git
+


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Move component versions to a dedicated makefile to share between build pipelines.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review comments

## Testing

### Darwin/Linux
```
$ FIO_VER=3.27 make -f Makefile.buildx tarball
$ tar xf gravity.tar
$ /path/to/gravity package list --state-dir=. | grep fio
* gravitational.io/fio:3.27.0 7.6MB
```
The build also reflects the versions of other packages as specified in versions.mk.

## Linux

```
$ make -C e production telekube
```
Verified that the package versions were as specified in versions.mk.

Also green robotest results mean that the robotest scripts successfully assembled all the necessary cluster images.
