### PR TITLE
Updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Support Notice
 
-The gravity project is no longer under active development. The project's development has been limited to maintenance and support for our commercial customers until maintenance agreements expire.
+**The Gravity project is no longer under active development.** 
+The project's development has been limited to maintenance and support for our
+commercial customers until maintenance agreements expire.
 
-Please see our blog post for more information: https://goteleport.com/blog/gravitational-is-teleport/
+Please see our blog post for more information:
+https://goteleport.com/blog/gravitational-is-teleport/
 
 ---
 
-<a href='https://gravitational.com/gravity/'>
+<a href='https://gravitational.com/gravity/download/'>
     <img src='https://gravitational.com/gravitational/images/logos/logo-gravity-x-large.png' alt='Gravity'>
 </a>
 
@@ -20,7 +23,7 @@ the world without a massive DevOps team.
 
 |Project Links| Description
 |---|----
-| [Gravity Website](https://gravitational.com/gravity/)  | The official website of the enterprise edition of Gravity |
+| [Gravity Downloads](https://goteleport.com/gravity/download/)  | The latest binaries |
 | [Gravity Documentation](https://gravitational.com/gravity/docs/)  | Gravity Documentation |
 | [Gravity Examples](examples/) | Examples of applications packaged with Gravity |
 | [Blog](http://blog.gravitational.com) | Our blog, where we publish Gravity news |
@@ -41,7 +44,7 @@ Gravity has been running in production in major financial institutions,
 government data centers and enterprises. Gravitational open sourced it in the
 fall of 2018.
 
-<a href='https://gravitational.com/gravity/'>
+<a href='https://gravitational.com/gravity/download/'>
     <img src='https://gravitational.com/gravitational/images/graphics/gravity-oss-hero.png' alt='Gravity'>
 </a>
 


### PR DESCRIPTION
## Description

Removed dead links to /gravity/ page and replaced them with links to the downloads page.

## Type of change

Just the README file.

## Linked tickets and other PRs

The ticket is in the Teleport web site repo.
