### PR TITLE
[8.0.x] Do not export images starting with leader.telekube.local

### DIFF
--- a/lib/app/service/docker.go
+++ b/lib/app/service/docker.go
@@ -69,6 +69,22 @@ func exportLayers(
 	return nil
 }
 
+// excludeImagesStartingWith excludes the items witch start with prefix
+// It works with zero memory allocation and changes the input slice
+func excludeImagesStartingWith(images []string, prefix string) []string {
+	if prefix == "" {
+		return images
+	}
+	x := 0
+	for _, image := range images {
+		if !strings.HasPrefix(image, prefix) {
+			images[x] = image
+			x++
+		}
+	}
+	return images[:x]
+}
+
 // parseImageNameTag parses the specified image reference into name/tag tuple.
 // The returned name will include domain/path parts merged in a way to conform
 // to telekube package name syntax.

--- a/lib/app/service/docker_test.go
+++ b/lib/app/service/docker_test.go
@@ -18,6 +18,8 @@ package service
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
 
 	"github.com/gravitational/gravity/lib/compare"
 	"github.com/gravitational/gravity/lib/loc"
@@ -81,5 +83,81 @@ func (s *VendorSuite) TestGeneratesProperPackageName(c *C) {
 		runtimePackage, err := generate(testCase.image)
 		c.Assert(err, IsNil, comment)
 		c.Assert(*runtimePackage, compare.DeepEquals, testCase.result, comment)
+	}
+}
+
+func Test_excludeImagesStartingWith(t *testing.T) {
+	type args struct {
+		images []string
+		prefix string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty input - no changes",
+			args: args{
+				images: []string{},
+				prefix: "123",
+			},
+			want: []string{},
+		},
+		{
+			name: "empty pattern - nothing is excluded",
+			args: args{
+				images: []string{"name1", "name2"},
+				prefix: "",
+			},
+			want: []string{"name1", "name2"},
+		},
+		{
+			name: "exclude all images. result is empty slice",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2"},
+				prefix: "registry1",
+			},
+			want: []string{},
+		},
+		{
+			name: "doesn't exclude images since the pattern does not match",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2", "registry2/name2"},
+				prefix: "registry3",
+			},
+			want: []string{"registry1/name1", "registry1/name2", "registry2/name2"},
+		},
+		{
+			name: "search pattern at the start of slice",
+			args: args{
+				images: []string{"registry1/image1", "registry1/image2", "registry2/image3", "registry2/image4"},
+				prefix: "registry1",
+			},
+			want: []string{"registry2/image3", "registry2/image4"},
+		},
+		{
+			name: "search pattern in the middle of slice",
+			args: args{
+				images: []string{"registry1/image1", "registry2/image2", "registry2/image3", "registry3/image4"},
+				prefix: "registry2",
+			},
+			want: []string{"registry1/image1", "registry3/image4"},
+		},
+		{
+			name: "search pattern at the end of slice",
+			args: args{
+				images: []string{"registry1/name1", "registry1/name2", "registry2/name2", "registry2/name3"},
+				prefix: "registry2",
+			},
+			want: []string{"registry1/name1", "registry1/name2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludeImagesStartingWith(tt.args.images, tt.args.prefix); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("excludeImagesStartingWith() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/lib/app/service/vendor.go
+++ b/lib/app/service/vendor.go
@@ -268,7 +268,8 @@ func (v *vendorer) VendorDir(ctx context.Context, unpackedDir string, req Vendor
 		return trace.Wrap(err)
 	}
 
-	if err = v.pullAndExportImages(ctx, teleutils.Deduplicate(images), unpackedDir, req.ImageCacheDir, req.Parallel,
+	exportImages := excludeImagesStartingWith(teleutils.Deduplicate(images), v.registryURL)
+	if err = v.pullAndExportImages(ctx, exportImages, unpackedDir, req.ImageCacheDir, req.Parallel,
 		req.Pull, req.ProgressReporter); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
Images defined for the internal registry starting with leader.telekube.local: 5000 must be excluded from the export list.

## Type of change
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #2557
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2558

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
