### PR TITLE
Fix post-merge/nightly robotest configs and include 9.0.x upgrade testing

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -7,15 +7,12 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[7.1.0-alpha.5]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
-UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release
-UPGRADE_MAP[7.0.0]="ubuntu:16"
 
-# 6.3 won't be a supported upgrades to 7.1, it is not *intentionally* broken yet
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 6.3.x))]="centos:7.9" # compatible non-LTS version
-# UPGRADE_MAP[6.3.0]="ubuntu:16"  # disabled due to https://github.com/gravitational/gravity/issues/1009
+# Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.2 redhat:7.9 centos:8.2 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[8.0.0-beta.1]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
 function build_upgrade_size_suite {
   local to_tarball=${INSTALLER_URL}

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -7,8 +7,11 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> space separated list of linux distros to upgrade from
 declare -A UPGRADE_MAP
+# Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[8.0.0-beta.1]="redhat:7.9 centos:8.2 ubuntu:18"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
-UPGRADE_MAP[8.0.0-beta.0]="redhat:8.2 centos:7.9 ubuntu:16 ubuntu:18"
 
 function build_upgrade_suite {
   local size='"flavor":"three","nodes":3,"role":"node"'


### PR DESCRIPTION
## Description
This patch introduces two changes:

 - post-merge/nightly runs no longer attempt to upgrade from pre-7.1 as
   that gives too much kubernetes version skew.  This was missed in #2541
 - Add upgrade testing from the nascent 9.0 branch. This is new.

Without this, we're wasting time and money running upgrade tests that are expected to fail
after each merge to master, as seen in the many red Xs in the history of https://github.com/gravitational/gravity/commits/66b57ecbd50d05d84f34572a4261a5b49f1a9a39

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
N/A

## TODOs
- [x] Self-review the change
- [x] Address review feedback

## Testing done
The PR build covers the pr.sh changes.  I didn't take time to manually test the nightly.sh changes
because this seems low ROI, but I'm relatively confident in them.  If this is a red flag to any reviewers, I can loop back and test nightly.

