### PR TITLE
Replace deprecated kube controller-manager port

### DIFF
--- a/lib/install/phases/postsystem.go
+++ b/lib/install/phases/postsystem.go
@@ -189,7 +189,7 @@ func schedulerHealthz(ctx context.Context, leaderIP string) error {
 // controllerManagerHealthz checks for a healthy status from the controller-manager
 // healthz endpoint for the specified leaderIP.
 func controllerManagerHealthz(ctx context.Context, leaderIP string) error {
-	url := fmt.Sprintf("http://%s:%d/healthz", leaderIP, ports.InsecureKubeControllerManagerPort)
+	url := fmt.Sprintf("https://%s:%d/healthz", leaderIP, ports.KubeControllerManagerPort)
 	if err := healthzCheck(ctx, url); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Replace deprecated kube controller manager port. Used the wrong port in https://github.com/gravitational/gravity/pull/2562.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and PRs

* Requires https://github.com/gravitational/planet/pull/854

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->