### PR TITLE
Fixing 'canceled' mispelling for gravity leave confirmation check

### DIFF
--- a/tool/gravity/cli/input.go
+++ b/tool/gravity/cli/input.go
@@ -72,7 +72,7 @@ func enforceConfirmation(title string, args ...interface{}) error {
 		return trace.Wrap(err)
 	}
 	if !confirmed {
-		return trace.CompareFailed("Operation has been canceled by user.")
+		return trace.CompareFailed("Operation has been cancelled by user.")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Fixes `gravity leave --force` ignoring cancellation at confirmation dialog.

[utils.go](https://github.com/gravitational/gravity/blob/ad8a2289e9db9bb6e9dd7bb759c9b80f681d9bf6/tool/gravity/cli/utils.go#L236) expects the cancellation error with a spelling of "cancelled" however it was spelled "canceled" which caused the confirmation check's failure to identify a user entering 'no'. 

`return trace.IsCompareFailed(err) && strings.Contains(err.Error(), "cancelled")`

## Type of change
* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #2566

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Compiled and tested in my own environment.
Before change:
```
[root@ip-10-1-0-54 ec2-user]# ./gravity leave --force
Please confirm removing ip-10-1-0-54.ca-central-1.compute.internal (10.1.0.54) from the cluster (yes/no):
no
Fri Jul 16 18:03:00 UTC Uninstalling system service {gravitational.io/teleport:3.2.17 active}
Fri Jul 16 18:03:00 UTC Uninstalling system service {gravitational.io/planet:7.0.59-11709 active}
Fri Jul 16 18:03:17 UTC Removing network interface "flannel.1"
...
```
After change:
```
[root@ip-10-1-0-54 ec2-user]# ./gravity leave --force
Please confirm removing ip-10-1-0-54.ca-central-1.compute.internal (10.1.0.54) from the cluster (yes/no):
no
[ERROR]: Operation has been cancelled by user.
```

## Additional information
<!--Optional. Anything else that may be relevant.-->

This bug probably exists in other version of gravity as well though I haven't checked outside of 7.0.x to say for certain.
