### PR TITLE
Fix HA config update on an existing cluster

### DIFF
--- a/lib/ops/constants.go
+++ b/lib/ops/constants.go
@@ -55,8 +55,6 @@ const (
 	SiteLabelName = "Name"
 	// SystemRepository is the system package repository
 	SystemRepository = "gravitational.io"
-	// ProviderGeneric is the generic cluster infrastructure provider
-	ProviderGeneric = "generic"
 	// ProgressStateCompleted signifies the operation completed progress value
 	ProgressStateCompleted = "completed"
 	// ProgressStateInProgress signifies the operation in-progress progress value

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1440,7 +1440,7 @@ func (s *site) addClusterConfig(config clusterconfig.Interface, overrideArgs map
 		args = append(args,
 			fmt.Sprintf("--feature-gates=%v", strings.Join(features, ",")))
 	}
-	if globalConfig.HighAvailability {
+	if globalConfig.HighAvailability != nil && *globalConfig.HighAvailability {
 		args = append(args, "--high-availability")
 	}
 	return args

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -682,7 +682,7 @@ func (r configCollection) WriteText(w io.Writer) error {
 	if len(config.FeatureGates) != 0 {
 		fmt.Fprintf(t, "Feature Gates:\t%v\n", formatFeatureGates(config.FeatureGates))
 	}
-	fmt.Fprintf(t, "High Availability:\t%v\n", config.HighAvailability)
+	fmt.Fprintf(t, "High Availability:\t%v\n", formatBoolPtr(config.HighAvailability))
 	displayCloudConfig := config.CloudProvider != "" || config.CloudConfig != ""
 	if displayCloudConfig {
 		common.PrintCustomTableHeader(t, []string{"Cloud"}, "-")
@@ -737,6 +737,13 @@ func formatFeatureGates(features map[string]bool) string {
 		result = append(result, fmt.Sprintf("%v=%v", feature, enabled))
 	}
 	return strings.Join(result, ",")
+}
+
+func formatBoolPtr(ptr *bool) string {
+	if ptr == nil {
+		return "<unset>"
+	}
+	return fmt.Sprint(*ptr)
 }
 
 type operationsCollection struct {

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -164,7 +164,12 @@ func (r Resource) Merge(other Resource) Resource {
 			r.Spec.Global.FeatureGates[k] = v
 		}
 	}
-	r.Spec.Global.HighAvailability = other.Spec.Global.HighAvailability
+	if other.Spec.Global.HighAvailability != nil {
+		if r.Spec.Global.HighAvailability == nil {
+			r.Spec.Global.HighAvailability = new(bool)
+		}
+		*r.Spec.Global.HighAvailability = *other.Spec.Global.HighAvailability
+	}
 	return r
 }
 
@@ -270,6 +275,7 @@ func (r Global) IsEmpty() bool {
 		r.PodSubnetSize == "" &&
 		r.ServiceNodePortRange == "" &&
 		r.ProxyPortRange == "" &&
+		r.HighAvailability == nil &&
 		len(r.FeatureGates) == 0
 }
 
@@ -302,7 +308,7 @@ type Global struct {
 	// Targets: all components
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// HighAvailability enables high availability mode for Kubernetes.
-	HighAvailability bool `json:"highAvailability,omitempty"`
+	HighAvailability *bool `json:"highAvailability,omitempty"`
 }
 
 // specSchemaTemplate is JSON schema for the cluster configuration resource

--- a/lib/storage/clusterconfig/clusterconfig_test.go
+++ b/lib/storage/clusterconfig/clusterconfig_test.go
@@ -185,7 +185,7 @@ spec:
 							"FeatureB": false,
 						},
 						PodSubnetSize:    "26",
-						HighAvailability: true,
+						HighAvailability: newBoolPtr(true),
 					},
 				},
 			},
@@ -243,7 +243,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature1": true,
 							"feature2": false,
 						},
-						HighAvailability: true,
+						HighAvailability: newBoolPtr(true),
 					},
 				},
 			},
@@ -262,7 +262,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature1": true,
 							"feature2": false,
 						},
-						HighAvailability: true,
+						HighAvailability: newBoolPtr(true),
 					},
 				},
 			},
@@ -385,6 +385,10 @@ func validate(expectedConfig kubeletConfiguration) func(obtained, expected *Reso
 		obtained.Spec.ComponentConfigs.Kubelet.Config = configBytes
 		c.Assert(config, compare.DeepEquals, expectedConfig)
 	}
+}
+
+func newBoolPtr(b bool) *bool {
+	return &b
 }
 
 type kubeletConfiguration struct {

--- a/lib/validate/clusterconfig.go
+++ b/lib/validate/clusterconfig.go
@@ -19,6 +19,7 @@ package validate
 import (
 	"net"
 
+	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 
 	"github.com/gravitational/trace"
@@ -44,7 +45,7 @@ func ClusterConfiguration(existing, update clusterconfig.Interface) error {
 			return trace.BadParameter("cannot change cloud configuration: cluster does not have cloud provider configured")
 		}
 	}
-	if newGlobalConfig.CloudProvider != "" && globalConfig.CloudProvider != newGlobalConfig.CloudProvider {
+	if newGlobalConfig.CloudProvider != "" && globalConfig.CloudProvider != normalizedCloudProvider(newGlobalConfig.CloudProvider) {
 		return trace.BadParameter("changing cloud provider is not supported (%q -> %q)",
 			newGlobalConfig.CloudProvider, globalConfig.CloudProvider)
 	}
@@ -93,4 +94,13 @@ func ClusterConfiguration(existing, update clusterconfig.Interface) error {
 
 func isCloudConfigEmpty(global clusterconfig.Global) bool {
 	return global.CloudProvider == "" && global.CloudConfig == ""
+}
+
+func normalizedCloudProvider(provider string) string {
+	switch provider {
+	case schema.ProviderGeneric, schema.ProviderOnPrem:
+		return schema.ProviderOnPrem
+	default:
+		return provider
+	}
 }

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -1461,7 +1461,7 @@ func (i *InstallConfig) validateOrDetectCloudProvider(cloudProvider string, mani
 				"instance", cloudProvider)
 		}
 		return schema.ProviderGCE, nil
-	case ops.ProviderGeneric, schema.ProvisionerOnPrem:
+	case schema.ProviderGeneric, schema.ProvisionerOnPrem:
 		return schema.ProviderOnPrem, nil
 	case "":
 		log.Info("Will auto-detect provider.")

--- a/versions.mk
+++ b/versions.mk
@@ -10,8 +10,7 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-#PLANET_TAG ?= 9.0.4-$(K8S_VER_SUFFIX)
-PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)-3-g87470a2
+PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)
 PLANET_BRANCH ?= $(PLANET_TAG)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,8 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)
+#PLANET_TAG ?= 9.0.4-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)-3-g87470a2
 PLANET_BRANCH ?= $(PLANET_TAG)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Fixes an issue with the HA configuration update on an existing cluster.
While testing planet changes to accommodate the tip of coordinate (which was updated based on work on the [reconcile loop](https://github.com/gravitational/planet/pull/575) which was never merged) I stumbled on this behavior.

Given this configuration:
```
# config.yaml
kind: ClusterConfiguration
version: v1
spec:
  global:
    cloudProvider: generic
    highAvailability: true
```

Before the change:
```
$ gravity resource create -f ./haconfig.yaml --confirm
[ERROR]: provided cluster configuration is empty
```

After the change:
```
$ gravity resource create -f haconfig.yaml --confirm
gravity resource create -f ./haconfig.yaml --confirm
Mon Jul 19 13:29:51 UTC	Deploying agents on cluster nodes
Deployed agent on vm-2 (172.17.0.3)
Deployed agent on vm-3 (172.17.0.4)
Deployed agent on vm-1 (172.17.0.2)
Executing "/update-config" locally
Mon Jul 19 13:30:02 UTC	Update runtime configuration
Executing "/masters/vm-1/stepdown" locally
Mon Jul 19 13:30:04 UTC	Step down "vm-1" as Kubernetes leader
Disable leader elections on vm-1
Waiting for new leader election
Executing "/masters/vm-1/drain" locally
Mon Jul 19 13:30:06 UTC	Drain node "vm-1"
	Still executing "/masters/vm-1/drain" locally (10 seconds elapsed)
Executing "/masters/vm-1/restart" locally
Mon Jul 19 13:30:18 UTC	Restart container on node "vm-1"
	Still executing "/masters/vm-1/restart" locally (10 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (20 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (30 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (40 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (50 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (1 minute elapsed)
	Still executing "/masters/vm-1/restart" locally (1 minute elapsed)
	Still executing "/masters/vm-1/restart" locally (1 minute elapsed)
	Still executing "/masters/vm-1/restart" locally (1 minute elapsed)
	Still executing "/masters/vm-1/restart" locally (1 minute elapsed)
Executing "/masters/vm-1/elect" locally
Mon Jul 19 13:31:58 UTC	Make node "vm-1" Kubernetes leader
Disable leader elections on vm-2
Disable leader elections on vm-3
Enable leader elections on vm-1
Waiting for new leader election
Executing "/masters/vm-1/taint" locally
Mon Jul 19 13:32:00 UTC	Taint node "vm-1"
	Still executing "/masters/vm-1/taint" locally (10 seconds elapsed)
Executing "/masters/vm-1/uncordon" locally
Mon Jul 19 13:32:17 UTC	Uncordon node "vm-1"
Executing "/masters/vm-1/endpoints" locally
Mon Jul 19 13:32:19 UTC	Wait for endpoints on node "vm-1"
Executing "/masters/vm-1/untaint" locally
Mon Jul 19 13:32:20 UTC	Remove taint from node "vm-1"
Executing "/masters/vm-2/drain" on remote node vm-2
Mon Jul 19 13:32:21 UTC	Drain node "vm-2"
Executing "/masters/vm-2/restart" on remote node vm-2
Mon Jul 19 13:32:29 UTC	Restart container on node "vm-2"
	Still executing "/masters/vm-2/restart" on remote node vm-2 (10 seconds elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (20 seconds elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (30 seconds elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (40 seconds elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (50 seconds elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (1 minute elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (1 minute elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (1 minute elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (1 minute elapsed)
	Still executing "/masters/vm-2/restart" on remote node vm-2 (1 minute elapsed)
Executing "/masters/vm-2/taint" on remote node vm-2
Mon Jul 19 13:34:11 UTC	Taint node "vm-2"
Executing "/masters/vm-2/uncordon" on remote node vm-2
Mon Jul 19 13:34:13 UTC	Uncordon node "vm-2"
Executing "/masters/vm-2/endpoints" on remote node vm-2
Mon Jul 19 13:34:16 UTC	Wait for endpoints on node "vm-2"
Executing "/masters/vm-2/untaint" on remote node vm-2
Mon Jul 19 13:34:19 UTC	Remove taint from node "vm-2"
Executing "/masters/vm-2/enable-elections" on remote node vm-2
Mon Jul 19 13:34:22 UTC	Enable leader election on node "vm-2"
Executing "/masters/vm-3/drain" on remote node vm-3
Mon Jul 19 13:34:25 UTC	Drain node "vm-3"
Executing "/masters/vm-3/restart" on remote node vm-3
Mon Jul 19 13:34:31 UTC	Restart container on node "vm-3"
	Still executing "/masters/vm-3/restart" on remote node vm-3 (10 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (20 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (30 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (40 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (50 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (1 minute elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (1 minute elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (1 minute elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (1 minute elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (1 minute elapsed)
Executing "/masters/vm-3/taint" on remote node vm-3
Mon Jul 19 13:36:13 UTC	Taint node "vm-3"
Executing "/masters/vm-3/uncordon" on remote node vm-3
Mon Jul 19 13:36:15 UTC	Uncordon node "vm-3"
Executing "/masters/vm-3/endpoints" on remote node vm-3
Mon Jul 19 13:36:17 UTC	Wait for endpoints on node "vm-3"
Executing "/masters/vm-3/untaint" on remote node vm-3
Mon Jul 19 13:36:20 UTC	Remove taint from node "vm-3"
Executing "/masters/vm-3/enable-elections" on remote node vm-3
Mon Jul 19 13:36:23 UTC	Enable leader election on node "vm-3"
operation(update configuration(4cc884e6-553c-44dc-af28-01920e1aae8a), cluster=test, created=2021-07-19 13:29) finished in 6 minutes
```

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/planet/pull/855, https://github.com/gravitational/coordinate/pull/15

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
Tested with multiple HA configuration updates on a 3-node cluster (all control plane nodes).
