### PR TITLE
Add RHEL/CentOS 8.4 to gravity test matrix

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 3.0.0
+ROBOTEST_VERSION ?= 3.1.0
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build

--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -9,9 +9,9 @@ source $(dirname $0)/lib/utils.sh
 declare -A UPGRADE_MAP
 
 # Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[9.0.0-beta.2]="redhat:8.2 redhat:7.9 centos:8.2 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[8.0.0-beta.1]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[8.0.0-beta.1]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
 function build_upgrade_size_suite {
@@ -80,7 +80,7 @@ EOF
 }
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_sizes=( \
     '"flavor":"six","nodes":6,"role":"node"')
   for os in $oses; do

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -8,9 +8,9 @@ source $(dirname $0)/lib/utils.sh
 # UPGRADE_MAP maps gravity version -> space separated list of linux distros to upgrade from
 declare -A UPGRADE_MAP
 # Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
-UPGRADE_MAP[9.0.0-beta.2]="redhat:8.2 centos:7.9 ubuntu:18 ubuntu:20"
-UPGRADE_MAP[8.0.0-beta.1]="redhat:7.9 centos:8.2 ubuntu:18"
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[8.0.0-beta.1]="redhat:7.9 centos:8.4 ubuntu:18"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
 function build_upgrade_suite {
@@ -55,7 +55,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.3 redhat:7.9 centos:8.2 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
Add RHEL/CentOS 8.4 testing to the PR and post-merge robotest configs.
This ensures Gravity is and stays compatible with these releases.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/gravity/issues/2563
* Builds off https://github.com/gravitational/robotest/pull/287

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
CI covers all the important parts.

I did some manual testing during development. Here is a 3 node upgrade from 8.0.0-apha.0 to 9.0.0-beta.2: https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2294aeba7e-c495-4ac2-aeea-b7c23dbc826a%22%0Alabels.__suite__%3D%221162a757-f510-47de-b6a0-692225f76ad9%22;timeRange=2021-07-20T21:39:51Z%2F2021-07-20T22:39:51Z?project=robotest-production

## Additional information
Needs ports to 8.0 and 7.0.
