### PR TITLE
Use fixed 9.0.0-beta.2 tag instead of floating ref

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -22,7 +22,8 @@ function build_upgrade_size_suite {
     '"flavor":"six","nodes":6,"role":"node"' \
     '"flavor":"one","nodes":1,"role":"node"')
   local suite=''
-  local from_tarball=$(tag_to_image $(recommended_upgrade_tag $(branch 7.0.x)))
+  # local from_tarball=$(tag_to_image $(recommended_upgrade_tag $(branch 7.0.x)))
+  local from_tarball=$(tag_to_image 9.0.0-beta.2)
   for size in ${cluster_sizes[@]}; do
       suite+=$(build_upgrade_step $from_tarball $to_tarball $os $size)
     suite+=' '


### PR DESCRIPTION
## Description
We were still attempting some upgrades from 7.0.x latest to 9.0.0. These fail since 14b79594a48f6bef7512af60b16c49b930feba9b, as seen at https://drone.teleport.dev/gravitational/gravity/242/1/8.

I missed this in https://github.com/gravitational/gravity/pull/2565.

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Fixed some work overlooked in https://github.com/gravitational/gravity/pull/2565

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<details><summary>before: <code>ROBOTEST_CONFIG=nightly make -C e/assets/robotest get-config</code></summary>

```console
walt@work:~/git/gravity$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'grav/master'.
walt@work:~/git/gravity$ ROBOTEST_CONFIG=nightly make -C e/assets/robotest get-config | tee before
make: Entering directory '/home/walt/git/gravity/e/assets/robotest'
install={"installer_url":"/images/telekube-9.0.0-beta.2.11.tar","nodes":3,"flavor":"three","role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/opscenter-9.0.0-beta.2.11.tar","nodes":3,"flavor":"ha","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:8.4"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:7.8"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"centos:8.4"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.8"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"sles:12-sp5"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"sles:15-sp2"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:16"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:20"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"debian:9"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"debian:10"}
resize={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
resize={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"redhat:7.9"}
shrink={"installer_url":"/images/robotest-9.0.0-beta.2.11.tar","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
upgrade={"from":"/images/robotest-7.0.33.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.33.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.0.33.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"one","nodes":1,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"centos:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"sles:12-sp5","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"sles:15-sp2","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"debian:9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"debian:10","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.1.0-alpha.6.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.11.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
make: Leaving directory '/home/walt/git/gravity/e/assets/robotest'
```

</details>

<details><summary>after: <code>ROBOTEST_CONFIG=nightly make -C e/assets/robotest get-config</code></summary>

```console
walt@work:~/git/gravity$ git checkout fix-post-merge 
Switched to branch 'fix-post-merge'  
walt@work:~/git/gravity$ ROBOTEST_CONFIG=nightly make -C e/assets/robotest get-config | tee after
make: Entering directory '/home/walt/git/gravity/e/assets/robotest'
install={"installer_url":"/images/telekube-9.0.0-beta.2.12.tar","nodes":3,"flavor":"three","role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/opscenter-9.0.0-beta.2.12.tar","nodes":3,"flavor":"ha","role":"node","os":"ubuntu:18","ops_advertise_addr":"example.com:443"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:8.4"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"redhat:7.8"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"centos:8.4"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.8"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"sles:12-sp5"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"sles:15-sp2"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:16"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:18"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"ubuntu:20"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"debian:9"}
install={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"debian:10"}
resize={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","to":3,"flavor":"one","nodes":1,"role":"node","state_dir":"/var/lib/telekube","os":"ubuntu:18"}
resize={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","to":6,"flavor":"three","nodes":3,"role":"node","state_dir":"/var/lib/telekube","os":"redhat:7.9"}
shrink={"installer_url":"/images/robotest-9.0.0-beta.2.12.tar","nodes":3,"flavor":"three","role":"node","os":"redhat:7.9"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"six","nodes":6,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"one","nodes":1,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"centos:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"sles:12-sp5","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"sles:15-sp2","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:16","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"debian:9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-9.0.0-beta.2.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"debian:10","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-7.1.0-alpha.6.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"redhat:8.4","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"centos:7.9","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
upgrade={"from":"/images/robotest-8.0.0-beta.1.tar","installer_url":"/images/robotest-9.0.0-beta.2.12.tar","flavor":"three","nodes":3,"role":"node","os":"ubuntu:20","service_uid":997,"service_gid":994,"storage_driver":"overlay2"}
make: Leaving directory '/home/walt/git/gravity/e/assets/robotest'
```

7.1.0-alpha.6 is ok (and intentional) here because it is equivalent to 8.0.0-alpha.0
</details>

Furthermore, here is a `nightly` run with the new code from my dev environment: https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__suite__%3D%22cedb42b8-b0e0-42e9-b738-0e7cfbfc0442%22;timeRange=2021-07-21T19:14:51Z%2F2021-07-21T20:14:51Z;cursorTimestamp=2021-07-21T19:19:08.648691697Z?project=robotest-production

## Additional information
I cheated on the testing in https://github.com/gravitational/gravity/pull/2565, which is how I missed this.  I need to do a full nightly run from my dev env to be sure I've caught everything.
