### PR TITLE
Add RHEL/CentOS 8.4 to supported versions in the docs

### DIFF
--- a/docs/7.x/requirements.md
+++ b/docs/7.x/requirements.md
@@ -14,8 +14,8 @@ Gravity officially supports the following Linux distributions:
 
 | Linux Distribution       | Version             | Docker Storage Drivers                |
 |--------------------------|---------------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
 | Debian                   | 9, 10               | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04, 20.04 | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04               | `overlay`, `overlay2`                 |
@@ -41,8 +41,8 @@ specified in the manifest:
 
 | Distribution Name        | ID                         | Version             |
 |--------------------------|----------------------------|---------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3    |
-| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3    |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.4    |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.4    |
 | Debian                   | debian                     | 9                   |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04, 20.04 |
 | Ubuntu-Core              | ubuntu                     | 16.04               |
@@ -263,8 +263,8 @@ Gravity requires that these modules are loaded prior to installation.
 | Linux Distribution                   | Version             | Modules                                         |
 |--------------------------------------|---------------------|-------------------------------------------------|
 | CentOS                               | 7.2                 | bridge, ebtable_filter, iptables, overlay       |
-| CentOS                               | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
-| RedHat Linux                         | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
+| CentOS                               | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
 | Debian                               | 9, 10               | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu                               | 16.04, 18.04, 20.04 | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu-Core                          | 16.04               | br_netfilter, ebtable_filter, iptables, overlay |

--- a/docs/8.x/requirements.md
+++ b/docs/8.x/requirements.md
@@ -14,8 +14,8 @@ Gravity officially supports the following Linux distributions:
 
 | Linux Distribution       | Version             | Docker Storage Drivers                |
 |--------------------------|---------------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
 | Debian                   | 9, 10               | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04, 20.04 | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04               | `overlay`, `overlay2`                 |
@@ -41,8 +41,8 @@ specified in the manifest:
 
 | Distribution Name        | ID                         | Version             |
 |--------------------------|----------------------------|---------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3    |
-| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3    |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.4    |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.4    |
 | Debian                   | debian                     | 9                   |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04, 20.04 |
 | Ubuntu-Core              | ubuntu                     | 16.04               |
@@ -261,8 +261,8 @@ Gravity requires that these modules are loaded prior to installation.
 | Linux Distribution                   | Version             | Modules                                         |
 |--------------------------------------|---------------------|-------------------------------------------------|
 | CentOS                               | 7.2                 | bridge, ebtable_filter, iptables, overlay       |
-| CentOS                               | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
-| RedHat Linux                         | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
+| CentOS                               | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
 | Debian                               | 9, 10               | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu                               | 16.04, 18.04, 20.04 | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu-Core                          | 16.04               | br_netfilter, ebtable_filter, iptables, overlay |

--- a/docs/9.x/requirements.md
+++ b/docs/9.x/requirements.md
@@ -14,8 +14,8 @@ Gravity officially supports the following Linux distributions:
 
 | Linux Distribution       | Version             | Docker Storage Drivers                |
 |--------------------------|---------------------|---------------------------------------|
-| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
-| CentOS                   | 7.2-7.9, 8.0-8.3*   | `overlay`, `overlay2`                 |
+| Red Hat Enterprise Linux | 7.4-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
+| CentOS                   | 7.2-7.9, 8.0-8.4*   | `overlay`, `overlay2`                 |
 | Debian                   | 9, 10               | `overlay`, `overlay2`                 |
 | Ubuntu                   | 16.04, 18.04, 20.04 | `overlay`, `overlay2`                 |
 | Ubuntu-Core              | 16.04               | `overlay`, `overlay2`                 |
@@ -41,8 +41,8 @@ specified in the manifest:
 
 | Distribution Name        | ID                         | Version             |
 |--------------------------|----------------------------|---------------------|
-| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.3    |
-| CentOS                   | centos                     | 7.2-7.9, 8.0-8.3    |
+| Red Hat Enterprise Linux | rhel                       | 7.4-7.9, 8.0-8.4    |
+| CentOS                   | centos                     | 7.2-7.9, 8.0-8.4    |
 | Debian                   | debian                     | 9                   |
 | Ubuntu                   | ubuntu                     | 16.04, 18.04, 20.04 |
 | Ubuntu-Core              | ubuntu                     | 16.04               |
@@ -261,8 +261,8 @@ Gravity requires that these modules are loaded prior to installation.
 | Linux Distribution                   | Version             | Modules                                         |
 |--------------------------------------|---------------------|-------------------------------------------------|
 | CentOS                               | 7.2                 | bridge, ebtable_filter, iptables, overlay       |
-| CentOS                               | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
-| RedHat Linux                         | 7.3-7.9, 8.0-8.3    | br_netfilter, ebtable_filter, iptables, overlay |
+| CentOS                               | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
+| RedHat Linux                         | 7.3-7.9, 8.0-8.4    | br_netfilter, ebtable_filter, iptables, overlay |
 | Debian                               | 9, 10               | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu                               | 16.04, 18.04, 20.04 | br_netfilter, ebtable_filter, iptables, overlay |
 | Ubuntu-Core                          | 16.04               | br_netfilter, ebtable_filter, iptables, overlay |


### PR DESCRIPTION
## Description
See title.  These were tested in the related PRs.

## Type of change
* Documentation
* This change has a user-facing impact

## Linked tickets and other PRs
* Requires #2574, #2575, #2576 
* Fixes #2563

## TODOs
- [x] Self-review the change
- [x] Make sure CI passes
- [x] Write documentation
- [ ] Address review feedback

## Testing done
Eyeballed the changes at https://github.com/wadells/gravity/blob/26145037becdabae89a8573329df7db1b78430ee/docs/7.x/requirements.md. Docs CI will check everything else that is important to test.
