### PR TITLE
[6.1] add missing retry loop when updating taints (#2578)

### DIFF
--- a/lib/kubernetes/nodes.go
+++ b/lib/kubernetes/nodes.go
@@ -78,10 +78,17 @@ func SetUnschedulable(ctx context.Context, client corev1.NodeInterface, nodeName
 
 // UpdateTaints adds and/or removes taints specified with add/remove correspondingly on the specified node.
 func UpdateTaints(ctx context.Context, client corev1.NodeInterface, nodeName string, taintsToAdd []v1.Taint, taintsToRemove []v1.Taint) error {
-	node, err := client.Get(nodeName, metav1.GetOptions{})
-	if err != nil {
+	var node *v1.Node
+	var err error
+
+	err = Retry(ctx, func() error {
+		node, err = client.Get(nodeName, metav1.GetOptions{})
 		return rigging.ConvertError(err)
+	})
+	if err != nil {
+		return trace.Wrap(err)
 	}
+
 	newTaints := append([]v1.Taint{}, taintsToAdd...)
 	oldTaints := node.Spec.Taints
 	// add taints that already exist but are not updated to newTaints


### PR DESCRIPTION
(cherry picked from commit c6f3401988646404629a82de2795c40ca7347626)

Backport #2578 

## Description
<!--Required. Provide high-level overview of what the change is for.-->
Reported by customer S they're sometimes seeing failures in the taint phase. I'm missing any stack traces, but doing just a code review I did find a kubernetes API call that isn't covered by a retry loop. So this PR adds in a retry loop.


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)


## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [N/A] Write tests
- [ ] Perform manual testing
- [ ] Address review feedback


