### PR TITLE
[8.0.x] Fix label reconciliation

### DIFF
--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -749,7 +749,7 @@ func (p *Process) reconcileNode(ctx context.Context, client *kubernetes.Clientse
 	requiredLabels := server.GetNodeLabels(profile.Labels)
 	needUpdate := false
 	node.Labels, needUpdate = reconcileLabels(p, node.Labels, requiredLabels)
-	if needUpdate {
+	if !needUpdate {
 		return nil
 	}
 	newData, err := json.Marshal(node)


### PR DESCRIPTION
## Description
Label reconciliation doesn't work.
There is a message in the gravity-site log that repeats every minute:
```
2021-07-22T13:00:58Z ERRO [PROCESS]   Unable to get reconcile mode, will reset to EnsureExists. error:[
ERROR REPORT:
Original Error: *trace.BadParameterError empty ReconcileMode value
Stack Trace:
        /gopath/src/github.com/gravitational/gravity/lib/defaults/labels.go:62 github.com/gravitational/gravity/lib/>
        /gopath/src/github.com/gravitational/gravity/lib/process/process.go:775 github.com/gravitational/gravity/lib>
        /gopath/src/github.com/gravitational/gravity/lib/process/process.go:750 github.com/gravitational/gravity/lib>
        /gopath/src/github.com/gravitational/gravity/lib/process/process.go:725 github.com/gravitational/gravity/lib>
        /gopath/src/github.com/gravitational/gravity/lib/process/process.go:806 github.com/gravitational/gravity/lib>
        /gopath/src/github.com/gravitational/gravity/lib/process/process.go:909 github.com/gravitational/gravity/lib>
        /go/src/runtime/asm_amd64.s:1337 runtime.goexit
```

## Type of change
Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #2584

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)
