### PR TITLE
Allows flannel backend override

### DIFF
--- a/docs/9.x/config.md
+++ b/docs/9.x/config.md
@@ -61,6 +61,9 @@ spec:
     # Enables Kubernetes high availability mode. When HA mode is enabled, Kubernetes
     # control plane components run on all master nodes.
     highAvailability: true
+    # The flannel backend is automatically selected based on the cloud provider,
+    # but the selected backend can be overridden if specified in the cluster configuration.
+    flannelBackend: "vxlan"
     # A set of key=value pairs that describe feature gates for alpha/experimental features
     featureGates:
       AllAlpha: true

--- a/docs/9.x/config.md
+++ b/docs/9.x/config.md
@@ -63,6 +63,7 @@ spec:
     highAvailability: true
     # The flannel backend is automatically selected based on the cloud provider,
     # but the selected backend can be overridden if specified in the cluster configuration.
+    # Supports values "vxlan", "aws-vpc", and "gce".
     flannelBackend: "vxlan"
     # A set of key=value pairs that describe feature gates for alpha/experimental features
     featureGates:

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1443,6 +1443,10 @@ func (s *site) addClusterConfig(config clusterconfig.Interface, overrideArgs map
 	if globalConfig.HighAvailability != nil && *globalConfig.HighAvailability {
 		args = append(args, "--high-availability")
 	}
+	if globalConfig.FlannelBackend != "" {
+		args = append(args,
+			fmt.Sprintf("--flannel-backend=%v", globalConfig.FlannelBackend))
+	}
 	return args
 }
 

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -664,6 +664,9 @@ func (r configCollection) WriteText(w io.Writer) error {
 		fmt.Fprintf(t, "%v\n", string(config.Config))
 	}
 	config := r.GetGlobalConfig()
+	if len(config.FlannelBackend) != 0 {
+		fmt.Fprintf(t, "Flannel Backend:\t%v\n", config.FlannelBackend)
+	}
 	if len(config.PodCIDR) != 0 {
 		fmt.Fprintf(t, "Pod IP Range:\t%v\n", config.PodCIDR)
 	}

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -140,6 +140,9 @@ func (r Resource) Merge(other Resource) Resource {
 		}
 	}
 	// Changing cloud provider is not supported
+	if other.Spec.Global.FlannelBackend != "" {
+		r.Spec.Global.FlannelBackend = other.Spec.Global.FlannelBackend
+	}
 	if other.Spec.Global.PodCIDR != "" {
 		r.Spec.Global.PodCIDR = other.Spec.Global.PodCIDR
 	}
@@ -276,6 +279,7 @@ func (r Global) IsEmpty() bool {
 		r.ServiceNodePortRange == "" &&
 		r.ProxyPortRange == "" &&
 		r.HighAvailability == nil &&
+		r.FlannelBackend == "" &&
 		len(r.FeatureGates) == 0
 }
 
@@ -309,6 +313,8 @@ type Global struct {
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// HighAvailability enables high availability mode for Kubernetes.
 	HighAvailability *bool `json:"highAvailability,omitempty"`
+	// FlannelBackend specifies the backend to pair with flannel.
+	FlannelBackend string `json:"flannelBackend,omitempty"`
 }
 
 // specSchemaTemplate is JSON schema for the cluster configuration resource
@@ -357,7 +363,8 @@ const specSchemaTemplate = `{
                  "^[a-zA-Z]+[a-zA-Z0-9]*$": {"type": "boolean"}
               }
             },
-            "highAvailability": {"type": "boolean"}
+            "highAvailability": {"type": "boolean"},
+            "flannelBackend": {"type": "string"}
           }
         },
         "kubelet": {

--- a/lib/storage/clusterconfig/clusterconfig_test.go
+++ b/lib/storage/clusterconfig/clusterconfig_test.go
@@ -170,7 +170,8 @@ spec:
       FeatureA: true
       FeatureB: false
     podSubnetSize: "26"
-    highAvailability: true`,
+    highAvailability: true
+    flannelBackend: "vxlan"`,
 			resource: &Resource{
 				Kind:    storage.KindClusterConfiguration,
 				Version: "v1",
@@ -186,6 +187,7 @@ spec:
 						},
 						PodSubnetSize:    "26",
 						HighAvailability: newBoolPtr(true),
+						FlannelBackend:   "vxlan",
 					},
 				},
 			},
@@ -244,6 +246,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature2": false,
 						},
 						HighAvailability: newBoolPtr(true),
+						FlannelBackend:   "vxlan",
 					},
 				},
 			},
@@ -263,6 +266,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature2": false,
 						},
 						HighAvailability: newBoolPtr(true),
+						FlannelBackend:   "vxlan",
 					},
 				},
 			},
@@ -290,6 +294,7 @@ address: 10.0.0.1
 							"feature1": true,
 							"feature2": false,
 						},
+						FlannelBackend: "vxlan",
 					},
 				},
 			},
@@ -336,6 +341,7 @@ address: 10.0.0.1
 							"feature1": true,
 							"feature3": true,
 						},
+						FlannelBackend: "vxlan",
 					},
 				},
 			},

--- a/lib/update/clusterconfig/plan.go
+++ b/lib/update/clusterconfig/plan.go
@@ -194,11 +194,11 @@ func shouldUpdateNodes(clusterConfig clusterconfig.Interface, numWorkerNodes int
 	if numWorkerNodes == 0 {
 		return false
 	}
-	var hasComponentUpdate, hasCIDRUpdate bool
 	config := clusterConfig.GetGlobalConfig()
-	hasComponentUpdate = len(config.FeatureGates) != 0
-	hasCIDRUpdate = len(config.PodCIDR) != 0 || len(config.ServiceCIDR) != 0 || config.PodSubnetSize != ""
-	return !clusterConfig.GetKubeletConfig().IsEmpty() || hasComponentUpdate || hasCIDRUpdate
+	hasComponentUpdate := len(config.FeatureGates) != 0
+	hasCIDRUpdate := len(config.PodCIDR) != 0 || len(config.ServiceCIDR) != 0 || config.PodSubnetSize != ""
+	hasFlannelUpdate := config.FlannelBackend != ""
+	return !clusterConfig.GetKubeletConfig().IsEmpty() || hasComponentUpdate || hasCIDRUpdate || hasFlannelUpdate
 }
 
 type planConfig struct {

--- a/lib/validate/clusterconfig.go
+++ b/lib/validate/clusterconfig.go
@@ -89,6 +89,10 @@ func ClusterConfiguration(existing, update clusterconfig.Interface) error {
 		return trace.Wrap(err)
 	}
 
+	if !isSupportedBackend(newGlobalConfig.FlannelBackend) {
+		return trace.BadParameter("unsupported flannel backend was specified: %v", newGlobalConfig.FlannelBackend)
+	}
+
 	return nil
 }
 
@@ -103,4 +107,16 @@ func normalizedCloudProvider(provider string) string {
 	default:
 		return provider
 	}
+}
+
+// isSupportedBackend returns true if the specified backend is a supported flannel
+// backend.
+func isSupportedBackend(backend string) bool {
+	supportedBackends := []string{"aws-vpc", "gce", "vxlan"}
+	for _, supportedBackend := range supportedBackends {
+		if supportedBackend == backend {
+			return true
+		}
+	}
+	return false
 }

--- a/tool/gravity/cli/config_test.go
+++ b/tool/gravity/cli/config_test.go
@@ -46,6 +46,7 @@ spec:
     cloudProvider: gce
     serviceCIDR: "100.200.0.0/16"
     podSubnetSize: "26"
+    flannelBackend: "vxlan"
     cloudConfig: |
       [global]
       node-tags=example-cluster
@@ -72,10 +73,11 @@ spec:
 		// updateClusterConfig pushes the cluster configuration resource at the end
 		clusterConfigToMap(clusterconfig.New(clusterconfig.Spec{
 			Global: clusterconfig.Global{
-				CloudProvider: "gce",
-				ServiceCIDR:   "100.200.0.0/16",
-				PodCIDR:       "100.96.0.0/16",
-				PodSubnetSize: "26",
+				CloudProvider:  "gce",
+				ServiceCIDR:    "100.200.0.0/16",
+				PodCIDR:        "100.96.0.0/16",
+				PodSubnetSize:  "26",
+				FlannelBackend: "vxlan",
 				CloudConfig: `[global]
 node-tags=example-cluster
 multizone="true"

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)-2-g217d3c07
+PLANET_TAG ?= 9.0.5-$(K8S_VER_SUFFIX)
 PLANET_BRANCH ?= $(PLANET_TAG)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 9.0.3-$(K8S_VER_SUFFIX)-2-g217d3c07
 PLANET_BRANCH ?= $(PLANET_TAG)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR allows override of the flannel backend. This change will be necessary for implementing geo-diversity in Teleport Cloud.

Flannel backend can be overridden through the cluster configuration resource by setting the `flannelBackend` field:
```yaml
# config.yaml
kind: clusterconfiguration
metadata:
  name: cluster-configuration
spec:
  global:
    cloudProvider: aws
    flannelBackend: vxlan
version: v1
```

Run `gravity resource create config.yaml` to update the cluster configuration.

Run `gravity exec etcdctl get /coreos.com/network/config` to verify desired flannel backend.
```
{"Network":"100.96.0.0/16", "SubnetLen": 24, "Backend": {"Type": "vxlan", "RouteTableFilter": ["tag:KubernetesCluster=vibranttu9012"], "Port": 8472}}
```

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/cloud/pull/747
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/planet/pull/856

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback
- [x] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
- [x] Install gravity cluster on AWS and verify cluster configuration update is able to set flannel backend to `vxlan`
- [x] Verify flannel backend can be switched back to `aws-vpc`