### PR TITLE
Forward port RPC credentials rotation on upgrade

### DIFF
--- a/lib/blob/fs/fs.go
+++ b/lib/blob/fs/fs.go
@@ -27,17 +27,25 @@ import (
 
 	"github.com/gravitational/gravity/lib/blob"
 	"github.com/gravitational/gravity/lib/defaults"
+	"github.com/gravitational/gravity/lib/systeminfo"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 )
 
-func New(path string) (blob.Objects, error) {
-	if path == "" {
-		return nil, trace.BadParameter("missing Path parameter")
+// New creates a new instance of the local fs blob service
+// rooted as the given path
+func New(root string) (blob.Objects, error) {
+	return NewWithConfig(Config{Path: root})
+}
+
+// NewWithConfig creates a new instance of the local fs blob service with the specified configuration
+func NewWithConfig(config Config) (blob.Objects, error) {
+	if err := config.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	o := &objects{dir: path}
-	for _, d := range []string{o.tempDir(), o.blobDir()} {
+	o := &objects{config: config}
+	for _, d := range []string{config.tempDir(), config.blobDir()} {
 		if err := os.MkdirAll(d, defaults.SharedDirMask); err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
@@ -45,16 +53,31 @@ func New(path string) (blob.Objects, error) {
 	return o, nil
 }
 
+// Config defines the blob service configuration
+type Config struct {
+	// Path specifies the directory for blobs
+	Path string
+	// User optionally specifies the user context for file operations
+	User *systeminfo.User
+}
+
+func (r *Config) checkAndSetDefaults() error {
+	if r.Path == "" {
+		return trace.BadParameter("missing Path parameter")
+	}
+	return nil
+}
+
+func (r Config) tempDir() string {
+	return filepath.Join(r.Path, "tmp")
+}
+
+func (r Config) blobDir() string {
+	return filepath.Join(r.Path, "blobs")
+}
+
 type objects struct {
-	dir string
-}
-
-func (o *objects) tempDir() string {
-	return filepath.Join(o.dir, "tmp")
-}
-
-func (o *objects) blobDir() string {
-	return filepath.Join(o.dir, "blobs")
+	config Config
 }
 
 // hashDir helps us to organize the blobs in the folder -
@@ -63,7 +86,7 @@ func (o *objects) blobDir() string {
 // of the sha512 hash - this will allow to scale in cases
 // when there are too many files in one directory
 func (o *objects) hashDir(h string) string {
-	return filepath.Join(o.blobDir(), h[0:3])
+	return filepath.Join(o.config.blobDir(), h[0:3])
 }
 
 func (o *objects) Close() error {
@@ -73,7 +96,7 @@ func (o *objects) Close() error {
 // GetBLOBs returns a list of BLOBs in the storage
 func (o *objects) GetBLOBs() ([]string, error) {
 	var out []string
-	blobDir := o.blobDir()
+	blobDir := o.config.blobDir()
 	err := filepath.Walk(blobDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Warningf("error while traversing %v: %v", blobDir, err)
@@ -97,12 +120,14 @@ func (o *objects) GetBLOBs() ([]string, error) {
 func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	// step1 : write data and compute it's hash to the temporary file,
 	// then move it to the proper location based on it's hash
-	f, err := ioutil.TempFile(o.tempDir(), "blob")
+	f, err := ioutil.TempFile(o.config.tempDir(), "blob")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer f.Close()
 
+	// if true, sets proper directory/file ownership.
+	hasUser := o.config.User != nil && os.Geteuid() != o.config.User.UID
 	hasher := sha512.New()
 	w := io.MultiWriter(f, hasher)
 	size, err := io.Copy(w, data)
@@ -119,14 +144,28 @@ func (o *objects) WriteBLOB(data io.Reader) (*blob.Envelope, error) {
 	hash := fmt.Sprintf("%x", hasher.Sum(nil)[:sha512.Size/2])
 	targetDir := o.hashDir(hash)
 	if err := os.MkdirAll(targetDir, defaults.SharedDirMask); err != nil {
+		// This will fail as expected if the command is not run as root or
+		// under a different user context
 		defer os.Remove(f.Name())
 		return nil, trace.ConvertSystemError(err)
+	}
+	if hasUser {
+		if err := os.Chown(targetDir, o.config.User.UID, o.config.User.GID); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	// now place it to the right place in the filesystem
 	targetPath := filepath.Join(targetDir, hash)
 	if err := os.Rename(f.Name(), targetPath); err != nil {
 		defer os.Remove(f.Name())
 		return nil, trace.Wrap(err)
+	}
+	if hasUser {
+		// This will fail as expected if the command is not run as root or
+		// under a different user context
+		if err := os.Chown(targetPath, o.config.User.UID, o.config.User.GID); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	fileInfo, err := os.Stat(targetPath)
 	if err != nil {

--- a/lib/blob/fs/fs.go
+++ b/lib/blob/fs/fs.go
@@ -34,7 +34,7 @@ import (
 )
 
 // New creates a new instance of the local fs blob service
-// rooted as the given path
+// rooted at the given path
 func New(root string) (blob.Objects, error) {
 	return NewWithConfig(Config{Path: root})
 }

--- a/lib/expand/fsm.go
+++ b/lib/expand/fsm.go
@@ -48,7 +48,7 @@ type FSMConfig struct {
 	// Packages is package service of the cluster the node is joining to
 	Packages pack.PackageService
 	// LocalBackend is local backend of the joining node
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// LocalApps is local apps service of the joining node
 	LocalApps app.Applications
 	// LocalPackages is local package service of the joining node

--- a/lib/expand/join.go
+++ b/lib/expand/join.go
@@ -281,7 +281,7 @@ type PeerConfig struct {
 	// Insecure turns on FSM insecure mode
 	Insecure bool
 	// LocalBackend is local backend of the joining node
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// LocalApps is local apps service of the joining node
 	LocalApps app.Applications
 	// LocalPackages is local package service of the joining node

--- a/lib/expand/phases/agent.go
+++ b/lib/expand/phases/agent.go
@@ -130,7 +130,7 @@ func NewAgentStop(p fsm.ExecutorParams, operator ops.Operator, packages pack.Pac
 		Key:      opKey(p.Plan),
 		Operator: operator,
 	}
-	credentials, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	credentials, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/fsm/rpc.go
+++ b/lib/fsm/rpc.go
@@ -251,13 +251,18 @@ func IsMasterServer(server storage.Server) bool {
 	return server.ClusterRole == string(schema.ServiceRoleMaster)
 }
 
-// GetClientCredentials returns the RPC credentials for an update operation
+// GetClientCredentials reads the RPC credentials for an update operation from a predefined directory.
+//
+// The reason credentials are not read from the cluster package service is that
+// during certain operations (cluster upgrades, cluster or environment configuration updates), the etcd backend
+// might be temporarily inaccessible between commands hence in this mode, the credentials
+// are cached on disk.
 func GetClientCredentials() (credentials.TransportCredentials, error) {
 	secretsDir, err := AgentSecretsDir()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	creds, err := rpc.ClientCredentials(secretsDir)
+	creds, err := rpc.ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/install/config.go
+++ b/lib/install/config.go
@@ -121,7 +121,7 @@ type Config struct {
 	// LocalApps is the machine-local application service
 	LocalApps app.Applications
 	// LocalBackend is the machine-local backend
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// ServiceUser specifies the user to use as a service user in planet
 	// and for unprivileged kubernetes services
 	ServiceUser systeminfo.User

--- a/lib/install/fsm.go
+++ b/lib/install/fsm.go
@@ -65,7 +65,7 @@ type FSMConfig struct {
 	// LocalApps is the machine-local apps service
 	LocalApps app.Applications
 	// LocalBackend is the machine-local backend
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// Spec is the FSM spec
 	Spec fsm.FSMSpecFunc
 	// Credentials is the credentials for gRPC agents

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -44,7 +44,7 @@ import (
 )
 
 // NewBootstrap returns a new "bootstrap" phase executor
-func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications, backend storage.Backend,
+func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applications, backend storage.LocalBackend,
 	remote fsm.Remote) (fsm.PhaseExecutor, error) {
 	if p.Phase.Data == nil || p.Phase.Data.ServiceUser == nil {
 		return nil, trace.BadParameter("service user is required: %#v", p.Phase.Data)
@@ -112,7 +112,7 @@ type bootstrapExecutor struct {
 	// Application is the application being installed
 	Application app.Application
 	// LocalBackend is the machine-local backend
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// ServiceUser is the user used for services and system storage
 	ServiceUser systeminfo.User
 	// ExecutorParams is common executor params

--- a/lib/install/phases/bootstrap.go
+++ b/lib/install/phases/bootstrap.go
@@ -98,7 +98,6 @@ func NewBootstrap(p fsm.ExecutorParams, operator ops.Operator, apps app.Applicat
 		ExecutorParams:   p,
 		ServiceUser:      *serviceUser,
 		remote:           remote,
-		dnsConfig:        p.Plan.DNSConfig,
 		mounts:           mounts,
 		stateDir:         p.Phase.Data.Server.StateDir(),
 		seLinux:          p.Phase.Data.Server.SELinux,
@@ -118,8 +117,6 @@ type bootstrapExecutor struct {
 	ServiceUser systeminfo.User
 	// ExecutorParams is common executor params
 	fsm.ExecutorParams
-	// dnsConfig specifies local cluster DNS configuration to set
-	dnsConfig storage.DNSConfig
 	// remote specifies the server remote control interface
 	remote fsm.Remote
 	// mounts lists additional application-specific volume mounts
@@ -342,15 +339,45 @@ func (p *bootstrapExecutor) logIntoCluster() error {
 }
 
 func (p *bootstrapExecutor) configureSystemMetadata() error {
-	err := p.LocalBackend.SetSELinux(p.seLinux)
+	if err := p.LocalBackend.SetSELinux(p.seLinux); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.configureDNS(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.configureNodeAddr(); err != nil {
+		return trace.Wrap(err)
+	}
+	return p.configureServiceUser()
+}
+
+// configureDNS creates local cluster DNS configuration in local state database
+func (p *bootstrapExecutor) configureDNS() error {
+	err := p.LocalBackend.SetDNSConfig(p.Plan.DNSConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.LocalBackend.SetDNSConfig(p.dnsConfig)
+	p.Infof("Created DNS configuration: %v.", p.Plan.DNSConfig)
+	return nil
+}
+
+// configureNodeAddr persists the node advertise IP in local state database
+func (p *bootstrapExecutor) configureNodeAddr() error {
+	err := p.LocalBackend.SetNodeAddr(p.Phase.Data.Server.AdvertiseIP)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	p.Infof("Created DNS configuration: %v.", p.dnsConfig)
+	p.Infof("Set node address: %v.", p.Phase.Data.Server.AdvertiseIP)
+	return nil
+}
+
+// configureServiceUser persists the service user in local state database
+func (p *bootstrapExecutor) configureServiceUser() error {
+	err := p.LocalBackend.SetServiceUser(p.ServiceUser.OSUser())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.Infof("Set service user: %v.", p.ServiceUser)
 	return nil
 }
 

--- a/lib/install/utils.go
+++ b/lib/install/utils.go
@@ -214,7 +214,7 @@ func LoadRPCCredentials(ctx context.Context, packages pack.PackageService) (*rpc
 
 // ClientCredentials returns the contents of the default RPC credentials package
 func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
-	clientCreds, err := rpc.ClientCredentialsFromPackage(packages, loc.RPCSecrets)
+	clientCreds, err := rpc.ClientCredentials(packages)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch RPC credentials")
 	}

--- a/lib/localenv/clusterenv.go
+++ b/lib/localenv/clusterenv.go
@@ -18,10 +18,13 @@ package localenv
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gravitational/gravity/lib/app"
 	"github.com/gravitational/gravity/lib/app/service"
+	"github.com/gravitational/gravity/lib/blob"
+	libcluster "github.com/gravitational/gravity/lib/blob/cluster"
 	"github.com/gravitational/gravity/lib/blob/fs"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/httplib"
@@ -30,10 +33,11 @@ import (
 	"github.com/gravitational/gravity/lib/pack/localpack"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/keyval"
+	"github.com/gravitational/gravity/lib/systeminfo"
 	"github.com/gravitational/gravity/lib/users"
 	"github.com/gravitational/gravity/lib/users/usersservice"
-	"github.com/gravitational/teleport/lib/events"
 
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/trace"
 	"k8s.io/client-go/kubernetes"
 )
@@ -52,9 +56,26 @@ func (env *LocalEnvironment) NewClusterEnvironment(opts ...ClusterEnvironmentOpt
 	if err != nil && !trace.IsNotFound(err) {
 		log.WithError(err).Warn("Failed to create audit log.")
 	}
+	user, err := env.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.UserFromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := env.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
 	config := clusterEnvironmentConfig{
-		client:   client,
-		auditLog: auditLog,
+		client:      client,
+		auditLog:    auditLog,
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
 	}
 	for _, opt := range opts {
 		opt(&config)
@@ -84,7 +105,33 @@ type ClusterEnvironment struct {
 // returns a new instance of cluster environment.
 // The resulting environment will not have a kubernetes client
 func NewClusterEnvironment() (*ClusterEnvironment, error) {
-	return newClusterEnvironment(clusterEnvironmentConfig{})
+	stateDir, err := LocalGravityDir()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := New(stateDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := env.Backend.GetServiceUser()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	var serviceUser *systeminfo.User
+	if user != nil {
+		serviceUser, err = systeminfo.UserFromOSUser(*user)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	nodeAddr, err := env.Backend.GetNodeAddr()
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	return newClusterEnvironment(clusterEnvironmentConfig{
+		serviceUser: serviceUser,
+		nodeAddr:    nodeAddr,
+	})
 }
 
 // WithClient is an option to override the kubernetes client to use
@@ -122,9 +169,37 @@ func newClusterEnvironment(config clusterEnvironmentConfig) (*ClusterEnvironment
 		return nil, trace.Wrap(err)
 	}
 
-	objects, err := fs.New(packagesDir)
+	localObjects, err := fs.NewWithConfig(fs.Config{
+		Path: packagesDir,
+		User: config.serviceUser,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	var objects blob.Objects
+	if config.nodeAddr == "" {
+		objects, err = fs.New(packagesDir)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		// To be able to use cluster-level package service,
+		// a node address is required. This is not available on nodes prior to upgrade
+		// with an version that did not support the necessary system metadata (node address
+		// and service user).
+		// This is normally not a problem as the cluster-level package service is not required
+		// during the upgrade.
+		objects, err = libcluster.New(libcluster.Config{
+			Local:         localObjects,
+			WriteFactor:   1,
+			Backend:       backend,
+			ID:            config.nodeAddr,
+			AdvertiseAddr: fmt.Sprintf("https://%v", config.nodeAddr),
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	unpackedDir, err := SiteUnpackedDir()
@@ -199,5 +274,7 @@ type clusterEnvironmentConfig struct {
 	// Falls back to defaults.EtcdRetryInterval if unspecified
 	etcdTimeout time.Duration
 	// auditLog provides API to the cluster audit log
-	auditLog events.IAuditLog
+	auditLog    events.IAuditLog
+	serviceUser *systeminfo.User
+	nodeAddr    string
 }

--- a/lib/localenv/localenv.go
+++ b/lib/localenv/localenv.go
@@ -115,7 +115,7 @@ type DNSConfig storage.DNSConfig
 type LocalEnvironment struct {
 	LocalEnvironmentArgs
 	// Backend is the local backend client
-	Backend storage.Backend
+	Backend storage.LocalBackend
 	// Objects is the local objects storage client
 	Objects blob.Objects
 	// Packages is the local package service
@@ -424,7 +424,7 @@ func (env *LocalEnvironment) AppServiceLocal(config AppConfig) (service appbase.
 		}
 	}
 
-	backend := env.Backend
+	var backend storage.Backend = env.Backend
 	if config.Backend != nil {
 		backend = config.Backend
 	}

--- a/lib/process/process.go
+++ b/lib/process/process.go
@@ -498,7 +498,7 @@ func (p *Process) ImportState(importDir string) (err error) {
 
 // InitRPCCredentials initializes the package with RPC secrets
 func (p *Process) InitRPCCredentials() error {
-	pkg, err := rpc.InitRPCCredentials(p.packages)
+	pkg, err := rpc.InitCredentials(p.packages)
 	if err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err, "failed to init RPC credentials")
 	}

--- a/lib/rpc/tls.go
+++ b/lib/rpc/tls.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
@@ -35,11 +36,22 @@ import (
 	"github.com/gravitational/license/authority"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
 )
 
-// InitRPCCredentials creates a package with RPC secrets in the specified package service
-func InitRPCCredentials(packages pack.PackageService) (*loc.Locator, error) {
+// LoadCredentialsData returns an io.Reader into the credentials package.
+// Caller is responsible for closing the returned reader
+func LoadCredentialsData(packages pack.PackageService) (env *pack.PackageEnvelope, rc io.ReadCloser, err error) {
+	env, rc, err = packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return env, rc, nil
+}
+
+// InitCredentials creates a package with RPC secrets in the specified package service
+func InitCredentials(packages pack.PackageService) (*loc.Locator, error) {
 	longLivedClient := true
 	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
 	if err != nil {
@@ -159,22 +171,47 @@ func GenerateAgentCredentials(hosts []string, commonName string, longLivedClient
 	return archive, nil
 }
 
-// Credentials returns both server and client credentials read from the
-// specified directory
-func Credentials(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
-	server, err = ServerCredentials(secretsDir)
+// CredentialsFromDir returns both server and client credentials read from the
+// specified secrets dir
+func CredentialsFromDir(secretsDir string) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	server, err = ServerCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	client, err = ClientCredentials(secretsDir)
+	client, err = ClientCredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	return server, client, nil
 }
 
-// ClientCredentials loads the client agent credentials from the specified location
-func ClientCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// Credentials returns both server and client credentials read from the
+// specified package service
+func Credentials(packages pack.PackageService) (server credentials.TransportCredentials, client credentials.TransportCredentials, err error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	tlsArchive, err := utils.ReadTLSArchive(reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	server, err = ServerCredentialsFromKeyPairs(*tlsArchive[pb.Server],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	client, err = ClientCredentialsFromKeyPairs(*tlsArchive[pb.Client],
+		*tlsArchive[pb.CA])
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return server, client, nil
+}
+
+// ClientCredentialsFromDir loads the client agent credentials from the specified location
+func ClientCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	clientCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Cert))
 	clientKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Client, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -203,9 +240,9 @@ func ClientCredentials(secretsDir string) (credentials.TransportCredentials, err
 	return creds, nil
 }
 
-// ClientCredentialsFromPackage reads client credentials from the specified package
-func ClientCredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Locator) (credentials.TransportCredentials, error) {
-	_, reader, err := packages.ReadPackage(secretsPackage)
+// ClientCredentials reads client credentials from specified package service
+func ClientCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -240,8 +277,8 @@ func ClientCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
-// ServerCredentials loads server agent credentials from the specified location
-func ServerCredentials(secretsDir string) (credentials.TransportCredentials, error) {
+// ServerCredentialsFromDir loads server agent credentials from the specified location
+func ServerCredentialsFromDir(secretsDir string) (credentials.TransportCredentials, error) {
 	serverCertPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Cert))
 	serverKeyPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.Server, pb.Key))
 	caPath := filepath.Join(secretsDir, fmt.Sprintf("%s.%s", pb.CA, pb.Cert))
@@ -272,9 +309,9 @@ func ServerCredentials(secretsDir string) (credentials.TransportCredentials, err
 	return creds, nil
 }
 
-// ServerCredentialsFromPackage reads server credentials from the specified package
-func ServerCredentialsFromPackage(packages pack.PackageService, secretsPackage loc.Locator) (credentials.TransportCredentials, error) {
-	_, reader, err := packages.ReadPackage(secretsPackage)
+// ServerCredentials reads server credentials from the specified package service
+func ServerCredentials(packages pack.PackageService) (credentials.TransportCredentials, error) {
+	_, reader, err := packages.ReadPackage(loc.RPCSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -310,6 +347,36 @@ func ServerCredentialsFromKeyPairs(keys, caKeys authority.TLSKeyPair) (credentia
 	return creds, nil
 }
 
+// UpsertCredentials creates or updates RPC secrets package in the specified package service
+func UpsertCredentials(packages pack.PackageService) (*loc.Locator, error) {
+	longLivedClient := true
+	keys, err := GenerateAgentCredentials(nil, defaults.SystemAccountOrg, longLivedClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	err = upsertPackage(packages, loc.RPCSecrets, keys)
+	if err != nil {
+		return &loc.RPCSecrets, trace.Wrap(err)
+	}
+
+	return &loc.RPCSecrets, nil
+}
+
+// UpsertCredentialsFromData creates or updates RPC credentials from the specified data
+func UpsertCredentialsFromData(packages pack.PackageService, r io.Reader, labels map[string]string) error {
+	err := packages.UpsertRepository(defaults.SystemAccountOrg, time.Time{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	essential := map[string]string{
+		pack.PurposeLabel: pack.PurposeRPCCredentials,
+	}
+	runtimeLabels := utils.CombineLabels(essential, labels)
+	_, err = packages.UpsertPackage(loc.RPCSecrets, r, pack.WithLabels(runtimeLabels))
+	return trace.Wrap(err)
+}
+
 // AgentAddr returns a complete agent address for specified address addr.
 // If addr already contains a port, the address is returned unaltered,
 // otherwise, a default RPC agent port is added
@@ -325,7 +392,6 @@ func createPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 		return trace.Wrap(err)
 	}
 	defer reader.Close()
-
 	err = packages.UpsertRepository(pkg.Repository, time.Time{})
 	if err != nil {
 		return trace.Wrap(err)
@@ -359,21 +425,23 @@ func upsertPackage(packages pack.PackageService, pkg loc.Locator, archive utils.
 }
 
 func validateCertificateExpiration(pemBytes []byte, now time.Time) error {
-	const tolerance = 30 * time.Second
 	cert, err := tlsca.ParseCertificatePEM(pemBytes)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if now.Add(-tolerance).Before(cert.NotBefore) {
-		// return newCertError("certificate is valid in the future")
+	logrus.WithFields(logrus.Fields{
+		"now":        now,
+		"not-before": cert.NotBefore.String(),
+		"not-after":  cert.NotAfter.String(),
+	}).Info("Validate certificate.")
+	if now.Before(cert.NotBefore) {
 		return trace.BadParameter("certificate is valid in the future").
 			AddFields(trace.Fields{
 				"now":        now,
 				"not-before": cert.NotBefore,
 			})
 	}
-	if now.Add(tolerance).After(cert.NotAfter) {
-		// return newCertError("certificate is valid in the past")
+	if now.After(cert.NotAfter) {
 		return trace.BadParameter("certificate is valid in the past").
 			AddFields(trace.Fields{
 				"now":       now,

--- a/lib/storage/keyval/bolt.go
+++ b/lib/storage/keyval/bolt.go
@@ -36,7 +36,7 @@ import (
 )
 
 // NewBolt returns new BoltDB-backed engine
-func NewBolt(cfg BoltConfig) (storage.Backend, error) {
+func NewBolt(cfg BoltConfig) (storage.LocalBackend, error) {
 	err := cfg.CheckAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/storage/keyval/constants.go
+++ b/lib/storage/keyval/constants.go
@@ -72,6 +72,8 @@ const (
 	systemP                     = "system"
 	dnsP                        = "dns"
 	seLinuxP                    = "seLinux"
+	nodeAddrP                   = "nodeaddress"
+	serviceUserP                = "serviceuser"
 	chartsP                     = "charts"
 	indexP                      = "index"
 

--- a/lib/storage/keyval/system.go
+++ b/lib/storage/keyval/system.go
@@ -50,3 +50,33 @@ func (b *backend) GetSELinux() (enabled bool, err error) {
 func (b *backend) SetSELinux(enabled bool) error {
 	return b.upsertVal(b.key(systemP, seLinuxP), &enabled, forever)
 }
+
+// GetNodeAddr returns the current node advertise IP
+func (b *backend) GetNodeAddr() (addr string, err error) {
+	var nodeAddr string
+	err = b.getVal(b.key(systemP, nodeAddrP), &nodeAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return nodeAddr, nil
+}
+
+// SetNodeAddr sets current node advertise IP
+func (b *backend) SetNodeAddr(addr string) error {
+	return b.upsertVal(b.key(systemP, nodeAddrP), addr, forever)
+}
+
+// GetServiceUser returns the current serviceo user
+func (b *backend) GetServiceUser() (*storage.OSUser, error) {
+	var user storage.OSUser
+	err := b.getVal(b.key(systemP, serviceUserP), &user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &user, nil
+}
+
+// SetServiceUser sets current service user
+func (b *backend) SetServiceUser(user storage.OSUser) error {
+	return b.upsertVal(b.key(systemP, serviceUserP), &user, forever)
+}

--- a/lib/storage/keyval/system.go
+++ b/lib/storage/keyval/system.go
@@ -66,7 +66,7 @@ func (b *backend) SetNodeAddr(addr string) error {
 	return b.upsertVal(b.key(systemP, nodeAddrP), addr, forever)
 }
 
-// GetServiceUser returns the current serviceo user
+// GetServiceUser returns the current service user
 func (b *backend) GetServiceUser() (*storage.OSUser, error) {
 	var user storage.OSUser
 	err := b.getVal(b.key(systemP, serviceUserP), &user)

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1538,8 +1538,14 @@ type Backend interface {
 	Links
 	ClusterImport
 	LegacyRoles
-	SystemMetadata
 	Charts
+}
+
+// LocalBackend represents the node-local backend
+type LocalBackend interface {
+	Backend
+	// SystemMetadata manages node-local system metadata
+	SystemMetadata
 }
 
 const (

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1087,6 +1087,14 @@ type SystemMetadata interface {
 	GetSELinux() (enabled bool, err error)
 	// SetSELinux sets SELinux support
 	SetSELinux(enabled bool) error
+	// GetNodeAddr returns the current node advertise IP
+	GetNodeAddr() (addr string, err error)
+	// SetNodeAddr sets current node advertise IP
+	SetNodeAddr(addr string) error
+	// GetServiceUser returns the current service user
+	GetServiceUser() (*OSUser, error)
+	// SetServiceUser sets current service user
+	SetServiceUser(OSUser) error
 }
 
 // DefaultDNSConfig defines the default cluster local DNS configuration

--- a/lib/storage/utils.go
+++ b/lib/storage/utils.go
@@ -325,7 +325,7 @@ func DisableAccess(backend Backend, name string, delay time.Duration) error {
 
 // GetDNSConfig returns the DNS configuration from the backend using fallback
 // if no configuration is available
-func GetDNSConfig(backend Backend, fallback DNSConfig) (config *DNSConfig, err error) {
+func GetDNSConfig(backend LocalBackend, fallback DNSConfig) (config *DNSConfig, err error) {
 	config, err = backend.GetDNSConfig()
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)

--- a/lib/systeminfo/user.go
+++ b/lib/systeminfo/user.go
@@ -197,6 +197,15 @@ func DefaultServiceUser() *User {
 	}
 }
 
+// OSUser returns a new storage user from this user
+func (r User) OSUser() storage.OSUser {
+	return storage.OSUser{
+		Name: r.Name,
+		UID:  strconv.Itoa(r.UID),
+		GID:  strconv.Itoa(r.GID),
+	}
+}
+
 // UserFromOSUser returns a new user from the specified storage user
 func UserFromOSUser(user storage.OSUser) (*User, error) {
 	uid, err := strconv.Atoi(user.UID)

--- a/lib/update/cluster/engine.go
+++ b/lib/update/cluster/engine.go
@@ -68,7 +68,7 @@ type Config struct {
 	update.Config
 	// HostLocalBackend is the host-local backend that stores bootstrap configuration
 	// like DNS, logins etc.
-	HostLocalBackend storage.Backend
+	HostLocalBackend storage.LocalBackend
 	// Packages is the local package service
 	Packages pack.PackageService
 	// ClusterPackages is the package service that talks to cluster API

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -161,7 +161,7 @@ func (p *updatePhaseBootstrap) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.pullSystemUpdates(ctx)
+	err = p.pullSystemUpdates()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -236,7 +236,7 @@ func (p *updatePhaseBootstrap) updateServiceUser() error {
 	return p.HostLocalBackend.SetServiceUser(p.ServiceUser.OSUser())
 }
 
-func (p *updatePhaseBootstrap) pullSystemUpdates(ctx context.Context) error {
+func (p *updatePhaseBootstrap) pullSystemUpdates() error {
 	p.Info("Pull system updates.")
 	updates := []loc.Locator{p.GravityPackage}
 	if p.Server.Runtime.SecretsPackage != nil {

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -60,7 +60,7 @@ type updatePhaseBootstrap struct {
 	LocalBackend storage.Backend
 	// HostLocalBackend is the host-local state backend used to persist global settings
 	// like DNS configuration, logins etc.
-	HostLocalBackend storage.Backend
+	HostLocalBackend storage.LocalBackend
 	// GravityPath is the path to the new gravity binary
 	GravityPath string
 	// GravityPackage specifies the new gravity package
@@ -80,7 +80,7 @@ type updatePhaseBootstrap struct {
 func NewUpdatePhaseBootstrap(
 	p fsm.ExecutorParams,
 	operator ops.Operator,
-	backend, localBackend, hostLocalBackend storage.Backend,
+	backend, localBackend storage.Backend, hostLocalBackend storage.LocalBackend,
 	localPackages, packages pack.PackageService,
 	remote fsm.Remote,
 	logger log.FieldLogger,

--- a/lib/update/cluster/phases/bootstrap.go
+++ b/lib/update/cluster/phases/bootstrap.go
@@ -149,7 +149,7 @@ func (p *updatePhaseBootstrap) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.updateDNSConfig()
+	err = p.updateSystemMetadata()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -161,7 +161,7 @@ func (p *updatePhaseBootstrap) Execute(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.pullSystemUpdates()
+	err = p.pullSystemUpdates(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -204,6 +204,16 @@ func (p *updatePhaseBootstrap) exportGravity(ctx context.Context) error {
 	return trace.Wrap(err)
 }
 
+func (p *updatePhaseBootstrap) updateSystemMetadata() error {
+	if err := p.updateDNSConfig(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := p.updateNodeAddr(); err != nil {
+		return trace.Wrap(err)
+	}
+	return p.updateServiceUser()
+}
+
 // updateDNSConfig persists the DNS configuration in the local backend if it has not been set
 func (p *updatePhaseBootstrap) updateDNSConfig() error {
 	p.Infof("Update cluster DNS configuration as %v.", p.Plan.DNSConfig)
@@ -214,7 +224,19 @@ func (p *updatePhaseBootstrap) updateDNSConfig() error {
 	return nil
 }
 
-func (p *updatePhaseBootstrap) pullSystemUpdates() error {
+// updateNodeAddr persists the node advertise IP in the local state database
+func (p *updatePhaseBootstrap) updateNodeAddr() error {
+	p.Infof("Update node address as %v.", p.Server.AdvertiseIP)
+	return p.HostLocalBackend.SetNodeAddr(p.Server.AdvertiseIP)
+}
+
+// updateServiceUser persists the service user in the local state database
+func (p *updatePhaseBootstrap) updateServiceUser() error {
+	p.Infof("Update service user as %v.", p.ServiceUser)
+	return p.HostLocalBackend.SetServiceUser(p.ServiceUser.OSUser())
+}
+
+func (p *updatePhaseBootstrap) pullSystemUpdates(ctx context.Context) error {
 	p.Info("Pull system updates.")
 	updates := []loc.Locator{p.GravityPackage}
 	if p.Server.Runtime.SecretsPackage != nil {

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/fsm"
 	"github.com/gravitational/gravity/lib/install"
+	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/ops"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/rpc"
@@ -172,7 +173,8 @@ func (p *updatePhaseInit) PostCheck(context.Context) error {
 func (p *updatePhaseInit) Execute(context.Context) error {
 	err := removeLegacyUpdateDirectory(p.FieldLogger)
 	if err != nil {
-		return trace.Wrap(err, "failed to remove legacy update directory")
+		// Handle on best-effort basis - do not consider this a fatal error
+		p.WithError(err).Warn("Failed to remove legacy update directory.")
 	}
 	if err := p.createAdminAgent(); err != nil {
 		return trace.Wrap(err, "failed to create cluster admin agent")
@@ -180,7 +182,7 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	if err := p.upsertServiceUser(); err != nil {
 		return trace.Wrap(err, "failed to upsert service user")
 	}
-	if err := p.initRPCCredentials(); err != nil {
+	if err := p.updateRPCCredentials(); err != nil {
 		return trace.Wrap(err, "failed to update RPC credentials")
 	}
 	if err := p.initTeleportAuthToken(); err != nil {
@@ -250,28 +252,56 @@ func (p *updatePhaseInit) initTeleportAuthToken() error {
 	return nil
 }
 
-func (p *updatePhaseInit) initRPCCredentials() error {
-	// FIXME: the secrets package is currently only generated once.
-	// Even though the package is generated with some time buffer in advance,
-	// we need to make sure if the existing package needs to be rotated (i.e.
-	// as expiring soon).
-	// This will ether need to generate a new package version and then the
-	// problem becomes how the agents will know the name of the package.
-	// Or, the package version is recycled and then we need to make sure
-	// to restart the cluster controller (gravity-site) to make sure it has
-	// reloaded its copy of the credentials.
-	// See: https://github.com/gravitational/gravity/issues/3607.
-	pkg, err := rpc.InitRPCCredentials(p.Packages)
-	if err != nil && !trace.IsAlreadyExists(err) {
+// updateRPCCredentials rotates the RPC credentials used for install/expand/leave operations.
+func (p *updatePhaseInit) updateRPCCredentials() error {
+	// This assumes that the cluster controller Pods are eventually restarted
+	// by the upcoming phase for these changes to take effect.
+	//
+	// Currently the upgrade short-circuits the application-only upgrades by not
+	// including the init phase so this is safe.
+	//
+	// Keep it in mind for future changes.
+	// See https://github.com/gravitational/gravity/issues/3607 for more details when we had
+	// to be careful about it previously.
+	p.Info("Update RPC credentials")
+	err := p.backupRPCCredentials()
+	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	if trace.IsAlreadyExists(err) {
-		p.Info("RPC credentials already initialized.")
-	} else {
-		p.Infof("Initialized RPC credentials: %v.", pkg)
+	loc, err := rpc.UpsertCredentials(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
 	}
+	p.WithField("package", loc.String()).Info("Update RPC credentials.")
+	return nil
+}
 
+func (p *updatePhaseInit) backupRPCCredentials() error {
+	p.Info("Backup RPC credentials")
+	env, rc, err := rpc.LoadCredentialsData(p.Packages)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	_, err = p.Packages.UpsertPackage(rpcBackupPackage(p.Operation.SiteDomain), rc, pack.WithLabels(env.RuntimeLabels))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (p *updatePhaseInit) restoreRPCCredentials() error {
+	p.Info("Restore RPC credentials from backup")
+	env, rc, err := p.Packages.ReadPackage(rpcBackupPackage(p.Operation.SiteDomain))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer rc.Close()
+	delete(env.RuntimeLabels, pack.OperationIDLabel)
+	err = rpc.UpsertCredentialsFromData(p.Packages, rc, env.RuntimeLabels)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -511,11 +541,23 @@ func removeLegacyUpdateDirectory(log log.FieldLogger) error {
 }
 
 // Rollback rolls back the init phase
-func (p *updatePhaseInit) Rollback(context.Context) error {
+func (p *updatePhaseInit) Rollback(ctx context.Context) error {
+	err := p.restoreRPCCredentials()
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
 	if err := p.removeConfiguredPackages(); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
+}
+
+func rpcBackupPackage(repository string) loc.Locator {
+	return loc.Locator{
+		Repository: repository,
+		Name:       "rpcagent-secrets-backup",
+		Version:    loc.FirstVersion,
+	}
 }
 
 // removeConfiguredPackages removes packages configured during init phase

--- a/tool/gravity/cli/config.go
+++ b/tool/gravity/cli/config.go
@@ -139,7 +139,7 @@ type InstallConfig struct {
 	// LocalApps is the machine-local apps service
 	LocalApps appservice.Applications
 	// LocalBackend is the machine-local backend
-	LocalBackend storage.Backend
+	LocalBackend storage.LocalBackend
 	// GCENodeTags defines the VM instance tags on GCE
 	GCENodeTags []string
 	// LocalClusterClient is a factory for creating client to the installed cluster

--- a/tool/gravity/cli/rpcagent.go
+++ b/tool/gravity/cli/rpcagent.go
@@ -126,7 +126,7 @@ func newAgent() (rpcserver.Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	serverCreds, clientCreds, err := rpc.Credentials(secretsDir)
+	serverCreds, clientCreds, err := rpc.CredentialsFromDir(secretsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Forward port of https://github.com/gravitational/gravity/pull/1749 to bring feature parity with 7.x.
Part of a bigger attempt to forward-port intermediate version support to 9.x.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/1749

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
1. Install a 3-node cluster
2. Attempt to upgrade a 3-node cluster from base version 8.0.0-beta.1.5
  2.1. Trigger manual upgrade
  2.2. Step over /init to rotate RPC credentials
  2.3. Roll back the operation (to also restore credenetials)
3. Upgrade a 3-node cluster from base version 8.0.0-beta.1.5


## Additional information
<!--Optional. Anything else that may be relevant.-->
