### PR TITLE
Fix empty flannel backend configuration expectation on an existing cluster

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -1345,6 +1345,9 @@ var (
 
 	// KubeControllerManagerPort specifies the default controller manager healthz port
 	KubeControllerManagerPort = 10257
+
+	// FlannelBackend specifies the default flannel backend
+	FlannelBackend = "vxlan"
 )
 
 // HookSecurityContext returns default securityContext for hook pods

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1444,9 +1444,9 @@ func (s *site) addClusterConfig(config clusterconfig.Interface, overrideArgs map
 	if globalConfig.HighAvailability != nil && *globalConfig.HighAvailability {
 		args = append(args, "--high-availability")
 	}
-	if globalConfig.FlannelBackend != "" {
+	if globalConfig.FlannelBackend != nil {
 		args = append(args,
-			fmt.Sprintf("--flannel-backend=%v", globalConfig.FlannelBackend))
+			fmt.Sprintf("--flannel-backend=%v", *globalConfig.FlannelBackend))
 	}
 	return args
 }

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -664,9 +664,7 @@ func (r configCollection) WriteText(w io.Writer) error {
 		fmt.Fprintf(t, "%v\n", string(config.Config))
 	}
 	config := r.GetGlobalConfig()
-	if len(config.FlannelBackend) != 0 {
-		fmt.Fprintf(t, "Flannel Backend:\t%v\n", config.FlannelBackend)
-	}
+	fmt.Fprintf(t, "Flannel Backend:\t%v\n", utils.FormatStringPtrWithDefault(config.FlannelBackend, defaults.FlannelBackend))
 	if len(config.PodCIDR) != 0 {
 		fmt.Fprintf(t, "Pod IP Range:\t%v\n", config.PodCIDR)
 	}
@@ -685,7 +683,7 @@ func (r configCollection) WriteText(w io.Writer) error {
 	if len(config.FeatureGates) != 0 {
 		fmt.Fprintf(t, "Feature Gates:\t%v\n", formatFeatureGates(config.FeatureGates))
 	}
-	fmt.Fprintf(t, "High Availability:\t%v\n", formatBoolPtr(config.HighAvailability))
+	fmt.Fprintf(t, "High Availability:\t%v\n", utils.FormatBoolPtr(config.HighAvailability))
 	displayCloudConfig := config.CloudProvider != "" || config.CloudConfig != ""
 	if displayCloudConfig {
 		common.PrintCustomTableHeader(t, []string{"Cloud"}, "-")
@@ -740,13 +738,6 @@ func formatFeatureGates(features map[string]bool) string {
 		result = append(result, fmt.Sprintf("%v=%v", feature, enabled))
 	}
 	return strings.Join(result, ",")
-}
-
-func formatBoolPtr(ptr *bool) string {
-	if ptr == nil {
-		return "<unset>"
-	}
-	return fmt.Sprint(*ptr)
 }
 
 type operationsCollection struct {

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -140,8 +140,11 @@ func (r Resource) Merge(other Resource) Resource {
 		}
 	}
 	// Changing cloud provider is not supported
-	if other.Spec.Global.FlannelBackend != "" {
-		r.Spec.Global.FlannelBackend = other.Spec.Global.FlannelBackend
+	if other.Spec.Global.FlannelBackend != nil {
+		if r.Spec.Global.FlannelBackend == nil {
+			r.Spec.Global.FlannelBackend = new(string)
+		}
+		*r.Spec.Global.FlannelBackend = *other.Spec.Global.FlannelBackend
 	}
 	if other.Spec.Global.PodCIDR != "" {
 		r.Spec.Global.PodCIDR = other.Spec.Global.PodCIDR
@@ -279,7 +282,7 @@ func (r Global) IsEmpty() bool {
 		r.ServiceNodePortRange == "" &&
 		r.ProxyPortRange == "" &&
 		r.HighAvailability == nil &&
-		r.FlannelBackend == "" &&
+		r.FlannelBackend == nil &&
 		len(r.FeatureGates) == 0
 }
 
@@ -313,8 +316,8 @@ type Global struct {
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// HighAvailability enables high availability mode for Kubernetes.
 	HighAvailability *bool `json:"highAvailability,omitempty"`
-	// FlannelBackend specifies the backend to pair with flannel.
-	FlannelBackend string `json:"flannelBackend,omitempty"`
+	// FlannelBackend optionally specifies the backend to pair with flannel.
+	FlannelBackend *string `json:"flannelBackend,omitempty"`
 }
 
 // specSchemaTemplate is JSON schema for the cluster configuration resource

--- a/lib/storage/clusterconfig/clusterconfig_test.go
+++ b/lib/storage/clusterconfig/clusterconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/gravity/lib/constants"
 	"github.com/gravitational/gravity/lib/defaults"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/utils"
 
 	teleservices "github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
@@ -187,7 +188,7 @@ spec:
 						},
 						PodSubnetSize:    "26",
 						HighAvailability: newBoolPtr(true),
-						FlannelBackend:   "vxlan",
+						FlannelBackend:   utils.StringPtr("vxlan"),
 					},
 				},
 			},
@@ -246,7 +247,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature2": false,
 						},
 						HighAvailability: newBoolPtr(true),
-						FlannelBackend:   "vxlan",
+						FlannelBackend:   utils.StringPtr("vxlan"),
 					},
 				},
 			},
@@ -266,7 +267,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 							"feature2": false,
 						},
 						HighAvailability: newBoolPtr(true),
-						FlannelBackend:   "vxlan",
+						FlannelBackend:   utils.StringPtr("vxlan"),
 					},
 				},
 			},
@@ -294,7 +295,7 @@ address: 10.0.0.1
 							"feature1": true,
 							"feature2": false,
 						},
-						FlannelBackend: "vxlan",
+						FlannelBackend: utils.StringPtr("vxlan"),
 					},
 				},
 			},
@@ -341,7 +342,7 @@ address: 10.0.0.1
 							"feature1": true,
 							"feature3": true,
 						},
-						FlannelBackend: "vxlan",
+						FlannelBackend: utils.StringPtr("vxlan"),
 					},
 				},
 			},

--- a/lib/update/clusterconfig/plan.go
+++ b/lib/update/clusterconfig/plan.go
@@ -197,7 +197,7 @@ func shouldUpdateNodes(clusterConfig clusterconfig.Interface, numWorkerNodes int
 	config := clusterConfig.GetGlobalConfig()
 	hasComponentUpdate := len(config.FeatureGates) != 0
 	hasCIDRUpdate := len(config.PodCIDR) != 0 || len(config.ServiceCIDR) != 0 || config.PodSubnetSize != ""
-	hasFlannelUpdate := config.FlannelBackend != ""
+	hasFlannelUpdate := config.FlannelBackend != nil
 	return !clusterConfig.GetKubeletConfig().IsEmpty() || hasComponentUpdate || hasCIDRUpdate || hasFlannelUpdate
 }
 

--- a/lib/utils/units.go
+++ b/lib/utils/units.go
@@ -146,13 +146,38 @@ func BoolPtr(v bool) *bool {
 	return &v
 }
 
+// FormatBoolPtr formats the bool pointer value for output
+func FormatBoolPtr(v *bool) string {
+	if v == nil {
+		return "<unset>"
+	}
+	return fmt.Sprint(*v)
+}
+
 // DurationPtr returns a pointer to the provided duration value
 func DurationPtr(v time.Duration) *teleservices.Duration {
 	d := teleservices.NewDuration(v)
 	return &d
 }
 
+// StringValue returns the string value in v or an empty string if it's nil
+func StringValue(v *string) string {
+	if v != nil {
+		return *v
+	}
+	return ""
+}
+
 // StringPtr returns a pointer to the provided string
 func StringPtr(s string) *string {
 	return &s
+}
+
+// FormatStringPtrWithDefault formats the string pointer value for output.
+// If the pointer value is nil, the specified default is used
+func FormatStringPtrWithDefault(v *string, def string) string {
+	if v == nil {
+		return def
+	}
+	return *v
 }

--- a/lib/validate/clusterconfig.go
+++ b/lib/validate/clusterconfig.go
@@ -89,8 +89,13 @@ func ClusterConfiguration(existing, update clusterconfig.Interface) error {
 		return trace.Wrap(err)
 	}
 
-	if !isSupportedBackend(newGlobalConfig.FlannelBackend) {
-		return trace.BadParameter("unsupported flannel backend was specified: %v", newGlobalConfig.FlannelBackend)
+	if newGlobalConfig.FlannelBackend != nil {
+		if *newGlobalConfig.FlannelBackend == "" {
+			return trace.BadParameter("flannel backend cannot be reset")
+		}
+		if !isSupportedBackend(*newGlobalConfig.FlannelBackend) {
+			return trace.BadParameter("unsupported flannel backend was specified: %v", *newGlobalConfig.FlannelBackend)
+		}
 	}
 
 	return nil

--- a/tool/gravity/cli/config_test.go
+++ b/tool/gravity/cli/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/gravity/lib/ops/resources"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
+	"github.com/gravitational/gravity/lib/utils"
 
 	"gopkg.in/check.v1"
 )
@@ -77,7 +78,7 @@ spec:
 				ServiceCIDR:    "100.200.0.0/16",
 				PodCIDR:        "100.96.0.0/16",
 				PodSubnetSize:  "26",
-				FlannelBackend: "vxlan",
+				FlannelBackend: utils.StringPtr("vxlan"),
 				CloudConfig: `[global]
 node-tags=example-cluster
 multizone="true"


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
I guess this is similar to the HA reconfiguration [fix](https://github.com/gravitational/gravity/pull/2573) - enable cluster configuration updates on an existing cluster (when flannel backend is not updated).

Configuration file used:
```yaml
kind: ClusterConfiguration
version: v1
spec:
  global:
    cloudProvider: generic
    highAvailability: true
```

Before the change:
```
$ gravity resource create -f haconfig-active.yaml --confirm
[ERROR]: unsupported flannel backend was specified:
```

After the change:
```
$ gravity resource create -f haconfig-active.yaml --confirm
Wed Aug 11 12:44:01 UTC	Deploying agents on cluster nodes
Deployed agent on vm-3 (172.17.0.4)
Deployed agent on vm-2 (172.17.0.3)
Deployed agent on vm-1 (172.17.0.2)
...
```
<details><summary><code>Logs</code></summary>

```
Executing "/update-config" locally
Wed Aug 11 12:44:12 UTC	Update runtime configuration
Executing "/masters/vm-1/stepdown" locally
Wed Aug 11 12:44:15 UTC	Step down "vm-1" as Kubernetes leader
Disable leader elections on vm-1
Waiting for new leader election
Executing "/masters/vm-1/drain" locally
Wed Aug 11 12:44:17 UTC	Drain node "vm-1"
	Still executing "/masters/vm-1/drain" locally (10 seconds elapsed)
Executing "/masters/vm-1/restart" locally
Wed Aug 11 12:44:33 UTC	Restart container on node "vm-1"
	Still executing "/masters/vm-1/restart" locally (10 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (20 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (30 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (40 seconds elapsed)
	Still executing "/masters/vm-1/restart" locally (50 seconds elapsed)
Executing "/masters/vm-1/elect" locally
Wed Aug 11 12:45:23 UTC	Make node "vm-1" Kubernetes leader
Disable leader elections on vm-3
Disable leader elections on vm-2
Enable leader elections on vm-1
Waiting for new leader election
Executing "/masters/vm-1/taint" locally
Wed Aug 11 12:45:26 UTC	Taint node "vm-1"
	Still executing "/masters/vm-1/taint" locally (10 seconds elapsed)
Executing "/masters/vm-1/uncordon" locally
Wed Aug 11 12:45:40 UTC	Uncordon node "vm-1"
Executing "/masters/vm-1/endpoints" locally
Wed Aug 11 12:45:41 UTC	Wait for endpoints on node "vm-1"
Executing "/masters/vm-1/untaint" locally
Wed Aug 11 12:45:42 UTC	Remove taint from node "vm-1"
Executing "/masters/vm-3/drain" on remote node vm-3
Wed Aug 11 12:45:43 UTC	Drain node "vm-3"
	Still executing "/masters/vm-3/drain" on remote node vm-3 (10 seconds elapsed)
Executing "/masters/vm-3/restart" on remote node vm-3
Wed Aug 11 12:45:57 UTC	Restart container on node "vm-3"
	Still executing "/masters/vm-3/restart" on remote node vm-3 (10 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (20 seconds elapsed)
	Still executing "/masters/vm-3/restart" on remote node vm-3 (30 seconds elapsed)
Executing "/masters/vm-3/taint" on remote node vm-3
Wed Aug 11 12:46:33 UTC	Taint node "vm-3"
Executing "/masters/vm-3/uncordon" on remote node vm-3
Wed Aug 11 12:46:35 UTC	Uncordon node "vm-3"
Executing "/masters/vm-3/endpoints" on remote node vm-3
Wed Aug 11 12:46:38 UTC	Wait for endpoints on node "vm-3"
Executing "/masters/vm-3/untaint" on remote node vm-3
Wed Aug 11 12:46:41 UTC	Remove taint from node "vm-3"
Executing "/masters/vm-3/enable-elections" on remote node vm-3
Wed Aug 11 12:46:44 UTC	Enable leader election on node "vm-3"
Executing "/masters/vm-2/drain" on remote node vm-2
Wed Aug 11 12:46:47 UTC	Drain node "vm-2"
Executing "/masters/vm-2/restart" on remote node vm-2
Wed Aug 11 12:46:51 UTC	Restart container on node "vm-2"
	Still executing "/masters/vm-2/restart" on remote node vm-2 (10 seconds elapsed)
Executing "/masters/vm-2/taint" on remote node vm-2
Wed Aug 11 12:47:07 UTC	Taint node "vm-2"
Executing "/masters/vm-2/uncordon" on remote node vm-2
Wed Aug 11 12:47:09 UTC	Uncordon node "vm-2"
Executing "/masters/vm-2/endpoints" on remote node vm-2
Wed Aug 11 12:47:12 UTC	Wait for endpoints on node "vm-2"
Executing "/masters/vm-2/untaint" on remote node vm-2
Wed Aug 11 12:47:14 UTC	Remove taint from node "vm-2"
Executing "/masters/vm-2/enable-elections" on remote node vm-2
Wed Aug 11 12:47:18 UTC	Enable leader election on node "vm-2"
Wed Aug 11 12:47:22 UTC	Operation has completed
operation(update configuration(db0c9be5-5c81-4c45-8525-af7d64034c0a), cluster=test, created=2021-08-11 12:44) finished in 3 minutes
```
</details>

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
1. Updated cluster configuration with the configuration file from above.
2. Attempt to updated flannel backend from an invalid value (explicitly empty and unsupported value).
3. Update flannel backend using an explicitly set value.

## Additional information
<!--Optional. Anything else that may be relevant.-->
