### PR TITLE
Return error stack traces for the CLI client

### DIFF
--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -967,7 +967,7 @@ func (h *WebHandler) wrap(fn func(w http.ResponseWriter, r *http.Request, p http
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		if err := fn(w, r, p); err != nil {
 			log.WithFields(fields.FromRequest(r)).WithError(err).Info("Handler error.")
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 		}
 	}
 }
@@ -979,7 +979,7 @@ func (h *WebHandler) needsAuth(fn serviceHandler) httprouter.Handle {
 		authResult, err := h.Authenticator.Authenticate(w, r)
 		if err != nil {
 			logger.WithError(err).Warn("Authentication error.")
-			trace.WriteError(w, trace.Unwrap(trace.AccessDenied("bad username or password"))) // Hide the actual error.
+			httplib.WriteError(w, trace.AccessDenied("bad username or password"), r.Header) // Hide the actual error.
 			return
 		}
 
@@ -995,7 +995,7 @@ func (h *WebHandler) needsAuth(fn serviceHandler) httprouter.Handle {
 			} else {
 				logger.WithError(err).Debug("Handler error.")
 			}
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 		}
 	}
 }

--- a/lib/blob/handler/blobhandler.go
+++ b/lib/blob/handler/blobhandler.go
@@ -93,7 +93,7 @@ func (s *Server) notFound(w http.ResponseWriter, r *http.Request) {
 		"method":     r.Method,
 		"url":        r.URL.String(),
 	}).Warn("Invalid request.")
-	trace.WriteError(w, trace.Unwrap(err))
+	httplib.WriteError(w, err, r.Header)
 }
 
 func (s *Server) getBLOBs(w http.ResponseWriter, r *http.Request, p httprouter.Params, objects blob.Objects) error {
@@ -177,7 +177,7 @@ func (s *Server) needsAuth(fn authHandle, objects blob.Objects) httprouter.Handl
 		authCreds, err := httplib.ParseAuthHeaders(r)
 		if err != nil {
 			log.WithError(err).Warn("Invalid auth headers.")
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 			return
 		}
 
@@ -185,8 +185,7 @@ func (s *Server) needsAuth(fn authHandle, objects blob.Objects) httprouter.Handl
 		if err != nil {
 			log.WithError(err).Info("Authentication error.")
 			// we hide the error from the remote user to avoid giving any hints
-			trace.WriteError(
-				w, trace.Unwrap(trace.AccessDenied("bad username or password")))
+			httplib.WriteError(w, trace.AccessDenied("bad username or password"), r.Header)
 			return
 		}
 
@@ -195,7 +194,7 @@ func (s *Server) needsAuth(fn authHandle, objects blob.Objects) httprouter.Handl
 			if !trace.IsNotFound(err) && !trace.IsAlreadyExists(err) {
 				log.Errorf("handler error: %v", trace.DebugReport(err))
 			}
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 		}
 	}
 }

--- a/lib/httplib/http.go
+++ b/lib/httplib/http.go
@@ -205,3 +205,19 @@ var Methods = []string{
 	http.MethodPatch,
 	http.MethodHead,
 }
+
+// WriteError serializes the given error into the provided response writer.
+// The amount of serialized information depends on the HTTP headers.
+func WriteError(w http.ResponseWriter, err error, hdr http.Header) {
+	if hdr.Get(clientIDHeader) != gravityCLIClientID {
+		// Remove stack traces if this is not a gravity client
+		trace.WriteError(w, trace.Unwrap(err))
+		return
+	}
+	trace.WriteError(w, err)
+}
+
+const (
+	clientIDHeader     = "X-Gravity-Client-ID"
+	gravityCLIClientID = "gravity"
+)

--- a/lib/install/fsmspec.go
+++ b/lib/install/fsmspec.go
@@ -119,10 +119,6 @@ func DefaultFSMSpec(config FSMConfig) fsm.FSMSpecFunc {
 				config.Operator,
 				config.OperationKey)
 
-		case phases.ConfigurePhase:
-			return phases.NewConfigure(p,
-				config.Operator)
-
 		case phases.WaitPhase:
 			client, err := getKubeClient(p)
 			if err != nil {

--- a/lib/ops/opshandler/opshandler.go
+++ b/lib/ops/opshandler/opshandler.go
@@ -359,7 +359,7 @@ func (h *WebHandler) getSiteInstructions(w http.ResponseWriter, r *http.Request,
 	instructions, err := h.cfg.Operator.GetSiteInstructions(token, serverProfile, r.URL.Query())
 	if err != nil {
 		log.WithError(err).Warn("Failed to query cluster install instructions.")
-		trace.WriteError(w, trace.Unwrap(err))
+		httplib.WriteError(w, err, r.Header)
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
@@ -2441,7 +2441,7 @@ func NeedsAuth(devmode bool, backend storage.Backend, operator ops.Operator, aut
 			if trace.IsAccessDenied(err) {
 				log.WithFields(fields.FromRequest(r)).WithError(err).Warn("Access denied.")
 			}
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 		}
 	}
 }

--- a/lib/pack/webpack/webpack.go
+++ b/lib/pack/webpack/webpack.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gravitational/gravity/lib/httplib"
 	"github.com/gravitational/gravity/lib/loc"
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/storage"
@@ -320,7 +321,7 @@ func (s *Server) needsAuth(fn authHandle) httprouter.Handle {
 		authResult, err := s.cfg.Authenticator.Authenticate(w, r)
 		if err != nil {
 			logger.WithError(err).Warn("Authentication error.")
-			trace.WriteError(w, trace.Unwrap(trace.AccessDenied("bad username or password"))) // Hide the actual error.
+			httplib.WriteError(w, trace.AccessDenied("bad username or password"), r.Header) // Hide the actual error.
 			return
 		}
 
@@ -334,7 +335,7 @@ func (s *Server) needsAuth(fn authHandle) httprouter.Handle {
 			} else if !trace.IsNotFound(err) && !trace.IsAlreadyExists(err) {
 				logger.WithError(err).Error("Handler error.")
 			}
-			trace.WriteError(w, trace.Unwrap(err))
+			httplib.WriteError(w, err, r.Header)
 		}
 	}
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Revisit https://github.com/gravitational/gravity/issues/2269 to implement conditional stack traces for HTTP APIs.
The [original implementation](https://github.com/gravitational/gravity/pull/2357) removes the stack traces from HTTP APIs
errors unconditionally which results in reduced troubleshooting efficacy
when the errors contain important details about a failure from the CLI
client.
In order to counter this and provide useful information when necessary,
the stack traces are only stripped if the request does not contain a
custom marker identifying the gravity client.

## Type of change
<!--Required. Keep only those that apply.-->

* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2269.

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
```
$ curl -k -H "Content-Type: application/json" -d '{"username": "example", "password":"invalid"}' https://localhost:61009/proxy/v1/webapi/sessions
{
    "error": {
        "message": "access denied"
    }
}
```

Before the change:
```
$ ./gravity --debug resume
Thu Aug 12 13:02:34 UTC	Connecting to installer
Thu Aug 12 13:02:34 UTC	Connected to installer
Thu Aug 12 13:02:34 UTC	Successfully added "node" node on 172.17.0.2
Thu Aug 12 13:02:34 UTC	All agents have connected!
Thu Aug 12 13:02:35 UTC	Executing "/configure" locally
Thu Aug 12 13:02:36 UTC	Configuring cluster packages
Thu Aug 12 13:02:36 UTC	Configure packages for all nodes
Thu Aug 12 13:02:39 UTC	Executing operation finished in 4 seconds
Thu Aug 12 13:02:39 UTC	Saving debug report to /root/installer/crashreport.tgz
[ERROR]: failed to execute phase "/configure"
```
and the log:

<details><summary><code>Logs</code></summary>

```
2021-08-12T13:02:39Z WARN [INSTALLER] Failed to execute. error:[
ERROR REPORT:
Original Error: *internal.RawTrace 
Stack Trace:
        github.com/gravitational/teleport@v3.2.17+incompatible/lib/httplib/httplib.go:122 github.com/gravitational/teleport/lib/httplib.ConvertResponse
        github.com/gravitational/gravity@/lib/ops/opsclient/opsclient.go:1670 github.com/gravitational/gravity/lib/ops/opsclient.(*Client).PostJSON
        github.com/gravitational/gravity@/lib/ops/opsclient/opsclient.go:943 github.com/gravitational/gravity/lib/ops/opsclient.(*Client).ConfigurePackages
        github.com/gravitational/gravity@/lib/install/phases/configure.go:69 github.com/gravitational/gravity/lib/install/phases.(*configureExecutor).Execute
        github.com/gravitational/gravity@/lib/fsm/fsm.go:525 github.com/gravitational/gravity/lib/fsm.(*FSM).executeOnePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:442 github.com/gravitational/gravity/lib/fsm.(*FSM).executePhaseLocally
        github.com/gravitational/gravity@/lib/fsm/fsm.go:402 github.com/gravitational/gravity/lib/fsm.(*FSM).executePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:246 github.com/gravitational/gravity/lib/fsm.(*FSM).ExecutePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:175 github.com/gravitational/gravity/lib/fsm.(*FSM).ExecutePlan
        github.com/gravitational/gravity@/lib/install/operation.go:81 github.com/gravitational/gravity/lib/install.(*Installer).ExecuteOperation
        github.com/gravitational/gravity@/lib/install/engine/cli/cli.go:107 github.com/gravitational/gravity/lib/install/engine/cli.(*Engine).execute
        github.com/gravitational/gravity@/lib/install/engine/cli/cli.go:79 github.com/gravitational/gravity/lib/install/engine/cli.(*Engine).Execute
        github.com/gravitational/gravity@/lib/install/install.go:258 github.com/gravitational/gravity/lib/install.(*Installer).execute
        github.com/gravitational/gravity@/lib/install/install.go:206 github.com/gravitational/gravity/lib/install.(*Installer).startExecuteLoop.func1
        runtime/asm_amd64.s:1357 runtime.goexit
User Message: failed to execute phase "/configure"
```
</details>

After the change:

```
$ ./gravity --debug resume
Thu Aug 12 12:17:04 UTC	Connecting to installer
Thu Aug 12 12:17:04 UTC	Connected to installer
Thu Aug 12 12:17:04 UTC	Successfully added "node" node on 172.17.0.2
Thu Aug 12 12:17:04 UTC	All agents have connected!
Thu Aug 12 12:17:05 UTC	Executing "/configure" locally
Thu Aug 12 12:17:06 UTC	Configuring cluster packages
Thu Aug 12 12:17:06 UTC	Configure packages for all nodes
Thu Aug 12 12:17:09 UTC	Saving debug report to /root/installer/crashreport.tgz
[ERROR]: failed to execute phase "/configure"
	failed to parse name: 'foo-type'
	1:14: expected operand, found 'type'
```
and the corresponding log:

<details><summary><code>Logs</code></summary>

```
2021-08-12T11:19:40Z WARN [INSTALLER] Failed to execute. error:[
ERROR REPORT:
Original Error: *internal.RawTrace 1:14: expected operand, found 'type'
Stack Trace:
        github.com/gravitational/configure@v0.0.0-20191213111049-fce91dea0d0d/schema/schema.go:323 github.com/gravitational/configure/schema.(*cparser).checkName
        github.com/gravitational/configure@v0.0.0-20191213111049-fce91dea0d0d/schema/schema.go:207 github.com/gravitational/configure/schema.(*cparser).parseParam
        github.com/gravitational/configure@v0.0.0-20191213111049-fce91dea0d0d/schema/schema.go:192 github.com/gravitational/configure/schema.(*cparser).parse
        github.com/gravitational/configure@v0.0.0-20191213111049-fce91dea0d0d/schema/schema.go:38 github.com/gravitational/configure/schema.ParseJSON
        github.com/gravitational/gravity@/lib/pack/manifest.go:190 github.com/gravitational/gravity/lib/pack.ParseManifestJSON
        github.com/gravitational/gravity@/lib/pack/manifest.go:175 github.com/gravitational/gravity/lib/pack.ReadManifest
        github.com/gravitational/gravity@/lib/pack/utils.go:136 github.com/gravitational/gravity/lib/pack.GetConfigPackage
        github.com/gravitational/gravity@/lib/ops/opsservice/configure.go:870 github.com/gravitational/gravity/lib/ops/opsservice.(*site).getPlanetConfigPackage
        github.com/gravitational/gravity@/lib/ops/opsservice/configure.go:1033 github.com/gravitational/gravity/lib/ops/opsservice.(*site).configurePlanetServer
        github.com/gravitational/gravity@/lib/ops/opsservice/configure.go:847 github.com/gravitational/gravity/lib/ops/opsservice.(*site).configurePlanetMaster
        github.com/gravitational/gravity@/lib/ops/opsservice/configure.go:378 github.com/gravitational/gravity/lib/ops/opsservice.(*site).configurePackages
        github.com/gravitational/gravity@/lib/ops/opsservice/configure.go:111 github.com/gravitational/gravity/lib/ops/opsservice.(*Operator).ConfigurePackages
        github.com/gravitational/gravity@/lib/ops/opsroute/forward.go:521 github.com/gravitational/gravity/lib/ops/opsroute.(*Router).ConfigurePackages
        github.com/gravitational/gravity@/lib/ops/operatoracl.go:664 github.com/gravitational/gravity/lib/ops.(*OperatorACL).ConfigurePackages
        github.com/gravitational/gravity@/lib/ops/opshandler/opshandler.go:1620 github.com/gravitational/gravity/lib/ops/opshandler.(*WebHandler).configurePackages
        github.com/gravitational/gravity@/lib/ops/opshandler/opshandler.go:2432 github.com/gravitational/gravity/lib/ops/opshandler.NeedsAuth.func1
        github.com/gravitational/gravity@/lib/ops/opshandler/opshandler.go:2439 github.com/gravitational/gravity/lib/ops/opshandler.NeedsAuth.func2
        @/github.com/julienschmidt/httprouter/router.go:299 github.com/julienschmidt/httprouter.(*Router).ServeHTTP
        github.com/gravitational/teleport@v3.2.17+incompatible/lib/auth/middleware.go:299 github.com/gravitational/teleport/lib/auth.(*AuthMiddleware).ServeHTTP
        github.com/gravitational/gravity@/lib/ops/opshandler/opshandler.go:344 github.com/gravitational/gravity/lib/ops/opshandler.(*WebHandler).ServeHTTP
github.com/gravitational/gravity@/lib/ops/opshandler/opshandler.go:344 github.com/gravitational/gravity/lib/ops/opshandler.(*WebHandler).ServeHTTP
        @/github.com/julienschmidt/httprouter/router.go:237 github.com/julienschmidt/httprouter.(*Router).Handler.func1
        @/github.com/julienschmidt/httprouter/router.go:299 github.com/julienschmidt/httprouter.(*Router).ServeHTTP
        github.com/gravitational/gravity@/lib/httplib/http.go:187 github.com/gravitational/gravity/lib/httplib.GRPCHandlerFunc.func1
        net/http/server.go:2007 net/http.HandlerFunc.ServeHTTP
        net/http/server.go:2802 net/http.serverHandler.ServeHTTP
        net/http/server.go:1890 net/http.(*conn).serve
        runtime/asm_amd64.s:1357 runtime.goexit
Caught:
        github.com/gravitational/teleport@v3.2.17+incompatible/lib/httplib/httplib.go:122 github.com/gravitational/teleport/lib/httplib.ConvertResponse
        github.com/gravitational/gravity@/lib/ops/opsclient/opsclient.go:1670 github.com/gravitational/gravity/lib/ops/opsclient.(*Client).PostJSON
        github.com/gravitational/gravity@/lib/ops/opsclient/opsclient.go:943 github.com/gravitational/gravity/lib/ops/opsclient.(*Client).ConfigurePackages
        github.com/gravitational/gravity@/lib/install/phases/configure.go:69 github.com/gravitational/gravity/lib/install/phases.(*configureExecutor).Execute
        github.com/gravitational/gravity@/lib/fsm/fsm.go:525 github.com/gravitational/gravity/lib/fsm.(*FSM).executeOnePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:442 github.com/gravitational/gravity/lib/fsm.(*FSM).executePhaseLocally
        github.com/gravitational/gravity@/lib/fsm/fsm.go:402 github.com/gravitational/gravity/lib/fsm.(*FSM).executePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:246 github.com/gravitational/gravity/lib/fsm.(*FSM).ExecutePhase
        github.com/gravitational/gravity@/lib/fsm/fsm.go:175 github.com/gravitational/gravity/lib/fsm.(*FSM).ExecutePlan
        github.com/gravitational/gravity@/lib/install/operation.go:81 github.com/gravitational/gravity/lib/install.(*Installer).ExecuteOperation
        github.com/gravitational/gravity@/lib/install/engine/cli/cli.go:107 github.com/gravitational/gravity/lib/install/engine/cli.(*Engine).execute
        github.com/gravitational/gravity@/lib/install/engine/cli/cli.go:79 github.com/gravitational/gravity/lib/install/engine/cli.(*Engine).Execute
        github.com/gravitational/gravity@/lib/install/install.go:258 github.com/gravitational/gravity/lib/install.(*Installer).execute
        github.com/gravitational/gravity@/lib/install/install.go:206 github.com/gravitational/gravity/lib/install.(*Installer).startExecuteLoop.func1
        runtime/asm_amd64.s:1357 runtime.goexit
User Message: failed to parse name: 'foo-type'
        1:14: expected operand, found 'type'
```
</details>

## Additional information
<!--Optional. Anything else that may be relevant.-->
