### PR TITLE
Remove sles/SUSE from robotest configs

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -9,8 +9,8 @@ source $(dirname $0)/lib/utils.sh
 declare -A UPGRADE_MAP
 
 # Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[8.0.0-beta.1]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
@@ -81,7 +81,7 @@ EOF
 }
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_sizes=( \
     '"flavor":"six","nodes":6,"role":"node"')
   for os in $oses; do

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -55,7 +55,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
We not aware of any customers that use SLES, and this test is
currently broken because GCP removed the SLES disk image robotest
depends on, resulting in the following error:

   Error: Error resolving image name 'suse-cloud/sles-15-sp2-v20201014': Could not find image or family suse-cloud/sles-15-sp2-v20201014

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
* Works around https://github.com/gravitational/robotest/issues/290

## TODOs
- [x] Self-review the change
- [ ] Verify CI Passes
- [ ] Address review feedback

## Testing done
None.  If CI passes this is good to go.

## Additional information
After a discussion with @knisbet in slack, we determined we weren't getting a good ROI running
SLES tests regularly.  I'll fix/remove this upstream in Robotest at some point (see https://github.com/gravitational/robotest/issues/290), but this at least will unblock gravity merges.

This needs backports to 8.0.x and 7.0.x, but no further, as we don't test against sles on 6.1/5.5.
