### PR TITLE
Switch gravity repo CODEOWNERS to the newer terraformed teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Global Owners
-*  @gravitational/codeowners-gravity-code
+*  @gravitational/gravity-team
 
-# Web UI
-/web/ @gravitational/codeowners-gravity-web
+# Edits to this file
+/.github/CODEOWNERS @knisbet


### PR DESCRIPTION
## Description
This allows us to retire the codowers-gravity group and subgroups, which
are exceptions to the rule.

Currently @gravitational/codeowners-gravity-code is empty, meaning we can't easily merge to this repo.  Instead of fixing it again, I figured we should flip to use the sanctioned IT managed groups.


## Type of change
* Internal change

## Linked tickets and other PRs
N/A

## TODOs
- [ ] Address review feedback
- [ ] Ports
- [ ] (after merge of this and ports) Nuke the old gravity-codeowners groups

## Testing done
None.

## Additional Information
I'll backport this to all active branches after we've agreed the updates look correct.