### PR TITLE
[8.0] Remove sles/SUSE from robotest configs

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -7,8 +7,8 @@ source $(dirname $0)/lib/utils.sh
 
 # UPGRADE_MAP maps gravity version -> list of linux distros to upgrade from
 declare -A UPGRADE_MAP
-UPGRADE_MAP[7.1.0-alpha.5]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[7.1.0-alpha.5]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[$(recommended_upgrade_tag $(branch 7.0.x))]="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[7.0.13]="centos:7" # 7.0.13 + centos is combination that is critical in the field -- 2020-07 walt
 UPGRADE_MAP[7.0.12]="ubuntu:18"  # 7.0.12 is the first LTS 7.0 release
 UPGRADE_MAP[7.0.0]="ubuntu:16"
@@ -83,7 +83,7 @@ EOF
 }
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.2 redhat:7.8 centos:8.2 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_sizes=( \
     '"flavor":"six","nodes":6,"role":"node"')
   for os in $oses; do

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -57,7 +57,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
8.0.x backport of #2606.

We not aware of any customers that use SLES, and this test is
currently broken because GCP removed the SLES disk image robotest
depends on, resulting in the following error:

   Error: Error resolving image name 'suse-cloud/sles-15-sp2-v20201014': Could not find image or family suse-cloud/sles-15-sp2-v20201014

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
* Works around https://github.com/gravitational/robotest/issues/290
* Ports #2606.

## TODOs
- [x] Self-review the change
- [ ] Verify CI Passes
- [ ] Address review feedback

## Testing done
None.  If CI passes this is good to go.
