### PR TITLE
[7.0] Remove sles/SUSE from robotest configs

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -83,7 +83,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
7.0.x backport of #2606.

We not aware of any customers that use SLES, and this test is
currently broken because GCP removed the SLES disk image robotest
depends on, resulting in the following error:

   Error: Error resolving image name 'suse-cloud/sles-15-sp2-v20201014': Could not find image or family suse-cloud/sles-15-sp2-v20201014

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* This change has a user-facing impact

## Linked tickets and other PRs
* Works around https://github.com/gravitational/robotest/issues/290
* Ports #2606.

## TODOs
- [x] Self-review the change
- [ ] Verify CI Passes
- [ ] Address review feedback

## Testing done
None.  If CI passes this is good to go.
