### PR TITLE
Generate prometheus-operator key pair

### DIFF
--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -284,6 +284,8 @@ const (
 	LograngeCollectorKeyPair = "logrange-collector"
 	// LograngeForwarderKeyPair is a cert/key used by logrange forwarder component
 	LograngeForwarderKeyPair = "logrange-forwarder"
+	// PrometheusKeyPair is a cert/key used by prometheus-operator
+	PrometheusKeyPair = "prometheus-operator"
 
 	// ClusterAdminGroup is a group name for Kubernetes cluster amdin
 	ClusterAdminGroup = "system:masters"

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -614,6 +614,7 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 		constants.LograngeAggregatorKeyPair:     {},
 		constants.LograngeCollectorKeyPair:      {},
 		constants.LograngeForwarderKeyPair:      {},
+		constants.PrometheusKeyPair:             {group: constants.ClusterAdminGroup},
 	}
 
 	for name, config := range keyPairTypes {

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.6-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 9.0.6-$(K8S_VER_SUFFIX)-3-gcefd691d
 # system applications
 INGRESS_APP_TAG ?= 0.0.1
 STORAGE_APP_TAG ?= 0.0.4

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.2
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.6-$(K8S_VER_SUFFIX)-3-gcefd691d
+PLANET_TAG ?= 9.0.7-$(K8S_VER_SUFFIX)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1
 STORAGE_APP_TAG ?= 0.0.4


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Generate prometheus-operator key pair. These will be used by the prometheus-operator when querying controller-manager and scheduler metrics.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/cloud/issues/873
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/planet/pull/858

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing
The generated prometheus-operator key pair have the proper RBAC permissions to query the metrics
```
$ sudo gravity exec curl https://172.28.128.102:10257/metrics --cacert /var/state/root.cert --cert /var/state/prometheus-operator.cert --key /var/state/prometheus-operator.key
...
```