### PR TITLE
Bump robotest to 3.1.1

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 3.1.0
+ROBOTEST_VERSION ?= 3.1.1
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build


### PR DESCRIPTION
## Description
This unblocks all the currently failing robotest CI runs.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Fixes https://github.com/gravitational/robotest/issues/290, https://github.com/gravitational/robotest/issues/291
* Depends on https://github.com/gravitational/robotest/issues/292, https://github.com/gravitational/robotest/issues/293  I've already released these in https://github.com/gravitational/robotest/releases/tag/v3.1.1

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing done
See https://drone.teleport.dev/gravitational/gravity/356/1/10, where I tested these changes with the pre-release robotest-suite:3.1.1-dev.6-84542214.
