### PR TITLE
[7.0] Bump robotest to 3.1.1

### DIFF
--- a/assets/robotest/Makefile
+++ b/assets/robotest/Makefile
@@ -30,7 +30,7 @@ ROBOTEST_CONFIG_SCRIPT = $(TOP)/config/$(ROBOTEST_CONFIG).sh
 # End variables expected to be set outside this Makefile.
 # Everything below is Robotest specific.
 
-ROBOTEST_VERSION ?= 3.1.0
+ROBOTEST_VERSION ?= 3.1.1
 ROBOTEST_DOCKER_IMAGE ?= quay.io/gravitational/robotest-suite:$(ROBOTEST_VERSION)
 
 # ROBOTEST_BUILDDIR is the root of all robotest build artifacts for this build


### PR DESCRIPTION
## Description
7.0.x backport of #2613

This unblocks all the currently failing robotest CI runs.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports #2613

## TODOs
- [x] Self-review the change
- [ ] Verify CI passes
- [ ] Address review feedback

## Testing done
The Drone build is sufficient testing.  See the original PR for further validation.