### PR TITLE
[5.5] Bump robotest to 3.1.1

### DIFF
--- a/build.assets/robotest/run.sh
+++ b/build.assets/robotest/run.sh
@@ -11,7 +11,7 @@ readonly ROBOTEST_SCRIPT=$(mktemp -d)/runsuite.sh
 
 # a number of environment variables are expected to be set
 # see https://github.com/gravitational/robotest/blob/v2.0.0/suite/README.md
-export ROBOTEST_VERSION=${ROBOTEST_VERSION:-3.0.0}
+export ROBOTEST_VERSION=${ROBOTEST_VERSION:-3.1.1}
 export ROBOTEST_REPO=quay.io/gravitational/robotest-suite:$ROBOTEST_VERSION
 export INSTALLER_URL=$GRAVITY_BUILDDIR/telekube.tar
 export GRAVITY_URL=$GRAVITY_BUILDDIR/gravity


### PR DESCRIPTION
## Description
5.5.x backport of #2613

This unblocks all the currently failing robotest CI runs.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Ports #2613

## TODOs
- [x] Self-review the change
- [ ] Verify CI passes
- [ ] Address review feedback

## Testing done
The Drone build is sufficient testing.  See the original PR for further validation.