### PR TITLE
[6.1] Update tiller registry

### DIFF
--- a/assets/tiller-app/Makefile
+++ b/assets/tiller-app/Makefile
@@ -6,7 +6,7 @@ OPS_URL ?= https://opscenter.localhost.localdomain:33009
 GRAVITY ?= gravity
 UPDATE_METADATA_OPTS := --repository=$(REPOSITORY) --name=$(NAME) --version=$(VERSION)
 
-TILLER_IMAGE ?= gcr.io/kubernetes-helm/tiller:v$(TILLER_VERSION)
+TILLER_IMAGE ?= ghcr.io/helm/tiller:v$(TILLER_VERSION)
 
 .PHONY: import
 import:

--- a/assets/tiller-app/resources/resources.yaml
+++ b/assets/tiller-app/resources/resources.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: -1
       containers:
         - name: tiller
-          image: gcr.io/kubernetes-helm/tiller:canary
+          image: ghcr.io/helm/tiller:canary
           imagePullPolicy: IfNotPresent
           command: ["/tiller"]
           args: ["--listen=127.0.0.1:44134"]

--- a/web/src/cluster/components/K8s/Deployments/Deployments.story.js
+++ b/web/src/cluster/components/K8s/Deployments/Deployments.story.js
@@ -38,7 +38,7 @@ const deployments = [
       "metadata": {
         "annotations": {
           "deployment.kubernetes.io/revision": "1",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"labels\":{\"app\":\"helm\",\"name\":\"tiller\"},\"name\":\"tiller-deploy\",\"namespace\":\"kube-system\"},\"spec\":{\"replicas\":1,\"strategy\":{},\"template\":{\"metadata\":{\"annotations\":{\"seccomp.security.alpha.kubernetes.io/pod\":\"docker/default\"},\"creationTimestamp\":null,\"labels\":{\"app\":\"helm\",\"name\":\"tiller\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TILLER_NAMESPACE\",\"value\":\"kube-system\"}],\"image\":\"leader.telekube.local:5000/kubernetes-helm/tiller:v2.8.1\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/liveness\",\"port\":44135},\"initialDelaySeconds\":1,\"timeoutSeconds\":1},\"name\":\"tiller\",\"ports\":[{\"containerPort\":44134,\"name\":\"tiller\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readiness\",\"port\":44135},\"initialDelaySeconds\":1,\"timeoutSeconds\":1},\"resources\":{},\"securityContext\":{\"runAsUser\":1000}}],\"securityContext\":{\"runAsUser\":1000},\"tolerations\":[{\"key\":\"gravitational.io/runlevel\",\"operator\":\"Equal\",\"value\":\"system\"},{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\",\"operator\":\"Exists\"}]}}},\"status\":{}}\n"
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"labels\":{\"app\":\"helm\",\"name\":\"tiller\"},\"name\":\"tiller-deploy\",\"namespace\":\"kube-system\"},\"spec\":{\"replicas\":1,\"strategy\":{},\"template\":{\"metadata\":{\"annotations\":{\"seccomp.security.alpha.kubernetes.io/pod\":\"docker/default\"},\"creationTimestamp\":null,\"labels\":{\"app\":\"helm\",\"name\":\"tiller\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TILLER_NAMESPACE\",\"value\":\"kube-system\"}],\"image\":\"leader.telekube.local:5000/helm/tiller:v2.8.1\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/liveness\",\"port\":44135},\"initialDelaySeconds\":1,\"timeoutSeconds\":1},\"name\":\"tiller\",\"ports\":[{\"containerPort\":44134,\"name\":\"tiller\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readiness\",\"port\":44135},\"initialDelaySeconds\":1,\"timeoutSeconds\":1},\"resources\":{},\"securityContext\":{\"runAsUser\":1000}}],\"securityContext\":{\"runAsUser\":1000},\"tolerations\":[{\"key\":\"gravitational.io/runlevel\",\"operator\":\"Equal\",\"value\":\"system\"},{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\",\"operator\":\"Exists\"}]}}},\"status\":{}}\n"
         },
         "selfLink": "/apis/extensions/v1beta1/namespaces/kube-system/deployments/tiller-deploy",
         "resourceVersion": "891",
@@ -119,7 +119,7 @@ const deployments = [
                 ],
                 "imagePullPolicy": "IfNotPresent",
                 "terminationMessagePolicy": "File",
-                "image": "leader.telekube.local:5000/kubernetes-helm/tiller:v2.8.1"
+                "image": "leader.telekube.local:5000/helm/tiller:v2.8.1"
               }
             ],
             "restartPolicy": "Always",

--- a/web/src/cluster/components/K8s/Pods/Pods.story.js
+++ b/web/src/cluster/components/K8s/Pods/Pods.story.js
@@ -775,7 +775,7 @@ const podInfos = [
               }
             ],
             "terminationMessagePolicy": "File",
-            "image": "leader.telekube.local:5000/kubernetes-helm/tiller:v2.8.1"
+            "image": "leader.telekube.local:5000/helm/tiller:v2.8.1"
           }
         ],
         "serviceAccount": "default",
@@ -844,8 +844,8 @@ const podInfos = [
             "lastState": {},
             "ready": true,
             "restartCount": 0,
-            "image": "leader.telekube.local:5000/kubernetes-helm/tiller:v2.8.1",
-            "imageID": "docker-pullable://leader.telekube.local:5000/kubernetes-helm/tiller@sha256:f0af436a310c8c906b7f261fc9d5625596a9791f06ca36b88d556d23a0cecf4e",
+            "image": "leader.telekube.local:5000/helm/tiller:v2.8.1",
+            "imageID": "docker-pullable://leader.telekube.local:5000/helm/tiller@sha256:f0af436a310c8c906b7f261fc9d5625596a9791f06ca36b88d556d23a0cecf4e",
             "containerID": "docker://d8c1fd7f1720911846ac4d0d826b681d0b1a95a4f39aa54a6a2c8b38c4949b56"
           }
         ],


### PR DESCRIPTION
## Description
Per https://helm.sh/docs/faq/troubleshooting/#tiller-installations-stopped-working-and-access-is-denied

    [https://gcr.io/kubernetes-helm/tiller] began the removal of images in August
    2021. We have made these images available at [ghcr.io/helm/tiller].

I updated the storybook components because my grep turned them up. Not
necessary, but not harmful either.


## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to #2618 

## TODOs
- [x] Self-review the change
- [ ] Verify CI passes
- [ ] Address review feedback

## Testing done
None.  The CI build should be sufficient.  I'll check further if it fails.

## Additional information
Needs ports to 5.5. (edit, turns out this fix needs to go to all active branches)
