### PR TITLE
[5.5] Update tiller registry

### DIFF
--- a/assets/tiller-app/Makefile
+++ b/assets/tiller-app/Makefile
@@ -6,7 +6,7 @@ OPS_URL ?= https://opscenter.localhost.localdomain:33009
 GRAVITY ?= gravity
 UPDATE_METADATA_OPTS := --repository=$(REPOSITORY) --name=$(NAME) --version=$(VERSION)
 
-TILLER_IMAGE ?= gcr.io/kubernetes-helm/tiller:v$(TILLER_VERSION)
+TILLER_IMAGE ?= ghcr.io/helm/tiller:v$(TILLER_VERSION)
 
 .PHONY: import
 import:

--- a/assets/tiller-app/resources/resources.yaml
+++ b/assets/tiller-app/resources/resources.yaml
@@ -30,7 +30,7 @@ spec:
         runAsUser: -1
       containers:
         - name: tiller
-          image: gcr.io/kubernetes-helm/tiller:canary
+          image: ghcr.io/helm/tiller:canary
           imagePullPolicy: IfNotPresent
           command: ["/tiller"]
           args: ["--listen=127.0.0.1:44134"]

--- a/web/src/app/__tests__/apiData/k8sNodes.json
+++ b/web/src/app/__tests__/apiData/k8sNodes.json
@@ -157,8 +157,8 @@
           },
           {
             "names": [
-              "apiserver:5000/kubernetes-helm/tiller@sha256:6520882517f1d6cc54b63e5208cae0cb1f6f2f60f55f512a60527bc893fc22ac",
-              "apiserver:5000/kubernetes-helm/tiller:v2.3.0"
+              "apiserver:5000/helm/tiller@sha256:6520882517f1d6cc54b63e5208cae0cb1f6f2f60f55f512a60527bc893fc22ac",
+              "apiserver:5000/helm/tiller:v2.3.0"
             ],
             "sizeBytes": 55998274
           },


### PR DESCRIPTION
## Description
5.5 backport of #2619 

Per https://helm.sh/docs/faq/troubleshooting/#tiller-installations-stopped-working-and-access-is-denied

    [https://gcr.io/kubernetes-helm/tiller] began the removal of images in August
    2021. We have made these images available at [ghcr.io/helm/tiller].

I updated the web test data because my grep turned it up. Not
necessary, but not harmful either.

(cherry picked from commit 1fe8bbdec99c120d6ea5ce3bcd0b7aedd9e7012e)

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to #2618 

## TODOs
- [x] Self-review the change
- [ ] Verify CI passes
- [ ] Address review feedback

## Testing done
None.  The CI build should be sufficient.  I'll check further if it fails.

## Additional information
Needs ports to 5.5.
