### PR TITLE
Remove gitBranch field

### DIFF
--- a/mage/packages.go
+++ b/mage/packages.go
@@ -79,7 +79,6 @@ var (
 		repository: "gravitational.io",
 		name:       "planet",
 		version:    planetVersion,
-		gitBranch:  planetBranch,
 		gitRepo:    "https://github.com/gravitational/planet",
 		env: map[string]string{
 			"PLANET_BUILD_TAG": planetVersion,


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Previously removed planetBranch in https://github.com/gravitational/gravity/pull/2611. Missed one instance of planet branch.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)