### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # Global Owners
 *  @gravitational/codeowners-gravity-code
 
-# Web UI
-/web/ @gravitational/codeowners-gravity-web
+# This file
+/.github/CODEOWNERS @gravitational/admins


### PR DESCRIPTION

## Description
Remove codeowners-gravity-web as @alex-kovoy no longer works on gravity,
but his review currently blocks some changes (e.g. #2624).

Add gravitational/admins as reviewers to this file, to implement org
level review if we decide to change our reviewers.


## Type of change
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
N/A

## TODOs
- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback

## Testing done
None.  Let me know if you think this is important and I can loop back.
