### PR TITLE
[8.0.x] adjust clusterconfiguration on upgrade

### DIFF
--- a/lib/storage/plan.go
+++ b/lib/storage/plan.go
@@ -211,6 +211,12 @@ type UpdateOperationData struct {
 	Servers []UpdateServer `json:"updates,omitempty"`
 	// ClusterConfig optionally specifies data specific to cluster configuration operation
 	ClusterConfig *ClusterConfigData `json:"cluster_config,omitempty"`
+	// ClusterConfigBytes optionally specifies the existing cluster configuration for the cluster
+	// upgrade operation to roll back to
+	ClusterConfigBytes []byte `json:"cluster_config_bytes,omitempty"`
+	// UpdatedClusterConfigBytes optionally specifies the new cluster configuration for the cluster
+	// upgrade operation
+	UpdatedClusterConfigBytes []byte `json:"updated_cluster_config_bytes,omitempty"`
 }
 
 // ClusterConfigData describes the configuration specific to cluster configuration update operation

--- a/lib/update/cluster/builder.go
+++ b/lib/update/cluster/builder.go
@@ -56,7 +56,9 @@ func (r phaseBuilder) init(leadMaster storage.Server) *update.Phase {
 			ExecServer:       &leadMaster,
 			InstalledPackage: &r.installedApp.Package,
 			Update: &storage.UpdateOperationData{
-				Servers: r.servers,
+				Servers:                   r.servers,
+				ClusterConfigBytes:        r.clusterConfigBytes,
+				UpdatedClusterConfigBytes: r.updatedClusterConfigBytes,
 			},
 		},
 	})

--- a/lib/update/cluster/phases/init.go
+++ b/lib/update/cluster/phases/init.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/users"
+	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/gravitational/rigging"
 	"github.com/gravitational/trace"
@@ -78,6 +79,7 @@ type updatePhaseInit struct {
 	existingDNS                storage.DNSConfig
 	existingEnviron            map[string]string
 	existingClusterConfigBytes []byte
+	updatedClusterConfigBytes  []byte
 	existingClusterConfig      clusterconfig.Interface
 }
 
@@ -125,11 +127,8 @@ func NewUpdatePhaseInit(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clusterConfig, err := operator.GetClusterConfiguration(operation.ClusterKey())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	configBytes, err := clusterconfig.Marshal(clusterConfig)
+
+	clusterConfig, err := clusterconfig.Unmarshal(p.Phase.Data.Update.ClusterConfigBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -152,7 +151,8 @@ func NewUpdatePhaseInit(
 		installedApp:               *installedApp,
 		existingDocker:             existingDocker,
 		existingDNS:                p.Plan.DNSConfig,
-		existingClusterConfigBytes: configBytes,
+		existingClusterConfigBytes: p.Phase.Data.Update.ClusterConfigBytes,
+		updatedClusterConfigBytes:  p.Phase.Data.Update.UpdatedClusterConfigBytes,
 		existingClusterConfig:      clusterConfig,
 		existingEnviron:            env.GetKeyValues(),
 	}, nil
@@ -197,6 +197,9 @@ func (p *updatePhaseInit) Execute(context.Context) error {
 	}
 	if err := p.updateDockerConfig(); err != nil {
 		return trace.Wrap(err, "failed to update Docker configuration")
+	}
+	if err := p.updateClusterConfig(); err != nil {
+		return trace.Wrap(err, "failed to update cluster configuration")
 	}
 	for _, server := range p.Servers {
 		if server.Runtime.Update != nil {
@@ -366,6 +369,28 @@ func (p *updatePhaseInit) updateDockerConfig() error {
 	return nil
 }
 
+func (p *updatePhaseInit) updateClusterConfig() error {
+	p.Info("Update cluster configuration.")
+	if err := p.Operator.UpdateClusterConfiguration(ops.UpdateClusterConfigRequest{
+		ClusterKey: p.Operation.ClusterKey(),
+		Config:     p.updatedClusterConfigBytes,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (p *updatePhaseInit) revertClusterConfig() error {
+	p.Info("Revert cluster configuration.")
+	if err := p.Operator.UpdateClusterConfiguration(ops.UpdateClusterConfigRequest{
+		ClusterKey: p.Operation.ClusterKey(),
+		Config:     p.existingClusterConfigBytes,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 func (p *updatePhaseInit) upsertServiceUser() error {
 	cluster, err := p.Backend.GetLocalSite(defaults.SystemAccountID)
 	if err != nil {
@@ -438,7 +463,7 @@ func (p *updatePhaseInit) rotatePlanetConfig(server storage.UpdateServer) error 
 		Manifest:       p.updateManifest,
 		RuntimePackage: server.Runtime.Update.Package,
 		Package:        &server.Runtime.Update.ConfigPackage,
-		Config:         p.existingClusterConfigBytes,
+		Config:         p.updatedClusterConfigBytes,
 		Env:            p.existingEnviron,
 	})
 	if err != nil {
@@ -511,11 +536,15 @@ func removeLegacyUpdateDirectory(log log.FieldLogger) error {
 }
 
 // Rollback rolls back the init phase
-func (p *updatePhaseInit) Rollback(context.Context) error {
-	if err := p.removeConfiguredPackages(); err != nil {
+func (p *updatePhaseInit) Rollback(ctx context.Context) error {
+	if err := p.revertClusterConfig(); err != nil {
 		return trace.Wrap(err)
 	}
-	return nil
+
+	b := utils.NewExponentialBackOff(defaults.ShutdownTimeout)
+	return utils.RetryTransient(ctx, b, func() error {
+		return p.removeConfiguredPackages()
+	})
 }
 
 // removeConfiguredPackages removes packages configured during init phase

--- a/lib/update/cluster/plan.go
+++ b/lib/update/cluster/plan.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage"
+	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 	"github.com/gravitational/gravity/lib/update"
 	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/rigging"
@@ -201,6 +202,23 @@ func NewOperationPlan(config PlanConfig) (*storage.OperationPlan, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	clusterConfig, err := config.Operator.GetClusterConfiguration((*ops.SiteOperation)(config.Operation).ClusterKey())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	configBytes, err := clusterconfig.Marshal(clusterConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	updatedClusterConfig, err := updateClusterConfig(configBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	updatedConfigBytes, err := clusterconfig.Marshal(updatedClusterConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	plan, err := newOperationPlan(planConfig{
 		plan: storage.OperationPlan{
 			OperationID:    config.Operation.ID,
@@ -211,22 +229,24 @@ func NewOperationPlan(config PlanConfig) (*storage.OperationPlan, error) {
 			DNSConfig:      config.DNSConfig,
 			GravityPackage: *gravityPackage,
 		},
-		operator:          config.Operator,
-		operation:         *config.Operation,
-		servers:           updates,
-		installedRuntime:  *installedRuntime,
-		installedApp:      *installedApp,
-		updateRuntime:     *updateRuntime,
-		updateApp:         *updateApp,
-		links:             links,
-		trustedClusters:   trustedClusters,
-		packageService:    config.Packages,
-		shouldUpdateEtcd:  shouldUpdateEtcd,
-		updateCoreDNS:     updateCoreDNS,
-		updateDNSAppEarly: updateDNSAppEarly,
-		roles:             roles,
-		leadMaster:        *leader,
-		userConfig:        config.UserConfig,
+		operator:                  config.Operator,
+		operation:                 *config.Operation,
+		servers:                   updates,
+		installedRuntime:          *installedRuntime,
+		installedApp:              *installedApp,
+		updateRuntime:             *updateRuntime,
+		updateApp:                 *updateApp,
+		links:                     links,
+		trustedClusters:           trustedClusters,
+		packageService:            config.Packages,
+		shouldUpdateEtcd:          shouldUpdateEtcd,
+		updateCoreDNS:             updateCoreDNS,
+		updateDNSAppEarly:         updateDNSAppEarly,
+		roles:                     roles,
+		leadMaster:                *leader,
+		userConfig:                config.UserConfig,
+		clusterConfigBytes:        configBytes,
+		updatedClusterConfigBytes: updatedConfigBytes,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -310,6 +330,11 @@ type planConfig struct {
 	leadMaster storage.UpdateServer
 	// userConfig is user provided configuration to tune the upgrade
 	userConfig UserConfig
+	// clusterConfigBytes is the existing cluster configuration to restore
+	// in case of rollback
+	clusterConfigBytes []byte
+	// updatedClusterConfigBytes is the cluster configuration to apply during upgrade
+	updatedClusterConfigBytes []byte
 }
 
 func newOperationPlan(p planConfig) (*storage.OperationPlan, error) {
@@ -731,6 +756,24 @@ func filterServer(servers []storage.UpdateServer, server storage.UpdateServer) (
 		result = append(result, s)
 	}
 	return result
+}
+
+func updateClusterConfig(configBytes []byte) (clusterconfig.Interface, error) {
+	result, err := clusterconfig.Unmarshal(configBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	globalConfig := result.GetGlobalConfig()
+	// Remove the EndpointSlice feature gate if it had been explicitly turned off.
+	// The flag had been in Beta since k8s 1.18 and stabilized in 1.20.
+	// See https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+	if flag, exists := globalConfig.FeatureGates["EndpointSlice"]; exists && !flag {
+		delete(globalConfig.FeatureGates, "EndpointSlice")
+	}
+	result.SetGlobalConfig(globalConfig)
+
+	return result, nil
 }
 
 type runtimeConfig struct {


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Implicitly adjust cluster configuration on featuregates when upgrading to 8.x (k8s 1.19.12+).
This primarily concerns the configuration that explicitly turns `EndpointSlice` feature gate flag off as in this case, it might be problematic to upgrade as this flag needs to be paired with `EndpointSliceProxying` which is only [available](https://github.com/kubernetes/kubernetes/blob/v1.18.0/pkg/features/kube_features.go#L513-L517) since k8s `1.18`. 
The flag had been moved to Beta in k8s `1.18` and stabilized in `1.20`.  In future versions it will not be possible to turn it off (k8s `1.21+`).

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* Internal change (not necessarily a bug fix or a new feature)


## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Write tests
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

Tested on upgrades from 7.x to 8.x with the following configuration:
```yaml
# config.yaml
kind: ClusterConfiguration
version: v1
spec:
  global:
    featureGates: 
      AllAlpha: true
      APIResponseCompression: false
      BoundServiceAccountTokenVolume: false
      CSIMigration: false
      KubeletPodResources: false
      EndpointSlice: false
      IPv6DualStack: false
      RemoveSelfLink: false
```
and ensuring that the resulting `ClusterConfiguration` does not have the `EndpointSlice` feature gate turned off after the upgrade.