### PR TITLE
bump kubernetes to 1.21.5 for CVE-2021-25741

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -5,12 +5,12 @@ ETCD_VER ?= 2.3.7
 # abbreviated gravity version to use as a build ID
 GRAVITY_VERSION ?= $(shell ./version.sh)
 # current Kubernetes version
-K8S_VER ?= 1.21.2
+K8S_VER ?= 1.21.5
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.7-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 9.0.8-$(K8S_VER_SUFFIX)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1
 STORAGE_APP_TAG ?= 0.0.4


### PR DESCRIPTION
Bump kubernetes to 1.21.5 to avoid CVE-2021-25741. See https://groups.google.com/g/kubernetes-announce/c/-e9OlTcED5E for more information from the Kubernetes project.

Planet PR https://github.com/gravitational/planet/pull/862