### PR TITLE
bump kubernetes to 1.19.15 for CVE-2021-25741

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ASSETSDIR=$(TOP)/assets
 BINDIR ?= /usr/bin
 
 # Current Kubernetes version
-K8S_VER := 1.19.12
+K8S_VER := 1.19.15
 # Kubernetes version suffix for the planet package, constructed by concatenating
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
@@ -46,7 +46,7 @@ RELEASE_OUT ?=
 TELEPORT_TAG = 3.2.17
 # TELEPORT_REPOTAG adapts TELEPORT_TAG to the teleport tagging scheme
 TELEPORT_REPOTAG := v$(TELEPORT_TAG)
-PLANET_TAG := 8.0.4-$(K8S_VER_SUFFIX)
+PLANET_TAG := 8.0.6-$(K8S_VER_SUFFIX)
 PLANET_BRANCH := $(PLANET_TAG)
 K8S_APP_TAG := $(GRAVITY_TAG)
 TELEKUBE_APP_TAG := $(GRAVITY_TAG)


### PR DESCRIPTION
Bump kubernetes to 1.19.15 to avoid CVE-2021-25741. See https://groups.google.com/g/kubernetes-announce/c/-e9OlTcED5E for more information from the Kubernetes project.

Planet PR https://github.com/gravitational/planet/pull/863