### PR TITLE
[7.0] remove reconciliation during CLI display operations

### DIFF
--- a/tool/gravity/cli/plan.go
+++ b/tool/gravity/cli/plan.go
@@ -28,13 +28,11 @@ import (
 	"github.com/gravitational/gravity/lib/state"
 	"github.com/gravitational/gravity/lib/storage"
 	libenviron "github.com/gravitational/gravity/lib/system/environ"
-	"github.com/gravitational/gravity/lib/update"
 	clusterupdate "github.com/gravitational/gravity/lib/update/cluster"
 	"github.com/gravitational/gravity/lib/utils"
 
 	"github.com/fatih/color"
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 )
 
 func initUpdateOperationPlan(localEnv, updateEnv *localenv.LocalEnvironment) error {
@@ -132,28 +130,29 @@ func displayClusterOperationPlan(localEnv *localenv.LocalEnvironment, opKey ops.
 	return outputOrFollowPlan(localEnv, getClusterOperationPlanFunc(localEnv, opKey), opts)
 }
 
-func getUpdateOperationPlanFunc(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey) fsm.GetPlanFunc {
+func getUpdateOperationPlanFunc(environ LocalEnvironmentFactory, opKey ops.SiteOperationKey) (fsm.GetPlanFunc, error) {
+	updateEnv, err := environ.NewUpdateEnv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return func() (*storage.OperationPlan, error) {
-		updateEnv, err := environ.NewUpdateEnv()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		plan, err := fsm.GetOperationPlan(updateEnv.Backend, opKey)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		reconciledPlan, err := tryReconcilePlan(context.TODO(), localEnv, updateEnv, *plan)
-		if err != nil {
-			logrus.WithError(err).Warn("Failed to reconcile plan.")
-		} else {
-			plan = reconciledPlan
-		}
+
 		return plan, nil
-	}
+	}, nil
 }
 
 func displayUpdateOperationPlan(localEnv *localenv.LocalEnvironment, environ LocalEnvironmentFactory, opKey ops.SiteOperationKey, opts displayPlanOptions) error {
-	return outputOrFollowPlan(localEnv, getUpdateOperationPlanFunc(localEnv, environ, opKey), opts)
+	f, err := getUpdateOperationPlanFunc(environ, opKey)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return outputOrFollowPlan(localEnv, f, opts)
 }
 
 func getInstallOperationPlanFunc(opKey ops.SiteOperationKey) fsm.GetPlanFunc {
@@ -293,20 +292,6 @@ func outputPhaseError(phase storage.OperationPhase) error {
 		fmt.Print(color.RedString("\n\t%v\n", phaseErr.Err))
 	}
 	return nil
-}
-
-func tryReconcilePlan(ctx context.Context, localEnv, updateEnv *localenv.LocalEnvironment, plan storage.OperationPlan) (*storage.OperationPlan, error) {
-	clusterEnv, err := localEnv.NewClusterEnvironment(localenv.WithEtcdTimeout(1 * time.Second))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	reconciler := update.NewDefaultReconciler(clusterEnv.Backend, updateEnv.Backend,
-		plan.ClusterName, plan.OperationID, logrus.WithField("operation-id", plan.OperationID))
-	reconciledPlan, err := reconciler.ReconcilePlan(ctx, plan)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return reconciledPlan, nil
 }
 
 func getPlanFromWizardBackend(opKey ops.SiteOperationKey) (*storage.OperationPlan, error) {


### PR DESCRIPTION
(cherry picked from commit 2d87e54d14c0cefb148865e64e9e006608f40171)

## Description
<!--Required. Provide high-level overview of what the change is for.-->
1. Only initialize the environment client once and re-use for subsequent calls. Initializing the client repeatedly leads to resource leaks, as the etcd client and teleport client do not get collected when going out of scope.
2. Do not reconcile the plan when retrieving the plan during follow. Reconciling should happen automatically as phases complete, so having the CLI do so when tailing the plan leads to extra work.

The above combined were causing `./gravity plan --tail` to consume multiple cores worth of CPU usage during normal operation.


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

* Fixes #2641
* Ports #2642

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->
The plan reconciliation sync the plan in the local database and etcd. This is done by the upgrade process, so having the CLI call this shouldn't be required, and it just wastes time and resource to run through this.

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
