### PR TITLE
Allow encryption of Kubernetes resources

### DIFF
--- a/docs/9.x/config.md
+++ b/docs/9.x/config.md
@@ -65,6 +65,17 @@ spec:
     # but the selected backend can be overridden if specified in the cluster configuration.
     # Supports values "vxlan", "aws-vpc", and "gce".
     flannelBackend: "vxlan"
+    # Enables Kubernetes resource encryption at rest.
+    # Rotating keys or disabling encryption requires manual configuration changes.
+    # See https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/ for more details.
+    encryptionProvider:
+      disabled: false
+      aws:
+        accountID: "1234567890"
+        keyID: "mrk-1234567890"
+        # region should be left unspecified when using a multi-region key. The region
+        # will be automatically selected from ec2 instance metadata.
+        region: "us-west-2"
     # A set of key=value pairs that describe feature gates for alpha/experimental features
     featureGates:
       AllAlpha: true

--- a/docs/9.x/config.md
+++ b/docs/9.x/config.md
@@ -67,7 +67,8 @@ spec:
     flannelBackend: "vxlan"
     # Enables Kubernetes resource encryption at rest.
     # Rotating keys or disabling encryption requires manual configuration changes.
-    # See https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/ for more details.
+    # See https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/ and
+    # https://github.com/kubernetes-sigs/aws-encryption-provider for more details.
     encryptionProvider:
       disabled: false
       aws:

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -1448,6 +1448,14 @@ func (s *site) addClusterConfig(config clusterconfig.Interface, overrideArgs map
 		args = append(args,
 			fmt.Sprintf("--flannel-backend=%v", *globalConfig.FlannelBackend))
 	}
+	if ep := globalConfig.EncryptionProvider; ep != nil && !ep.Disabled {
+		if ep.AWS != nil {
+			args = append(args, "--encryption-provider=aws")
+			args = append(args, fmt.Sprintf("--aws-account-id=%v", ep.AWS.AccountID))
+			args = append(args, fmt.Sprintf("--aws-key-id=%v", ep.AWS.KeyID))
+			args = append(args, fmt.Sprintf("--aws-key-region=%v", ep.AWS.Region))
+		}
+	}
 	return args
 }
 

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -692,6 +692,7 @@ func (r configCollection) WriteText(w io.Writer) error {
 		}
 		formatCloudConfig(t, config.CloudConfig)
 	}
+	formatEncryptionProvider(t, config.EncryptionProvider)
 	_, err := io.WriteString(w, t.String())
 	return trace.Wrap(err)
 }
@@ -738,6 +739,17 @@ func formatFeatureGates(features map[string]bool) string {
 		result = append(result, fmt.Sprintf("%v=%v", feature, enabled))
 	}
 	return strings.Join(result, ",")
+}
+
+func formatEncryptionProvider(w io.Writer, ep *clusterconfig.EncryptionProvider) {
+	if ep == nil || ep.Disabled || ep.AWS == nil {
+		fmt.Fprintf(w, "Encryption Provider:\t<unset>\n")
+		return
+	}
+	fmt.Fprintf(w, "Encryption Provider:\n")
+	fmt.Fprintf(w, "\tAWS:\n")
+	fmt.Fprintf(w, fmt.Sprintf("\t\tARN:\t%v\n", ep.AWS.ARN()))
+	return
 }
 
 type operationsCollection struct {

--- a/lib/ops/resources/gravity/collection.go
+++ b/lib/ops/resources/gravity/collection.go
@@ -743,13 +743,12 @@ func formatFeatureGates(features map[string]bool) string {
 
 func formatEncryptionProvider(w io.Writer, ep *clusterconfig.EncryptionProvider) {
 	if ep == nil || ep.Disabled || ep.AWS == nil {
-		fmt.Fprintf(w, "Encryption Provider:\t<unset>\n")
+		fmt.Fprint(w, "Encryption Provider:\t<unset>\n")
 		return
 	}
-	fmt.Fprintf(w, "Encryption Provider:\n")
-	fmt.Fprintf(w, "\tAWS:\n")
-	fmt.Fprintf(w, fmt.Sprintf("\t\tARN:\t%v\n", ep.AWS.ARN()))
-	return
+	fmt.Fprint(w, "Encryption Provider:\n")
+	fmt.Fprint(w, "\tAWS:\n")
+	fmt.Fprintf(w, "\t\tARN:\t%v\n", ep.AWS.ARN())
 }
 
 type operationsCollection struct {

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -155,7 +155,7 @@ func (r Resource) Merge(other Resource) Resource {
 		}
 		r.Spec.Global.EncryptionProvider.Disabled = other.Spec.Global.EncryptionProvider.Disabled
 		if other.Spec.Global.EncryptionProvider.Disabled {
-			r.Spec.Global.EncryptionProvider.AWS = &AWSEncryptionProvider{}
+			r.Spec.Global.EncryptionProvider.AWS = nil
 		}
 	}
 	if other.Spec.Global.FlannelBackend != nil {

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -148,7 +148,7 @@ func (r Resource) Merge(other Resource) Resource {
 		r.Spec.Global.EncryptionProvider.Disabled = other.Spec.Global.EncryptionProvider.Disabled
 		if other.Spec.Global.EncryptionProvider.AWS != nil {
 			if r.Spec.Global.EncryptionProvider.AWS == nil {
-				r.Spec.Global.EncryptionProvider.AWS = &AWSEncrytpionProvider{}
+				r.Spec.Global.EncryptionProvider.AWS = &AWSEncryptionProvider{}
 			}
 			r.Spec.Global.EncryptionProvider.AWS.AccountID = other.Spec.Global.EncryptionProvider.AWS.AccountID
 			r.Spec.Global.EncryptionProvider.AWS.KeyID = other.Spec.Global.EncryptionProvider.AWS.KeyID
@@ -293,12 +293,12 @@ type EncryptionProvider struct {
 	// Disabled disables resource encryption if set to true.
 	Disabled bool `json:"disabled,omitempty"`
 	// AWS specifies AWS encryption provider configuration.
-	AWS *AWSEncrytpionProvider `json:"aws,omitempty"`
+	AWS *AWSEncryptionProvider `json:"aws,omitempty"`
 }
 
 // AWSEncryptionProvider defines AWS encryption provider configuration. The
 // configured fields will be used to construct KMS key ARN.
-type AWSEncrytpionProvider struct {
+type AWSEncryptionProvider struct {
 	// AccountID specifies AWS account ID used to construct the KMS key ARN.
 	AccountID string `json:"accountID,omitempty"`
 	// KeyID specifies the KMS key ID used to construct the KMS key ARN.
@@ -309,7 +309,7 @@ type AWSEncrytpionProvider struct {
 
 // ARN returns the key ARN.
 // Format: `arn:aws:kms:${Region}:${AccountID}:key/${KeyID}`
-func (r *AWSEncrytpionProvider) ARN() string {
+func (r *AWSEncryptionProvider) ARN() string {
 	return fmt.Sprintf("arn:aws:kms:%v:%v:key/%v", r.Region, r.AccountID, r.KeyID)
 }
 

--- a/lib/storage/clusterconfig/clusterconfig.go
+++ b/lib/storage/clusterconfig/clusterconfig.go
@@ -145,7 +145,6 @@ func (r Resource) Merge(other Resource) Resource {
 		if r.Spec.Global.EncryptionProvider == nil {
 			r.Spec.Global.EncryptionProvider = &EncryptionProvider{}
 		}
-		r.Spec.Global.EncryptionProvider.Disabled = other.Spec.Global.EncryptionProvider.Disabled
 		if other.Spec.Global.EncryptionProvider.AWS != nil {
 			if r.Spec.Global.EncryptionProvider.AWS == nil {
 				r.Spec.Global.EncryptionProvider.AWS = &AWSEncryptionProvider{}
@@ -153,6 +152,10 @@ func (r Resource) Merge(other Resource) Resource {
 			r.Spec.Global.EncryptionProvider.AWS.AccountID = other.Spec.Global.EncryptionProvider.AWS.AccountID
 			r.Spec.Global.EncryptionProvider.AWS.KeyID = other.Spec.Global.EncryptionProvider.AWS.KeyID
 			r.Spec.Global.EncryptionProvider.AWS.Region = other.Spec.Global.EncryptionProvider.AWS.Region
+		}
+		r.Spec.Global.EncryptionProvider.Disabled = other.Spec.Global.EncryptionProvider.Disabled
+		if other.Spec.Global.EncryptionProvider.Disabled {
+			r.Spec.Global.EncryptionProvider.AWS = &AWSEncryptionProvider{}
 		}
 	}
 	if other.Spec.Global.FlannelBackend != nil {

--- a/lib/storage/clusterconfig/clusterconfig_test.go
+++ b/lib/storage/clusterconfig/clusterconfig_test.go
@@ -172,7 +172,12 @@ spec:
       FeatureB: false
     podSubnetSize: "26"
     highAvailability: true
-    flannelBackend: "vxlan"`,
+    flannelBackend: "vxlan"
+    encryptionProvider:
+      aws:
+        accountID: "12345"
+        keyID: "12345"
+        region: "us-east-1"`,
 			resource: &Resource{
 				Kind:    storage.KindClusterConfiguration,
 				Version: "v1",
@@ -189,6 +194,14 @@ spec:
 						PodSubnetSize:    "26",
 						HighAvailability: newBoolPtr(true),
 						FlannelBackend:   utils.StringPtr("vxlan"),
+						EncryptionProvider: &EncryptionProvider{
+							Disabled: false,
+							AWS: &AWSEncrytpionProvider{
+								AccountID: "12345",
+								KeyID:     "12345",
+								Region:    "us-east-1",
+							},
+						},
 					},
 				},
 			},
@@ -248,6 +261,14 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 						},
 						HighAvailability: newBoolPtr(true),
 						FlannelBackend:   utils.StringPtr("vxlan"),
+						EncryptionProvider: &EncryptionProvider{
+							Disabled: false,
+							AWS: &AWSEncrytpionProvider{
+								AccountID: "12345",
+								KeyID:     "12345",
+								Region:    "us-east-1",
+							},
+						},
 					},
 				},
 			},
@@ -268,6 +289,14 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 						},
 						HighAvailability: newBoolPtr(true),
 						FlannelBackend:   utils.StringPtr("vxlan"),
+						EncryptionProvider: &EncryptionProvider{
+							Disabled: false,
+							AWS: &AWSEncrytpionProvider{
+								AccountID: "12345",
+								KeyID:     "12345",
+								Region:    "us-east-1",
+							},
+						},
 					},
 				},
 			},
@@ -296,6 +325,14 @@ address: 10.0.0.1
 							"feature2": false,
 						},
 						FlannelBackend: utils.StringPtr("vxlan"),
+						EncryptionProvider: &EncryptionProvider{
+							Disabled: false,
+							AWS: &AWSEncrytpionProvider{
+								AccountID: "12345",
+								KeyID:     "12345",
+								Region:    "us-east-1",
+							},
+						},
 					},
 				},
 			},
@@ -343,6 +380,14 @@ address: 10.0.0.1
 							"feature3": true,
 						},
 						FlannelBackend: utils.StringPtr("vxlan"),
+						EncryptionProvider: &EncryptionProvider{
+							Disabled: false,
+							AWS: &AWSEncrytpionProvider{
+								AccountID: "12345",
+								KeyID:     "12345",
+								Region:    "us-east-1",
+							},
+						},
 					},
 				},
 			},

--- a/lib/storage/clusterconfig/clusterconfig_test.go
+++ b/lib/storage/clusterconfig/clusterconfig_test.go
@@ -196,7 +196,7 @@ spec:
 						FlannelBackend:   utils.StringPtr("vxlan"),
 						EncryptionProvider: &EncryptionProvider{
 							Disabled: false,
-							AWS: &AWSEncrytpionProvider{
+							AWS: &AWSEncryptionProvider{
 								AccountID: "12345",
 								KeyID:     "12345",
 								Region:    "us-east-1",
@@ -263,7 +263,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 						FlannelBackend:   utils.StringPtr("vxlan"),
 						EncryptionProvider: &EncryptionProvider{
 							Disabled: false,
-							AWS: &AWSEncrytpionProvider{
+							AWS: &AWSEncryptionProvider{
 								AccountID: "12345",
 								KeyID:     "12345",
 								Region:    "us-east-1",
@@ -291,7 +291,7 @@ func (*S) TestMergesClusterConfiguration(c *C) {
 						FlannelBackend:   utils.StringPtr("vxlan"),
 						EncryptionProvider: &EncryptionProvider{
 							Disabled: false,
-							AWS: &AWSEncrytpionProvider{
+							AWS: &AWSEncryptionProvider{
 								AccountID: "12345",
 								KeyID:     "12345",
 								Region:    "us-east-1",
@@ -327,7 +327,7 @@ address: 10.0.0.1
 						FlannelBackend: utils.StringPtr("vxlan"),
 						EncryptionProvider: &EncryptionProvider{
 							Disabled: false,
-							AWS: &AWSEncrytpionProvider{
+							AWS: &AWSEncryptionProvider{
 								AccountID: "12345",
 								KeyID:     "12345",
 								Region:    "us-east-1",
@@ -382,7 +382,7 @@ address: 10.0.0.1
 						FlannelBackend: utils.StringPtr("vxlan"),
 						EncryptionProvider: &EncryptionProvider{
 							Disabled: false,
-							AWS: &AWSEncrytpionProvider{
+							AWS: &AWSEncryptionProvider{
 								AccountID: "12345",
 								KeyID:     "12345",
 								Region:    "us-east-1",

--- a/lib/validate/clusterconfig.go
+++ b/lib/validate/clusterconfig.go
@@ -19,7 +19,6 @@ package validate
 import (
 	"net"
 
-	"github.com/gravitational/gravity/lib/cloudprovider/aws"
 	"github.com/gravitational/gravity/lib/schema"
 	"github.com/gravitational/gravity/lib/storage/clusterconfig"
 
@@ -108,14 +107,6 @@ func ClusterConfiguration(existing, update clusterconfig.Interface) error {
 		}
 		if newGlobalConfig.EncryptionProvider.AWS.KeyID == "" {
 			return trace.BadParameter("AWS KMS key ID must be provided for the encryption provider")
-		}
-		if newGlobalConfig.EncryptionProvider.AWS.Region == "" {
-			// If a region is unspecified, query the region from the aws instance metadata.
-			instance, err := aws.NewLocalInstance()
-			if err != nil {
-				return trace.BadParameter("AWS KMS key region must be provided")
-			}
-			newGlobalConfig.EncryptionProvider.AWS.Region = instance.Region
 		}
 	}
 

--- a/tool/gravity/cli/config_test.go
+++ b/tool/gravity/cli/config_test.go
@@ -86,7 +86,7 @@ spec:
 				FlannelBackend: utils.StringPtr("vxlan"),
 				EncryptionProvider: &clusterconfig.EncryptionProvider{
 					Disabled: false,
-					AWS: &clusterconfig.AWSEncrytpionProvider{
+					AWS: &clusterconfig.AWSEncryptionProvider{
 						AccountID: "12345",
 						KeyID:     "12345",
 						Region:    "us-east-1",

--- a/tool/gravity/cli/config_test.go
+++ b/tool/gravity/cli/config_test.go
@@ -48,6 +48,11 @@ spec:
     serviceCIDR: "100.200.0.0/16"
     podSubnetSize: "26"
     flannelBackend: "vxlan"
+    encryptionProvider:
+      aws:
+        accountID: "12345"
+        keyID: "12345"
+        region: us-east-1
     cloudConfig: |
       [global]
       node-tags=example-cluster
@@ -79,6 +84,14 @@ spec:
 				PodCIDR:        "100.96.0.0/16",
 				PodSubnetSize:  "26",
 				FlannelBackend: utils.StringPtr("vxlan"),
+				EncryptionProvider: &clusterconfig.EncryptionProvider{
+					Disabled: false,
+					AWS: &clusterconfig.AWSEncrytpionProvider{
+						AccountID: "12345",
+						KeyID:     "12345",
+						Region:    "us-east-1",
+					},
+				},
 				CloudConfig: `[global]
 node-tags=example-cluster
 multizone="true"

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.5
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.9-$(K8S_VER_SUFFIX)-6-g98abc105
+PLANET_TAG ?= 9.0.10-$(K8S_VER_SUFFIX)
 # system applications
 INGRESS_APP_TAG ?= 0.0.1
 STORAGE_APP_TAG ?= 0.0.4

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.21.5
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 9.0.9-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 9.0.9-$(K8S_VER_SUFFIX)-6-g98abc105
 # system applications
 INGRESS_APP_TAG ?= 0.0.1
 STORAGE_APP_TAG ?= 0.0.4


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
These changes allow Kubernetes resources to be encrypted at rest.

aws encryption provider can now be specified in the cluster configuration.
```yaml
# config.yaml
...
# Enables Kubernetes resource encryption at rest.
# Rotating keys or disabling encryption requires manual configuration changes.
# See https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/ for more details.
encryptionProvider:
  disabled: false
  aws:
    accountID: "1234567890"
    keyID: "1234567890"
    # region should be left unspecified when using a multi-region key. The region
    # will be automatically selected from ec2 instance metadata.
    region: "us-west-2"
```
Set the `accountID` and `keyID`. If using a multi-region key leave the region field unspecified. Then run the gravity command `gravity resource create config.yaml`

Key rotation or disabling encryption is not automatically handled. Keys must be manually rotated first and then the cluster configuration should be updated to persist changes. Same with disabling encryption.

## Type of change
<!--Required. Keep only those that apply.-->

* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/planet/pull/865

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback
- [x] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing
- [x] Enable resource encryption on a single node
- [x] Test single region key while forcing leader change
- [x] Test multi region key while forcing leader change
- [x] Test key rotation
- [x] Test disable encryption
- [x] Test upgrade with resource encryption enabled