### PR TITLE
Bump golangci-lint to 1.42.1 and fix the resulting lint warnings

### DIFF
--- a/e/lib/periodic/statechecker_test.go
+++ b/e/lib/periodic/statechecker_test.go
@@ -59,7 +59,7 @@ func (s *StateCheckerSuite) SetUpTest(c *C) {
 			Backend:  s.localServices.Backend,
 			Operator: s.remoteServices.Operator,
 			Packages: s.localServices.Packages,
-			Tunnel:   testutils.FakeReverseTunnel{},
+			Tunnel:   &testutils.FakeReverseTunnel{},
 		},
 		FieldLogger: logrus.WithField(trace.Component, "state-checker"),
 	}
@@ -84,7 +84,7 @@ func (s *StateCheckerSuite) TestStateChecker(c *C) {
 	c.Assert(err, IsNil)
 
 	// make sure remote tunnel says the site is offline
-	s.stateChecker.conf.Tunnel = testutils.FakeReverseTunnel{
+	s.stateChecker.conf.Tunnel = &testutils.FakeReverseTunnel{
 		Sites: []testutils.FakeRemoteSite{
 			{
 				Name:   "local.com",
@@ -134,7 +134,7 @@ func (s *StateCheckerSuite) TestStateChecker(c *C) {
 	c.Assert(err, IsNil)
 
 	// add the site to the reverse tunnel now
-	s.stateChecker.conf.Tunnel = testutils.FakeReverseTunnel{
+	s.stateChecker.conf.Tunnel = &testutils.FakeReverseTunnel{
 		Sites: []testutils.FakeRemoteSite{
 			{
 				Name:   "local.com",

--- a/lib/archive/test_utils.go
+++ b/lib/archive/test_utils.go
@@ -1,3 +1,4 @@
+//go:build !release
 // +build !release
 
 /*

--- a/lib/rpc/internal/inprocess/pipe.go
+++ b/lib/rpc/internal/inprocess/pipe.go
@@ -1,3 +1,4 @@
+//go:build !go1.8 && go1.10
 // +build !go1.8,go1.10
 
 /*

--- a/lib/rpc/internal/inprocess/pipe_go18.go
+++ b/lib/rpc/internal/inprocess/pipe_go18.go
@@ -4,6 +4,7 @@
 //
 // This is a verbatim copy of src/net/pipe.go
 //
+//go:build go1.8
 // +build go1.8
 
 package inprocess

--- a/lib/system/caps.go
+++ b/lib/system/caps.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/lib/system/selinux/internal/policy/policy.go
+++ b/lib/system/selinux/internal/policy/policy.go
@@ -1,3 +1,4 @@
+//go:build !selinux_embed
 // +build !selinux_embed
 
 /*

--- a/lib/testutils/auth.go
+++ b/lib/testutils/auth.go
@@ -59,7 +59,7 @@ type FakeReverseTunnel struct {
 	Sites []FakeRemoteSite
 }
 
-func (s FakeReverseTunnel) GetSites() []teletunnel.RemoteSite {
+func (s *FakeReverseTunnel) GetSites() []teletunnel.RemoteSite {
 	var sites []teletunnel.RemoteSite
 	for _, site := range s.Sites {
 		sites = append(sites, site)
@@ -67,7 +67,7 @@ func (s FakeReverseTunnel) GetSites() []teletunnel.RemoteSite {
 	return sites
 }
 
-func (s FakeReverseTunnel) GetSite(name string) (teletunnel.RemoteSite, error) {
+func (s *FakeReverseTunnel) GetSite(name string) (teletunnel.RemoteSite, error) {
 	for _, site := range s.Sites {
 		if site.GetName() == name {
 			return site, nil
@@ -76,7 +76,7 @@ func (s FakeReverseTunnel) GetSite(name string) (teletunnel.RemoteSite, error) {
 	return nil, trace.NotFound("site %v not found", name)
 }
 
-func (s FakeReverseTunnel) RemoveSite(name string) error {
+func (s *FakeReverseTunnel) RemoveSite(name string) error {
 	for i, site := range s.Sites {
 		if site.GetName() == name {
 			s.Sites = append(s.Sites[:i], s.Sites[i+1:]...)
@@ -86,18 +86,17 @@ func (s FakeReverseTunnel) RemoveSite(name string) error {
 	return trace.NotFound("site %v not found", name)
 }
 
-func (s FakeReverseTunnel) Start() error {
+func (*FakeReverseTunnel) Start() error {
 	return nil
 }
 
-func (s FakeReverseTunnel) Close() error {
+func (*FakeReverseTunnel) Close() error {
 	return nil
 }
 
-func (s FakeReverseTunnel) Wait() {
-}
+func (*FakeReverseTunnel) Wait() {}
 
-func (s FakeReverseTunnel) Shutdown(context.Context) error {
+func (*FakeReverseTunnel) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/lib/users/usersservice/usersservice.go
+++ b/lib/users/usersservice/usersservice.go
@@ -342,13 +342,9 @@ func (c *UsersService) GetAccessChecker(user storage.User) (teleservices.AccessC
 // is checked against stored hash for AdminUser and token is compared as is
 // for AgentUser (treated as API key)
 func (c *UsersService) AuthenticateUserBasicAuth(username, password string) (storage.User, error) {
-	i, err := c.backend.GetUser(username)
+	user, err := c.backend.GetUser(username)
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	user, ok := i.(storage.User)
-	if !ok {
-		return nil, trace.BadParameter("unexpected user type %T", i)
 	}
 
 	if err = c.checkCanUseBasicAuth(user); err != nil {

--- a/versions.mk
+++ b/versions.mk
@@ -25,7 +25,7 @@ PROTOC_VER ?= 3.10.0
 PROTOC_PLATFORM ?= linux-x86_64
 GOGO_PROTO_TAG ?= v1.3.0
 GRPC_GATEWAY_TAG ?= v1.11.3
-GOLANGCI_LINT_VER ?= 1.40.1
+GOLANGCI_LINT_VER ?= 1.42.1
 # wormhole container URI for default install
 WORMHOLE_IMG ?= quay.io/gravitational/wormhole:0.3.3
 SELINUX_VERSION ?= 6.0.0


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This PR bumps the `golangci-lint` to `v1.42.1` and fixes the resulting warnings:
```
lib/rpc/internal/inprocess/pipe_go18.go:6: File is not `gofmt`-ed (gofmt)
//
lib/rpc/internal/inprocess/pipe_go18.go:6: File is not `goimports`-ed (goimports)
//
lib/system/selinux/internal/policy/policy.go:1: File is not `gofmt`-ed (gofmt)
// +build !selinux_embed
lib/system/selinux/internal/policy/policy.go:1: File is not `goimports`-ed (goimports)
// +build !selinux_embed
lib/archive/test_utils.go:1: File is not `gofmt`-ed (gofmt)
// +build !release
lib/system/caps.go:1: File is not `gofmt`-ed (gofmt)
// +build !linux
lib/archive/test_utils.go:1: File is not `goimports`-ed (goimports)
// +build !release
lib/system/caps.go:1: File is not `goimports`-ed (goimports)
// +build !linux
lib/users/usersservice/usersservice.go:349:14: S1040: type assertion to the same type: i already has type storage.User (gosimple)
	user, ok := i.(storage.User)
	            ^
lib/testutils/auth.go:82:4: SA4005: ineffective assignment to field FakeReverseTunnel.Sites (staticcheck)
			s.Sites = append(s.Sites[:i], s.Sites[i+1:]...
```

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)
