### PR TITLE
Mount helm3 binary to init containers

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -160,6 +160,14 @@ func configureVolumes(job *batchv1.Job, p Params) {
 			},
 		},
 		{
+			Name: VolumeHelm3Bin,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: defaults.Helm3Bin,
+				},
+			},
+		},
+		{
 			Name: VolumeCerts,
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
@@ -214,6 +222,10 @@ func configureVolumeMounts(job *batchv1.Job, p Params) {
 		{
 			Name:      VolumeHelmBin,
 			MountPath: HelmPath,
+		},
+		{
+			Name:      VolumeHelm3Bin,
+			MountPath: Helm3Path,
 		},
 		{
 			Name:      VolumeCerts,

--- a/lib/app/hooks/constants.go
+++ b/lib/app/hooks/constants.go
@@ -54,6 +54,9 @@ const (
 	// HelmPath is where helm binary gets mounted inside hook containers
 	HelmPath = "/usr/local/bin/helm"
 
+	// Helm3Path is where helm3 binary gets mounted inside hook containers
+	Helm3Path = "/usr/local/bin/helm3"
+
 	// HelmValuesFile is the name of the file with helm values
 	HelmValuesFile = "values.yaml"
 
@@ -65,6 +68,9 @@ const (
 
 	// VolumeHelmBin is the name of the volume with helm binary
 	VolumeHelmBin = "helm-bin"
+
+	// VolumeHelm3Bin is the name of the volume with helm3 binary
+	VolumeHelm3Bin = "helm-3-bin"
 
 	// VolumeHelm is the name of the volume with helm values file
 	VolumeHelm = "helm"


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Mount helm3 binary to init containers.

## Reason for change
I'm in the process of upgrading the [ingress-app](https://github.com/gravitational/ingress-app) to use [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.49.3 which requires helm3.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
- [x] Verify helm3 is mounted into init containers

<details>

After gravity install, describe ingress-app-install job and verify helm3 volume and mounts
```
$ sudo kubectl describe job -n kube-system ingress-app-install-25381b
Name:                     ingress-app-install-25381b
Namespace:                kube-system
Selector:                 controller-uid=f761c119-fe0b-4606-ae45-925bfb779534
Labels:                   controller-uid=f761c119-fe0b-4606-ae45-925bfb779534
                          job-name=ingress-app-install-25381b
Annotations:              <none>
Parallelism:              1
Completions:              1
Completion Mode:          NonIndexed
Start Time:               Wed, 13 Oct 2021 22:24:51 +0000
Completed At:             Wed, 13 Oct 2021 22:25:06 +0000
Duration:                 15s
Active Deadline Seconds:  1200s
Pods Statuses:            0 Running / 1 Succeeded / 0 Failed
Pod Template:
  Labels:  controller-uid=f761c119-fe0b-4606-ae45-925bfb779534
           job-name=ingress-app-install-25381b
  Init Containers:
   init:
    Image:      leader.telekube.local:5000/gravitational/debian-tall:buster
    Port:       <none>
    Host Port:  <none>
    Command:
      /bin/sh
      -c
      -e
    Args:

      TMPDIR=/tmp/state /opt/bin/gravity app unpack --service-uid=980665 gravitational.io/ingress-app:0.0.2-dev /var/lib/gravity/resources
      cat <<EOF > /var/lib/gravity/helm/values.yaml

      EOF

    Environment:
      APP_PACKAGE:  gravitational.io/ingress-app:0.0.2-dev
      POD_IP:        (v1:status.podIP)
    Mounts:
      /etc/ssl/certs from certs (rw)
      /opt/bin from bin (rw)
      /tmp/state from state-dir (rw)
      /usr/local/bin/helm from helm-bin (rw)
      /usr/local/bin/helm3 from helm-3-bin (rw)
      /usr/local/bin/kubectl from kubectl-bin (rw)
      /var/lib/gravity/helm from helm (rw)
      /var/lib/gravity/local from gravity (rw)
      /var/lib/gravity/resources from resources (rw)
  Containers:
   hook:
    Image:      leader.telekube.local:5000/gravitational/debian-tall:stretch
    Port:       <none>
    Host Port:  <none>
    Command:
      /bin/sh
      /var/lib/gravity/resources/install.sh
    Environment:
      DEVMODE:                   false
      GRAVITY_CLUSTER_FLAVOR:    one
      GRAVITY_CLUSTER_NAME:      beautifulpare7062
      GRAVITY_CLUSTER_PROVIDER:  generic
      GRAVITY_SERVICE_USER:      980665
    Mounts:
      /etc/ssl/certs from certs (rw)
      /opt/bin from bin (rw)
      /usr/local/bin/helm from helm-bin (rw)
      /usr/local/bin/helm3 from helm-3-bin (rw)
      /usr/local/bin/kubectl from kubectl-bin (rw)
      /var/lib/gravity/helm from helm (rw)
      /var/lib/gravity/resources from resources (rw)
  Volumes:
   bin:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/bin
    HostPathType:
   kubectl-bin:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/bin/kubectl
    HostPathType:
   helm-bin:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/bin/helm
    HostPathType:
   helm-3-bin:
    Type:          HostPath (bare host directory volume)
    Path:          /usr/bin/helm3
    HostPathType:
   certs:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/ssl/certs
    HostPathType:
   gravity:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/gravity/local
    HostPathType:
...
```
</details>