### PR TITLE
Generate TLS key pair for controller-manager

### DIFF
--- a/assets/rbac-app/resources/resources.yaml
+++ b/assets/rbac-app/resources/resources.yaml
@@ -273,3 +273,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: gravity:coredns
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-controller-manager:auth-delegate
+subjects:
+- kind: User
+  name: system:kube-controller-manager
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-scheduler:auth-delegate
+subjects:
+- kind: User
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -263,6 +263,8 @@ const (
 	ProxyKeyPair = "proxy"
 	// SchedulerKeyPair is a name of the K8s scheduler client key pair
 	SchedulerKeyPair = "scheduler"
+	// ControllerManagerKeyPair is a name of the K8s controller-manager client key pair
+	ControllerManagerKeyPair = "controller-manager"
 	// KubectlKeyPair is a name of the kubectl client key pair
 	KubectlKeyPair = "kubectl"
 	// ETCDKeyPair is a name of the etcd key pair

--- a/lib/ops/opsservice/configure.go
+++ b/lib/ops/opsservice/configure.go
@@ -597,11 +597,12 @@ func (s *site) getPlanetMasterSecretsPackage(ctx *operationContext, p planetMast
 	}
 
 	keyPairTypes := map[string]rbacConfig{
-		constants.APIServerKeyPair: {},
-		constants.ETCDKeyPair:      {},
-		constants.SchedulerKeyPair: {group: constants.ClusterAdminGroup},
-		constants.KubectlKeyPair:   {group: constants.ClusterAdminGroup},
-		constants.ProxyKeyPair:     {userName: constants.ClusterKubeProxyUser, group: constants.ClusterNodeGroup},
+		constants.APIServerKeyPair:         {},
+		constants.ETCDKeyPair:              {},
+		constants.SchedulerKeyPair:         {group: constants.ClusterAdminGroup},
+		constants.ControllerManagerKeyPair: {group: constants.ClusterAdminGroup},
+		constants.KubectlKeyPair:           {group: constants.ClusterAdminGroup},
+		constants.ProxyKeyPair:             {userName: constants.ClusterKubeProxyUser, group: constants.ClusterNodeGroup},
 		constants.KubeletKeyPair: {
 			userName: constants.ClusterNodeNamePrefix + ":" + p.master.KubeNodeID(),
 			group:    constants.ClusterNodeGroup,

--- a/tool/gravity/cli/rotate.go
+++ b/tool/gravity/cli/rotate.go
@@ -202,5 +202,6 @@ var certNames = []string{
 	constants.KubeletKeyPair,
 	constants.ProxyKeyPair,
 	constants.SchedulerKeyPair,
+	constants.ControllerManagerKeyPair,
 	constants.KubectlKeyPair,
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Generate TLS key-pair for the kube-controller-manager as it needs its own keys for clients authentication/authorization. As an example of a client requiring authentication is Prometheus which scrapes `/metrics` endpoint.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/planet/pull/867

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
