### PR TITLE
Bump ingress-app to version 0.0.2

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -12,7 +12,7 @@ K8S_VER ?= 1.21.5
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
 PLANET_TAG ?= 9.0.10-$(K8S_VER_SUFFIX)
 # system applications
-INGRESS_APP_TAG ?= 0.0.1
+INGRESS_APP_TAG ?= 0.0.2
 STORAGE_APP_TAG ?= 0.0.4
 LOGGING_APP_TAG ?= 7.1.2
 MONITORING_APP_TAG ?= 7.1.4


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
This upgrades ingress-nginx controller to v0.49.3

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/cloud/issues/996
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires https://github.com/gravitational/ingress-app/pull/2, https://github.com/gravitational/gravity/pull/2664, https://github.com/gravitational/gravity/pull/2665

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback
- [x] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->
- [x] Verify gravity installs with ingress enabled
- [x] Verify gravity upgrades with ingress enabled