### PR TITLE
[8.0.x] Mount helm3 binary to init containers (#2665)

### DIFF
--- a/lib/app/hooks/configure.go
+++ b/lib/app/hooks/configure.go
@@ -161,6 +161,14 @@ func configureVolumes(job *batchv1.Job, p Params) {
 			},
 		},
 		{
+			Name: VolumeHelm3Bin,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: defaults.Helm3Bin,
+				},
+			},
+		},
+		{
 			Name: VolumeCerts,
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
@@ -215,6 +223,10 @@ func configureVolumeMounts(job *batchv1.Job, p Params) {
 		{
 			Name:      VolumeHelmBin,
 			MountPath: HelmPath,
+		},
+		{
+			Name:      VolumeHelm3Bin,
+			MountPath: Helm3Path,
 		},
 		{
 			Name:      VolumeCerts,

--- a/lib/app/hooks/constants.go
+++ b/lib/app/hooks/constants.go
@@ -51,8 +51,11 @@ const (
 	// KubectlPath is where kubectl binary gets mounted inside hook containers
 	KubectlPath = "/usr/local/bin/kubectl"
 
-	// Helm is where helm binary gets mounted inside hook containers
+	// HelmPath is where helm binary gets mounted inside hook containers
 	HelmPath = "/usr/local/bin/helm"
+
+	// Helm3Path is where helm3 binary gets mounted inside hook containers
+	Helm3Path = "/usr/local/bin/helm3"
 
 	// HelmValuesFile is the name of the file with helm values
 	HelmValuesFile = "values.yaml"
@@ -66,7 +69,10 @@ const (
 	// VolumeHelmBin is the name of the volume with helm binary
 	VolumeHelmBin = "helm-bin"
 
-	// VolumeHelmValues is the name of the volume with helm values file
+	// VolumeHelm3Bin is the name of the volume with helm3 binary
+	VolumeHelm3Bin = "helm-3-bin"
+
+	// VolumeHelm is the name of the volume with helm values file
 	VolumeHelm = "helm"
 
 	// VolumeBackup is the name of the volume that stores results of the backup hook


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Mount helm3 binary to init containers.

## Reason for change
I'm in the process of upgrading the [ingress-app](https://github.com/gravitational/ingress-app) to use [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.49.3 which requires helm3.

## Type of change
<!--Required. Keep only those that apply.-->

* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and PRs
* Ports https://github.com/gravitational/gravity/pull/2665