### PR TITLE
[8.0.x] Update image parsing implementation (#2664)

### DIFF
--- a/lib/docker/cleaner_test.go
+++ b/lib/docker/cleaner_test.go
@@ -115,12 +115,12 @@ func (s *CleanerSuite) TestCleanRegistry(c *check.C) {
 	s.registry = newRegistry(s.registryDir, s.sync, c)
 
 	for _, image := range requiredImages {
-		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image.Repository, image.Tag)
+		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image)
 		c.Assert(err, check.IsNil)
 		c.Assert(exists, check.Equals, true)
 	}
 	for _, image := range expectedDeletedImages {
-		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image.Repository, image.Tag)
+		exists, err := s.sync.ImageExists(ctx, s.registry.info.GetURL(), image)
 		c.Assert(err, check.IsNil)
 		c.Assert(exists, check.Equals, false)
 	}

--- a/lib/docker/synchronizer.go
+++ b/lib/docker/synchronizer.go
@@ -30,6 +30,7 @@ import (
 	regclient "github.com/docker/distribution/registry/client"
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gravitational/trace"
+	digest "github.com/opencontainers/go-digest"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -114,8 +115,8 @@ func (h *Synchronizer) pushCmd(image loc.DockerImage) error {
 }
 
 // ImageExists checks if the image exists in the registry
-func (h *Synchronizer) ImageExists(ctx context.Context, registryURL, repository, tag string) (bool, error) {
-	refName, err := dockerref.WithName(repository)
+func (h *Synchronizer) ImageExists(ctx context.Context, registryURL string, img loc.DockerImage) (bool, error) {
+	refName, err := dockerref.WithName(img.Repository)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
@@ -129,7 +130,7 @@ func (h *Synchronizer) ImageExists(ctx context.Context, registryURL, repository,
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	_, err = manifestService.Get(ctx, "", distribution.WithTag(tag))
+	_, err = manifestService.Get(ctx, digest.Digest(img.Digest), distribution.WithTag(img.Tag))
 	if err != nil {
 		if strings.Contains(err.Error(), "manifest unknown") {
 			return false, nil
@@ -178,9 +179,9 @@ func (h *Synchronizer) checkImageInRegistry(ctx context.Context, image string, r
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	exists, err := h.ImageExists(ctx, reg.GetURL(), parsedImage.Repository, parsedImage.Tag)
+	exists, err := h.ImageExists(ctx, reg.GetURL(), *parsedImage)
 	if err != nil {
-		return false, trace.Wrap(err)
+		return false, trace.Wrap(err, "image %s does not exist in registry %s", image, reg.GetURL())
 	}
 	return exists, nil
 }

--- a/lib/loc/docker.go
+++ b/lib/loc/docker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loc
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -26,19 +27,21 @@ type DockerImage struct {
 	Registry   string `json:"registry"`
 	Repository string `json:"repository"`
 	Tag        string `json:"tag"`
+	Digest     string `json:"digest"`
 }
 
+// String returns the string representation of the DockerImage.
+// Format: [Registry/]Repository[:Tag][@Digest]
 func (d *DockerImage) String() string {
 	out := d.Repository
 	if d.Registry != "" {
-		out = d.Registry + "/" + d.Repository
+		out = fmt.Sprintf("%s/%s", d.Registry, out)
 	}
 	if d.Tag != "" {
-		if strings.HasPrefix(d.Tag, "sha256:") {
-			out = out + "@" + d.Tag
-		} else {
-			out = out + ":" + d.Tag
-		}
+		out = fmt.Sprintf("%s:%s", out, d.Tag)
+	}
+	if d.Digest != "" {
+		out = fmt.Sprintf("%s@%s", out, d.Digest)
 	}
 	return out
 }
@@ -48,33 +51,62 @@ func ParseDockerImage(image string) (*DockerImage, error) {
 	if image == "" {
 		return nil, trace.BadParameter("image name can not be empty")
 	}
-	remote, tag := ParseRepositoryTag(image)
-	parts := strings.SplitN(remote, "/", 2)
-
-	if len(parts) == 1 {
-		return &DockerImage{Registry: "", Repository: parts[0], Tag: tag}, nil
-	} else if !strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":") && parts[0] != "localhost" {
-		return &DockerImage{Registry: "", Repository: strings.Join(parts, "/"), Tag: tag}, nil
-	}
-	return &DockerImage{Registry: parts[0], Repository: strings.Join(parts[1:], "/"), Tag: tag}, nil
+	return &DockerImage{
+		Registry:   parseRegistry(image),
+		Repository: parseRepository(image),
+		Tag:        parseTag(image),
+		Digest:     parseDigest(image),
+	}, nil
 }
 
-// Get a repos name and returns the right reposName + tag|digest
-// The tag can be confusing because of a port in a repository name.
-//     Ex: localhost.localdomain:5000/samalba/hipache:latest
-//     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
-func ParseRepositoryTag(repos string) (string, string) {
-	n := strings.Index(repos, "@")
-	if n >= 0 {
-		parts := strings.Split(repos, "@")
-		return parts[0], parts[1]
+func parseRegistry(image string) string {
+	parts := strings.SplitN(image, "/", 2)
+	if len(parts) == 1 {
+		return ""
 	}
-	n = strings.LastIndex(repos, ":")
+	if isRegistry(parts[0]) {
+		return parts[0]
+	}
+	return ""
+}
+
+func parseRepository(image string) string {
+	image = strings.Split(image, "@")[0]
+	parts := strings.SplitN(image, "/", 2)
+	if len(parts) == 1 {
+		return strings.Split(image, ":")[0]
+	}
+	if isRegistry(parts[0]) {
+		return strings.Split(parts[1], ":")[0]
+	}
+	return strings.Split(image, ":")[0]
+}
+
+func parseTag(image string) string {
+	image = strings.Split(image, "@")[0]
+	n := strings.LastIndex(image, ":")
 	if n < 0 {
-		return repos, ""
+		return ""
 	}
-	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
-		return repos[:n], tag
+	afterColon := image[n+1:]
+	if strings.Contains(afterColon, "/") {
+		return ""
 	}
-	return repos, ""
+	return afterColon
+}
+
+func parseDigest(image string) string {
+	parts := strings.Split(image, "@")
+	if len(parts) == 1 {
+		return ""
+	}
+	return parts[1]
+}
+
+// isRegistry returns true if the provided str string is a registry.
+// Ex: localhost.localdomain:5000, k8s.gcr.io, quay.io
+func isRegistry(str string) bool {
+	return strings.Contains(str, ".") ||
+		strings.Contains(str, ":") ||
+		strings.Contains(str, "localhost")
 }

--- a/lib/loc/loc_test.go
+++ b/lib/loc/loc_test.go
@@ -95,9 +95,12 @@ func (s *LocatorSuite) TestParseDockerImage(c *C) {
 	}{
 		{input: "", expected: DockerImage{Repository: "test"}, error: true},
 		{input: "test", expected: DockerImage{Repository: "test"}},
+		{input: "test/test:v0.0.1", expected: DockerImage{Repository: "test/test", Tag: "v0.0.1"}},
+		{input: "test/test@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", expected: DockerImage{Repository: "test/test", Digest: "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"}},
 		{input: "apiserver:5000/test", expected: DockerImage{Registry: "apiserver:5000", Repository: "test"}},
 		{input: "apiserver:5000/test:v0.0.1", expected: DockerImage{Registry: "apiserver:5000", Repository: "test", Tag: "v0.0.1"}},
-		{input: "apiserver:5000/test@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", expected: DockerImage{Registry: "apiserver:5000", Repository: "test", Tag: "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"}},
+		{input: "apiserver:5000/test@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", expected: DockerImage{Registry: "apiserver:5000", Repository: "test", Digest: "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"}},
+		{input: "apiserver:5000/test/test:v0.0.1@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb", expected: DockerImage{Registry: "apiserver:5000", Repository: "test/test", Tag: "v0.0.1", Digest: "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"}},
 	}
 	for i, tc := range tcs {
 		comment := Commentf("test case %v", i+1)


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Include image digest in docker images and update the parsing implementation to allow parsing of images with both a tag and a digest.

These changes will allow proper parsing of images in the format:
```
k8s.gcr.io/ingress-nginx/controller:v0.49.3@sha256:35fe394c82164efa8f47f3ed0be981b3f23da
```

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->
* Ports https://github.com/gravitational/gravity/pull/2664