### PR TITLE
Fix data race in concurrent exec

### DIFF
--- a/lib/utils/buf_test.go
+++ b/lib/utils/buf_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncBuffer(t *testing.T) {
+	// setup
+	b := NewSyncBuffer()
+	defer func() {
+		assert.Nil(t, b.Close())
+	}()
+
+	// execute
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, err := io.WriteString(b, "Brown fox jumps over the lazy dog.\n")
+			assert.Nil(t, err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// verify
+	expected := `Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+Brown fox jumps over the lazy dog.
+`
+	assert.Equal(t, b.String(), expected)
+}

--- a/lib/utils/exec_test.go
+++ b/lib/utils/exec_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/gravitational/gravity/lib/run"
+	"github.com/gravitational/trace"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestOutputRace(t *testing.T) {
+	g, ctx := run.WithContext(context.Background())
+	for i := 0; i < 10; i++ {
+		g.Go(ctx, func() error {
+			cmd := helperCommandContext(ctx)
+			var out bytes.Buffer
+			logger := logrus.WithField(trace.Component, t.Name())
+			return ExecL(cmd, &out, logger)
+		})
+	}
+	_ = g.Wait()
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("TEST_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	msg := "toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.example.com/increase-rate-limit"
+	fmt.Fprintln(os.Stderr, msg)
+	fmt.Fprintln(os.Stdout, msg)
+}
+
+func helperCommandContext(ctx context.Context, s ...string) (cmd *exec.Cmd) {
+	cs := []string{"-test.run=TestHelperProcess", "--"}
+	cs = append(cs, s...)
+	if ctx != nil {
+		cmd = exec.CommandContext(ctx, os.Args[0], cs...)
+	} else {
+		cmd = exec.Command(os.Args[0], cs...)
+	}
+	cmd.Env = append(os.Environ(), "TEST_WANT_HELPER_PROCESS=1")
+	return cmd
+}


### PR DESCRIPTION


## Description
<!--Required. Provide high-level overview of what the change is for.-->
Stumbled on a data race during tests due to violation of [this](https://github.com/golang/go/blob/go1.13.8/src/os/exec/exec.go#L112-L113):
<details>
  <summary>Logs</summary>

```
[2021-11-16T21:01:01.380Z] #3 627.8 ==================
[2021-11-16T21:01:01.380Z] #3 627.8 WARNING: DATA RACE
[2021-11-16T21:01:01.380Z] #3 627.8 Write at 0x00c0012d1ac0 by goroutine 75:
[2021-11-16T21:01:01.380Z] #3 627.8   bytes.(*Buffer).Write()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/bytes/buffer.go:169 +0x42
[2021-11-16T21:01:01.380Z] #3 627.8   io.(*multiWriter).Write()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/multi.go:60 +0xbb
[2021-11-16T21:01:01.380Z] #3 627.8   io.copyBuffer()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/io.go:404 +0x282
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).writerDescriptor.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/io.go:364 +0x7a
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).Start.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/os/exec/exec.go:435 +0x34
[2021-11-16T21:01:01.380Z] #3 627.8 
[2021-11-16T21:01:01.380Z] #3 627.8 Previous write at 0x00c0012d1ac0 by goroutine 72:
[2021-11-16T21:01:01.380Z] #3 627.8   bytes.(*Buffer).Write()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/bytes/buffer.go:169 +0x42
[2021-11-16T21:01:01.380Z] #3 627.8   io.(*multiWriter).Write()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/multi.go:60 +0xbb
[2021-11-16T21:01:01.380Z] #3 627.8   io.copyBuffer()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/io.go:404 +0x282
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).writerDescriptor.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/io/io.go:364 +0x7a
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).Start.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/os/exec/exec.go:435 +0x34
[2021-11-16T21:01:01.380Z] #3 627.8 
[2021-11-16T21:01:01.380Z] #3 627.8 Goroutine 75 (running) created at:
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).Start()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/os/exec/exec.go:434 +0xa8d
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/utils.ExecWithInput()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/utils/exec.go:207 +0x1da
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/utils.ExecL()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/utils/exec.go:182 +0x256
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Puller).Pull()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/docker.go:48 +0x1a7
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).pullAndPush()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:191 +0x138
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).pullAndExportImageIfNeeded()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:174 +0x336
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).PullAndExportImages.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:149 +0xfe
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/run.(*Group).Go.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/run/run.go:85 +0x9d
[2021-11-16T21:01:01.380Z] #3 627.8 
[2021-11-16T21:01:01.380Z] #3 627.8 Goroutine 72 (running) created at:
[2021-11-16T21:01:01.380Z] #3 627.8   os/exec.(*Cmd).Start()
[2021-11-16T21:01:01.380Z] #3 627.8       /go/src/os/exec/exec.go:434 +0xa8d
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/utils.ExecWithInput()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/utils/exec.go:207 +0x1da
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/utils.ExecL()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/utils/exec.go:182 +0x256
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Puller).Pull()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/docker.go:48 +0x1a7
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).pullAndPush()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:191 +0x138
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).pullAndExportImageIfNeeded()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:174 +0x336
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/docker.(*Synchronizer).PullAndExportImages.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/docker/synchronizer.go:149 +0xfe
[2021-11-16T21:01:01.380Z] #3 627.8   github.com/gravitational/gravity/lib/run.(*Group).Go.func1()
[2021-11-16T21:01:01.380Z] #3 627.8       /host/gravity/lib/run/run.go:85 +0x9d
[2021-11-16T21:01:01.380Z] #3 627.8 ==================
```

</details>

This PR fixes it by employing concurrency-friendly writer for the shared sink.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes #, refs #
<!--This PR depends on the following PRs (e.g. planet, satellite, etc.).-->
* Requires #
<!--This PR is a back-/forward-port of the following PR.-->
* Ports #

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [ ] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Performance/Scaling
<!--Optional. Add any relevant details on how this PR reacts when scaled to 1k nodes, and any additional scaling considerations for the reviewers.-->

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->

## Additional information
<!--Optional. Anything else that may be relevant.-->
