### PR TITLE
[8.0.x] Bump go version to 1.17.5

### DIFF
--- a/Makefile.buildx
+++ b/Makefile.buildx
@@ -4,7 +4,7 @@ CURRENT_DIR := $(realpath $(patsubst %/,%,$(dir $(MKFILE_PATH))))
 BUILDDIR ?= $(CURRENT_DIR)/_build
 
 include versions.mk
-GOLANG_VER := 1.13.8-stretch
+GOLANG_VER := 1.17.5-stretch
 
 # Set to non-empty value to trigger streaming builder progress
 CI ?=

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/debian-venti:go1.13.8-stretch
+FROM quay.io/gravitational/debian-venti:go1.17.5-stretch
 
 ARG PROTOC_VER
 ARG PROTOC_PLATFORM
@@ -40,7 +40,7 @@ RUN (mkdir -p /gopath/src/github.com/gravitational && \
      git clone https://github.com/gravitational/version.git && \
      cd /gopath/src/github.com/gravitational/version && \
      git checkout ${VERSION_TAG} && \
-     go install github.com/gravitational/version/cmd/linkflags)
+     go install github.com/gravitational/version/cmd/linkflags@0.0.2)
 
 RUN (wget --quiet -O /tmp/${TARBALL} ${PROTOC_URL} && \
      unzip -d /opt/protoc /tmp/${TARBALL} && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -118,7 +118,7 @@ test: buildbox test-etcd
 		-e "GRAVITY_PKG_PATH=$(GRAVITY_PKG_PATH)" \
 		-e "TEST_PACKAGES=$(TEST_PACKAGES)" \
 		-t $(BBOX) \
-		dumb-init make -C $(SRCDIR)/build.assets FLAGS='-cover -race -mod=vendor' TEST_ETCD=true TEST_K8S=$(TEST_K8S) test-inside-container
+		dumb-init make -C $(SRCDIR)/build.assets FLAGS='-gcflags=all=-d=checkptr=0 -cover -race -mod=vendor' TEST_ETCD=true TEST_K8S=$(TEST_K8S) test-inside-container
 
 
 .PHONY: test-inside-container

--- a/lib/app/handler/handler.go
+++ b/lib/app/handler/handler.go
@@ -561,7 +561,6 @@ func (h *WebHandler) createApp(w http.ResponseWriter, req *http.Request,
 	var labelsMap string
 	var upsertS string
 	var manifestS string
-
 	err := form.Parse(req,
 		form.FileSlice("package", &files),
 		form.String("labels", &labelsMap),
@@ -588,7 +587,10 @@ func (h *WebHandler) createApp(w http.ResponseWriter, req *http.Request,
 	}()
 
 	reader := files[0]
-	appPackageName := reader.Name()
+	appPackageName, err := utils.ParseFilename(req, "package")
+	if err != nil {
+		return trace.Wrap(err, "failed to parse package name")
+	}
 	locator, err := loc.ParseLocator(appPackageName)
 	if err != nil {
 		return trace.BadParameter(err.Error())

--- a/lib/pack/webpack/webpack.go
+++ b/lib/pack/webpack/webpack.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/gravity/lib/pack"
 	"github.com/gravitational/gravity/lib/storage"
 	"github.com/gravitational/gravity/lib/users"
+	"github.com/gravitational/gravity/lib/utils"
 	"github.com/gravitational/gravity/lib/utils/fields"
 
 	"github.com/gravitational/form"
@@ -266,7 +267,11 @@ func (s *Server) createPackage(w http.ResponseWriter, r *http.Request, p httprou
 		}
 	}()
 
-	loc, err := loc.ParseLocator(files[0].Name())
+	packageName, err := utils.ParseFilename(r, "package")
+	if err != nil {
+		return trace.Wrap(err, "failed to parse package name")
+	}
+	loc, err := loc.ParseLocator(packageName)
 	if err != nil {
 		return trace.BadParameter(err.Error())
 	}

--- a/lib/system/selinux/Dockerfile
+++ b/lib/system/selinux/Dockerfile
@@ -11,6 +11,6 @@ COPY ./internal/generate /go/src/github.com/gravitational/gravity/lib/system/sel
 RUN set -ex && \
 	GO111MODULE=off go get -u github.com/gravitational/vfsgen && \
 	cd /go/src/github.com/gravitational/vfsgen && \
-	go install -tags generate_policy github.com/gravitational/gravity/lib/system/selinux/internal/generate
+	GO111MODULE=off go install -tags generate_policy github.com/gravitational/gravity/lib/system/selinux/internal/generate
 
 WORKDIR "/go/src/github.com/gravitational/gravity/lib/system/selinux/internal/policy/"

--- a/lib/system/selinux/Dockerfile
+++ b/lib/system/selinux/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.12.9-buster
+ARG GOLANG_VER=1.17.5-buster
+FROM golang:${GOLANG_VER}
 
 RUN set -ex && \
 	mkdir -p /go/src/github.com/gravitational/gravity/lib/system/selinux/internal/generate && \
@@ -8,7 +9,7 @@ COPY ./internal/policy/policy.go /go/src/github.com/gravitational/gravity/lib/sy
 COPY ./internal/generate /go/src/github.com/gravitational/gravity/lib/system/selinux/internal/generate/
 
 RUN set -ex && \
-	go get -u github.com/gravitational/vfsgen && \
+	GO111MODULE=off go get -u github.com/gravitational/vfsgen && \
 	cd /go/src/github.com/gravitational/vfsgen && \
 	go install -tags generate_policy github.com/gravitational/gravity/lib/system/selinux/internal/generate
 

--- a/lib/utils/form.go
+++ b/lib/utils/form.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"mime"
+	"net/http"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	defaultMaxMemory = 32 << 20 // 32 MiB
+)
+
+// ParseFilename parses the filename for the specified form data.
+func ParseFilename(req *http.Request, key string) (string, error) {
+	if err := req.ParseMultipartForm(defaultMaxMemory); err != nil {
+		return "", trace.Wrap(err)
+	}
+	if req.MultipartForm == nil {
+		return "", trace.BadParameter("request does not contain multipart form")
+	}
+	fileHeaders, exists := req.MultipartForm.File[key]
+	if !exists {
+		return "", trace.NotFound("multipart form does not contain %s data", key)
+	}
+	if len(fileHeaders) != 1 {
+		return "", trace.BadParameter("expected a single file parameter but got %d", len(fileHeaders))
+	}
+	_, params, _ := mime.ParseMediaType(fileHeaders[0].Header.Get("Content-Disposition"))
+	filename, exists := params["filename"]
+	if !exists {
+		return "", trace.NotFound("file header does not contain filename")
+	}
+	return filename, nil
+}

--- a/lib/utils/form_test.go
+++ b/lib/utils/form_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+type FormutilsSuite struct{}
+
+var _ = Suite(&FormutilsSuite{})
+
+func newRequestWithPackage(filename string) (*http.Request, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	_, err := writer.CreateFormFile("package", filename)
+	if err != nil {
+		return nil, err
+	}
+	writer.Close()
+	request, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, "", body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", writer.FormDataContentType())
+	return request, nil
+}
+
+func (s *FormutilsSuite) TestParseFilename(c *C) {
+	var testCases = []struct {
+		filename string
+		comment  string
+	}{
+		{
+			filename: "gravitational.io/app-template:0.0.1",
+			comment:  "expected original filename",
+		},
+		{
+			filename: "test.txt",
+			comment:  "expected original filename",
+		},
+		{
+			filename: "path/to/file",
+			comment:  "expected original filename",
+		},
+	}
+
+	for _, testCase := range testCases {
+		req, err := newRequestWithPackage(testCase.filename)
+		c.Assert(err, IsNil)
+		filename, err := ParseFilename(req, "package")
+		c.Assert(err, IsNil)
+		c.Assert(filename, Equals, testCase.filename, Commentf(testCase.comment))
+	}
+}

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.19.15
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 8.0.9-$(K8S_VER_SUFFIX)
+PLANET_TAG ?= 8.0.9-$(K8S_VER_SUFFIX)-2-ga1753883
 # system applications
 INGRESS_APP_TAG ?= 0.0.2
 STORAGE_APP_TAG ?= 0.0.4

--- a/versions.mk
+++ b/versions.mk
@@ -10,7 +10,7 @@ K8S_VER ?= 1.19.15
 # major + minor padded to 2 chars with 0 + patch also padded to 2 chars, e.g.
 # 1.13.5 -> 11305, 1.13.12 -> 11312, 2.0.0 -> 20000 and so on
 K8S_VER_SUFFIX ?= $(shell printf "%d%02d%02d" $(shell echo $(K8S_VER) | sed "s/\./ /g"))
-PLANET_TAG ?= 8.0.9-$(K8S_VER_SUFFIX)-2-ga1753883
+PLANET_TAG ?= 8.0.10-$(K8S_VER_SUFFIX)
 # system applications
 INGRESS_APP_TAG ?= 0.0.2
 STORAGE_APP_TAG ?= 0.0.4


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Bump go version to `1.17.5`.

> Go 1.14 adds -d=checkptr as a compile-time option for adding instrumentation to check that Go code is following unsafe.Pointer safety rules dynamically. This option is enabled by default (except on Windows) with the -race or -msan flags, and can be disabled with -gcflags=all=-d=checkptr=0. 

This lead to failed test cases related to some older dependencies. Disabling the check for now.

Go 1.17 changed how filenames were parsed in multipart forms https://github.com/golang/go/issues/45789. Filename no longer includes directory path in filename. dd03d1e adds a workaround to this change.


## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2693
* Requires https://github.com/gravitational/planet/pull/872
* Ports https://github.com/gravitational/gravity/pull/2694

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Perform manual testing
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Testing
- [ ] Basic manual testing by installing a cluster and joining nodes.