### PR TITLE
[8.0.x] Replace sles:15-sp2 test case with sles:15

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -57,7 +57,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Replaces `sles:15-sp2` test case with `sles:15`. Image used for `sles:15-sp2` test case is no longer available. See https://github.com/gravitational/gravity/issues/2703. 

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Refs https://github.com/gravitational/gravity/issues/2703
* Ports https://github.com/gravitational/gravity/pull/2704

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [ ] Address review feedback