### PR TITLE
Deprecate 5.5 support

### DIFF
--- a/docs/9.x/changelog.md
+++ b/docs/9.x/changelog.md
@@ -15,7 +15,6 @@ Find the latest Open Source Gravity releases at [Gravity Downloads](https://grav
 | [8.0](#80-releases) | 8.0.0-beta.9  | No  | pre-release          | January 27, 2022     | Set upon release        | 1.19.15              | 3.2.17-gravity   |
 | [7.0](#70-releases) | 7.0.37        | Yes | April 3, 2020        | January 27, 2022     | July 9, 2022            | 1.17.9               | 3.2.14-gravity   |
 | [6.1](#61-releases) | 6.1.55        | Yes | August 2, 2019       | January 27, 2022     | November 10, 2021       | 1.15.12              | 3.2.14-gravity   |
-| [5.5](#55-releases) | 5.5.60        | Yes | March 8, 2019        | June 25, 2021        | March 8, 2021           | 1.13.11              | 3.0.7-gravity    |
 
 Gravity offers one Long Term Support (LTS) version for every 2nd Kubernetes
 minor version, allowing for seamless upgrades per Kubernetes
@@ -42,6 +41,7 @@ extend updates past End of Support through customer agreements if required.
 | [6.2](#62-releases) | 6.2.5        | No  | September 24, 2019   | December 18, 2019 (6.3) | 1.16.3               | 3.2.13           |
 | [6.0](#60-releases) | 6.0.10       | No  | July 17, 2019        | August 2, 2019 (6.1)    | 1.14.7               | 3.2.12           |
 | [5.6](#56-releases) | 5.6.8        | No  | April 19, 2019       | July 17, 2019 (6.0)     | 1.14.7               | 3.0.6-gravity    |
+| [5.5](#55-releases) | 5.5.60       | Yes | March 8, 2019        | January 31, 2022        | 1.13.11              | 3.0.7-gravity    |
 | [5.4](#54-releases) | 5.4.10       | No  | December 14, 2018    | March 8, 2019 (5.5)     | 1.13.5               | 2.4.10           |
 | [5.3](#53-releases) | 5.3.9        | No  | October 19, 2018     | December 14, 2018 (5.4) | 1.12.3               | 2.4.7            |
 | [5.2](#52-releases) | 5.2.18       | Yes | October 15, 2018     | October 15, 2019        | 1.11.9               | 2.4.10           |


### PR DESCRIPTION
## Description
We no longer have any paying customers using 5.5, and it is otherwise well past its end of support date.

## Type of change
* Documentation
* This change has a user-facing impact

## TODOs
- [ ] Address review feedback

## Testing done
None.
