### PR TITLE
Remove linux distros that no longer run gravity

### DIFF
--- a/assets/robotest/config/nightly.sh
+++ b/assets/robotest/config/nightly.sh
@@ -9,8 +9,8 @@ source $(dirname $0)/lib/utils.sh
 declare -A UPGRADE_MAP
 
 # Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
-# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
-UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+# UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 redhat:7.9 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 redhat:7.9 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
 UPGRADE_MAP[8.0.0-beta.1]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
@@ -81,7 +81,7 @@ EOF
 }
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.8 centos:8.4 centos:7.8 sles:12-sp5 sles:15-sp2 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_sizes=( \
     '"flavor":"six","nodes":6,"role":"node"')
   for os in $oses; do

--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -9,8 +9,8 @@ source $(dirname $0)/lib/utils.sh
 declare -A UPGRADE_MAP
 # Use a fixed tag until we cut our first non-pre-release, as recommended_upgrade_tag skips pre-releases
 # UPGRADE_MAP[$(recommended_upgrade_tag $(branch 9.0.x))]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
-UPGRADE_MAP[9.0.0-beta.2]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
-UPGRADE_MAP[8.0.0-beta.1]="redhat:7.9 centos:8.4 ubuntu:18"
+UPGRADE_MAP[9.0.0-beta.10]="redhat:8.4 centos:7.9 ubuntu:18 ubuntu:20"
+UPGRADE_MAP[8.0.0-beta.1]="redhat:7.9 centos:7.9 ubuntu:18"
 UPGRADE_MAP[7.1.0-alpha.6]="ubuntu:20"
 
 function build_upgrade_suite {
@@ -55,7 +55,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:7.9 ubuntu:16 ubuntu:18 ubuntu:20"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
After some further customers have departed, we no longer need to support suse or centos 8 (which is eol, per https://www.centos.org/centos-linux-eol/)

Since suse is [actively causing failures](https://github.com/gravitational/gravity/pull/2723), removing these distros from robotest will save us both debugging time and cpu time, since we won't run as many tests.

See [this slack convo](https://goteleport.slack.com/archives/CFF83PHFH/p1649116780934659?thread_ts=1649111554.469659&cid=CFF83PHFH) for a discussion of which distros we still need to support.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
N/A

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Address review feedback
- [x] Check CI is green

## Testing done
N/A.  A clean CI run is proof enough.
