### PR TITLE
[7.0.x] Remove sles:12 robotest case

### DIFF
--- a/assets/robotest/config/pr.sh
+++ b/assets/robotest/config/pr.sh
@@ -83,7 +83,7 @@ EOF
 
 function build_install_suite {
   local suite=''
-  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:12-sp5 sles:15 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
+  local oses="redhat:8.4 redhat:7.9 centos:8.4 centos:7.9 sles:15 ubuntu:16 ubuntu:18 ubuntu:20 debian:9 debian:10"
   local cluster_size='"flavor":"one","nodes":1,"role":"node"'
   for os in $oses; do
     suite+=$(cat <<EOF


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Removes `sles:12-sp5` test case. Robotest is currently failing with:
```log
error: Error resolving image name 'suse-cloud/sles-12-sp5-v20210605': Could not find image or family suse-cloud/sles-12-sp5-v20210605
```

The image used by robotest is no longer available from google cloud
```
$ gcloud compute --project opensuse-cloud images list  --show-deprecated | grep sles-12-sp5
sles-12-sp5-v20210903                                         suse-cloud           sles-12                           DEPRECATED  READY
sles-12-sp5-v20211204                                         suse-cloud           sles-12                           DEPRECATED  READY
sles-12-sp5-v20220126                                         suse-cloud           sles-12                                       READY
sles-12-sp5-sap-v20210903                                     suse-sap-cloud       sles-12-sp5-sap                   DEPRECATED  READY
sles-12-sp5-sap-v20211204                                     suse-sap-cloud       sles-12-sp5-sap                   DEPRECATED  READY
sles-12-sp5-sap-v20220126                                     suse-sap-cloud       sles-12-sp5-sap                               READY
```

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)