### PR TITLE
[7.0.x] Use default gravity dir for etcd backupFile

### DIFF
--- a/lib/update/cluster/phases/etcd.go
+++ b/lib/update/cluster/phases/etcd.go
@@ -71,11 +71,7 @@ func NewPhaseUpgradeEtcdBackup(logger log.FieldLogger) (fsm.PhaseExecutor, error
 
 func (p *PhaseUpgradeEtcdBackup) Execute(ctx context.Context) error {
 	p.Info("Backup etcd.")
-	backupFile, err := backupFile()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "backup", backupFile)
+	out, err := utils.RunPlanetCommand(ctx, p.FieldLogger, "etcd", "backup", backupFile())
 	if err != nil {
 		return trace.Wrap(err, "failed to backup etcd").AddField("output", string(out))
 	}
@@ -331,10 +327,6 @@ func restartGravitySite(ctx context.Context, client *kubeapi.Clientset, logger l
 	return trace.Wrap(err)
 }
 
-func backupFile() (string, error) {
-	stateDir, err := state.GetStateDir()
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	return filepath.Join(state.GravityUpdateDir(stateDir), defaults.EtcdUpgradeBackupFile), nil
+func backupFile() (path string) {
+	return filepath.Join(state.GravityUpdateDir(defaults.GravityDir), defaults.EtcdUpgradeBackupFile)
 }


### PR DESCRIPTION
## Description
<!--Required. Provide high-level overview of what the change is for.-->
Fixes upgrade upgrade failure on missing etcd.bak file when using custom install directories.

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## Linked tickets and other PRs
<!--Required. Keep only those that apply.-->

<!--This PR addresses the following issues.-->
* Closes https://github.com/gravitational/gravity/issues/2734
<!--This PR is a back-/forward-port of the following PR.-->
* Ports https://github.com/gravitational/gravity/pull/2010

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Perform manual testing
- [ ] Address review feedback

## Testing done
<!--Required. Explain what kind of testing these changes underwent.-->


```
$ sudo ./gravity install --cloud-provider=generic --mount=data:/opt/app --state-dir=/opt/app/gravity (install 6.1.33)
$ sudo ./upload (upload new 7.0.38-dev.2 cluster image)
$ sudo ./gravity upgrade
$ sudo ./gravity plan
Phase                              Description                                                               State         Node            Requires                                             Updated
-----                              -----------                                                               -----         ----            --------                                             -------
✓ init                             Initialize update operation                                               Completed     -               -                                                    Tue Apr 26 23:02 UTC
  ✓ robotest-f168927b-node-0       Initialize node "robotest-f168927b-node-0"                                Completed     10.138.0.66     -                                                    Tue Apr 26 23:02 UTC
✓ checks                           Run preflight checks                                                      Completed     -               /init                                                Tue Apr 26 23:02 UTC
✓ pre-update                       Run pre-update application hook                                           Completed     -               /init,/checks                                        Tue Apr 26 23:02 UTC
✓ bootstrap                        Bootstrap update operation on nodes                                       Completed     -               /checks,/pre-update                                  Tue Apr 26 23:02 UTC
  ✓ robotest-f168927b-node-0       Bootstrap node "robotest-f168927b-node-0"                                 Completed     10.138.0.66     -                                                    Tue Apr 26 23:02 UTC
✓ coredns                          Provision CoreDNS resources                                               Completed     -               /bootstrap                                           Tue Apr 26 23:02 UTC
✓ masters                          Update master nodes                                                       Completed     -               /coredns                                             Tue Apr 26 23:04 UTC
  ✓ robotest-f168927b-node-0       Update system software on master node "robotest-f168927b-node-0"          Completed     -               -                                                    Tue Apr 26 23:04 UTC
    ✓ drain                        Drain node "robotest-f168927b-node-0"                                     Completed     10.138.0.66     -                                                    Tue Apr 26 23:02 UTC
    ✓ system-upgrade               Update system software on node "robotest-f168927b-node-0"                 Completed     10.138.0.66     /masters/robotest-f168927b-node-0/drain              Tue Apr 26 23:03 UTC
    ✓ health                       Health check node "robotest-f168927b-node-0"                              Completed     -               /masters/robotest-f168927b-node-0/system-upgrade     Tue Apr 26 23:03 UTC
    ✓ taint                        Taint node "robotest-f168927b-node-0"                                     Completed     10.138.0.66     /masters/robotest-f168927b-node-0/health             Tue Apr 26 23:03 UTC
    ✓ uncordon                     Uncordon node "robotest-f168927b-node-0"                                  Completed     10.138.0.66     /masters/robotest-f168927b-node-0/taint              Tue Apr 26 23:03 UTC
    ✓ endpoints                    Wait for DNS/cluster endpoints on "robotest-f168927b-node-0"              Completed     10.138.0.66     /masters/robotest-f168927b-node-0/uncordon           Tue Apr 26 23:03 UTC
    ✓ untaint                      Remove taint from node "robotest-f168927b-node-0"                         Completed     10.138.0.66     /masters/robotest-f168927b-node-0/endpoints          Tue Apr 26 23:04 UTC
✓ etcd                             Upgrade etcd 3.3.22 to 3.4.9                                              Completed     -               -                                                    Tue Apr 26 23:05 UTC
  ✓ backup                         Backup etcd data                                                          Completed     -               -                                                    Tue Apr 26 23:04 UTC
    ✓ robotest-f168927b-node-0     Backup etcd on node "robotest-f168927b-node-0"                            Completed     -               -                                                    Tue Apr 26 23:04 UTC
  ✓ shutdown                       Shutdown etcd cluster                                                     Completed     -               -                                                    Tue Apr 26 23:04 UTC
    ✓ robotest-f168927b-node-0     Shutdown etcd on node "robotest-f168927b-node-0"                          Completed     -               /etcd/backup/robotest-f168927b-node-0                Tue Apr 26 23:04 UTC
  ✓ upgrade                        Upgrade etcd servers                                                      Completed     -               -                                                    Tue Apr 26 23:04 UTC
    ✓ robotest-f168927b-node-0     Upgrade etcd on node "robotest-f168927b-node-0"                           Completed     -               /etcd/shutdown/robotest-f168927b-node-0              Tue Apr 26 23:04 UTC
  ✓ migrate                        Migrate etcd data to new version                                          Completed     -               -                                                    Tue Apr 26 23:04 UTC
    ✓ robotest-f168927b-node-0     Migrate etcd data to version 3.4.9 on node "robotest-f168927b-node-0"     Completed     -               /etcd/upgrade/robotest-f168927b-node-0               Tue Apr 26 23:04 UTC
  ✓ restart                        Restart etcd servers                                                      Completed     -               -                                                    Tue Apr 26 23:05 UTC
    ✓ robotest-f168927b-node-0     Restart etcd on node "robotest-f168927b-node-0"                           Completed     -               /etcd/migrate/robotest-f168927b-node-0               Tue Apr 26 23:04 UTC
    ✓ gravity-site                 Restart gravity-site service                                              Completed     -               -                                                    Tue Apr 26 23:05 UTC
✓ config                           Update system configuration on nodes                                      Completed     -               /etcd                                                Tue Apr 26 23:05 UTC
  ✓ robotest-f168927b-node-0       Update system configuration on node "robotest-f168927b-node-0"            Completed     -               -                                                    Tue Apr 26 23:05 UTC
✓ openebs                          Create OpenEBS configuration                                              Completed     10.138.0.66     /config                                              Tue Apr 26 23:05 UTC
✓ runtime                          Update application runtime                                                Completed     -               /openebs                                             Tue Apr 26 23:12 UTC
  ✓ rbac-app                       Update system application "rbac-app" to 7.0.38-dev.2                      Completed     -               -                                                    Tue Apr 26 23:05 UTC
  ✓ dns-app                        Update system application "dns-app" to 7.0.4                              Completed     -               /runtime/rbac-app                                    Tue Apr 26 23:06 UTC
  ✓ storage-app                    Update system application "storage-app" to 0.0.3                          Completed     -               /runtime/dns-app                                     Tue Apr 26 23:08 UTC
  ✓ logging-app                    Update system application "logging-app" to 7.0.1                          Completed     -               /runtime/storage-app                                 Tue Apr 26 23:09 UTC
  ✓ monitoring-app                 Update system application "monitoring-app" to 7.0.12                      Completed     -               /runtime/logging-app                                 Tue Apr 26 23:11 UTC
  ✓ tiller-app                     Update system application "tiller-app" to 7.0.2                           Completed     -               /runtime/monitoring-app                              Tue Apr 26 23:11 UTC
  ✓ site                           Update system application "site" to 7.0.38-dev.2                          Completed     -               /runtime/tiller-app                                  Tue Apr 26 23:12 UTC
  ✓ kubernetes                     Update system application "kubernetes" to 7.0.38-dev.2                    Completed     -               /runtime/site                                        Tue Apr 26 23:12 UTC
✓ migration                        Perform system database migration                                         Completed     -               /runtime                                             Tue Apr 26 23:12 UTC
  ✓ labels                         Update node labels                                                        Completed     -               -                                                    Tue Apr 26 23:12 UTC
✓ app                              Update installed application                                              Completed     -               /migration                                           Tue Apr 26 23:12 UTC
  ✓ telekube                       Update application "telekube" to 7.0.38-dev.2                             Completed     -               -                                                    Tue Apr 26 23:12 UTC
✓ gc                               Run cleanup tasks                                                         Completed     -               /app                                                 Tue Apr 26 23:12 UTC
  ✓ robotest-f168927b-node-0       Clean up node "robotest-f168927b-node-0"                                  Completed     -               -                                                    Tue Apr 26 23:12 UTC
```