### PR TITLE
Remove mac publishing infrastructure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -414,15 +414,8 @@ steps:
         from_secret: AWS_S3_RW_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
-      MAC_ANSIBLE_BUILD_HOST:
-        from_secret: MAC_ANSIBLE_BUILD_HOST
-      MAC_ANSIBLE_SSH_KEY:
-        from_secret: MAC_ANSIBLE_SSH_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli ansible
-      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
       - export WORKSPACE=/drone/src
       - export GRAVITY_TAG=$DRONE_COMMIT_REF
       - cd ops/hub
@@ -506,23 +499,6 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: publish on mac
-    image: docker:git
-    environment:
-      TELE_KEY:
-        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
-      MAC_ANSIBLE_BUILD_HOST:
-        from_secret: MAC_ANSIBLE_BUILD_HOST
-      MAC_ANSIBLE_SSH_KEY:
-        from_secret: MAC_ANSIBLE_SSH_KEY
-    commands:
-      - apk add --no-cache make ansible
-      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
-      - export TELEKUBE_TAG=$DRONE_COMMIT_REF
-      - cd ops/xcloud
-      - make release-telekube-mac
 
 services:
   - name: run docker daemon
@@ -537,6 +513,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: e677c50a91a689705b0e249f508ccb73560a362be1dafeec3b8112d2d485afda
+hmac: bb3915c0a4071e845865c2f7fbf78351563c99a752556909bdc8607fb0ebdc2d
 
 ...


### PR DESCRIPTION
## Description
This box went belly up in https://github.com/gravitational/ops/issues/369

While these changes don't address all the codepaths related to the defunct gravity mac build infra, they do remove blatantly broken secrets.

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/ops/issues/369
* Requires https://github.com/gravitational/ops/pull/419
* Requires https://github.com/gravitational/gravity/pull/2747

## TODOs
- [x] Self-review the change
- [ ] Perform manual testing
- [ ] Write documentation
- [x] Address review feedback

## Testing done
None yet.

## Additional information
I need to clean up some of the code in ops to prevent the publish-oss pipeline from failing due to lack of environment variables. 
