### PR TITLE
Fix gravity docs CI

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -3,8 +3,8 @@
 # A multi step build is used to keep the go toolchain outside the final container
 
 # milv-builder, contains the whole go toolchain
-FROM quay.io/gravitational/debian-venti:go1.14.4-buster AS milv-builder
-RUN GO111MODULE=on go get -u -v github.com/magicmatatjahu/milv@v0.0.6
+FROM golang:1.19-buster AS milv-builder
+RUN GO111MODULE=on go install github.com/magicmatatjahu/milv@v0.0.6
 
 # docbox, contains everything for building gravity documentation
 FROM quay.io/gravitational/mkdocs-base:1.0.3-1
@@ -16,6 +16,6 @@ ARG PORT
 RUN getent group  $GID || groupadd builder --gid=$GID -o; \
     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash;
 
-COPY --from=milv-builder /gopath/bin/milv /usr/bin/milv
+COPY --from=milv-builder /go/bin/milv /usr/bin/milv
 
 EXPOSE $PORT

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,9 +45,8 @@ $(DOCBOX_ID_FILE): Dockerfile
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
 		--build-arg PORT=$(PORT) \
+		--iidfile $(DOCBOX_ID_FILE) \
 		--tag $(DOCBOX) .
-	# prefer --iidfile to touch, but jenkin's docker is too old. See ops issue #141
-	touch $(DOCBOX_ID_FILE)
 
 # builds a docker container which is used for running `mkdocs`
 .PHONY:bbox


### PR DESCRIPTION
## Description
The gravity docs CI broke due to upstream dependencies, as seen in https://drone.platform.teleport.sh/gravitational/docker-debian/138/1/4

This PR fixes the docs build. I also fixed an old hack related to jenkins I noticed in the Makefile while testing

## Type of change
* Regression fix (non-breaking change which fixes a regression)
* Internal change (not necessarily a bug fix or a new feature)

## Linked tickets and other PRs
The upstream issue is discussed at https://github.com/rivo/uniseg/issues/22

I didn't file a ticket for this problem, as it seemed pretty straight forward

## TODOs
- [x] Self-review the change
- [x] Verify docs CI passes
- [x] Address review feedback


## Implementation
Its possible (and probably more correct) to work around this by installing dep instead, but I found it easier to upgrade the go version.

## Testing done
CI is sufficient. Nonetheless, here is what it looks like on my machine:

<details><summary>make lint</summary>

```console
walt@work:~/git/gravity/docs$ make lint
mkdir -p ../build/docs
docker build \
        --build-arg UID=$(id -u) \
        --build-arg GID=$(id -g) \
        --build-arg PORT=6601 \
        --iidfile ../build/.docs-buildbox.id \
        --tag docs-buildbox:latest .
Sending build context to Docker daemon  19.97MB
Step 1/9 : FROM golang:1.19-buster AS milv-builder
 ---> b87d16c02fec
Step 2/9 : RUN GO111MODULE=on go install github.com/magicmatatjahu/milv@v0.0.6
 ---> Using cache
 ---> 9b8270b953d6
Step 3/9 : FROM quay.io/gravitational/mkdocs-base:1.0.3-1
 ---> 64250a644023
Step 4/9 : ARG UID
 ---> Using cache
 ---> 47ad6327c79f
Step 5/9 : ARG GID
 ---> Using cache
 ---> 7031afbe217a
Step 6/9 : ARG PORT
 ---> Using cache
 ---> 067caed4d288
Step 7/9 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash;
 ---> Using cache
 ---> d1296c1b048d
Step 8/9 : COPY --from=milv-builder /go/bin/milv /usr/bin/milv
 ---> Using cache
 ---> bf0729cb108d
Step 9/9 : EXPOSE $PORT
 ---> Using cache
 ---> 22d5f87965f7
Successfully built 22d5f87965f7
Successfully tagged docs-buildbox:latest
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-lint
cd 4.x && milv -ignore-external
NO ISSUES :-)
cd 5.x && milv -ignore-external
NO ISSUES :-)
cd 6.x && milv -ignore-external
NO ISSUES :-)
cd 7.x && milv -ignore-external
NO ISSUES :-)
cd 8.x && milv -ignore-external
NO ISSUES :-)
cd 9.x && milv -ignore-external
NO ISSUES :-)
walt@work:~/git/gravity/docs$ make lint
docker run --rm=true -u $(id -u):$(id -g) -v "$(pwd)/../":/home -w /home/docs -h docs docs-buildbox:latest make container-lint
cd 4.x && milv -ignore-external
NO ISSUES :-)
cd 5.x && milv -ignore-external
NO ISSUES :-)
cd 6.x && milv -ignore-external
NO ISSUES :-)
cd 7.x && milv -ignore-external
NO ISSUES :-)
cd 8.x && milv -ignore-external
NO ISSUES :-)
cd 9.x && milv -ignore-external
NO ISSUES :-)
```

</details>