### PR TITLE
Fix Gravity publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -414,15 +414,8 @@ steps:
         from_secret: AWS_S3_RW_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
-      MAC_ANSIBLE_BUILD_HOST:
-        from_secret: MAC_ANSIBLE_BUILD_HOST
-      MAC_ANSIBLE_SSH_KEY:
-        from_secret: MAC_ANSIBLE_SSH_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli ansible
-      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
       - export WORKSPACE=/drone/src
       - export GRAVITY_TAG=$DRONE_COMMIT_REF
       - cd ops/hub
@@ -506,23 +499,6 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: publish on mac
-    image: docker:git
-    environment:
-      TELE_KEY:
-        from_secret: DISTRIBUTION_OPSCENTER_TOKEN
-      MAC_ANSIBLE_BUILD_HOST:
-        from_secret: MAC_ANSIBLE_BUILD_HOST
-      MAC_ANSIBLE_SSH_KEY:
-        from_secret: MAC_ANSIBLE_SSH_KEY
-    commands:
-      - apk add --no-cache make ansible
-      - mkdir -m 0700 /root/.ssh && echo "$MAC_ANSIBLE_SSH_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-      - ssh-keyscan -H $MAC_ANSIBLE_BUILD_HOST > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - export SSH_KEY_PATH=/root/.ssh/id_ed25519
-      - export TELEKUBE_TAG=$DRONE_COMMIT_REF
-      - cd ops/xcloud
-      - make release-telekube-mac
 
 services:
   - name: run docker daemon
@@ -537,6 +513,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: e677c50a91a689705b0e249f508ccb73560a362be1dafeec3b8112d2d485afda
+hmac: bb3915c0a4071e845865c2f7fbf78351563c99a752556909bdc8607fb0ebdc2d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -442,138 +442,6 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: publish-oss
-
-trigger:
-  event:
-  - promote
-  target:
-  - release
-  - publish-oss
-
-clone:
-  disable: true
-
-steps:
-  - name: clone gravity
-    image: docker:git
-    commands:
-    - git clone $DRONE_REPO_LINK gravity
-    - cd gravity
-    - git fetch --tags
-    - git checkout $DRONE_COMMIT
-  - name: clone ops
-    image: docker:git
-    environment:
-      OPS_REPO:
-        from_secret: OPS_REPO
-      GITHUB_OPS_DEPLOY_KEY:
-        from_secret: GITHUB_OPS_DEPLOY_KEY
-      OPS_REF: main
-    commands:
-    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
-    - git clone $OPS_REPO ops
-    - cd ops
-    - git checkout $OPS_REF
-  - name: wait for docker
-    image: docker
-    commands:
-      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-      - docker version
-    volumes:
-      - name: dockersock
-        path: /var/run
-  - name: assume AWS role
-    image: amazon/aws-cli
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_S3_RO_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
-      AWS_ROLE:
-        from_secret: AWS_S3_RO_ROLE
-    volumes:
-      - name: awsconfig
-        path: /root/.aws
-    commands:
-      - aws sts get-caller-identity
-      - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-          $(aws sts assume-role \
-            --role-arn "$AWS_ROLE" \
-            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-            --output text) \
-          > /root/.aws/credentials
-      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity --profile default
-  - name: build
-    image: docker:git
-    commands:
-      - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - cd gravity
-      - make production telekube build-tsh release hub-vars
-    volumes:
-      - name: awsconfig
-        path: /root/.aws
-      - name: dockersock
-        path: /var/run
-  - name: assume publish AWS role
-    image: amazon/aws-cli
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_S3_RW_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
-      AWS_ROLE:
-        from_secret: AWS_S3_RW_ROLE
-    volumes:
-      - name: awsconfig
-        path: /root/.aws
-    commands:
-      - aws sts get-caller-identity
-      - |-
-        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-          $(aws sts assume-role \
-            --role-arn "$AWS_ROLE" \
-            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-            --output text) \
-          > /root/.aws/credentials
-      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-      - aws sts get-caller-identity --profile default
-  - name: publish
-    image: docker:git
-    commands:
-      - apk add --no-cache make bash libc6-compat aws-cli ansible
-      - export WORKSPACE=/drone/src
-      - export GRAVITY_TAG=$DRONE_COMMIT_REF
-      - cd ops/hub
-      - make bucket sync
-    volumes:
-      - name: awsconfig
-        path: /root/.aws
-      - name: dockersock
-        path: /var/run
-
-services:
-  - name: run docker daemon
-    image: docker:20.10.6-dind
-    privileged: true
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
-  - name: awsconfig
-    temp: {}
-  - name: dockersock
-    temp: {}
-
----
-kind: pipeline
-type: kubernetes
 name: publish-enterprise
 
 trigger:
@@ -583,31 +451,11 @@ trigger:
   - release
   - publish-enterprise
 
-clone:
-  disable: true
-
 steps:
-  - name: clone gravity
+  - name: fetch tags
     image: docker:git
     commands:
-    - git clone $DRONE_REPO_LINK gravity
-    - cd gravity
-    - git fetch --tags
-    - git checkout $DRONE_COMMIT
-  - name: clone ops
-    image: docker:git
-    environment:
-      OPS_REPO:
-        from_secret: OPS_REPO
-      GITHUB_OPS_DEPLOY_KEY:
-        from_secret: GITHUB_OPS_DEPLOY_KEY
-      OPS_REF: main
-    commands:
-    - mkdir -m 0700 /root/.ssh && echo "$GITHUB_OPS_DEPLOY_KEY" > /root/.ssh/id_ed25519 && chmod 600 /root/.ssh/id_ed25519
-    - ssh-keyscan -H github.com > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
-    - git clone $OPS_REPO ops
-    - cd ops
-    - git checkout $OPS_REF
+      - git fetch --tags
   - name: wait for docker
     image: docker
     commands:
@@ -647,7 +495,6 @@ steps:
         from_secret: DISTRIBUTION_OPSCENTER_TOKEN
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
-      - cd gravity
       - make -C e production
       - e/build/current/tele login --hub get.gravitational.io --token $TELE_KEY
       - make -C e telekube opscenter publish-telekube publish-artifacts
@@ -672,6 +519,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 80e78cddb5959d64b1d8db9bf864fd902f9b477114c5af8ba2f23ee84b58faa2
+hmac: 65a5d59e47ea7a322188e7e3a6a98a079e06943733643b39ad5083e2bab12b92
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -34,18 +34,39 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: build
-    image: docker:git
+  - name: assume AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RO_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: build
+    image: docker:git
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
       - make -C e production telekube opscenter
       - make build-tsh
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
   - name: unit test
@@ -98,6 +119,8 @@ services:
         path: /tmp
 
 volumes:
+  - name: awsconfig
+    temp: {}
   - name: dockersock
     temp: {}
   - name: dockertmp
@@ -133,18 +156,39 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: build
-    image: docker:git
+  - name: assume AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RO_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: build
+    image: docker:git
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
       - make -C e production telekube opscenter
       - make build-tsh
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
   - name: build robotest images
@@ -190,6 +234,8 @@ services:
         path: /tmp
 
 volumes:
+  - name: awsconfig
+    temp: {}
   - name: dockersock
     temp: {}
   - name: dockertmp
@@ -305,19 +351,64 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: build
-    image: docker:git
+  - name: assume AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RO_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: build
+    image: docker:git
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
       - make -C e production
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
+  - name: assume publish AWS role
+    image: amazon/aws-cli
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_S3_RW_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RW_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
   - name: publish dependencies
     image: docker:git
     environment:
@@ -325,14 +416,12 @@ steps:
         from_secret: QUAY_IO_SCAN_UPLOAD_USER
       TELE_COPY_TO_PASS:
         from_secret: QUAY_IO_SCAN_UPLOAD_TOKEN
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_S3_RW_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli
       - make -C e publish
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
 
@@ -345,6 +434,8 @@ services:
         path: /var/run
 
 volumes:
+  - name: awsconfig
+    temp: {}
   - name: dockersock
     temp: {}
 
@@ -393,27 +484,67 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: build
-    image: docker:git
+  - name: assume AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RO_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: build
+    image: docker:git
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli fakeroot
       - cd gravity
       - make production telekube build-tsh release hub-vars
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
-  - name: publish
-    image: docker:git
+  - name: assume publish AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RW_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RW_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RW_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: publish
+    image: docker:git
     commands:
       - apk add --no-cache make bash libc6-compat aws-cli ansible
       - export WORKSPACE=/drone/src
@@ -421,6 +552,8 @@ steps:
       - cd ops/hub
       - make bucket sync
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
 
@@ -433,6 +566,8 @@ services:
         path: /var/run
 
 volumes:
+  - name: awsconfig
+    temp: {}
   - name: dockersock
     temp: {}
 
@@ -481,13 +616,33 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-  - name: publish on linux
-    image: docker:git
+  - name: assume AWS role
+    image: amazon/aws-cli
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_S3_RO_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_S3_RO_SECRET_ACCESS_KEY
+      AWS_ROLE:
+        from_secret: AWS_S3_RO_ROLE
+    volumes:
+      - name: awsconfig
+        path: /root/.aws
+    commands:
+      - aws sts get-caller-identity
+      - |-
+        printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
+          $(aws sts assume-role \
+            --role-arn "$AWS_ROLE" \
+            --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
+            --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+            --output text) \
+          > /root/.aws/credentials
+      - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+      - aws sts get-caller-identity --profile default
+  - name: publish on linux
+    image: docker:git
+    environment:
       TELE_KEY:
         from_secret: DISTRIBUTION_OPSCENTER_TOKEN
     commands:
@@ -497,6 +652,8 @@ steps:
       - e/build/current/tele login --hub get.gravitational.io --token $TELE_KEY
       - make -C e telekube opscenter publish-telekube publish-artifacts
     volumes:
+      - name: awsconfig
+        path: /root/.aws
       - name: dockersock
         path: /var/run
 
@@ -511,8 +668,10 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+  - name: awsconfig
+    temp: {}
 ---
 kind: signature
-hmac: bb3915c0a4071e845865c2f7fbf78351563c99a752556909bdc8607fb0ebdc2d
+hmac: 80e78cddb5959d64b1d8db9bf864fd902f9b477114c5af8ba2f23ee84b58faa2
 
 ...

--- a/docs/9.x/changelog.md
+++ b/docs/9.x/changelog.md
@@ -56,6 +56,21 @@ extend updates past End of Support through customer agreements if required.
 
 9.0 is currently pre-release.
 
+### 9.0.0-beta.12 (upcoming)
+
+!!! warning
+    This release includes breaking changes.
+    The formerly avialable OSS and Mac artifacts are no longer published.
+    These artifacts will remain available for 9.0.0-beta.11 and below until July, 2023
+    but will not be published for any future Gravity releases.
+
+#### Breaking Changes
+* Removed MacOS builds of `tele` and `tsh` ([#2752](https://github.com/gravitational/gravity/pull/2752))
+* Stopped publishing OSS Gravity to hub.gravitational.io ([#2752](https://github.com/gravitational/gravity/pull/2752))
+
+#### Internal Changes
+* Several other minor code cleanup and build improvements.
+
 ### 9.0.0-beta.11 (April 4, 2022)
 
 #### Bugfixes
@@ -381,6 +396,21 @@ All changes listed are in comparison to 7.0.30 LTS.
 
 
 ## 7.0 Releases
+
+### 7.0.41 (upcoming)
+
+!!! warning
+    This release includes breaking changes.
+    The formerly avialable OSS and Mac artifacts are no longer published.
+    These artifacts will remain available for 9.0.0-beta.11 and below until July, 2023
+    but will not be published for any future Gravity releases.
+
+#### Breaking Changes
+* Removed MacOS builds of `tele` and `tsh` ([#2753](https://github.com/gravitational/gravity/pull/2753))
+* Stopped publishing OSS Gravity to hub.gravitational.io ([#2753](https://github.com/gravitational/gravity/pull/2753))
+
+#### Internal Changes
+* Several other minor code cleanup and build improvements.
 
 ### 7.0.40 (June 2, 2022)
 

--- a/docs/9.x/cli.md
+++ b/docs/9.x/cli.md
@@ -23,7 +23,7 @@ The typical Gravity workflow is as follows:
 
 ## tele
 
-`tele` is the Gravity CLI client and can run on macOS and Linux. With `tele` you can:
+`tele` is the Linux Gravity CLI client. With `tele` you can:
 
 * Package Kubernetes Clusters into self-installing Cluster Images.
 * Publish Cluster Images into the Gravity Hub. (Enterprise version only)
@@ -36,8 +36,8 @@ more details in [Building Cluster Images](pack.md) section.
 ## tsh
 
 `tsh` allows to remotely connect to any Gravity Cluster using SSH and
-Kubernetes API. It runs on MacOS and Linux. You can use `tsh` to remotely
-login into any node in a Gravity Cluster, even those located behind firewalls.
+Kubernetes API. You can use `tsh` to remotely login into any node in a
+Gravity Cluster, even those located behind firewalls.
 
 Gravity uses Teleport for remotely accessing Clusters. See more details in the
 [Teleport User Manual](https://gravitational.com/teleport/docs/user-manual/).


### PR DESCRIPTION
## Description
This PR includes several fixes and changes for our Gravity publishing logic:

* We no longer publish Mac copies of `tele`.  None of the active customers use this, and maintaining the build infrastructure broke earlier this year.  See https://github.com/gravitational/ops/issues/369.
* We no longer publish the OSS version gravity and its assets (the copy storied in hub.gravitational.io).  This was done to dramatically simplify publishing logic, as I was able to drop all dependence on ansible and the code in `ops`. See https://github.com/gravitational/ops/pull/438.
* Gravity's use of AWS is updated to be AWS FTR compliant.

We'll want a release note for this, as removing both Mac & OSS builds are user facing changes.

Needs backporting to `version/7.0.x` and probably `version/8.0.x` too for consistency, though no one uses that branch.

## Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change has a user-facing impact

## Linked tickets and other PRs

* Depends on https://github.com/gravitational/ops/pull/441
* Fixes https://github.com/gravitational/ops/issues/369
* Contributes to https://github.com/gravitational/SecOps/issues/162
* Contributes to https://github.com/gravitational/SecOps/issues/213
* Contributes to https://github.com/gravitational/SecOps/issues/310

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [ ] Address review feedback

## Testing done
See https://drone.platform.teleport.sh/gravitational/gravity/756/2/1

The PR build for this PR cover the rest of it.