### PR TITLE
Patch/Fixed CVE-2022-24785: gravitational/gravity Path Traversal

### DIFF
--- a/e/web/package-lock.json
+++ b/e/web/package-lock.json
@@ -13503,9 +13503,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "move-concurrently": {
       "version": "1.0.1",


### PR DESCRIPTION
## Description
A Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with "dot-dot-slash (../)" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.

```js
curl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa
```
<!--Required. Provide high-level overview of what the change is for.-->

## Type of change
<!--Required. Keep only those that apply.-->

* Bug fix (non-breaking change which fixes an issue)

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [ ] Self-review the change
- [ ] Write tests
- [ ] Perform manual testing
- [ ] Write documentation
- [ ] Address review feedback
- [ ] Update upstream references / tags / versions after upstream PR merges (linked above)

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

One way to achieve this is by using a malicious zip archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily. The following is an example of a zip archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in /root/.ssh/ overwriting the authorized_keys file:
```js
unction isLocaleNameSane(name) {
     // Prevent names that look like filesystem paths, i.e contain '/' or '\'
     return name.match('^[^/\\\\]*$') != null;
```
[CVE-2022-24785](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24785) [CWE-22](https://cwe.mitre.org/data/definitions/22.html) [CWE-27](https://cwe.mitre.org/data/definitions/27.html) `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N`