### PR TITLE
Prepare the gravity repo for archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,15 @@
-# Support Notice
-
-**The Gravity project is no longer under active development.**
-
-Gravity's development has been limited to maintenance and support for our
-commercial customers until maintenance agreements expire.
-
-Please see our blog post for more information:
-https://goteleport.com/blog/gravitational-is-teleport/
-
-Current Gravity releases will remain available until June 30th, 2023.  After
-June, 2023 both Open Source Gravity and Enterprise Gravity hosting and release
-infrastructure will be turned off.
-
----
-
 # Gravity
 
-Gravity is a [Kubernetes](https://kubernetes.io/) packaging solution
-that takes the drama out of deploying and running applications in someone
-else's cloud accounts, on-premise data centers, edge locations and other
-"uncharted territory" environments.
+> **Warning**
+> Gravity was archived 2023-07-01.
+>
+> Please see our [Gravitational is Teleport](https://goteleport.com/blog/gravitational-is-teleport/)
+> blog post for more information.
+>
+> If you're looking for a similar solution, we recommend using a
+> [certified Kubernetes Distribution](https://kubernetes.io/partners/#conformance).
 
-With Gravity, Kubernetes apps can run and be regularly updated anywhere in
-the world without a massive DevOps team.
+Gravity is a [Kubernetes](https://kubernetes.io/) packaging solution.
 
 ## Introduction
 
@@ -34,47 +21,6 @@ A cluster image can be used to re-create full replicas of the original
 cluster in any environment where compliance and consistency matters, i.e. in
 locked-down AWS/GCE/Azure environments or even in air-gapped server rooms.
 An image can run without human supervision, as a "kubernetes appliance".
-
-Gravity has been running in production in major financial institutions,
-government data centers and enterprises. Gravitational open sourced it in the
-fall of 2018.
-
-## Gravity vs ...
-
-There are plenty of Kubernetes distributions out there. Most of them aim to be
-flexible, general purpose platforms. Gravity has a more narrow **focus
-on compliance and reducing the overhead of managing Kubernetes**:
-
-* Gravity clusters are idempotent, i.e. clusters created from the same image
-  are _always identical_. There is no configuration drift over time; no
-  "special snowflakes".
-* Gravity clusters are always "wrapped" with a privileged access gateway called
-  [Teleport](https://gravitational.com/teleport), which unifies k8s and SSH
-  authentication, integrates with SSO and keeps a detailed audit log for compliance
-  purposes. It even records the interactive SSH and `kubectl exec` sessions.
-* Gravity clusters deployed world-wide can be remotely managed via built-in
-  reverse SSH tunnels, i.e. developers can have access to thousands of k8s API
-  endpoints even if they're located behind NAT/firewalls.
-* Gravity includes tools to perform _infrastructure validation_ prior to
-  cluster provisioning. This allows cluster designers to prevent users from
-  installing clusters on infrastructure that does not meet the system requirements.
-* Gravity clusters only allow Kubernetes components that have been thoroughly
-  tested by [Gravitational Inc](https://gravitational.com) for compatibility
-  and stability. These components are called a "Kubernetes Runtime". Users can
-  pick a Runtime but Gravity does not allow any customization of
-  individual components of Kubernetes.
-
-## Who is Gravity for?
-
-We have seen the following primary use cases for using a image-based Kubernetes approach
-(there may be others):
-
-* Deploying and running complex SaaS applications into on-premises enterprise environments.
-* Deploying and running complex SaaS applications in thousands of edge locations (retail, transportation, energy, etc).
-
-Anyone who needs Kubernetes best practices out of the box, without having to
-proactively manage it can benefit from Gravity. It allows you to focus on
-building your product instead of managing Kubernetes.
 
 ## Cluster Images
 
@@ -100,63 +46,6 @@ The following examples are currently available:
 
 * [Wordpress](examples/wordpress). Deploys Wordpress CMS with an OpenEBS-backed persistent storage.
 
-## How do Initial Deployments work?
-
-A cluster image created with Gravity can be used for:
-
-1. Creating many Kubernetes clusters from scratch, on any infrastructure.
-2. Installing applications contained in the cluster image into an existing
-   Kubernetes cluster, like OpenShift.
-
-## How do Updates work?
-
-Developers can continuously update their applications using different methods:
-
-1. Vanilla CI/CD using Kubernetes APIs, which is available for every cluster.
-   This is probably what you're already doing.
-2. Via "polling model", when each Gravity cluster will automatically download
-   updates from a Gravity Hub, letting cluster users decide when/if they want
-   to upgrade. This method is recommended for traditional on-premise
-   environments when developers do not have access to each deployment site.
-3. Offline method, when a developer prepares a new cluster image which can be
-   distributed via offline media. This method is suitable for air-gapped
-   environments.
-
-## Remote Access and Compliance
-
-Each cluster provisioned with Gravity includes the built-in SSH/Kubernetes gateway
-called [Teleport](https://github.com/gravitational/teleport). Teleport provides the
-following benefits:
-
-* One-step authentication which issues credentials for both k8s API and SSH.
-* Ability to implement compliance rules like "developers must never touch production data".
-* Ability to grant remote access to the cluster via SSH or via k8s API, even if the
-  cluster is located behind NAT with no open ports.
-* Keeps a detailed audit log (including fully recorded interactive sessions)
-  for all SSH commands and all `kubectl` commands executed on cluster nodes.
-
-Teleport can also be used independently without Gravity, it has been [audited
-multiple times](https://gravitational.com/resources/audits/) by reputable
-cyber security companies and it has been deployed in production in [multiple
-organizations](https://gravitational.com/teleport).
-
-## Why did We Build Gravity?
-
-Gravity is built by [Teleport](https://goteleport.com).
-
-The original use case for Gravity was to allow Kubernetes applications to be
-deployed into 3rd party environments, like on-premises datacenters. That's why
-Gravity includes features like the built-in, graphical cluster installer,
-infrastructure validation and a built-in privileged access manager (Teleport)
-for providing remote support.
-
-These features also resonated with security-minded teams who need to run
-applications in environments where _compliance matters_. Gravity clusters are
-always identical and do not allow any configuration drift over time. This
-allows _cluster architects_ (aka, Devops or SREs) to "publish" clusters that are approved for
-production and allow multiple teams within the organization to rapidly scale their
-Kubernetes adoption without having to become security and Kubernetes experts themselves.
-
 ## Building from source
 
 Gravity is written in Go. There are two ways to build the Gravity tools from
@@ -180,7 +69,3 @@ $ make install
 # To remove the build artifacts:
 $ make clean
 ```
-
-## Contributing
-
-Gravity is not currently accepting community contributions.

--- a/docs/9.x/changelog.md
+++ b/docs/9.x/changelog.md
@@ -5,17 +5,13 @@ description: List of Gravity releases and changes between them.
 
 # Releases
 
-To install Gravity, see the [Gravity installation instructions](installation.md).
-
 ## Supported Versions
 
-Open Source Gravity is no longer supported.  Commercial customers with prior
-agreements may receive targeted releases for otherwise unsupported versions.
+Gravity is no longer supported.
 
 ## Unsupported Versions
 
-These versions are past their End of Support date, and no longer receive
-regular security and bug fixes.
+These versions no longer receive regular security and bug fixes.
 
 | Version             | Latest Patch  | LTS | Release Date         | End of Support          | Kubernetes Version   | Teleport Version |
 | ------------------- | ------------- | --- | -------------------- | ----------------------- | -------------------- | ---------------- |


### PR DESCRIPTION
The gravity repo will be archived at the top of July, and all supporting infrastructure turned off.

This PR updates the readme and changlog to reflect this change.